### PR TITLE
Move several features from `rustc-dep-of-std` to `not(feature = "std")`.

### DIFF
--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -3,7 +3,7 @@
 /// Minimal and unoptimized `strlen` implementation.
 ///
 /// TODO: Optimize this by reading a `usize` at a time.
-#[cfg(all(not(feature = "std"), feature = "rustc-dep-of-std"))]
+#[cfg(not(feature = "std"))]
 #[allow(unsafe_code)]
 unsafe fn strlen(mut s: *const u8) -> usize {
     let mut len = 0;
@@ -14,10 +14,10 @@ unsafe fn strlen(mut s: *const u8) -> usize {
     len
 }
 
-#[cfg(all(not(feature = "std"), feature = "rustc-dep-of-std"))]
+#[cfg(not(feature = "std"))]
 mod z_str;
 
-#[cfg(all(not(feature = "std"), feature = "rustc-dep-of-std"))]
+#[cfg(not(feature = "std"))]
 pub use z_str::{FromBytesWithNulError, FromVecWithNulError, NulError, ZStr, ZString};
 
 #[cfg(feature = "std")]

--- a/src/ffi/z_str.rs
+++ b/src/ffi/z_str.rs
@@ -734,7 +734,7 @@ impl ZString {
     /// assert_eq!(&*boxed,
     ///            CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul failed"));
     /// ```
-    #[cfg(not(feature = "rustc-dep-of-std"))]
+    #[cfg(feature = "std")]
     #[must_use = "`self` will be dropped if the result is not used"]
     #[cfg_attr(staged_api, stable(feature = "into_boxed_c_str", since = "1.20.0"))]
     pub fn into_boxed_c_str(self) -> Box<CStr> {
@@ -1209,7 +1209,7 @@ impl IntoStringError {
 
     /// Consumes this error, returning original [`CString`] which generated the
     /// error.
-    #[cfg(not(feature = "rustc-dep-of-std"))]
+    #[cfg(feature = "std")]
     #[must_use = "`self` will be dropped if the result is not used"]
     #[cfg_attr(staged_api, stable(feature = "cstring_into", since = "1.7.0"))]
     pub fn into_cstring(self) -> CString {
@@ -1594,7 +1594,7 @@ impl ZStr {
     /// let boxed = z_string.into_boxed_z_str();
     /// assert_eq!(boxed.into_c_string(), CString::new("foo").expect("ZString::new failed"));
     /// ```
-    #[cfg(not(feature = "rustc-dep-of-std"))]
+    #[cfg(feature = "std")]
     #[must_use = "`self` will be dropped if the result is not used"]
     #[cfg_attr(staged_api, stable(feature = "into_boxed_c_str", since = "1.20.0"))]
     pub fn into_c_string(self: Box<ZStr>) -> CString {

--- a/src/imp/libc/io/mod.rs
+++ b/src/imp/libc/io/mod.rs
@@ -1,6 +1,6 @@
 mod error;
 #[cfg(not(windows))]
-#[cfg(feature = "rustc-dep-of-std")]
+#[cfg(not(feature = "std"))]
 mod io_slice;
 #[cfg(not(windows))]
 mod poll_fd;
@@ -11,7 +11,7 @@ mod types;
 pub(crate) mod syscalls;
 
 #[cfg(not(windows))]
-#[cfg(feature = "rustc-dep-of-std")]
+#[cfg(not(feature = "std"))]
 pub use io_slice::{IoSlice, IoSliceMut};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub mod epoll;

--- a/src/imp/libc/io_lifetimes.rs
+++ b/src/imp/libc/io_lifetimes.rs
@@ -57,7 +57,7 @@ impl<T: io_lifetimes::AsSocket> AsSocketAsFd for T {
     }
 }
 
-pub(crate) trait IntoFd {
+pub trait IntoFd {
     fn into_fd(self) -> OwnedFd;
 }
 impl<T: io_lifetimes::IntoSocket> IntoFd for T {
@@ -67,7 +67,7 @@ impl<T: io_lifetimes::IntoSocket> IntoFd for T {
     }
 }
 
-pub(crate) trait FromFd {
+pub trait FromFd {
     fn from_fd(fd: OwnedFd) -> Self;
 }
 impl<T: io_lifetimes::FromSocket> FromFd for T {

--- a/src/imp/libc/net/ext.rs
+++ b/src/imp/libc/net/ext.rs
@@ -19,7 +19,7 @@ pub(crate) const fn in_addr_s_addr(addr: c::in_addr) -> u32 {
     addr.s_addr
 }
 
-#[cfg(feature = "rustc-dep-of-std")]
+#[cfg(not(feature = "std"))]
 #[cfg(windows)]
 #[inline]
 pub(crate) const fn in_addr_s_addr(addr: c::in_addr) -> u32 {
@@ -29,7 +29,7 @@ pub(crate) const fn in_addr_s_addr(addr: c::in_addr) -> u32 {
 
 // TODO: With Rust 1.55, we can use the above `in_addr_s_addr` definition
 // that uses a const-fn transmute.
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 #[cfg(windows)]
 #[inline]
 pub(crate) fn in_addr_s_addr(addr: c::in_addr) -> u32 {
@@ -43,7 +43,7 @@ pub(crate) const fn in_addr_new(s_addr: u32) -> c::in_addr {
     c::in_addr { s_addr }
 }
 
-#[cfg(feature = "rustc-dep-of-std")]
+#[cfg(not(feature = "std"))]
 #[cfg(windows)]
 #[inline]
 pub(crate) const fn in_addr_new(s_addr: u32) -> c::in_addr {
@@ -52,7 +52,7 @@ pub(crate) const fn in_addr_new(s_addr: u32) -> c::in_addr {
 
 // TODO: With Rust 1.55, we can use the above `in_addr_new` definition
 // that uses a const-fn transmute.
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 #[cfg(windows)]
 #[inline]
 pub(crate) fn in_addr_new(s_addr: u32) -> c::in_addr {
@@ -65,7 +65,7 @@ pub(crate) const fn in6_addr_s6_addr(addr: c::in6_addr) -> [u8; 16] {
     addr.s6_addr
 }
 
-#[cfg(feature = "rustc-dep-of-std")]
+#[cfg(not(feature = "std"))]
 #[cfg(windows)]
 #[inline]
 pub(crate) const fn in6_addr_s6_addr(addr: c::in6_addr) -> [u8; 16] {
@@ -74,7 +74,7 @@ pub(crate) const fn in6_addr_s6_addr(addr: c::in6_addr) -> [u8; 16] {
 
 // TODO: With Rust 1.55, we can use the above `in6_addr_s6_addr` definition
 // that uses a const-fn transmute.
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 #[cfg(windows)]
 #[inline]
 pub(crate) fn in6_addr_s6_addr(addr: c::in6_addr) -> [u8; 16] {
@@ -87,7 +87,7 @@ pub(crate) const fn in6_addr_new(s6_addr: [u8; 16]) -> c::in6_addr {
     c::in6_addr { s6_addr }
 }
 
-#[cfg(feature = "rustc-dep-of-std")]
+#[cfg(not(feature = "std"))]
 #[cfg(windows)]
 #[inline]
 pub(crate) const fn in6_addr_new(s6_addr: [u8; 16]) -> c::in6_addr {
@@ -96,7 +96,7 @@ pub(crate) const fn in6_addr_new(s6_addr: [u8; 16]) -> c::in6_addr {
 
 // TODO: With Rust 1.55, we can use the above `in6_addr_new` definition
 // that uses a const-fn transmute.
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 #[cfg(windows)]
 #[inline]
 pub(crate) fn in6_addr_new(s6_addr: [u8; 16]) -> c::in6_addr {
@@ -109,7 +109,7 @@ pub(crate) const fn sockaddr_in6_sin6_scope_id(addr: c::sockaddr_in6) -> u32 {
     addr.sin6_scope_id
 }
 
-#[cfg(feature = "rustc-dep-of-std")]
+#[cfg(not(feature = "std"))]
 #[cfg(windows)]
 #[inline]
 pub(crate) const fn sockaddr_in6_sin6_scope_id(addr: c::sockaddr_in6) -> u32 {
@@ -119,7 +119,7 @@ pub(crate) const fn sockaddr_in6_sin6_scope_id(addr: c::sockaddr_in6) -> u32 {
 
 // TODO: With Rust 1.55, we can use the above `sockaddr_in6_sin6_scope_id`
 // definition that uses a const-fn transmute.
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 #[cfg(windows)]
 #[inline]
 pub(crate) fn sockaddr_in6_sin6_scope_id(addr: c::sockaddr_in6) -> u32 {
@@ -127,14 +127,14 @@ pub(crate) fn sockaddr_in6_sin6_scope_id(addr: c::sockaddr_in6) -> u32 {
     addr.sin6_scope_id
 }
 
-#[cfg(feature = "rustc-dep-of-std")]
+#[cfg(not(feature = "std"))]
 #[cfg(not(windows))]
 #[inline]
 pub(crate) fn sockaddr_in6_sin6_scope_id_mut(addr: &mut c::sockaddr_in6) -> &mut u32 {
     &mut addr.sin6_scope_id
 }
 
-#[cfg(feature = "rustc-dep-of-std")]
+#[cfg(not(feature = "std"))]
 #[cfg(windows)]
 #[inline]
 pub(crate) fn sockaddr_in6_sin6_scope_id_mut(addr: &mut c::sockaddr_in6) -> &mut u32 {
@@ -178,7 +178,7 @@ pub(crate) const fn sockaddr_in6_new(
     }
 }
 
-#[cfg(feature = "rustc-dep-of-std")]
+#[cfg(not(feature = "std"))]
 #[cfg(windows)]
 #[inline]
 pub(crate) const fn sockaddr_in6_new(
@@ -200,7 +200,7 @@ pub(crate) const fn sockaddr_in6_new(
 
 // TODO: With Rust 1.55, we can use the above `sockaddr_in6_new`
 // definition that uses a const-fn transmute.
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 #[cfg(windows)]
 #[inline]
 pub(crate) fn sockaddr_in6_new(

--- a/src/imp/linux_raw/fs/dir.rs
+++ b/src/imp/linux_raw/fs/dir.rs
@@ -1,11 +1,11 @@
 use super::FileType;
 use crate::as_ptr;
+#[cfg(feature = "std")]
+use crate::fd::IntoFd;
+use crate::fd::{AsFd, BorrowedFd};
 #[cfg(target_os = "wasi")]
 use crate::ffi::ZString;
 use crate::ffi::{ZStr, ZString};
-#[cfg(not(feature = "rustc-dep-of-std"))]
-use crate::imp::fd::IntoFd;
-use crate::imp::fd::{AsFd, BorrowedFd};
 use crate::io::{self, OwnedFd};
 use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
@@ -22,7 +22,7 @@ pub struct Dir {
 
 impl Dir {
     /// Construct a `Dir`, assuming ownership of the file descriptor.
-    #[cfg(not(any(io_lifetimes_use_std, feature = "rustc-dep-of-std")))]
+    #[cfg(not(any(io_lifetimes_use_std, not(feature = "std"))))]
     #[inline]
     pub fn from<F: IntoFd>(fd: F) -> io::Result<Self> {
         let fd = fd.into_fd();
@@ -30,7 +30,7 @@ impl Dir {
     }
 
     /// Construct a `Dir`, assuming ownership of the file descriptor.
-    #[cfg(any(io_lifetimes_use_std, feature = "rustc-dep-of-std"))]
+    #[cfg(any(io_lifetimes_use_std, not(feature = "std")))]
     #[inline]
     pub fn from<F: Into<OwnedFd>>(fd: F) -> io::Result<Self> {
         let fd = fd.into();

--- a/src/imp/linux_raw/io/epoll.rs
+++ b/src/imp/linux_raw/io/epoll.rs
@@ -57,9 +57,9 @@
 #![allow(unsafe_code)]
 
 use super::super::c;
-use crate::imp::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
-#[cfg(not(feature = "rustc-dep-of-std"))]
-use crate::imp::fd::{FromFd, FromRawFd, IntoFd, IntoRawFd};
+use crate::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
+#[cfg(feature = "std")]
+use crate::fd::{FromFd, FromRawFd, IntoFd, IntoRawFd};
 use crate::imp::linux_raw::syscalls::{epoll_add, epoll_create, epoll_del, epoll_mod, epoll_wait};
 use crate::io::{self, OwnedFd};
 use alloc::vec::Vec;
@@ -208,12 +208,12 @@ impl<'a> Context for Borrowing<'a> {
 ///
 /// This may be used with [`OwnedFd`], or higher-level types like
 /// [`std::fs::File`] or [`std::net::TcpStream`].
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 pub struct Owning<'context, T: IntoFd + FromFd> {
     _phantom: PhantomData<&'context T>,
 }
 
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 impl<'context, T: IntoFd + FromFd> Owning<'context, T> {
     /// Creates a new empty `Owning`.
     #[allow(clippy::new_without_default)] // This is a specialized type that doesn't need to be generically constructible.
@@ -225,7 +225,7 @@ impl<'context, T: IntoFd + FromFd> Owning<'context, T> {
     }
 }
 
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 impl<'context, T: AsFd + IntoFd + FromFd> Context for Owning<'context, T> {
     type Data = T;
     type Target = BorrowedFd<'context>;
@@ -383,21 +383,21 @@ impl<Context: self::Context> Epoll<Context> {
     }
 }
 
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 impl<'context, T: AsFd + IntoFd + FromFd> AsRawFd for Epoll<Owning<'context, T>> {
     fn as_raw_fd(&self) -> RawFd {
         self.epoll_fd.as_raw_fd()
     }
 }
 
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 impl<'context, T: AsFd + IntoFd + FromFd> IntoRawFd for Epoll<Owning<'context, T>> {
     fn into_raw_fd(self) -> RawFd {
         self.epoll_fd.into_raw_fd()
     }
 }
 
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 impl<'context, T: AsFd + IntoFd + FromFd> FromRawFd for Epoll<Owning<'context, T>> {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         Self {
@@ -407,21 +407,21 @@ impl<'context, T: AsFd + IntoFd + FromFd> FromRawFd for Epoll<Owning<'context, T
     }
 }
 
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 impl<'context, T: AsFd + IntoFd + FromFd> AsFd for Epoll<Owning<'context, T>> {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.epoll_fd.as_fd()
     }
 }
 
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 impl<'context, T: AsFd + IntoFd + FromFd> From<Epoll<Owning<'context, T>>> for OwnedFd {
     fn from(epoll: Epoll<Owning<'context, T>>) -> OwnedFd {
         epoll.epoll_fd
     }
 }
 
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 impl<'context, T: AsFd + IntoFd + FromFd> From<OwnedFd> for Epoll<Owning<'context, T>> {
     fn from(fd: OwnedFd) -> Self {
         Self {

--- a/src/imp/linux_raw/io/mod.rs
+++ b/src/imp/linux_raw/io/mod.rs
@@ -1,12 +1,12 @@
 pub mod epoll;
 pub(super) mod error;
-#[cfg(all(not(feature = "std"), feature = "rustc-dep-of-std"))]
+#[cfg(not(feature = "std"))]
 mod io_slice;
 mod poll_fd;
 mod types;
 
 pub use error::Error;
-#[cfg(all(not(feature = "std"), feature = "rustc-dep-of-std"))]
+#[cfg(not(feature = "std"))]
 pub use io_slice::{IoSlice, IoSliceMut};
 pub use poll_fd::{PollFd, PollFlags};
 pub use types::{

--- a/src/imp/linux_raw/mod.rs
+++ b/src/imp/linux_raw/mod.rs
@@ -18,7 +18,7 @@ pub(crate) mod syscalls;
 pub(crate) mod thread;
 pub(crate) mod time;
 
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 pub(crate) mod fd {
     pub use io_lifetimes::*;
 
@@ -29,7 +29,7 @@ pub(crate) mod fd {
     pub(crate) use std::os::unix::io::RawFd as LibcFd;
 }
 
-#[cfg(feature = "rustc-dep-of-std")]
+#[cfg(not(feature = "std"))]
 pub(crate) use crate::io::fd;
 
 // The linux_raw backend doesn't use actual libc, so we define selected

--- a/src/imp/linux_raw/net/ext.rs
+++ b/src/imp/linux_raw/net/ext.rs
@@ -13,7 +13,7 @@ pub(crate) const fn in_addr_new(s_addr: u32) -> c::in_addr {
     c::in_addr { s_addr }
 }
 
-#[cfg(feature = "rustc-dep-of-std")]
+#[cfg(not(feature = "std"))]
 #[inline]
 pub(crate) const fn in6_addr_s6_addr(addr: c::in6_addr) -> [u8; 16] {
     unsafe { addr.in6_u.u6_addr8 }
@@ -21,7 +21,7 @@ pub(crate) const fn in6_addr_s6_addr(addr: c::in6_addr) -> [u8; 16] {
 
 // TODO: With Rust 1.55, we can use the above `in6_addr_s6_addr` definition
 // that uses a const-fn union access instead of doing a transmute.
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(not(not(feature = "std")))]
 #[inline]
 pub(crate) fn in6_addr_s6_addr(addr: c::in6_addr) -> [u8; 16] {
     unsafe { core::mem::transmute(addr) }
@@ -39,7 +39,7 @@ pub(crate) const fn sockaddr_in6_sin6_scope_id(addr: c::sockaddr_in6) -> u32 {
     addr.sin6_scope_id
 }
 
-#[cfg(feature = "rustc-dep-of-std")]
+#[cfg(not(feature = "std"))]
 #[inline]
 pub(crate) fn sockaddr_in6_sin6_scope_id_mut(addr: &mut c::sockaddr_in6) -> &mut u32 {
     &mut addr.sin6_scope_id

--- a/src/io/error.rs
+++ b/src/io/error.rs
@@ -40,7 +40,7 @@ impl fmt::Display for Error {
         {
             std::io::Error::from(*self).fmt(fmt)
         }
-        #[cfg(all(not(feature = "std"), feature = "rustc-dep-of-std"))]
+        #[cfg(not(feature = "std"))]
         {
             write!(fmt, "os error {}", self.raw_os_error())
         }
@@ -53,7 +53,7 @@ impl fmt::Debug for Error {
         {
             std::io::Error::from(*self).fmt(fmt)
         }
-        #[cfg(all(not(feature = "std"), feature = "rustc-dep-of-std"))]
+        #[cfg(not(feature = "std"))]
         {
             write!(fmt, "os error {}", self.raw_os_error())
         }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -12,7 +12,7 @@ mod dup;
 mod error;
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 mod eventfd;
-#[cfg(feature = "rustc-dep-of-std")]
+#[cfg(not(feature = "std"))]
 pub(crate) mod fd;
 mod ioctl;
 #[cfg(not(any(windows, target_os = "redox")))]
@@ -30,7 +30,7 @@ mod poll;
 mod procfs;
 #[cfg(not(windows))]
 mod read_write;
-#[cfg(all(not(feature = "std"), feature = "rustc-dep-of-std"))]
+#[cfg(not(feature = "std"))]
 mod seek_from;
 #[cfg(not(windows))]
 mod stdio;
@@ -106,14 +106,14 @@ pub use imp::io::Winsize;
 
 // Declare `IoSlice` and `IoSliceMut`.
 #[cfg(not(windows))]
-#[cfg(all(not(feature = "std"), feature = "rustc-dep-of-std"))]
+#[cfg(not(feature = "std"))]
 pub use imp::io::{IoSlice, IoSliceMut};
 #[cfg(not(windows))]
 #[cfg(feature = "std")]
 pub use std::io::{IoSlice, IoSliceMut};
 
 // Declare `SeekFrom`.
-#[cfg(all(not(feature = "std"), feature = "rustc-dep-of-std"))]
+#[cfg(not(feature = "std"))]
 pub use seek_from::SeekFrom;
 #[cfg(feature = "std")]
 pub use std::io::SeekFrom;

--- a/src/io/procfs.rs
+++ b/src/io/procfs.rs
@@ -13,9 +13,9 @@ use crate::imp::fd::{AsFd, BorrowedFd};
 use crate::io::{self, OwnedFd};
 use crate::path::DecInt;
 use crate::process::{getgid, getpid, getuid, Gid, RawGid, RawUid, Uid};
-#[cfg(features = "rustc-dep-of-std")]
+#[cfg(feature = "rustc-dep-of-std")]
 use core::lazy::OnceCell;
-#[cfg(not(features = "rustc-dep-of-std"))]
+#[cfg(not(feature = "rustc-dep-of-std"))]
 use once_cell::sync::OnceCell;
 
 /// Linux's procfs always uses inode 1 for its root directory.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,12 +52,12 @@
 #![cfg_attr(all(linux_raw, asm, target_arch = "x86"), feature(naked_functions))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "rustc-dep-of-std", allow(incomplete_features))]
-#![cfg_attr(feature = "rustc-dep-of-std", feature(specialization))]
-#![cfg_attr(feature = "rustc-dep-of-std", feature(toowned_clone_into))]
-#![cfg_attr(feature = "rustc-dep-of-std", feature(vec_into_raw_parts))]
+#![cfg_attr(not(feature = "std"), allow(incomplete_features))]
+#![cfg_attr(not(feature = "std"), feature(specialization))]
+#![cfg_attr(not(feature = "std"), feature(slice_internals))]
+#![cfg_attr(not(feature = "std"), feature(toowned_clone_into))]
+#![cfg_attr(not(feature = "std"), feature(vec_into_raw_parts))]
 #![cfg_attr(feature = "rustc-dep-of-std", feature(const_raw_ptr_deref))]
-#![cfg_attr(feature = "rustc-dep-of-std", feature(slice_internals))]
 #![cfg_attr(feature = "rustc-dep-of-std", feature(core_intrinsics))]
 #![cfg_attr(
     all(not(feature = "rustc-dep-of-std"), core_intrinsics),
@@ -74,6 +74,8 @@ extern crate alloc;
 pub mod fd {
     use super::imp;
     pub use imp::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
+    #[cfg(feature = "std")]
+    pub use imp::fd::{FromFd, IntoFd};
 }
 
 #[cfg(not(windows))]

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2,9 +2,9 @@
 
 use crate::imp;
 
-#[cfg(all(not(feature = "std"), feature = "rustc-dep-of-std"))]
+#[cfg(not(feature = "std"))]
 mod addr;
-#[cfg(all(not(feature = "std"), feature = "rustc-dep-of-std"))]
+#[cfg(not(feature = "std"))]
 mod ip;
 mod send_recv;
 mod socket;
@@ -37,9 +37,9 @@ pub use imp::net::SocketAddrStorage;
 pub use imp::net::SocketAddrUnix;
 
 // Declare the `Ip` and `Socket` address types.
-#[cfg(all(not(feature = "std"), feature = "rustc-dep-of-std"))]
+#[cfg(not(feature = "std"))]
 pub use addr::{SocketAddr, SocketAddrV4, SocketAddrV6};
-#[cfg(all(not(feature = "std"), feature = "rustc-dep-of-std"))]
+#[cfg(not(feature = "std"))]
 pub use ip::{IpAddr, Ipv4Addr, Ipv6Addr, Ipv6MulticastScope};
 #[cfg(feature = "std")]
 pub use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};

--- a/src/net/socket_addr_any.rs
+++ b/src/net/socket_addr_any.rs
@@ -13,7 +13,7 @@
 use crate::net::SocketAddrUnix;
 use crate::net::{AddressFamily, SocketAddrStorage, SocketAddrV4, SocketAddrV6};
 use crate::{imp, io};
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 use core::fmt;
 
 /// `struct sockaddr_storage` as a Rust enum.
@@ -66,7 +66,7 @@ impl SocketAddrAny {
     }
 }
 
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(feature = "std")]
 impl fmt::Debug for SocketAddrAny {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
This makes rustix's no_std mode more usable outside of rustc-dep-of-std
mode.