### PR TITLE
Make the itoa dependency optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rustc_version = "0.4.0"
 
 [dependencies]
 bitflags = "1.3.2"
-itoa = { version = "0.4.7", default-features = false }
+itoa = { version = "0.4.7", default-features = false, optional = true }
 io-lifetimes = { version = "0.3.0", default-features = false }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
@@ -46,7 +46,7 @@ criterion = "0.3"
 default = []
 
 # Enable this to enable `proc_self_fd` (on Linux) and `ttyname`.
-procfs = ["once_cell"]
+procfs = ["once_cell", "itoa"]
 
 # Expose io-lifetimes' features for third-party crate impls.
 async-std = ["io-lifetimes/async-std"]

--- a/src/path/arg.rs
+++ b/src/path/arg.rs
@@ -1,4 +1,5 @@
 use crate::io;
+#[cfg(feature = "itoa")]
 use crate::path::DecInt;
 use std::borrow::Cow;
 use std::ffi::{CStr, CString, OsStr, OsString};
@@ -1182,6 +1183,7 @@ impl Arg for Vec<u8> {
     }
 }
 
+#[cfg(feature = "itoa")]
 impl Arg for DecInt {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -1,7 +1,9 @@
 //! Filesystem path operations.
 
 mod arg;
+#[cfg(feature = "itoa")]
 mod dec_int;
 
 pub use arg::Arg;
+#[cfg(feature = "itoa")]
 pub use dec_int::DecInt;

--- a/tests/net/unix.rs
+++ b/tests/net/unix.rs
@@ -8,6 +8,8 @@
     target_os = "redox",
     target_os = "wasi",
 )))]
+// This test uses `DecInt`.
+#![cfg(feature = "itoa")]
 
 use rsix::fs::{cwd, unlinkat, AtFlags};
 use rsix::io::{read, write};

--- a/tests/path/arg.rs
+++ b/tests/path/arg.rs
@@ -1,5 +1,7 @@
 use rsix::io;
-use rsix::path::{Arg, DecInt};
+use rsix::path::Arg;
+#[cfg(feature = "itoa")]
+use rsix::path::DecInt;
 use std::borrow::Cow;
 use std::ffi::{CStr, CString, OsStr, OsString};
 use std::path::{Component, Components, Iter, Path, PathBuf};
@@ -336,24 +338,27 @@ fn test_arg() {
         t.as_os_str()
     );
 
-    let t: DecInt = DecInt::new(43110);
-    assert_eq!("43110", t.as_str().unwrap());
-    assert_eq!("43110".to_owned(), Arg::to_string_lossy(&t));
-    #[cfg(not(windows))]
-    assert_eq!(cstr!("43110"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("43110"), t.as_c_str());
-    #[cfg(not(windows))]
-    assert_eq!(
-        cstr!("43110"),
-        Borrow::borrow(&t.clone().into_c_str().unwrap())
-    );
-    #[cfg(not(windows))]
-    assert_eq!(b"43110", t.as_maybe_utf8_bytes());
-    #[cfg(windows)]
-    assert_eq!(
-        &['4' as u16, '3' as _, '1' as _, '1' as _, 'o' as _],
-        t.as_os_str()
-    );
+    #[cfg(feature = "itoa")]
+    {
+        let t: DecInt = DecInt::new(43110);
+        assert_eq!("43110", t.as_str().unwrap());
+        assert_eq!("43110".to_owned(), Arg::to_string_lossy(&t));
+        #[cfg(not(windows))]
+        assert_eq!(cstr!("43110"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
+        assert_eq!(cstr!("43110"), t.as_c_str());
+        #[cfg(not(windows))]
+        assert_eq!(
+            cstr!("43110"),
+            Borrow::borrow(&t.clone().into_c_str().unwrap())
+        );
+        #[cfg(not(windows))]
+        assert_eq!(b"43110", t.as_maybe_utf8_bytes());
+        #[cfg(windows)]
+        assert_eq!(
+            &['4' as u16, '3' as _, '1' as _, '1' as _, 'o' as _],
+            t.as_os_str()
+        );
+    }
 }
 
 #[test]

--- a/tests/path/main.rs
+++ b/tests/path/main.rs
@@ -2,4 +2,5 @@
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 
 mod arg;
+#[cfg(feature = "itoa")]
 mod dec_int;


### PR DESCRIPTION
itoa is only used in DecInt, which rsix itself only needs in its
procfs code, so make the itoa dependency optional.