### PR TITLE
Use fine-grained feature detection instead of `rustc_version`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ exclude = ["/.github"]
 
 [build-dependencies]
 cc = { version = "1.0.68", optional = true }
-rustc_version = "0.4.0"
 
 [dependencies]
 bitflags = "1.3.2"

--- a/build.rs
+++ b/build.rs
@@ -102,18 +102,14 @@ fn use_feature(feature: &str) {
 
 /// Test whether the rustc at `var("RUSTC")` supports the given feature.
 fn has_feature(feature: &str) -> bool {
+    let out_dir = var("OUT_DIR").unwrap();
     let rustc = var("RUSTC").unwrap();
-
-    #[cfg(not(windows))]
-    let dev_null = "/dev/null";
-    #[cfg(windows)]
-    let dev_null = "NUL";
 
     let mut child = std::process::Command::new(rustc)
         .arg("--crate-type=rlib") // Don't require `main`.
-        .arg("--emit=dep-info") // Do as little as possible.
-        .arg("-o")
-        .arg(dev_null) // Don't write an output file.
+        .arg("--emit=metadata") // Do as little as possible but still parse.
+        .arg("--out-dir")
+        .arg(out_dir) // Put the output somewhere inconsequential.
         .arg("-") // Read from stdin.
         .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
         .spawn()

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,16 @@
 #[cfg(feature = "cc")]
 use cc::Build;
 use std::env::var;
+use std::io::Write;
 
 /// The directory for out-of-line ("outline") libraries.
 const OUTLINE_PATH: &str = "src/imp/linux_raw/arch/outline";
 
 fn main() {
+    // Don't rerun this on changes other than build.rs, as we only depend on
+    // the rustc version.
+    println!("cargo:rerun-if-changed=build.rs");
+
     let arch = var("CARGO_CFG_TARGET_ARCH").unwrap();
     let asm_name = format!("{}/{}.S", OUTLINE_PATH, arch);
     let os_name = var("CARGO_CFG_TARGET_OS").unwrap();
@@ -19,24 +24,17 @@ fn main() {
         || std::fs::metadata(&asm_name).is_err()
         || is_x32
     {
-        println!("cargo:rustc-cfg=libc");
+        use_feature("libc");
     } else {
-        println!("cargo:rustc-cfg=linux_raw");
+        use_feature("linux_raw");
 
-        if let rustc_version::Channel::Nightly = rustc_version::version_meta()
-            .expect("query rustc release channel")
-            .channel
-        {
-            println!("cargo:rustc-cfg=linux_raw_inline_asm");
-            println!("cargo:rustc-cfg=rustc_attrs");
-            println!("cargo:rustc-cfg=core_intrinsics");
-            println!("cargo:rustc-cfg=doc_cfg");
-        } else {
+        use_feature_or_nothing("rustc_attrs");
+        use_feature_or_nothing("core_intrinsics");
+        use_feature_or_nothing("doc_cfg");
+
+        use_feature_or_else("asm", || {
             link_in_librustix_outline(&arch, &asm_name);
-        }
-        if rustc_version::version().unwrap() >= rustc_version::Version::parse("1.56.0").unwrap() {
-            println!("cargo:rustc-cfg=const_fn_union");
-        }
+        });
     }
     println!("cargo:rerun-if-env-changed=CARGO_CFG_RUSTIX_USE_LIBC");
 }
@@ -82,4 +80,46 @@ fn link_in_librustix_outline(arch: &str, asm_name: &str) {
             to
         );
     }
+}
+
+fn use_feature_or_nothing(feature: &str) {
+    if has_feature(feature) {
+        use_feature(feature);
+    }
+}
+
+fn use_feature_or_else<F: FnOnce()>(feature: &str, or_else: F) {
+    if has_feature(feature) {
+        use_feature(feature);
+    } else {
+        or_else();
+    }
+}
+
+fn use_feature(feature: &str) {
+    println!("cargo:rustc-cfg={}", feature);
+}
+
+/// Test whether the rustc at `var("RUSTC")` supports the given feature.
+fn has_feature(feature: &str) -> bool {
+    let rustc = var("RUSTC").unwrap();
+
+    #[cfg(not(windows))]
+    let dev_null = "/dev/null";
+    #[cfg(windows)]
+    let dev_null = "NUL";
+
+    let mut child = std::process::Command::new(rustc)
+        .arg("--crate-type=rlib") // Don't require `main`.
+        .arg("--emit=dep-info") // Do as little as possible.
+        .arg("-o")
+        .arg(dev_null) // Don't write an output file.
+        .arg("-") // Read from stdin.
+        .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
+        .spawn()
+        .unwrap();
+
+    writeln!(child.stdin.take().unwrap(), "#![feature({})]", feature).unwrap();
+
+    child.wait().unwrap().success()
 }

--- a/src/imp/linux_raw/arch/mod.rs
+++ b/src/imp/linux_raw/arch/mod.rs
@@ -16,15 +16,15 @@
 #![allow(unsafe_code)]
 
 // When inline asm is available, use it.
-#[cfg(linux_raw_inline_asm)]
+#[cfg(asm)]
 pub(in crate::imp::linux_raw) mod inline;
-#[cfg(linux_raw_inline_asm)]
+#[cfg(asm)]
 pub(in crate::imp::linux_raw) use self::inline as asm;
 
 // When inline asm isn't available, use out-of-line asm.
-#[cfg(not(linux_raw_inline_asm))]
+#[cfg(not(asm))]
 pub(in crate::imp::linux_raw) mod outline;
-#[cfg(not(linux_raw_inline_asm))]
+#[cfg(not(asm))]
 pub(in crate::imp::linux_raw) use self::outline as asm;
 
 // On most architectures, the architecture syscall instruction is fast, so use

--- a/src/imp/linux_raw/vdso_wrappers.rs
+++ b/src/imp/linux_raw/vdso_wrappers.rs
@@ -305,7 +305,7 @@ unsafe fn _rustix_clock_gettime_via_syscall(
     ))
 }
 
-#[cfg(all(linux_raw_inline_asm, target_arch = "x86"))]
+#[cfg(all(asm, target_arch = "x86"))]
 #[naked]
 unsafe extern "C" fn rustix_int_0x80(
     _nr: SyscallNumber<'_>,
@@ -319,7 +319,7 @@ unsafe extern "C" fn rustix_int_0x80(
     asm!("int $$0x80", "ret", options(noreturn))
 }
 
-#[cfg(all(not(linux_raw_inline_asm), target_arch = "x86"))]
+#[cfg(all(not(asm), target_arch = "x86"))]
 extern "C" {
     fn rustix_int_0x80(
         _nr: SyscallNumber<'_>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,14 +45,11 @@
 
 #![deny(missing_docs)]
 #![cfg_attr(linux_raw, deny(unsafe_code))]
-#![cfg_attr(linux_raw_inline_asm, feature(asm))]
+#![cfg_attr(asm, feature(asm))]
 #![cfg_attr(any(rustc_attrs, feature = "rustc-dep-of-std"), feature(rustc_attrs))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
-#![cfg_attr(
-    all(linux_raw_inline_asm, target_arch = "x86"),
-    feature(naked_functions)
-)]
+#![cfg_attr(all(linux_raw, asm, target_arch = "x86"), feature(naked_functions))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "rustc-dep-of-std", allow(incomplete_features))]


### PR DESCRIPTION
Test whether rustc supports specific features, rather than assuming that
Nightly has all the features and Stable doesn't.