### PR TITLE
Use core::intrinsics::assume to tell the compiler about syscall return values

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,7 @@ fn main() {
         {
             println!("cargo:rustc-cfg=linux_raw_inline_asm");
             println!("cargo:rustc-cfg=rustc_attrs");
+            println!("cargo:rustc-cfg=core_intrinsics");
             println!("cargo:rustc-cfg=doc_cfg");
         } else {
             link_in_librustix_outline(&arch, &asm_name);

--- a/src/imp/linux_raw/io/error.rs
+++ b/src/imp/linux_raw/io/error.rs
@@ -166,6 +166,13 @@ pub(in crate::imp::linux_raw) unsafe fn try_decode_raw_fd<Num: RetNumber>(
     // this function is only used for system calls which return file
     // descriptors, and this produces smaller code.
     if raw.is_negative() {
+        // Tell the optimizer that we know the value is in the error range.
+        // This helps it avoid unnecessary integer conversions.
+        #[cfg(core_intrinsics)]
+        {
+            core::intrinsics::assume(raw.is_in_range(-4095..0));
+        }
+
         return Err(Error(raw.decode_error_code()));
     }
 
@@ -186,6 +193,13 @@ pub(in crate::imp::linux_raw) unsafe fn try_decode_void<Num: RetNumber>(
     // function is only used for system calls which have no other return value,
     // and this produces smaller code.
     if raw.is_nonzero() {
+        // Tell the optimizer that we know the value is in the error range.
+        // This helps it avoid unnecessary integer conversions.
+        #[cfg(core_intrinsics)]
+        {
+            core::intrinsics::assume(raw.is_in_range(-4095..0));
+        }
+
         return Err(Error(raw.decode_error_code()));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@
 #![cfg_attr(feature = "rustc-dep-of-std", feature(const_raw_ptr_deref))]
 #![cfg_attr(feature = "rustc-dep-of-std", feature(slice_internals))]
 #![cfg_attr(feature = "rustc-dep-of-std", feature(core_intrinsics))]
+#![cfg_attr(all(not(feature = "rustc-dep-of-std"), core_intrinsics), feature(core_intrinsics))]
 
 #[cfg(not(feature = "rustc-dep-of-std"))]
 extern crate alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,10 @@
 #![cfg_attr(feature = "rustc-dep-of-std", feature(const_raw_ptr_deref))]
 #![cfg_attr(feature = "rustc-dep-of-std", feature(slice_internals))]
 #![cfg_attr(feature = "rustc-dep-of-std", feature(core_intrinsics))]
-#![cfg_attr(all(not(feature = "rustc-dep-of-std"), core_intrinsics), feature(core_intrinsics))]
+#![cfg_attr(
+    all(not(feature = "rustc-dep-of-std"), core_intrinsics),
+    feature(core_intrinsics)
+)]
 
 #[cfg(not(feature = "rustc-dep-of-std"))]
 extern crate alloc;


### PR DESCRIPTION
Use core::intrinsics::assume to describe the ranges of errors after
return values. This results in a slightly faster instruction sequence
after some system calls.