### PR TITLE
Remove `Arg::as_maybe_utf8_bytes`, which isn't used anywhere.

### DIFF
--- a/src/path/arg.rs
+++ b/src/path/arg.rs
@@ -67,9 +67,6 @@ pub trait Arg {
     where
         Self: 'b;
 
-    /// Returns a view of this string as a byte slice.
-    fn as_maybe_utf8_bytes(&self) -> &[u8];
-
     /// Runs a closure with `self` passed in as a `&ZStr`.
     fn into_with_z_str<T, F>(self, f: F) -> io::Result<T>
     where
@@ -132,11 +129,6 @@ impl Arg for &str {
     }
 
     #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.as_bytes()
-    }
-
-    #[inline]
     fn into_with_z_str<T, F>(self, f: F) -> io::Result<T>
     where
         Self: Sized,
@@ -170,11 +162,6 @@ impl Arg for &String {
         Self: 'b,
     {
         self.as_str().into_z_str()
-    }
-
-    #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.as_bytes()
     }
 
     #[inline]
@@ -213,11 +200,6 @@ impl Arg for String {
         Ok(Cow::Owned(
             ZString::new(self).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
-    }
-
-    #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.as_bytes()
     }
 
     #[inline]
@@ -260,11 +242,6 @@ impl Arg for &OsStr {
     }
 
     #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.as_bytes()
-    }
-
-    #[inline]
     fn into_with_z_str<T, F>(self, f: F) -> io::Result<T>
     where
         Self: Sized,
@@ -300,11 +277,6 @@ impl Arg for &OsString {
         Self: 'b,
     {
         self.as_os_str().into_z_str()
-    }
-
-    #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.as_bytes()
     }
 
     #[inline]
@@ -347,11 +319,6 @@ impl Arg for OsString {
     }
 
     #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.as_bytes()
-    }
-
-    #[inline]
     fn into_with_z_str<T, F>(self, f: F) -> io::Result<T>
     where
         Self: Sized,
@@ -388,11 +355,6 @@ impl Arg for &Path {
         Ok(Cow::Owned(
             ZString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
-    }
-
-    #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.as_os_str().as_bytes()
     }
 
     #[inline]
@@ -437,11 +399,6 @@ impl Arg for &PathBuf {
     }
 
     #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        PathBuf::as_path(self).as_os_str().as_bytes()
-    }
-
-    #[inline]
     fn into_with_z_str<T, F>(self, f: F) -> io::Result<T>
     where
         Self: Sized,
@@ -478,11 +435,6 @@ impl Arg for PathBuf {
         Ok(Cow::Owned(
             ZString::new(self.into_os_string().into_vec()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
-    }
-
-    #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.as_os_str().as_bytes()
     }
 
     #[inline]
@@ -523,11 +475,6 @@ impl Arg for &ZStr {
     }
 
     #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.to_bytes()
-    }
-
-    #[inline]
     fn into_with_z_str<T, F>(self, f: F) -> io::Result<T>
     where
         Self: Sized,
@@ -562,11 +509,6 @@ impl Arg for &ZString {
     }
 
     #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.to_bytes()
-    }
-
-    #[inline]
     fn into_with_z_str<T, F>(self, f: F) -> io::Result<T>
     where
         Self: Sized,
@@ -598,11 +540,6 @@ impl Arg for ZString {
         Self: 'b,
     {
         Ok(Cow::Owned(self))
-    }
-
-    #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.as_bytes()
     }
 
     #[inline]
@@ -645,11 +582,6 @@ impl<'a> Arg for Cow<'a, str> {
             }
             .map_err(|_cstr_err| io::Error::INVAL)?,
         ))
-    }
-
-    #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.as_bytes()
     }
 
     #[inline]
@@ -696,11 +628,6 @@ impl<'a> Arg for Cow<'a, OsStr> {
     }
 
     #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.as_bytes()
-    }
-
-    #[inline]
     fn into_with_z_str<T, F>(self, f: F) -> io::Result<T>
     where
         Self: Sized,
@@ -733,11 +660,6 @@ impl<'a> Arg for Cow<'a, ZStr> {
         Self: 'b,
     {
         Ok(self)
-    }
-
-    #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.to_bytes()
     }
 
     #[inline]
@@ -777,11 +699,6 @@ impl<'a> Arg for Component<'a> {
         Ok(Cow::Owned(
             ZString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
-    }
-
-    #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.as_os_str().as_bytes()
     }
 
     #[inline]
@@ -826,11 +743,6 @@ impl<'a> Arg for Components<'a> {
     }
 
     #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.as_path().as_os_str().as_bytes()
-    }
-
-    #[inline]
     fn into_with_z_str<T, F>(self, f: F) -> io::Result<T>
     where
         Self: Sized,
@@ -872,11 +784,6 @@ impl<'a> Arg for Iter<'a> {
     }
 
     #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.as_path().as_os_str().as_bytes()
-    }
-
-    #[inline]
     fn into_with_z_str<T, F>(self, f: F) -> io::Result<T>
     where
         Self: Sized,
@@ -912,11 +819,6 @@ impl Arg for &[u8] {
         Ok(Cow::Owned(
             ZString::new(self).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
-    }
-
-    #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self
     }
 
     #[inline]
@@ -958,11 +860,6 @@ impl Arg for &Vec<u8> {
     }
 
     #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self
-    }
-
-    #[inline]
     fn into_with_z_str<T, F>(self, f: F) -> io::Result<T>
     where
         Self: Sized,
@@ -998,11 +895,6 @@ impl Arg for Vec<u8> {
         Ok(Cow::Owned(
             ZString::new(self).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
-    }
-
-    #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self
     }
 
     #[inline]
@@ -1044,11 +936,6 @@ impl Arg for DecInt {
             ZString::new(self.as_ref().as_os_str().as_bytes())
                 .map_err(|_cstr_err| io::Error::INVAL)?,
         ))
-    }
-
-    #[inline]
-    fn as_maybe_utf8_bytes(&self) -> &[u8] {
-        self.as_ref().as_os_str().as_bytes()
     }
 
     #[inline]

--- a/tests/path/arg.rs
+++ b/tests/path/arg.rs
@@ -16,7 +16,6 @@ fn test_arg() {
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: String = "hello".to_owned();
     assert_eq!("hello", Arg::as_str(&t).unwrap());
@@ -26,14 +25,12 @@ fn test_arg() {
         cstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: &OsStr = OsStr::new("hello");
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: OsString = OsString::from("hello".to_owned());
     assert_eq!("hello", t.as_str().unwrap());
@@ -43,14 +40,12 @@ fn test_arg() {
         cstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: &Path = Path::new("hello");
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: PathBuf = PathBuf::from("hello".to_owned());
     assert_eq!("hello", t.as_str().unwrap());
@@ -60,14 +55,12 @@ fn test_arg() {
         cstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: &CStr = cstr!("hello");
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: CString = cstr!("hello").to_owned();
     assert_eq!("hello", t.as_str().unwrap());
@@ -80,7 +73,6 @@ fn test_arg() {
         cstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: Components = Path::new("hello").components();
     assert_eq!("hello", t.as_str().unwrap());
@@ -90,14 +82,12 @@ fn test_arg() {
         cstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: Component = Path::new("hello").components().next().unwrap();
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: Iter = Path::new("hello").iter();
     assert_eq!("hello", t.as_str().unwrap());
@@ -107,7 +97,6 @@ fn test_arg() {
         cstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: Cow<'_, str> = Cow::Borrowed("hello");
     assert_eq!("hello", t.as_str().unwrap());
@@ -117,7 +106,6 @@ fn test_arg() {
         cstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: Cow<'_, str> = Cow::Owned("hello".to_owned());
     assert_eq!("hello", t.as_str().unwrap());
@@ -127,7 +115,6 @@ fn test_arg() {
         cstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: Cow<'_, OsStr> = Cow::Borrowed(OsStr::new("hello"));
     assert_eq!("hello", t.as_str().unwrap());
@@ -137,7 +124,6 @@ fn test_arg() {
         cstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: Cow<'_, OsStr> = Cow::Owned(OsString::from("hello".to_owned()));
     assert_eq!("hello", t.as_str().unwrap());
@@ -147,7 +133,6 @@ fn test_arg() {
         cstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: Cow<'_, CStr> = Cow::Borrowed(cstr!("hello"));
     assert_eq!("hello", t.as_str().unwrap());
@@ -157,7 +142,6 @@ fn test_arg() {
         cstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: Cow<'_, CStr> = Cow::Owned(cstr!("hello").to_owned());
     assert_eq!("hello", t.as_str().unwrap());
@@ -167,14 +151,12 @@ fn test_arg() {
         cstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: &[u8] = b"hello";
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     let t: Vec<u8> = b"hello".to_vec();
     assert_eq!("hello", t.as_str().unwrap());
@@ -184,7 +166,6 @@ fn test_arg() {
         cstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
-    assert_eq!(b"hello", t.as_maybe_utf8_bytes());
 
     #[cfg(feature = "itoa")]
     {
@@ -197,7 +178,6 @@ fn test_arg() {
             cstr!("43110"),
             Borrow::borrow(&t.clone().into_z_str().unwrap())
         );
-        assert_eq!(b"43110", t.as_maybe_utf8_bytes());
     }
 }
 
@@ -217,7 +197,6 @@ fn test_invalid() {
         cstr!(b"hello\xc0world"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
-    assert_eq!(b"hello\xc0world", t.as_maybe_utf8_bytes());
 }
 
 #[test]
@@ -227,5 +206,4 @@ fn test_embedded_nul() {
     assert_eq!("hello\0world".to_owned(), Arg::to_string_lossy(&t));
     assert_eq!(t.as_cow_z_str().unwrap_err(), io::Error::INVAL);
     assert_eq!(t.clone().into_z_str().unwrap_err(), io::Error::INVAL);
-    assert_eq!(b"hello\0world", t.as_maybe_utf8_bytes());
 }


### PR DESCRIPTION
This made `Arg` more work to implement for new types, isn't needed, and
in practice is as awkward as the "maybe" name suggests.