### PR TITLE
Remove `DecInt`'s `Deref` impl.

### DIFF
--- a/src/path/arg.rs
+++ b/src/path/arg.rs
@@ -975,18 +975,19 @@ impl Arg for Vec<u8> {
 impl Arg for DecInt {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        self.as_os_str().to_str().ok_or(io::Error::INVAL)
+        self.as_ref().as_os_str().to_str().ok_or(io::Error::INVAL)
     }
 
     #[inline]
     fn to_string_lossy(&self) -> Cow<str> {
-        Path::to_string_lossy(self)
+        Path::to_string_lossy(self.as_ref())
     }
 
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
-            CString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
+            CString::new(self.as_ref().as_os_str().as_bytes())
+                .map_err(|_cstr_err| io::Error::INVAL)?,
         ))
     }
 
@@ -996,13 +997,14 @@ impl Arg for DecInt {
         Self: 'b,
     {
         Ok(Cow::Owned(
-            CString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
+            CString::new(self.as_ref().as_os_str().as_bytes())
+                .map_err(|_cstr_err| io::Error::INVAL)?,
         ))
     }
 
     #[inline]
     fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.as_os_str().as_bytes()
+        self.as_ref().as_os_str().as_bytes()
     }
 
     #[inline]

--- a/src/path/dec_int.rs
+++ b/src/path/dec_int.rs
@@ -8,7 +8,6 @@ use crate::io::AsRawFd;
 use io_lifetimes::AsFd;
 use itoa::{fmt, Integer};
 use std::ffi::{CStr, OsStr};
-use std::ops::Deref;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
 #[cfg(target_os = "wasi")]
@@ -26,7 +25,7 @@ use std::path::Path;
 /// use rsix::path::DecInt;
 ///
 /// assert_eq!(
-///     format!("hello {}", DecInt::new(9876).display()),
+///     format!("hello {}", DecInt::new(9876).as_ref().display()),
 ///     "hello 9876"
 /// );
 /// ```
@@ -89,19 +88,10 @@ impl core::fmt::Write for DecIntWriter {
     }
 }
 
-impl Deref for DecInt {
-    type Target = Path;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        let as_os_str: &OsStr = OsStrExt::from_bytes(&self.buf[..self.len]);
-        Path::new(as_os_str)
-    }
-}
-
 impl AsRef<Path> for DecInt {
     #[inline]
     fn as_ref(&self) -> &Path {
-        &*self
+        let as_os_str: &OsStr = OsStrExt::from_bytes(&self.buf[..self.len]);
+        Path::new(as_os_str)
     }
 }

--- a/tests/path/dec_int.rs
+++ b/tests/path/dec_int.rs
@@ -2,19 +2,19 @@ use rsix::path::DecInt;
 
 #[test]
 fn test_dec_int() {
-    assert_eq!((*DecInt::new(0)).to_str().unwrap(), "0");
-    assert_eq!((*DecInt::new(-1)).to_str().unwrap(), "-1");
-    assert_eq!((*DecInt::new(789)).to_str().unwrap(), "789");
+    assert_eq!(DecInt::new(0).as_ref().to_str().unwrap(), "0");
+    assert_eq!(DecInt::new(-1).as_ref().to_str().unwrap(), "-1");
+    assert_eq!(DecInt::new(789).as_ref().to_str().unwrap(), "789");
     assert_eq!(
-        (*DecInt::new(i64::MIN)).to_str().unwrap(),
+        DecInt::new(i64::MIN).as_ref().to_str().unwrap(),
         i64::MIN.to_string()
     );
     assert_eq!(
-        (*DecInt::new(i64::MAX)).to_str().unwrap(),
+        DecInt::new(i64::MAX).as_ref().to_str().unwrap(),
         i64::MAX.to_string()
     );
     assert_eq!(
-        (*DecInt::new(u64::MAX)).to_str().unwrap(),
+        DecInt::new(u64::MAX).as_ref().to_str().unwrap(),
         u64::MAX.to_string()
     );
 }


### PR DESCRIPTION
`DecInt` isn't a smart pointer, so it should use `AsRef` instead of
`Deref` to avoid confusion.