### PR TITLE
Define flags for `AT_STATX_SYNC_AS_STAT` etc.

### DIFF
--- a/src/imp/libc/fs/types.rs
+++ b/src/imp/libc/fs/types.rs
@@ -60,15 +60,15 @@ bitflags! {
 
         /// `AT_STATX_SYNC_AS_STAT`
         #[cfg(all(target_os = "linux", target_env = "gnu"))]
-        const STATX_SYNC_AS_STAT = linux_raw_sys::general::AT_STATX_SYNC_AS_STAT;
+        const STATX_SYNC_AS_STAT = libc::AT_STATX_SYNC_AS_STAT;
 
         /// `AT_STATX_FORCE_SYNC`
         #[cfg(all(target_os = "linux", target_env = "gnu"))]
-        const STATX_FORCE_SYNC = linux_raw_sys::general::AT_STATX_FORCE_SYNC;
+        const STATX_FORCE_SYNC = libc::AT_STATX_FORCE_SYNC;
 
         /// `AT_STATX_DONT_SYNC`
         #[cfg(all(target_os = "linux", target_env = "gnu"))]
-        const STATX_DONT_SYNC = linux_raw_sys::general::AT_STATX_DONT_SYNC;
+        const STATX_DONT_SYNC = libc::AT_STATX_DONT_SYNC;
     }
 }
 

--- a/src/imp/libc/fs/types.rs
+++ b/src/imp/libc/fs/types.rs
@@ -57,6 +57,18 @@ bitflags! {
         /// `AT_EACCESS`
         #[cfg(not(any(target_os = "emscripten", target_os = "android")))]
         const EACCESS = c::AT_EACCESS;
+
+        /// `AT_STATX_SYNC_AS_STAT`
+        #[cfg(all(target_os = "linux", target_env = "gnu"))]
+        const STATX_SYNC_AS_STAT = linux_raw_sys::general::AT_STATX_SYNC_AS_STAT;
+
+        /// `AT_STATX_FORCE_SYNC`
+        #[cfg(all(target_os = "linux", target_env = "gnu"))]
+        const STATX_FORCE_SYNC = linux_raw_sys::general::AT_STATX_FORCE_SYNC;
+
+        /// `AT_STATX_DONT_SYNC`
+        #[cfg(all(target_os = "linux", target_env = "gnu"))]
+        const STATX_DONT_SYNC = linux_raw_sys::general::AT_STATX_DONT_SYNC;
     }
 }
 

--- a/src/imp/linux_raw/fs/types.rs
+++ b/src/imp/linux_raw/fs/types.rs
@@ -52,6 +52,15 @@ bitflags! {
 
         /// `AT_EACCESS`
         const EACCESS = linux_raw_sys::v5_11::general::AT_EACCESS;
+
+        /// `AT_STATX_SYNC_AS_STAT`
+        const STATX_SYNC_AS_STAT = linux_raw_sys::v5_4::general::AT_STATX_SYNC_AS_STAT;
+
+        /// `AT_STATX_FORCE_SYNC`
+        const STATX_FORCE_SYNC = linux_raw_sys::v5_4::general::AT_STATX_FORCE_SYNC;
+
+        /// `AT_STATX_DONT_SYNC`
+        const STATX_DONT_SYNC = linux_raw_sys::v5_4::general::AT_STATX_DONT_SYNC;
     }
 }
 
@@ -468,8 +477,6 @@ pub type StatFs = linux_raw_sys::general::statfs64;
 pub type StatFs = linux_raw_sys::general::statfs64;
 
 /// `struct statx` for use with [`statx`].
-///
-/// Only available on Linux with GLIBC for now.
 ///
 /// [`statx`]: crate::fs::statx
 pub type Statx = linux_raw_sys::v5_4::general::statx;


### PR DESCRIPTION
`statx` uses several dedicated `AtFlags` values: `AT_STATX_SYNC_AS_STAT`,
`AT_STATX_FORCE_SYNC`, and `AT_STATX_DONT_SYNC`. Define `AtFlags`
bindings for them.