### PR TITLE
Update I/O safety URLs to point to the RFC text, rather than the PR.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ version of this crate.
 [`cap-std`]: https://crates.io/crates/cap-std
 [`bitflags`]: https://crates.io/crates/bitflags
 [`Arg`]: https://docs.rs/rustix/latest/rustix/path/trait.Arg.html
-[I/O-safe]: https://github.com/rust-lang/rfcs/pull/3128
-[I/O safety]: https://github.com/rust-lang/rfcs/pull/3128
+[I/O-safe]: https://github.com/rust-lang/rfcs/blob/master/text/3128-io-safety.md
+[I/O safety]: https://github.com/rust-lang/rfcs/blob/master/text/3128-io-safety.md
 [y2038 bug]: https://en.wikipedia.org/wiki/Year_2038_problem
 [`OwnedFd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/struct.OwnedFd.html
 [`AsFd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/trait.AsFd.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! [`AsFd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/trait.AsFd.html
 //! [`OwnedFd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/struct.OwnedFd.html
 //! [io-lifetimes crate]: https://crates.io/crates/io-lifetimes
-//! [I/O-safe]: https://github.com/rust-lang/rfcs/pull/3128
+//! [I/O-safe]: https://github.com/rust-lang/rfcs/blob/master/text/3128-io-safety.md
 //! [`Result`]: https://docs.rs/rustix/latest/rustix/io/type.Result.html
 //! [`Arg`]: https://docs.rs/rustix/latest/rustix/path/trait.Arg.html
 


### PR DESCRIPTION
The RFC has been accepted, so we can now point to the official RFC text
rather than just the PR.