### PR TITLE
Rename `set_ipv6_{join_group,leave_group}`.

### DIFF
--- a/src/imp/libc/net/syscalls.rs
+++ b/src/imp/libc/net/syscalls.rs
@@ -1,14 +1,7 @@
 use super::super::c;
 use super::super::conv::{borrowed_fd, ret, ret_owned_fd, ret_send_recv, send_recv_len};
 use super::super::fd::BorrowedFd;
-#[cfg(not(any(
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd"
-)))]
-use super::ext::in6_addr_new;
-use super::ext::in_addr_new;
+use super::ext::{in6_addr_new, in_addr_new};
 #[cfg(not(windows))]
 use super::{encode_sockaddr_unix, SocketAddrUnix};
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
@@ -380,23 +373,9 @@ pub(crate) fn socketpair(
 
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) mod sockopt {
-    #[cfg(not(any(
-        target_os = "freebsd",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd"
-    )))]
-    use super::in6_addr_new;
-    use super::{c, in_addr_new, BorrowedFd};
+    use super::{c, in6_addr_new, in_addr_new, BorrowedFd};
     use crate::net::sockopt::Timeout;
-    #[cfg(not(any(
-        target_os = "freebsd",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd"
-    )))]
-    use crate::net::Ipv6Addr;
-    use crate::net::{Ipv4Addr, SocketType};
+    use crate::net::{Ipv4Addr, Ipv6Addr, SocketType};
     use crate::{as_mut_ptr, io};
     use core::convert::TryInto;
     use core::time::Duration;
@@ -752,12 +731,6 @@ pub(crate) mod sockopt {
         in_addr_new(u32::from_ne_bytes(addr.octets()))
     }
 
-    #[cfg(not(any(
-        target_os = "freebsd",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd"
-    )))]
     #[inline]
     fn to_ipv6mr(multiaddr: &Ipv6Addr, interface: u32) -> c::ipv6_mreq {
         c::ipv6_mreq {
@@ -766,12 +739,6 @@ pub(crate) mod sockopt {
         }
     }
 
-    #[cfg(not(any(
-        target_os = "freebsd",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd"
-    )))]
     #[inline]
     fn to_ipv6mr_multiaddr(multiaddr: &Ipv6Addr) -> c::in6_addr {
         in6_addr_new(multiaddr.octets())
@@ -783,13 +750,7 @@ pub(crate) mod sockopt {
         interface as c::c_int
     }
 
-    #[cfg(not(any(
-        target_os = "android",
-        target_os = "freebsd",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd"
-    )))]
+    #[cfg(not(target_os = "android"))]
     #[inline]
     fn to_ipv6mr_interface(interface: u32) -> c::c_uint {
         interface as c::c_uint

--- a/src/imp/libc/net/syscalls.rs
+++ b/src/imp/libc/net/syscalls.rs
@@ -645,31 +645,43 @@ pub(crate) mod sockopt {
         setsockopt(fd, c::IPPROTO_IP as _, c::IP_ADD_MEMBERSHIP, mreq)
     }
 
-    #[cfg(not(any(
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd"
-    )))]
     #[inline]
-    pub(crate) fn set_ipv6_join_group(
+    pub(crate) fn set_ipv6_add_membership(
         fd: BorrowedFd<'_>,
         multiaddr: &Ipv6Addr,
         interface: u32,
     ) -> io::Result<()> {
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "illumos",
+            target_os = "solaris",
+            target_os = "haiku",
+            target_os = "l4re"
+        )))]
+        use c::IPV6_ADD_MEMBERSHIP;
+        #[cfg(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "illumos",
+            target_os = "solaris",
+            target_os = "haiku",
+            target_os = "l4re"
+        ))]
+        use c::IPV6_JOIN_GROUP as IPV6_ADD_MEMBERSHIP;
+
         let mreq = to_ipv6mr(multiaddr, interface);
-        setsockopt(fd, c::IPPROTO_IPV6 as _, c::IPV6_ADD_MEMBERSHIP, mreq)
+        setsockopt(fd, c::IPPROTO_IPV6 as _, IPV6_ADD_MEMBERSHIP, mreq)
     }
 
-    #[cfg(not(any(
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd"
-    )))]
     #[inline]
     pub(crate) fn set_ip_drop_membership(
         fd: BorrowedFd<'_>,
@@ -680,22 +692,41 @@ pub(crate) mod sockopt {
         setsockopt(fd, c::IPPROTO_IP as _, c::IP_DROP_MEMBERSHIP, mreq)
     }
 
-    #[cfg(not(any(
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd",
-    )))]
     #[inline]
-    pub(crate) fn set_ipv6_leave_group(
+    pub(crate) fn set_ipv6_drop_membership(
         fd: BorrowedFd<'_>,
         multiaddr: &Ipv6Addr,
         interface: u32,
     ) -> io::Result<()> {
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "illumos",
+            target_os = "solaris",
+            target_os = "haiku",
+            target_os = "l4re"
+        )))]
+        use c::IPV6_DROP_MEMBERSHIP;
+        #[cfg(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "illumos",
+            target_os = "solaris",
+            target_os = "haiku",
+            target_os = "l4re"
+        ))]
+        use c::IPV6_LEAVE_GROUP as IPV6_DROP_MEMBERSHIP;
+
         let mreq = to_ipv6mr(multiaddr, interface);
-        setsockopt(fd, c::IPPROTO_IPV6 as _, c::IPV6_DROP_MEMBERSHIP, mreq)
+        setsockopt(fd, c::IPPROTO_IPV6 as _, IPV6_DROP_MEMBERSHIP, mreq)
     }
 
     #[inline]

--- a/src/imp/linux_raw/net/syscalls.rs
+++ b/src/imp/linux_raw/net/syscalls.rs
@@ -1172,7 +1172,7 @@ pub(crate) mod sockopt {
     }
 
     #[inline]
-    pub(crate) fn set_ipv6_join_group(
+    pub(crate) fn set_ipv6_add_membership(
         fd: BorrowedFd<'_>,
         multiaddr: &Ipv6Addr,
         interface: u32,
@@ -1202,7 +1202,7 @@ pub(crate) mod sockopt {
     }
 
     #[inline]
-    pub(crate) fn set_ipv6_leave_group(
+    pub(crate) fn set_ipv6_drop_membership(
         fd: BorrowedFd<'_>,
         multiaddr: &Ipv6Addr,
         interface: u32,

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -3,16 +3,7 @@
 #![doc(alias = "getsockopt")]
 #![doc(alias = "setsockopt")]
 
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-)))]
-use crate::net::Ipv6Addr;
-use crate::net::{Ipv4Addr, SocketType};
+use crate::net::{Ipv4Addr, Ipv6Addr, SocketType};
 use crate::{imp, io};
 use core::time::Duration;
 use imp::fd::AsFd;
@@ -424,7 +415,9 @@ pub fn set_ip_add_membership<Fd: AsFd>(
     imp::syscalls::sockopt::set_ip_add_membership(fd, multiaddr, interface)
 }
 
-/// `setsockopt(fd, IPPROTO_IPV6, IPV6_JOIN_GROUP, multiaddr, interface)`
+/// `setsockopt(fd, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, multiaddr, interface)`
+///
+/// `IPV6_ADD_MEMBERSHIP` is the same as `IPV6_JOIN_GROUP` in POSIX.
 ///
 /// # References
 ///  - [POSIX `setsockopt`]
@@ -436,24 +429,16 @@ pub fn set_ip_add_membership<Fd: AsFd>(
 /// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `ipv6`]: https://man7.org/linux/man-pages/man7/ipv6.7.html
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-)))]
 #[inline]
 #[doc(alias = "IPV6_JOIN_GROUP")]
 #[doc(alias = "IPV6_ADD_MEMBERSHIP")]
-pub fn set_ipv6_join_group<Fd: AsFd>(
+pub fn set_ipv6_add_membership<Fd: AsFd>(
     fd: &Fd,
     multiaddr: &Ipv6Addr,
     interface: u32,
 ) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_ipv6_join_group(fd, multiaddr, interface)
+    imp::syscalls::sockopt::set_ipv6_add_membership(fd, multiaddr, interface)
 }
 
 /// `setsockopt(fd, IPPROTO_IP, IP_DROP_MEMBERSHIP, multiaddr, interface)`
@@ -468,13 +453,6 @@ pub fn set_ipv6_join_group<Fd: AsFd>(
 /// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd"
-)))]
 #[inline]
 #[doc(alias = "IP_DROP_MEMBERSHIP")]
 pub fn set_ip_drop_membership<Fd: AsFd>(
@@ -486,7 +464,9 @@ pub fn set_ip_drop_membership<Fd: AsFd>(
     imp::syscalls::sockopt::set_ip_drop_membership(fd, multiaddr, interface)
 }
 
-/// `setsockopt(fd, IPPROTO_IPV6, IPV6_LEAVE_GROUP, multiaddr, interface)`
+/// `setsockopt(fd, IPPROTO_IPV6, IPV6_DROP_MEMBERSHIP, multiaddr, interface)`
+///
+/// `IPV6_DROP_MEMBERSHIP` is the same as `IPV6_LEAVE_GROUP` in POSIX.
 ///
 /// # References
 ///  - [POSIX `setsockopt`]
@@ -498,24 +478,16 @@ pub fn set_ip_drop_membership<Fd: AsFd>(
 /// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `ipv6`]: https://man7.org/linux/man-pages/man7/ipv6.7.html
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-)))]
 #[inline]
 #[doc(alias = "IPV6_LEAVE_GROUP")]
 #[doc(alias = "IPV6_DROP_MEMBERSHIP")]
-pub fn set_ipv6_leave_group<Fd: AsFd>(
+pub fn set_ipv6_drop_membership<Fd: AsFd>(
     fd: &Fd,
     multiaddr: &Ipv6Addr,
     interface: u32,
 ) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_ipv6_leave_group(fd, multiaddr, interface)
+    imp::syscalls::sockopt::set_ipv6_drop_membership(fd, multiaddr, interface)
 }
 
 /// `setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, nodelay)`


### PR DESCRIPTION
Some platforms, and POSIX, call these `IPV6_JOIN_GROUP` and `IPV6_LEAVE_GROUP`
while others call them `IPV6_ADD_MEMBERSHIP` and `IPV6_DROP_MEMBERSHIP`.

Switch to the add/drop-membership names, which is more consistent with the IPv4
versions, and are the names used in [std's implementation].

[std's implementation]: https://github.com/rust-lang/rust/blob/0a84708edca7c275cb99ad080317fbc7637516d8/library/std/src/sys_common/net.rs#L20