### PR TITLE
Remove a riscv workaround.

### DIFF
--- a/src/imp/libc/io/types.rs
+++ b/src/imp/libc/io/types.rs
@@ -390,11 +390,7 @@ pub enum Advice {
     #[cfg(any(target_os = "android", target_os = "linux"))]
     LinuxHwPoison = c::MADV_HWPOISON,
     /// `MADV_SOFT_OFFLINE`
-    // TODO: Enable riscv once <https://github.com/rust-lang/libc/pull/2391> lands.
-    #[cfg(all(
-        not(target_arch = "riscv64"),
-        any(target_os = "android", target_os = "linux")
-    ))]
+    #[cfg(any(target_os = "android", target_os = "linux"))]
     LinuxSoftOffline = c::MADV_SOFT_OFFLINE,
     /// `MADV_MERGEABLE`
     #[cfg(any(target_os = "android", target_os = "linux"))]


### PR DESCRIPTION
Remove a riscv workaround, now that
https://github.com/rust-lang/libc/pull/2391 has landed.