### PR TITLE
Remove workarounds for `POLLRDHUP` and `MAP_SYNC`.

### DIFF
--- a/src/imp/libc/io/poll_fd.rs
+++ b/src/imp/libc/io/poll_fd.rs
@@ -33,7 +33,10 @@ bitflags! {
         /// `POLLNVAL`
         const NVAL = c::POLLNVAL;
         /// `POLLRDHUP`
-        #[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))]
+        #[cfg(all(
+            any(target_os = "android", target_os = "linux"),
+            not(any(target_arch = "sparc", target_arch = "sparc64")))
+        )]
         const RDHUP = c::POLLRDHUP;
     }
 }

--- a/src/imp/libc/io/poll_fd.rs
+++ b/src/imp/libc/io/poll_fd.rs
@@ -33,10 +33,8 @@ bitflags! {
         /// `POLLNVAL`
         const NVAL = c::POLLNVAL;
         /// `POLLRDHUP`
-        // TODO: Submitted to upstream libc:
-        // <https://github.com/rust-lang/libc/pull/2390>
         #[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))]
-        const RDHUP = 0x2000;
+        const RDHUP = c::POLLRDHUP;
     }
 }
 

--- a/src/imp/libc/io/types.rs
+++ b/src/imp/libc/io/types.rs
@@ -237,8 +237,6 @@ bitflags! {
             target_os = "netbsd",
             target_os = "openbsd",
             target_os = "redox",
-            // TODO: Enable s390x once <https://github.com/rust-lang/libc/pull/2395> lands.
-            target_arch = "s390x",
         )))]
         const SYNC = c::MAP_SYNC;
         /// `MAP_UNINITIALIZED`


### PR DESCRIPTION
The fixes for these have landed in libc, so we no longer need the
workarounds.