### PR TITLE
fix sched_getaffinity

### DIFF
--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -491,12 +491,15 @@ pub(crate) fn getrandom(buf: &mut [u8], flags: GetRandomFlags) -> io::Result<usi
 #[inline]
 pub(crate) fn sched_getaffinity(pid: Pid, cpuset: &mut RawCpuSet) -> io::Result<()> {
     unsafe {
-        ret(syscall3(
+        // the raw linux syscall returns the size (in bytes) of the cpumask_t data type,
+        // that is used internally by the kernel to represent the CPU set bit mask
+        ret_usize(syscall3(
             nr(__NR_sched_getaffinity),
             c_uint(pid.as_raw()),
             size_of::<RawCpuSet, _>(),
             by_mut(&mut cpuset.bits),
         ))
+        .map(|_| ())
     }
 }
 


### PR DESCRIPTION
this function currently panics because it expects the syscall to behave like the `glibc` wrapper, which returns either 0 or an error.
the linux syscall returns a value on success.