### PR TITLE
Export a `zstr!` macro for `ZStr` literals.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ winapi = { version = "0.3.9", features = ["ws2ipdef", "ws2tcpip"] }
 
 [dev-dependencies]
 atty = "0.2.14"
-cstr = "0.2.8"
 tempfile = "3.2.0"
 libc = "0.2.98"
 serial_test = "0.5"

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -62,7 +62,7 @@ mod suite {
                     assert_eq!(
                         libc::fstatat(
                             libc::AT_FDCWD,
-                            cstr::cstr!("/").as_ptr() as _,
+                            rustix::zstr!("/").as_ptr() as _,
                             s.as_mut_ptr(),
                             0
                         ),
@@ -78,7 +78,7 @@ mod suite {
 
         c.bench_function("simple statat cstr", |b| {
             b.iter(|| {
-                statat(&cwd(), cstr::cstr!("/"), AtFlags::empty()).unwrap();
+                statat(&cwd(), rustix::zstr!("/"), AtFlags::empty()).unwrap();
             })
         });
     }

--- a/src/io/procfs.rs
+++ b/src/io/procfs.rs
@@ -162,7 +162,7 @@ fn check_procfs(file: BorrowedFd<'_>) -> io::Result<()> {
 /// `renameat` call that would otherwise fail, but which fails with `EXDEV`
 /// first if it would cross a mount point.
 fn is_mountpoint(file: BorrowedFd<'_>) -> bool {
-    let err = renameat(&file, cstr!("../."), &file, cstr!(".")).unwrap_err();
+    let err = renameat(&file, zstr!("../."), &file, zstr!(".")).unwrap_err();
     match err {
         io::Error::XDEV => true,  // the rename failed due to crossing a mount point
         io::Error::BUSY => false, // the rename failed normally
@@ -194,7 +194,7 @@ fn proc() -> io::Result<(BorrowedFd<'static>, &'static Stat)> {
             | OFlags::NOATIME;
 
         // Open "/proc".
-        let proc = openat(&cwd(), cstr!("/proc"), oflags, Mode::empty())
+        let proc = openat(&cwd(), zstr!("/proc"), oflags, Mode::empty())
             .map_err(|_err| io::Error::NOTSUP)?;
         let proc_stat = check_proc_entry(
             Kind::Proc,
@@ -279,7 +279,7 @@ pub fn proc_self_fd() -> io::Result<BorrowedFd<'static>> {
                 | OFlags::NOATIME;
 
             // Open "/proc/self/fd".
-            let proc_self_fd = openat(&proc_self, cstr!("fd"), oflags, Mode::empty())
+            let proc_self_fd = openat(&proc_self, zstr!("fd"), oflags, Mode::empty())
                 .map_err(|_err| io::Error::NOTSUP)?;
             let proc_self_fd_stat = check_proc_entry(
                 Kind::Fd,

--- a/src/path/arg.rs
+++ b/src/path/arg.rs
@@ -46,7 +46,7 @@ use std::path::{Component, Components, Iter, Path, PathBuf};
 /// }
 /// ```
 ///
-/// Users can then call `touch("foo")`, `touch(cstr!("foo"))`,
+/// Users can then call `touch("foo")`, `touch(zstr!("foo"))`,
 /// `touch(Path::new("foo"))`, or many other things.
 ///
 /// [`AsRef`]: std::convert::AsRef

--- a/src/zstr.rs
+++ b/src/zstr.rs
@@ -1,29 +1,46 @@
-/// A simple macro for `ZStr` literals that doesn't depend on `proc_macro2` or
-/// `syn` or anything else. Embedded NULs are not diagnosed at compile time,
-/// but are diagnosed at runtime in `debug_assertions` builds.
-#[cfg(debug_assertions)]
+/// A macro for [`ZStr`] literals.
+///
+/// This can make passing string literals to rustix APIs more efficient, since
+/// most underlying system calls with string arguments expect NUL-terminated
+/// strings, and passing strings to rustix as `ZStr`s means that rustix doesn't
+/// need to copy them into a separate buffer to NUL-terminate them.
+///
+/// [`ZStr`]: crate::ffi::ZStr
+///
+/// # Examples
+///
+/// ```rust
+/// let stat = rustix::fs::statat(&rustix::fs::cwd(), zstr!("test.txt"), AtFlags::empty())?;
+/// ```
 #[allow(unused_macros)]
-macro_rules! zstr {
-    ($str:literal) => {
-        crate::ffi::ZStr::from_bytes_with_nul(concat!($str, "\0").as_bytes()).unwrap()
-    };
-}
-#[cfg(not(debug_assertions))]
-#[allow(unused_macros)]
+#[macro_export]
 macro_rules! zstr {
     ($str:literal) => {{
-        #[allow(unsafe_code, unused_unsafe)]
-        unsafe {
-            crate::ffi::ZStr::from_bytes_with_nul_unchecked(concat!($str, "\0").as_bytes())
-        }
-    }};
-}
+        // Check for NUL manually, to ensure safety.
+        //
+        // In release builds, with strings that don't contain NULs, this
+        // constant-folds away.
+        //
+        // We don't use std's `CStr::from_bytes_with_nul`; as of this writing,
+        // that function isn't defined as `#[inline]` in std and doesn't
+        // constant-fold away.
+        assert!(
+            !$str.bytes().any(|b| b == b'\0'),
+            "zstr argument contains embedded NUL bytes",
+        );
 
-#[cfg(not(feature = "rustc-dep-of-std"))]
-#[allow(unused_macros)]
-macro_rules! cstr {
-    ($str:literal) => {{
-        zstr!($str)
+        // Now that we know the string doesn't have embedded NULs, we can call
+        // `from_bytes_with_nul_unchecked`, which as of this writing is defined
+        // as `#[inline]` and completely optimizes away.
+        //
+        // # Safety
+        //
+        // We have manually checked that the string does not contain embedded
+        // NULs above, and we append or own NUL terminator here.
+        #[allow(unsafe_code)]
+        unsafe {
+            $crate::ffi::ZStr::from_bytes_with_nul_unchecked(concat!($str, "\0").as_bytes())
+        }
     }};
 }
 
@@ -35,4 +52,10 @@ fn test_zstr() {
     assert_eq!(zstr!("").to_owned(), ZString::new("").unwrap());
     assert_eq!(zstr!("hello"), &*ZString::new("hello").unwrap());
     assert_eq!(zstr!("hello").to_owned(), ZString::new("hello").unwrap());
+}
+
+#[test]
+#[should_panic]
+fn test_invalid_zstr() {
+    let _ = zstr!("hello\0world");
 }

--- a/src/zstr.rs
+++ b/src/zstr.rs
@@ -9,8 +9,14 @@
 ///
 /// # Examples
 ///
-/// ```rust
-/// let stat = rustix::fs::statat(&rustix::fs::cwd(), zstr!("test.txt"), AtFlags::empty())?;
+/// ```rust,no_run
+/// # fn main() -> rustix::io::Result<()> {
+/// use rustix::zstr;
+/// use rustix::fs::{cwd, statat, AtFlags};
+///
+/// let metadata = statat(&cwd(), zstr!("test.txt"), AtFlags::empty())?;
+/// # Ok(())
+/// # }
 /// ```
 #[allow(unused_macros)]
 #[macro_export]

--- a/tests/path/arg.rs
+++ b/tests/path/arg.rs
@@ -1,169 +1,170 @@
+use rustix::ffi::{ZStr, ZString};
 use rustix::io;
 use rustix::path::Arg;
 #[cfg(feature = "itoa")]
 use rustix::path::DecInt;
 use std::borrow::Cow;
-use std::ffi::{CStr, CString, OsStr, OsString};
+use std::ffi::{OsStr, OsString};
 use std::path::{Component, Components, Iter, Path, PathBuf};
 
 #[test]
 fn test_arg() {
-    use cstr::cstr;
+    use rustix::zstr;
     use std::borrow::Borrow;
 
     let t: &str = "hello";
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
 
     let t: String = "hello".to_owned();
     assert_eq!("hello", Arg::as_str(&t).unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(
-        cstr!("hello"),
+        zstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
 
     let t: &OsStr = OsStr::new("hello");
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
 
     let t: OsString = OsString::from("hello".to_owned());
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(
-        cstr!("hello"),
+        zstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
 
     let t: &Path = Path::new("hello");
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
 
     let t: PathBuf = PathBuf::from("hello".to_owned());
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(
-        cstr!("hello"),
+        zstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
 
-    let t: &CStr = cstr!("hello");
+    let t: &ZStr = zstr!("hello");
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
 
-    let t: CString = cstr!("hello").to_owned();
+    let t: ZString = zstr!("hello").to_owned();
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     assert_eq!(
-        cstr!("hello"),
+        zstr!("hello"),
         Borrow::borrow(&Arg::as_cow_z_str(&t).unwrap())
     );
     assert_eq!(
-        cstr!("hello"),
+        zstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
 
     let t: Components = Path::new("hello").components();
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(
-        cstr!("hello"),
+        zstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
 
     let t: Component = Path::new("hello").components().next().unwrap();
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
 
     let t: Iter = Path::new("hello").iter();
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(
-        cstr!("hello"),
+        zstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
 
     let t: Cow<'_, str> = Cow::Borrowed("hello");
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(
-        cstr!("hello"),
+        zstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
 
     let t: Cow<'_, str> = Cow::Owned("hello".to_owned());
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(
-        cstr!("hello"),
+        zstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
 
     let t: Cow<'_, OsStr> = Cow::Borrowed(OsStr::new("hello"));
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(
-        cstr!("hello"),
+        zstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
 
     let t: Cow<'_, OsStr> = Cow::Owned(OsString::from("hello".to_owned()));
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(
-        cstr!("hello"),
+        zstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
 
-    let t: Cow<'_, CStr> = Cow::Borrowed(cstr!("hello"));
+    let t: Cow<'_, ZStr> = Cow::Borrowed(zstr!("hello"));
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(
-        cstr!("hello"),
+        zstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
 
-    let t: Cow<'_, CStr> = Cow::Owned(cstr!("hello").to_owned());
+    let t: Cow<'_, ZStr> = Cow::Owned(zstr!("hello").to_owned());
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(
-        cstr!("hello"),
+        zstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
 
     let t: &[u8] = b"hello";
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.into_z_str().unwrap()));
 
     let t: Vec<u8> = b"hello".to_vec();
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+    assert_eq!(zstr!("hello"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
     assert_eq!(
-        cstr!("hello"),
+        zstr!("hello"),
         Borrow::borrow(&t.clone().into_z_str().unwrap())
     );
 
@@ -172,10 +173,10 @@ fn test_arg() {
         let t: DecInt = DecInt::new(43110);
         assert_eq!("43110", t.as_str().unwrap());
         assert_eq!("43110".to_owned(), Arg::to_string_lossy(&t));
-        assert_eq!(cstr!("43110"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
-        assert_eq!(cstr!("43110"), t.as_c_str());
+        assert_eq!(zstr!("43110"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
+        assert_eq!(zstr!("43110"), t.as_c_str());
         assert_eq!(
-            cstr!("43110"),
+            zstr!("43110"),
             Borrow::borrow(&t.clone().into_z_str().unwrap())
         );
     }
@@ -183,19 +184,18 @@ fn test_arg() {
 
 #[test]
 fn test_invalid() {
-    use cstr::cstr;
     use std::borrow::Borrow;
 
     let t: &[u8] = b"hello\xc0world";
     assert_eq!(t.as_str().unwrap_err(), io::Error::INVAL);
     assert_eq!("hello\u{fffd}world".to_owned(), Arg::to_string_lossy(&t));
     assert_eq!(
-        cstr!(b"hello\xc0world"),
-        Borrow::borrow(&t.as_cow_z_str().unwrap())
+        b"hello\xc0world\0",
+        Borrow::<ZStr>::borrow(&t.as_cow_z_str().unwrap()).to_bytes_with_nul()
     );
     assert_eq!(
-        cstr!(b"hello\xc0world"),
-        Borrow::borrow(&t.clone().into_z_str().unwrap())
+        b"hello\xc0world\0",
+        Borrow::<ZStr>::borrow(&t.clone().into_z_str().unwrap()).to_bytes_with_nul()
     );
 }
 


### PR DESCRIPTION
Export rustix's `zstr!` macro for creating `ZStr` literals, which can
make passing string literals into rustix APIs more efficient.

While here, improve the safety of the `zstr!` macro -- implement a NUL
check in a way that can be optimized away in the common case, so that
the check can be always enabled, preventing any possibility of UB.