### PR TITLE
Relax the bitflags dependency to 1.2.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ cc = { version = "1.0.68", optional = true }
 rustc_version = "0.4.0"
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "1.2.1"
 itoa = { version = "0.4.7", default-features = false, optional = true }
 io-lifetimes = { version = "0.4.0", default-features = false, optional = true }
 


### PR DESCRIPTION
rustix can work with this version, and this matches the version of
bitflags that rustc itself uses.