### PR TITLE
Rename `rustix::io_lifetimes` to `rustix::fd`.

### DIFF
--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -3,7 +3,7 @@ use rustix::io::ttyname;
 #[cfg(not(windows))]
 use rustix::io::{self, isatty, stderr, stdin, stdout};
 #[cfg(not(windows))]
-use rustix::io_lifetimes::AsFd;
+use rustix::fd::AsFd;
 
 #[cfg(not(windows))]
 fn main() -> io::Result<()> {

--- a/src/imp/libc/io_lifetimes.rs
+++ b/src/imp/libc/io_lifetimes.rs
@@ -6,10 +6,10 @@
 pub use io_lifetimes::BorrowedSocket as BorrowedFd;
 pub(crate) use io_lifetimes::OwnedSocket as OwnedFd;
 #[cfg(feature = "std")]
-pub(crate) use std::os::windows::io::RawSocket as RawFd;
+pub use std::os::windows::io::RawSocket as RawFd;
 pub(crate) use winapi::um::winsock2::SOCKET as LibcFd;
 
-pub(crate) trait AsRawFd {
+pub trait AsRawFd {
     fn as_raw_fd(&self) -> RawFd;
 }
 #[cfg(feature = "std")]
@@ -20,7 +20,7 @@ impl<T: std::os::windows::io::AsRawSocket> AsRawFd for T {
     }
 }
 
-pub(crate) trait IntoRawFd {
+pub trait IntoRawFd {
     fn into_raw_fd(self) -> RawFd;
 }
 #[cfg(feature = "std")]
@@ -31,7 +31,7 @@ impl<T: std::os::windows::io::IntoRawSocket> IntoRawFd for T {
     }
 }
 
-pub(crate) trait FromRawFd {
+pub trait FromRawFd {
     unsafe fn from_raw_fd(raw_fd: RawFd) -> Self;
 }
 #[cfg(feature = "std")]

--- a/src/imp/libc/mod.rs
+++ b/src/imp/libc/mod.rs
@@ -26,17 +26,22 @@ pub(crate) mod fd {
 #[cfg(not(windows))]
 #[cfg(not(feature = "rustc-dep-of-std"))]
 pub(crate) mod fd {
-    pub(crate) use io_lifetimes::*;
+    pub use io_lifetimes::*;
 
     #[allow(unused_imports)]
     #[cfg(unix)]
-    pub(crate) use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd, RawFd as LibcFd};
+    pub use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+    #[allow(unused_imports)]
+    #[cfg(unix)]
+    pub(crate) use std::os::unix::io::RawFd as LibcFd;
     #[allow(unused_imports)]
     #[cfg(target_os = "wasi")]
-    pub(crate) use {
-        super::c::c_int as LibcFd,
+    pub use {
         std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
     };
+    #[allow(unused_imports)]
+    #[cfg(target_os = "wasi")]
+    pub(crate) use super::c::c_int as LibcFd;
 }
 
 // On Windows we emulate selected libc-compatible interfaces. On non-Windows,

--- a/src/imp/linux_raw/mod.rs
+++ b/src/imp/linux_raw/mod.rs
@@ -20,10 +20,13 @@ pub(crate) mod time;
 
 #[cfg(not(feature = "rustc-dep-of-std"))]
 pub(crate) mod fd {
-    pub(crate) use io_lifetimes::*;
+    pub use io_lifetimes::*;
 
     #[allow(unused_imports)]
-    pub(crate) use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd, RawFd as LibcFd};
+    pub use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+
+    #[allow(unused_imports)]
+    pub(crate) use std::os::unix::io::RawFd as LibcFd;
 }
 
 #[cfg(feature = "rustc-dep-of-std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,15 +67,14 @@
 #[cfg(not(feature = "rustc-dep-of-std"))]
 extern crate alloc;
 
-/// Re-export `io_lifetimes` since we use its types in our public API, so
-/// that our users don't need to do anything special to use the same version.
-#[cfg(feature = "rustc-dep-of-std")]
-pub mod io_lifetimes {
+/// Export `*Fd*` types and traits that we use in our public API, so that
+/// our users don't need to do anything special to use the same version.
+///
+/// Note that `OwnedFd` lives at [`rustix::io::OwnedFd`].
+pub mod fd {
     use super::imp;
     pub use imp::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
 }
-#[cfg(not(feature = "rustc-dep-of-std"))]
-pub use io_lifetimes;
 
 #[cfg(not(windows))]
 #[macro_use]

--- a/tests/fs/fcntl.rs
+++ b/tests/fs/fcntl.rs
@@ -1,7 +1,7 @@
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[test]
 fn test_fcntl_dupfd_cloexec() {
-    use rustix::io_lifetimes::AsFd;
+    use rustix::fd::AsFd;
     use std::os::unix::io::AsRawFd;
 
     let file = rustix::fs::openat(

--- a/tests/fs/openat2.rs
+++ b/tests/fs/openat2.rs
@@ -1,6 +1,6 @@
 use rustix::fs::{cwd, mkdirat, openat, openat2, symlinkat, Mode, OFlags, ResolveFlags};
 use rustix::io::OwnedFd;
-use rustix::io_lifetimes::AsFd;
+use rustix::fd::AsFd;
 use rustix::{io, path};
 use std::os::unix::io::AsRawFd;
 

--- a/tests/io/dup2_to_replace_stdio.rs
+++ b/tests/io/dup2_to_replace_stdio.rs
@@ -7,7 +7,7 @@
 #[test]
 fn dup2_to_replace_stdio() {
     use rustix::io::{dup2, pipe};
-    use rustix::io_lifetimes::AsFilelike;
+    use io_lifetimes::AsFilelike;
     use std::io::{BufRead, BufReader, Write};
     use std::mem::forget;
 

--- a/tests/io/epoll.rs
+++ b/tests/io/epoll.rs
@@ -2,7 +2,7 @@
 
 use rustix::io::epoll::{self, Epoll};
 use rustix::io::{ioctl_fionbio, read, write, OwnedFd};
-use rustix::io_lifetimes::AsFd;
+use rustix::fd::AsFd;
 use rustix::net::{
     accept, bind_v4, connect_v4, getsockname, listen, socket, AddressFamily, Ipv4Addr, Protocol,
     SocketAddrAny, SocketAddrV4, SocketType,

--- a/tests/io/from_into.rs
+++ b/tests/io/from_into.rs
@@ -1,7 +1,7 @@
 #[cfg(not(target_os = "redox"))]
 #[test]
 fn test_owned() {
-    use rustix::io_lifetimes::AsFd;
+    use rustix::fd::AsFd;
     #[cfg(unix)]
     use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
     #[cfg(target_os = "wasi")]
@@ -18,7 +18,7 @@ fn test_owned() {
     let raw = file.as_raw_fd();
     assert_eq!(raw, file.as_fd().as_raw_fd());
 
-    let owned: io_lifetimes::OwnedFd = file.into();
+    let owned: rustix::io::OwnedFd = file.into();
     let inner = owned.into_raw_fd();
     assert_eq!(raw, inner);
 

--- a/tests/time/dynamic_clocks.rs
+++ b/tests/time/dynamic_clocks.rs
@@ -1,6 +1,6 @@
 #![cfg(not(any(target_os = "redox", target_os = "wasi")))]
 
-use rustix::io_lifetimes::AsFd;
+use rustix::fd::AsFd;
 use rustix::time::{clock_gettime_dynamic, ClockId, DynamicClockId};
 
 #[test]


### PR DESCRIPTION
And have it export only the types and traits that rustix uses. This
makes it easier to provide a consistent interface whether the fd
types and traits are defined by the standard library or by Rustix
itself.