### PR TITLE
Various fixes needed for rustc-dep-of-std mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
         x86_64-unknown-linux-musl
         x86_64-unknown-linux-gnux32
         x86_64-linux-android
+        i686-linux-android
         x86_64-apple-darwin
         x86_64-unknown-freebsd
         x86_64-unknown-netbsd
@@ -71,6 +72,7 @@ jobs:
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-musl
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-gnux32
     - run: cargo check --workspace --release -vv --target=x86_64-linux-android
+    - run: cargo check --workspace --release -vv --target=i686-linux-android
     - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-freebsd
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-netbsd

--- a/src/ffi/z_str.rs
+++ b/src/ffi/z_str.rs
@@ -5,7 +5,6 @@
 //! ZStrings are like std's CStrings except that they use `u8` instead of
 //! `c_char`, so that they're not platform-dependent.
 
-#![rustfmt::skip]
 #![allow(unsafe_code)]
 #![deny(unsafe_op_in_unsafe_fn)]
 

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -108,6 +108,9 @@ pub(crate) fn openat(
     mode: Mode,
 ) -> io::Result<OwnedFd> {
     unsafe {
+        // Pass `mode` as a `c_uint` even if `mode_t` is narrower, since
+        // `libc_openat` is declared as a variadic function and narrrower
+        // arguments are promoted.
         ret_owned_fd(libc_openat(
             borrowed_fd(dirfd),
             c_str(path),

--- a/src/imp/libc/fs/types.rs
+++ b/src/imp/libc/fs/types.rs
@@ -499,6 +499,9 @@ bitflags! {
 
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 bitflags! {
+    /// `STATX_*` constants for use with [`statx`].
+    ///
+    /// [`statx`]: crate::fs::statx
     pub struct StatxFlags: u32 {
         /// `STATX_TYPE`
         const TYPE = c::STATX_TYPE;

--- a/src/imp/libc/io/poll_fd.rs
+++ b/src/imp/libc/io/poll_fd.rs
@@ -75,7 +75,7 @@ impl<'fd> PollFd<'fd> {
 
     /// Return the ready events.
     #[inline]
-    pub fn revents(self) -> PollFlags {
+    pub fn revents(&self) -> PollFlags {
         // Use `unwrap()` here because in theory we know we know all the bits
         // the OS might set here, but OS's have added extensions in the past.
         PollFlags::from_bits(self.pollfd.revents).unwrap()

--- a/src/imp/libc/io/types.rs
+++ b/src/imp/libc/io/types.rs
@@ -417,13 +417,15 @@ impl Advice {
     pub const DontNeed: Self = Self::Normal;
 }
 
-/// `struct termios`, for use with [`ioctl_tcgets`].
+/// `struct termios` for use with [`ioctl_tcgets`].
 ///
 /// [`ioctl_tcgets`]: crate::io::ioctl_tcgets
 #[cfg(not(target_os = "wasi"))]
 pub type Termios = c::termios;
 
-/// `struct winsize`
+/// `struct winsize` for use with [`ioctl_tiocgwinsz`].
+///
+/// [`ioctl_tiocgwinsz`]: crate::io::ioctl_tiocgwinsz
 #[cfg(not(target_os = "wasi"))]
 pub type Winsize = c::winsize;
 

--- a/src/imp/libc/net/syscalls.rs
+++ b/src/imp/libc/net/syscalls.rs
@@ -128,7 +128,7 @@ pub(crate) fn sendto_unix(
             send_recv_len(buf.len()),
             flags.bits(),
             as_ptr(&encode_sockaddr_unix(addr)).cast::<c::sockaddr>(),
-            size_of::<SocketAddrUnix>() as u32,
+            size_of::<SocketAddrUnix>() as _,
         ))?
     };
     Ok(nwritten as usize)

--- a/src/imp/libc/process/auxv.rs
+++ b/src/imp/libc/process/auxv.rs
@@ -1,5 +1,8 @@
 use super::super::c;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(
+    all(target_os = "android", target_pointer_width = "64"),
+    target_os = "linux"
+))]
 use crate::ffi::ZStr;
 
 #[inline]
@@ -7,7 +10,10 @@ pub(crate) fn page_size() -> usize {
     unsafe { c::sysconf(c::_SC_PAGESIZE) as usize }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(
+    all(target_os = "android", target_pointer_width = "64"),
+    target_os = "linux"
+))]
 #[inline]
 pub(crate) fn linux_hwcap() -> (usize, usize) {
     unsafe {
@@ -17,7 +23,10 @@ pub(crate) fn linux_hwcap() -> (usize, usize) {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(
+    all(target_os = "android", target_pointer_width = "64"),
+    target_os = "linux"
+))]
 #[inline]
 pub(crate) fn linux_execfn() -> &'static ZStr {
     unsafe { ZStr::from_ptr(c::getauxval(c::AT_EXECFN) as *const _) }

--- a/src/imp/libc/process/mod.rs
+++ b/src/imp/libc/process/mod.rs
@@ -6,7 +6,10 @@ use super::c;
 #[cfg(not(windows))]
 pub(crate) mod syscalls;
 pub(crate) use auxv::page_size;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(
+    all(target_os = "android", target_pointer_width = "64"),
+    target_os = "linux"
+))]
 pub(crate) use auxv::{linux_execfn, linux_hwcap};
 #[cfg(not(target_os = "wasi"))]
 pub(crate) use c::{

--- a/src/imp/linux_raw/fs/types.rs
+++ b/src/imp/linux_raw/fs/types.rs
@@ -362,6 +362,9 @@ bitflags! {
 }
 
 bitflags! {
+    /// `STATX_*` constants for use with [`statx`].
+    ///
+    /// [`statx`]: crate::fs::statx
     pub struct StatxFlags: u32 {
         /// `STATX_TYPE`
         const TYPE = linux_raw_sys::v5_4::general::STATX_TYPE;

--- a/src/imp/linux_raw/io/poll_fd.rs
+++ b/src/imp/linux_raw/io/poll_fd.rs
@@ -61,7 +61,7 @@ impl<'fd> PollFd<'fd> {
 
     /// Returns the ready events.
     #[inline]
-    pub fn revents(self) -> PollFlags {
+    pub fn revents(&self) -> PollFlags {
         // Use `unwrap()` here because in theory we know we know all the bits
         // the OS might set here, but OS's have added extensions in the past.
         PollFlags::from_bits(self.revents).unwrap()

--- a/src/imp/linux_raw/io/types.rs
+++ b/src/imp/linux_raw/io/types.rs
@@ -239,12 +239,14 @@ impl Advice {
     pub const DontNeed: Self = Self::Normal;
 }
 
-/// `struct termios`, for use with [`ioctl_tcgets`].
+/// `struct termios` for use with [`ioctl_tcgets`].
 ///
 /// [`ioctl_tcgets`]: crate::io::ioctl_tcgets
 pub type Termios = linux_raw_sys::general::termios;
 
-/// `struct winsize`
+/// `struct winsize` for use with [`ioctl_tiocgwinsz`].
+///
+/// [`ioctl_tiocgwinsz`]: crate::io::ioctl_tiocgwinsz
 pub type Winsize = linux_raw_sys::general::winsize;
 
 pub type Tcflag = linux_raw_sys::general::tcflag_t;

--- a/src/io/fd/owned.rs
+++ b/src/io/fd/owned.rs
@@ -4,7 +4,6 @@
 //!
 //! Owned and borrowed Unix-like file descriptors.
 
-#![rustfmt::skip]
 #![cfg_attr(staged_api, unstable(feature = "io_safety", issue = "87074"))]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![allow(unsafe_code)]

--- a/src/io/fd/raw.rs
+++ b/src/io/fd/raw.rs
@@ -4,7 +4,6 @@
 //!
 //! Raw Unix-like file descriptors.
 
-#![rustfmt::skip]
 #![cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))]
 #![allow(unsafe_code)]
 

--- a/src/io/seek_from.rs
+++ b/src/io/seek_from.rs
@@ -2,8 +2,6 @@
 //! library/std/src/io/mod.rs at revision
 //! dca3f1b786efd27be3b325ed1e01e247aa589c3b.
 
-#![rustfmt::skip]
-
 /// Enumeration of possible methods to seek within an I/O object.
 ///
 /// It is used by the [`Seek`] trait.

--- a/src/net/addr.rs
+++ b/src/net/addr.rs
@@ -6,7 +6,6 @@
 //! conceptually platform-independent, however in practice OS's have differing
 //! representations.
 
-#![rustfmt::skip]
 #![allow(unsafe_code)]
 
 use crate::imp::c;

--- a/src/net/ip.rs
+++ b/src/net/ip.rs
@@ -7,7 +7,6 @@
 //!
 //! [RFC 2832]: https://github.com/rust-lang/rfcs/pull/2832
 
-#![rustfmt::skip]
 #![allow(unsafe_code)]
 
 use crate::imp::c;

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -1,5 +1,8 @@
 //! `getsockopt` and `setsockopt` functions.
 
+#![doc(alias = "getsockopt")]
+#![doc(alias = "setsockopt")]
+
 #[cfg(not(any(
     target_os = "dragonfly",
     target_os = "freebsd",

--- a/src/process/auxv.rs
+++ b/src/process/auxv.rs
@@ -2,7 +2,16 @@
 //! pointers.
 #![cfg_attr(target_vendor = "mustang", allow(unsafe_code))]
 
-#[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
+#[cfg(any(
+    linux_raw,
+    all(
+        libc,
+        any(
+            all(target_os = "android", target_pointer_width = "64"),
+            target_os = "linux"
+        )
+    )
+))]
 use crate::ffi::ZStr;
 use crate::imp;
 
@@ -23,7 +32,16 @@ pub fn page_size() -> usize {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man3/getauxval.3.html
-#[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
+#[cfg(any(
+    linux_raw,
+    all(
+        libc,
+        any(
+            all(target_os = "android", target_pointer_width = "64"),
+            target_os = "linux"
+        )
+    )
+))]
 #[inline]
 pub fn linux_hwcap() -> (usize, usize) {
     imp::process::linux_hwcap()
@@ -38,7 +56,16 @@ pub fn linux_hwcap() -> (usize, usize) {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man3/getauxval.3.html
-#[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
+#[cfg(any(
+    linux_raw,
+    all(
+        libc,
+        any(
+            all(target_os = "android", target_pointer_width = "64"),
+            target_os = "linux"
+        )
+    )
+))]
 #[inline]
 pub fn linux_execfn() -> &'static ZStr {
     imp::process::linux_execfn()

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -29,7 +29,16 @@ mod wait;
 #[cfg(target_vendor = "mustang")]
 pub use auxv::init;
 pub use auxv::page_size;
-#[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
+#[cfg(any(
+    linux_raw,
+    all(
+        libc,
+        any(
+            all(target_os = "android", target_pointer_width = "64"),
+            target_os = "linux"
+        )
+    )
+))]
 pub use auxv::{linux_execfn, linux_hwcap};
 #[cfg(not(target_os = "wasi"))]
 pub use chdir::chdir;


### PR DESCRIPTION
Adjust `PollFd`'s API to be more usable, update the handling of read/write size limits, and add i686-linux-android cross-compilation CI testing.