### PR TITLE
Define `OFlags::CLOEXEC` for wasi.

### DIFF
--- a/src/imp/libc/fs/types.rs
+++ b/src/imp/libc/fs/types.rs
@@ -267,7 +267,8 @@ bitflags! {
                   target_os = "openbsd",
                   target_os = "redox",
                   target_os = "solaris",
-                  target_os = "vxworks"))]
+                  target_os = "vxworks",
+                  target_os = "wasi"))]
         const CLOEXEC = c::O_CLOEXEC;
 
         /// `O_TMPFILE`


### PR DESCRIPTION
WASI doesn't have fork/exec, and its `O_CLOEXEC` flag is defined to 0,
but it's still useful to define here, for compatibility with Unix code.