### PR TITLE
Update to errno 0.2.8, and use no-default-features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ io-lifetimes = { version = "0.3.0", default-features = false }
 once_cell = { version = "1.5.2", optional = true }
 
 [target.'cfg(any(rsix_use_libc, not(all(any(target_os = "linux"), any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64")))))'.dependencies]
-errno = "0.2.7"
+errno = { version = "0.2.8", default-features = false }
 libc = { version = "0.2.98", features = ["extra_traits"] }
 
 [target.'cfg(all(not(rsix_use_libc), any(target_os = "linux"), any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64")))'.dependencies]


### PR DESCRIPTION
Errno 0.2.8 supports no_std, which the no_std_demo branch needs, and
disables strerror functionality, which rsix as a whole doesn't need.