### PR TITLE
Fix some "winsock" doc links to be "winsock2" doc links.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Dan Gohman <dev@sunfishcode.online>",
     "Jakub Konka <kubkon@jakubkonka.com>",
 ]
-description = "Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls"
+description = "Safe Rust bindings to POSIX/Unix/Linux/Winsock2-like syscalls"
 documentation = "https://docs.rs/rustix"
 license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 repository = "https://github.com/bytecodealliance/rustix"
@@ -41,7 +41,7 @@ linux-raw-sys = { version = "0.0.36", default-features = false, features = ["gen
 errno = { version = "0.2.8", default-features = false }
 libc = { version = "0.2.98", features = ["extra_traits"] }
 
-# For the libc backend on Windows, use the Winsock API in winapi.
+# For the libc backend on Windows, use the Winsock2 API in winapi.
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["ws2ipdef", "ws2tcpip"] }
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1><code>rustix</code></h1>
 
   <p>
-    <strong>Safe Rust bindings to POSIX/Unix/Linux/Winsock syscalls</strong>
+    <strong>Safe Rust bindings to POSIX/Unix/Linux/Winsock2 syscalls</strong>
   </p>
 
   <strong>A <a href="https://bytecodealliance.org/">Bytecode Alliance</a> project</strong>
@@ -16,17 +16,17 @@
 </div>
 
 `rustix` provides efficient memory-safe and [I/O-safe] wrappers to POSIX-like,
-Unix-like, Linux, and Winsock syscall-like APIs, with configurable backends. It
-uses Rust references, slices, and return values instead of raw pointers, and
+Unix-like, Linux, and Winsock2 syscall-like APIs, with configurable backends.
+It uses Rust references, slices, and return values instead of raw pointers, and
 [`io-lifetimes`] instead of raw file descriptors, providing memory safety and
 [I/O safety]. It uses `Result`s for reporting errors, [`bitflags`] instead of
 bare integer flags, an [`Arg`] trait with optimizations to efficiently accept
 any Rust string type, and several other efficient conveniences.
 
-`rustix` is low-level and, and while the `net` API supports Winsock on Windows,
-the rest of the APIs do not support Windows; for higher-level and more portable
-APIs built on this functionality, see the [`system-interface`], [`cap-std`],
-and [`fs-set-times`] crates, for example.
+`rustix` is low-level and, and while the `net` API supports Winsock2 on
+Windows, the rest of the APIs do not support Windows; for higher-level and more
+portable APIs built on this functionality, see the [`system-interface`],
+[`cap-std`], and [`fs-set-times`] crates, for example.
 
 `rustix` currently has two backends available: `linux_raw` and `libc`.
 
@@ -45,7 +45,7 @@ It supports stable as well as nightly Rust.
 The `libc` backend is enabled by default on all other platforms, and can be
 set explicitly for any target by setting `RUSTFLAGS` to
 `--cfg rustix_use_libc`. It uses the [`libc`] crate which provides bindings to
-native `libc` libraries, as well as [`winapi`] for Winsock, and is portable to
+native `libc` libraries, as well as [`winapi`] for Winsock2, and is portable to
 many OS's.
 
 ## Similar crates

--- a/src/imp/libc/c.rs
+++ b/src/imp/libc/c.rs
@@ -1,4 +1,4 @@
-//! Adapt the Winsock API to resemble a POSIX-style libc API.
+//! Adapt the Winsock2 API to resemble a POSIX-style libc API.
 
 #![allow(unused_imports)]
 
@@ -50,7 +50,7 @@ pub(crate) use winapi::um::winsock2::{
 
 // [Documented] values for the `how` argument to `shutdown`.
 //
-// [Documented]: https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown#parameters
+// [Documented]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-shutdown#parameters
 const SD_RECEIVE: c_int = 0;
 const SD_SEND: c_int = 1;
 const SD_BOTH: c_int = 2;

--- a/src/imp/libc/io_lifetimes.rs
+++ b/src/imp/libc/io_lifetimes.rs
@@ -9,11 +9,11 @@ pub(crate) use io_lifetimes::OwnedSocket as OwnedFd;
 pub use std::os::windows::io::RawSocket as RawFd;
 pub(crate) use winapi::um::winsock2::SOCKET as LibcFd;
 
-/// A version of [`AsRawFd`] for use with Winsock APIs.
+/// A version of [`AsRawFd`] for use with Winsock2 API.
 ///
 /// [`AsRawFd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.AsRawFd.html
 pub trait AsRawFd {
-    /// A version of [`as_raw_fd`] for use with Winsock APIs.
+    /// A version of [`as_raw_fd`] for use with Winsock2 API.
     ///
     /// [`as_raw_fd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.FromRawFd.html#tymethod.as_raw_fd
     fn as_raw_fd(&self) -> RawFd;
@@ -26,11 +26,11 @@ impl<T: std::os::windows::io::AsRawSocket> AsRawFd for T {
     }
 }
 
-/// A version of [`IntoRawFd`] for use with Winsock APIs.
+/// A version of [`IntoRawFd`] for use with Winsock2 API.
 ///
 /// [`IntoRawFd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.IntoRawFd.html
 pub trait IntoRawFd {
-    /// A version of [`into_raw_fd`] for use with Winsock APIs.
+    /// A version of [`into_raw_fd`] for use with Winsock2 API.
     ///
     /// [`into_raw_fd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.FromRawFd.html#tymethod.into_raw_fd
     fn into_raw_fd(self) -> RawFd;
@@ -43,11 +43,11 @@ impl<T: std::os::windows::io::IntoRawSocket> IntoRawFd for T {
     }
 }
 
-/// A version of [`FromRawFd`] for use with Winsock APIs.
+/// A version of [`FromRawFd`] for use with Winsock2 API.
 ///
 /// [`FromRawFd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.FromRawFd.html
 pub trait FromRawFd {
-    /// A version of [`from_raw_fd`] for use with Winsock APIs.
+    /// A version of [`from_raw_fd`] for use with Winsock2 API.
     ///
     /// [`from_raw_fd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.FromRawFd.html#tymethod.from_raw_fd
     unsafe fn from_raw_fd(raw_fd: RawFd) -> Self;
@@ -60,7 +60,7 @@ impl<T: std::os::windows::io::FromRawSocket> FromRawFd for T {
     }
 }
 
-/// A version of [`AsFd`] for use with Winsock APIs.
+/// A version of [`AsFd`] for use with Winsock2 API.
 ///
 /// [`AsFd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.AsFd.html
 pub use io_lifetimes::AsSocket as AsFd;
@@ -78,11 +78,11 @@ impl<T: io_lifetimes::AsSocket> AsSocketAsFd for T {
     }
 }
 
-/// A version of [`IntoFd`] for use with Winsock APIs.
+/// A version of [`IntoFd`] for use with Winsock2 API.
 ///
 /// [`IntoFd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/trait.IntoFd.html
 pub trait IntoFd {
-    /// A version of [`into_fd`] for use with Winsock APIs.
+    /// A version of [`into_fd`] for use with Winsock2 API.
     ///
     /// [`into_fd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/trait.IntoFd.html#tymethod.into_fd
     fn into_fd(self) -> OwnedFd;
@@ -94,11 +94,11 @@ impl<T: io_lifetimes::IntoSocket> IntoFd for T {
     }
 }
 
-/// A version of [`FromFd`] for use with Winsock APIs.
+/// A version of [`FromFd`] for use with Winsock2 API.
 ///
 /// [`FromFd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/trait.FromFd.html
 pub trait FromFd {
-    /// A version of [`from_fd`] for use with Winsock APIs.
+    /// A version of [`from_fd`] for use with Winsock2 API.
     ///
     /// [`from_fd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/trait.FromFd.html#tymethod.from_fd
     fn from_fd(fd: OwnedFd) -> Self;

--- a/src/imp/libc/mod.rs
+++ b/src/imp/libc/mod.rs
@@ -1,7 +1,7 @@
 //! The libc backend.
 //!
 //! On most platforms, this uses the `libc` crate to make system calls. On
-//! Windows, this uses the Winsock APIs in `winapi`, which can be adapted
+//! Windows, this uses the Winsock2 API in `winapi`, which can be adapted
 //! to have a very `libc`-like interface.
 
 #[cfg(not(any(windows, target_os = "wasi")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! `rustix` provides efficient memory-safe and [I/O-safe] wrappers to
-//! POSIX-like, Unix-like, Linux, and Winsock syscall-like APIs, with
+//! POSIX-like, Unix-like, Linux, and Winsock2 syscall-like APIs, with
 //! configurable backends.
 //!
 //! For example, instead of calling libc directly, using an `unsafe` block,

--- a/src/net/send_recv.rs
+++ b/src/net/send_recv.rs
@@ -15,11 +15,11 @@ pub use imp::net::{RecvFlags, SendFlags};
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/recv.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/recv.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-recv
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-recv
 #[inline]
 pub fn recv<Fd: AsFd>(fd: &Fd, buf: &mut [u8], flags: RecvFlags) -> io::Result<usize> {
     let fd = fd.as_fd();
@@ -31,11 +31,11 @@ pub fn recv<Fd: AsFd>(fd: &Fd, buf: &mut [u8], flags: RecvFlags) -> io::Result<u
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/send.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/send.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send
 #[inline]
 pub fn send<Fd: AsFd>(fd: &Fd, buf: &[u8], flags: SendFlags) -> io::Result<usize> {
     let fd = fd.as_fd();
@@ -48,11 +48,11 @@ pub fn send<Fd: AsFd>(fd: &Fd, buf: &[u8], flags: SendFlags) -> io::Result<usize
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/recvfrom.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-recvfrom
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-recvfrom
 #[inline]
 pub fn recvfrom<Fd: AsFd>(
     fd: &Fd,
@@ -69,11 +69,11 @@ pub fn recvfrom<Fd: AsFd>(
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/sendto.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto
 #[inline]
 #[doc(alias = "sendto")]
 pub fn sendto_v4<Fd: AsFd>(
@@ -92,11 +92,11 @@ pub fn sendto_v4<Fd: AsFd>(
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/sendto.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto
 #[inline]
 #[doc(alias = "sendto")]
 pub fn sendto_v6<Fd: AsFd>(
@@ -115,11 +115,11 @@ pub fn sendto_v6<Fd: AsFd>(
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/sendto.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto
 #[inline]
 #[doc(alias = "sendto")]
 #[cfg(not(windows))]

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -25,11 +25,11 @@ impl Default for Protocol {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/socket.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-socket
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-socket
 #[inline]
 pub fn socket(domain: AddressFamily, type_: SocketType, protocol: Protocol) -> io::Result<OwnedFd> {
     imp::syscalls::socket(domain, type_, protocol)
@@ -48,11 +48,11 @@ pub fn socket(domain: AddressFamily, type_: SocketType, protocol: Protocol) -> i
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/socket.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-socket
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-socket
 #[inline]
 pub fn socket_with(
     domain: AddressFamily,
@@ -69,11 +69,11 @@ pub fn socket_with(
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/bind.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-bind
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-bind
 #[inline]
 #[doc(alias = "bind")]
 pub fn bind_v4<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV4) -> io::Result<()> {
@@ -87,11 +87,11 @@ pub fn bind_v4<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV4) -> io::Result<()> {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/bind.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-bind
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-bind
 #[inline]
 #[doc(alias = "bind")]
 pub fn bind_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> {
@@ -105,11 +105,11 @@ pub fn bind_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/bind.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-bind
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-bind
 #[inline]
 #[doc(alias = "bind")]
 #[cfg(not(windows))]
@@ -124,11 +124,11 @@ pub fn bind_unix<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrUnix) -> io::Result<()>
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/connect.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect
 #[inline]
 #[doc(alias = "connect")]
 pub fn connect_v4<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV4) -> io::Result<()> {
@@ -142,11 +142,11 @@ pub fn connect_v4<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV4) -> io::Result<()> 
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/connect.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect
 #[inline]
 #[doc(alias = "connect")]
 pub fn connect_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> {
@@ -176,11 +176,11 @@ pub fn connect_unix<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrUnix) -> io::Result<
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/listen.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen
 #[inline]
 pub fn listen<Fd: AsFd>(sockfd: &Fd, backlog: i32) -> io::Result<()> {
     let sockfd = sockfd.as_fd();
@@ -198,11 +198,11 @@ pub fn listen<Fd: AsFd>(sockfd: &Fd, backlog: i32) -> io::Result<()> {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/accept.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept
 #[inline]
 #[doc(alias = "accept4")]
 pub fn accept<Fd: AsFd>(sockfd: &Fd) -> io::Result<OwnedFd> {
@@ -225,11 +225,11 @@ pub fn accept<Fd: AsFd>(sockfd: &Fd) -> io::Result<OwnedFd> {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/accept4.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept
 #[inline]
 #[doc(alias = "accept4")]
 pub fn accept_with<Fd: AsFd>(sockfd: &Fd, flags: AcceptFlags) -> io::Result<OwnedFd> {
@@ -245,11 +245,11 @@ pub fn accept_with<Fd: AsFd>(sockfd: &Fd, flags: AcceptFlags) -> io::Result<Owne
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/accept.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept
 #[inline]
 #[doc(alias = "accept4")]
 pub fn acceptfrom<Fd: AsFd>(sockfd: &Fd) -> io::Result<(OwnedFd, SocketAddrAny)> {
@@ -268,11 +268,11 @@ pub fn acceptfrom<Fd: AsFd>(sockfd: &Fd) -> io::Result<(OwnedFd, SocketAddrAny)>
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/accept4.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept
 #[inline]
 #[doc(alias = "accept4")]
 pub fn acceptfrom_with<Fd: AsFd>(
@@ -288,11 +288,11 @@ pub fn acceptfrom_with<Fd: AsFd>(
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/shutdown.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-shutdown
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-shutdown
 #[inline]
 pub fn shutdown<Fd: AsFd>(sockfd: &Fd, how: Shutdown) -> io::Result<()> {
     let sockfd = sockfd.as_fd();
@@ -304,11 +304,11 @@ pub fn shutdown<Fd: AsFd>(sockfd: &Fd, how: Shutdown) -> io::Result<()> {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getsockname.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockname
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockname
 #[inline]
 pub fn getsockname<Fd: AsFd>(sockfd: &Fd) -> io::Result<SocketAddrAny> {
     let sockfd = sockfd.as_fd();
@@ -321,11 +321,11 @@ pub fn getsockname<Fd: AsFd>(sockfd: &Fd) -> io::Result<SocketAddrAny> {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
-///  - [Winsock]
+///  - [Winsock2]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getpeername.2.html
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getpeername
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getpeername
 #[inline]
 pub fn getpeername<Fd: AsFd>(sockfd: &Fd) -> io::Result<SocketAddrAny> {
     let sockfd = sockfd.as_fd();

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -19,15 +19,15 @@ pub use imp::net::Timeout;
 ///  - [POSIX `sys/socket.h`]
 ///  - [Linux `getsockopt`]
 ///  - [Linux `socket`]
-///  - [Winsock `getsockopt`]
-///  - [Winsock `SOL_SOCKET` options]
+///  - [Winsock2 `getsockopt`]
+///  - [Winsock2 `SOL_SOCKET` options]
 ///
 /// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
 /// [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
 /// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
 /// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
-/// [Winsock `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
-/// [Winsock `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
+/// [Winsock2 `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
+/// [Winsock2 `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
 #[inline]
 #[doc(alias = "SO_TYPE")]
 pub fn get_socket_type<Fd: AsFd>(fd: &Fd) -> io::Result<SocketType> {
@@ -42,15 +42,15 @@ pub fn get_socket_type<Fd: AsFd>(fd: &Fd) -> io::Result<SocketType> {
 ///  - [POSIX `sys/socket.h`]
 ///  - [Linux `setsockopt`]
 ///  - [Linux `socket`]
-///  - [Winsock `setsockopt`]
-///  - [Winsock `SOL_SOCKET` options]
+///  - [Winsock2 `setsockopt`]
+///  - [Winsock2 `SOL_SOCKET` options]
 ///
 /// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
 /// [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
-/// [Winsock `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
-/// [Winsock `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
+/// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
+/// [Winsock2 `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
 #[inline]
 #[doc(alias = "SO_REUSEADDR")]
 pub fn set_socket_reuseaddr<Fd: AsFd>(fd: &Fd, value: bool) -> io::Result<()> {
@@ -65,15 +65,15 @@ pub fn set_socket_reuseaddr<Fd: AsFd>(fd: &Fd, value: bool) -> io::Result<()> {
 ///  - [POSIX `sys/socket.h`]
 ///  - [Linux `setsockopt`]
 ///  - [Linux `socket`]
-///  - [Winsock `setsockopt`]
-///  - [Winsock `SOL_SOCKET` options]
+///  - [Winsock2 `setsockopt`]
+///  - [Winsock2 `SOL_SOCKET` options]
 ///
 /// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
 /// [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
-/// [Winsock `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
-/// [Winsock `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
+/// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
+/// [Winsock2 `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
 #[inline]
 #[doc(alias = "SO_BROADCAST")]
 pub fn set_socket_broadcast<Fd: AsFd>(fd: &Fd, broadcast: bool) -> io::Result<()> {
@@ -88,15 +88,15 @@ pub fn set_socket_broadcast<Fd: AsFd>(fd: &Fd, broadcast: bool) -> io::Result<()
 ///  - [POSIX `sys/socket.h`]
 ///  - [Linux `getsockopt`]
 ///  - [Linux `socket`]
-///  - [Winsock `getsockopt`]
-///  - [Winsock `SOL_SOCKET` options]
+///  - [Winsock2 `getsockopt`]
+///  - [Winsock2 `SOL_SOCKET` options]
 ///
 /// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
 /// [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
 /// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
 /// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
-/// [Winsock `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
-/// [Winsock `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
+/// [Winsock2 `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
+/// [Winsock2 `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
 #[inline]
 #[doc(alias = "SO_BROADCAST")]
 pub fn get_socket_broadcast<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
@@ -111,15 +111,15 @@ pub fn get_socket_broadcast<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
 ///  - [POSIX `sys/socket.h`]
 ///  - [Linux `setsockopt`]
 ///  - [Linux `socket`]
-///  - [Winsock `setsockopt`]
-///  - [Winsock `SOL_SOCKET` options]
+///  - [Winsock2 `setsockopt`]
+///  - [Winsock2 `SOL_SOCKET` options]
 ///
 /// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
 /// [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
-/// [Winsock `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
-/// [Winsock `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
+/// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
+/// [Winsock2 `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
 #[inline]
 #[doc(alias = "SO_LINGER")]
 pub fn set_socket_linger<Fd: AsFd>(fd: &Fd, linger: Option<Duration>) -> io::Result<()> {
@@ -134,15 +134,15 @@ pub fn set_socket_linger<Fd: AsFd>(fd: &Fd, linger: Option<Duration>) -> io::Res
 ///  - [POSIX `sys/socket.h`]
 ///  - [Linux `getsockopt`]
 ///  - [Linux `socket`]
-///  - [Winsock `getsockopt`]
-///  - [Winsock `SOL_SOCKET` options]
+///  - [Winsock2 `getsockopt`]
+///  - [Winsock2 `SOL_SOCKET` options]
 ///
 /// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
 /// [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
 /// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
 /// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
-/// [Winsock `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
-/// [Winsock `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
+/// [Winsock2 `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
+/// [Winsock2 `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
 #[inline]
 #[doc(alias = "SO_LINGER")]
 pub fn get_socket_linger<Fd: AsFd>(fd: &Fd) -> io::Result<Option<Duration>> {
@@ -190,15 +190,15 @@ pub fn get_socket_passcred<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
 ///  - [POSIX `sys/socket.h`]
 ///  - [Linux `setsockopt`]
 ///  - [Linux `socket`]
-///  - [Winsock `setsockopt`]
-///  - [Winsock `SOL_SOCKET` options]
+///  - [Winsock2 `setsockopt`]
+///  - [Winsock2 `SOL_SOCKET` options]
 ///
 /// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
 /// [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
-/// [Winsock `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
-/// [Winsock `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
+/// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
+/// [Winsock2 `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
 #[inline]
 #[doc(alias = "SO_RCVTIMEO")]
 #[doc(alias = "SO_SNDTIMEO")]
@@ -218,15 +218,15 @@ pub fn set_socket_timeout<Fd: AsFd>(
 ///  - [POSIX `sys/socket.h`]
 ///  - [Linux `getsockopt`]
 ///  - [Linux `socket`]
-///  - [Winsock `getsockopt`]
-///  - [Winsock `SOL_SOCKET` options]
+///  - [Winsock2 `getsockopt`]
+///  - [Winsock2 `SOL_SOCKET` options]
 ///
 /// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
 /// [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
 /// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
 /// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
-/// [Winsock `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
-/// [Winsock `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
+/// [Winsock2 `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
+/// [Winsock2 `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
 #[inline]
 #[doc(alias = "SO_RCVTIMEO")]
 #[doc(alias = "SO_SNDTIMEO")]
@@ -242,14 +242,14 @@ pub fn get_socket_timeout<Fd: AsFd>(fd: &Fd, id: Timeout) -> io::Result<Option<D
 ///  - [POSIX `netinet/in.h`]
 ///  - [Linux `setsockopt`]
 ///  - [Linux `ip`]
-///  - [Winsock `setsockopt`]
-///  - [Winsock `IPPROTO_IP` options]
+///  - [Winsock2 `setsockopt`]
+///  - [Winsock2 `IPPROTO_IP` options]
 ///
 /// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
-/// [Winsock `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
-/// [Winsock `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
+/// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
+/// [Winsock2 `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 #[inline]
 #[doc(alias = "IP_TTL")]
 pub fn set_ip_ttl<Fd: AsFd>(fd: &Fd, ttl: u32) -> io::Result<()> {
@@ -264,15 +264,15 @@ pub fn set_ip_ttl<Fd: AsFd>(fd: &Fd, ttl: u32) -> io::Result<()> {
 ///  - [POSIX `netinet/in.h`]
 ///  - [Linux `getsockopt`]
 ///  - [Linux `ip`]
-///  - [Winsock `getsockopt`]
-///  - [Winsock `IPPROTO_IPV6` options]
+///  - [Winsock2 `getsockopt`]
+///  - [Winsock2 `IPPROTO_IPV6` options]
 ///
 /// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
 /// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
 /// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
 /// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
-/// [Winsock `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
-/// [Winsock `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
+/// [Winsock2 `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
+/// [Winsock2 `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 #[inline]
 #[doc(alias = "IP_TTL")]
 pub fn get_ip_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
@@ -287,15 +287,15 @@ pub fn get_ip_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
 ///  - [POSIX `netinet/in.h`]
 ///  - [Linux `setsockopt`]
 ///  - [Linux `ipv6`]
-///  - [Winsock `setsockopt`]
-///  - [Winsock `IPPROTO_IPV6` options]
+///  - [Winsock2 `setsockopt`]
+///  - [Winsock2 `IPPROTO_IPV6` options]
 ///
 /// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
 /// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `ipv6`]: https://man7.org/linux/man-pages/man7/ipv6.7.html
-/// [Winsock `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
-/// [Winsock `IPPROTO_IPV6` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
+/// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
+/// [Winsock2 `IPPROTO_IPV6` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
 #[inline]
 #[doc(alias = "IPV6_V6ONLY")]
 pub fn set_ipv6_v6only<Fd: AsFd>(fd: &Fd, only_v6: bool) -> io::Result<()> {
@@ -310,15 +310,15 @@ pub fn set_ipv6_v6only<Fd: AsFd>(fd: &Fd, only_v6: bool) -> io::Result<()> {
 ///  - [POSIX `netinet/in.h`]
 ///  - [Linux `getsockopt`]
 ///  - [Linux `ipv6`]
-///  - [Winsock `getsockopt`]
-///  - [Winsock `IPPROTO_IPV6` options]
+///  - [Winsock2 `getsockopt`]
+///  - [Winsock2 `IPPROTO_IPV6` options]
 ///
 /// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
 /// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
 /// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
 /// [Linux `ipv6`]: https://man7.org/linux/man-pages/man7/ipv6.7.html
-/// [Winsock `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
-/// [Winsock `IPPROTO_IPV6` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
+/// [Winsock2 `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
+/// [Winsock2 `IPPROTO_IPV6` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
 #[inline]
 #[doc(alias = "IPV6_V6ONLY")]
 pub fn get_ipv6_v6only<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
@@ -333,15 +333,15 @@ pub fn get_ipv6_v6only<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
 ///  - [POSIX `netinet/in.h`]
 ///  - [Linux `setsockopt`]
 ///  - [Linux `ip`]
-///  - [Winsock `setsockopt`]
-///  - [Winsock `IPPROTO_IP` options]
+///  - [Winsock2 `setsockopt`]
+///  - [Winsock2 `IPPROTO_IP` options]
 ///
 /// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
 /// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
-/// [Winsock `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
-/// [Winsock `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
+/// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
+/// [Winsock2 `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 #[inline]
 #[doc(alias = "IP_MULTICAST_LOOP")]
 pub fn set_ip_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::Result<()> {
@@ -356,15 +356,15 @@ pub fn set_ip_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::Res
 ///  - [POSIX `netinet/in.h`]
 ///  - [Linux `getsockopt`]
 ///  - [Linux `ip`]
-///  - [Winsock `getsockopt`]
-///  - [Winsock `IPPROTO_IP` options]
+///  - [Winsock2 `getsockopt`]
+///  - [Winsock2 `IPPROTO_IP` options]
 ///
 /// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
 /// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
 /// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
 /// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
-/// [Winsock `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
-/// [Winsock `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
+/// [Winsock2 `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
+/// [Winsock2 `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 #[inline]
 #[doc(alias = "IP_MULTICAST_LOOP")]
 pub fn get_ip_multicast_loop<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
@@ -379,15 +379,15 @@ pub fn get_ip_multicast_loop<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
 ///  - [POSIX `netinet/in.h`]
 ///  - [Linux `setsockopt`]
 ///  - [Linux `ip`]
-///  - [Winsock `setsockopt`]
-///  - [Winsock `IPPROTO_IP` options]
+///  - [Winsock2 `setsockopt`]
+///  - [Winsock2 `IPPROTO_IP` options]
 ///
 /// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
 /// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
-/// [Winsock `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
-/// [Winsock `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
+/// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
+/// [Winsock2 `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 #[inline]
 #[doc(alias = "IP_MULTICAST_TTL")]
 pub fn set_ip_multicast_ttl<Fd: AsFd>(fd: &Fd, multicast_ttl: u32) -> io::Result<()> {
@@ -402,15 +402,15 @@ pub fn set_ip_multicast_ttl<Fd: AsFd>(fd: &Fd, multicast_ttl: u32) -> io::Result
 ///  - [POSIX `netinet/in.h`]
 ///  - [Linux `getsockopt`]
 ///  - [Linux `ip`]
-///  - [Winsock `getsockopt`]
-///  - [Winsock `IPPROTO_IP` options]
+///  - [Winsock2 `getsockopt`]
+///  - [Winsock2 `IPPROTO_IP` options]
 ///
 /// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
 /// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
 /// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
 /// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
-/// [Winsock `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
-/// [Winsock `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
+/// [Winsock2 `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
+/// [Winsock2 `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 #[inline]
 #[doc(alias = "IP_MULTICAST_TTL")]
 pub fn get_ip_multicast_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
@@ -425,15 +425,15 @@ pub fn get_ip_multicast_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
 ///  - [POSIX `netinet/in.h`]
 ///  - [Linux `setsockopt`]
 ///  - [Linux `ipv6`]
-///  - [Winsock `setsockopt`]
-///  - [Winsock `IPPROTO_IPV6` options]
+///  - [Winsock2 `setsockopt`]
+///  - [Winsock2 `IPPROTO_IPV6` options]
 ///
 /// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
 /// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `ipv6`]: https://man7.org/linux/man-pages/man7/ipv6.7.html
-/// [Winsock `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
-/// [Winsock `IPPROTO_IPV6` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
+/// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
+/// [Winsock2 `IPPROTO_IPV6` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
 #[inline]
 #[doc(alias = "IPV6_MULTICAST_LOOP")]
 pub fn set_ipv6_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::Result<()> {
@@ -448,15 +448,15 @@ pub fn set_ipv6_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::R
 ///  - [POSIX `netinet/in.h`]
 ///  - [Linux `getsockopt`]
 ///  - [Linux `ipv6`]
-///  - [Winsock `getsockopt`]
-///  - [Winsock `IPPROTO_IPV6` options]
+///  - [Winsock2 `getsockopt`]
+///  - [Winsock2 `IPPROTO_IPV6` options]
 ///
 /// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
 /// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
 /// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
 /// [Linux `ipv6`]: https://man7.org/linux/man-pages/man7/ipv6.7.html
-/// [Winsock `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
-/// [Winsock `IPPROTO_IPV6` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
+/// [Winsock2 `getsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockopt
+/// [Winsock2 `IPPROTO_IPV6` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
 #[inline]
 #[doc(alias = "IPV6_MULTICAST_LOOP")]
 pub fn get_ipv6_multicast_loop<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
@@ -471,15 +471,15 @@ pub fn get_ipv6_multicast_loop<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
 ///  - [POSIX `netinet/in.h`]
 ///  - [Linux `setsockopt`]
 ///  - [Linux `ip`]
-///  - [Winsock `setsockopt`]
-///  - [Winsock `IPPROTO_IP` options]
+///  - [Winsock2 `setsockopt`]
+///  - [Winsock2 `IPPROTO_IP` options]
 ///
 /// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
 /// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
-/// [Winsock `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
-/// [Winsock `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
+/// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
+/// [Winsock2 `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 #[inline]
 #[doc(alias = "IP_ADD_MEMBERSHIP")]
 pub fn set_ip_add_membership<Fd: AsFd>(
@@ -500,15 +500,15 @@ pub fn set_ip_add_membership<Fd: AsFd>(
 ///  - [POSIX `netinet/in.h`]
 ///  - [Linux `setsockopt`]
 ///  - [Linux `ipv6]
-///  - [Winsock `setsockopt`]
-///  - [Winsock `IPPROTO_IPV6` options]
+///  - [Winsock2 `setsockopt`]
+///  - [Winsock2 `IPPROTO_IPV6` options]
 ///
 /// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
 /// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `ipv6`]: https://man7.org/linux/man-pages/man7/ipv6.7.html
-/// [Winsock `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
-/// [Winsock `IPPROTO_IPV6` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
+/// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
+/// [Winsock2 `IPPROTO_IPV6` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
 #[inline]
 #[doc(alias = "IPV6_JOIN_GROUP")]
 #[doc(alias = "IPV6_ADD_MEMBERSHIP")]
@@ -528,15 +528,15 @@ pub fn set_ipv6_add_membership<Fd: AsFd>(
 ///  - [POSIX `netinet/in.h`]
 ///  - [Linux `setsockopt`]
 ///  - [Linux `ip`]
-///  - [Winsock `setsockopt`]
-///  - [Winsock `IPPROTO_IP` options]
+///  - [Winsock2 `setsockopt`]
+///  - [Winsock2 `IPPROTO_IP` options]
 ///
 /// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
 /// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
-/// [Winsock `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
-/// [Winsock `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
+/// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
+/// [Winsock2 `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 #[inline]
 #[doc(alias = "IP_DROP_MEMBERSHIP")]
 pub fn set_ip_drop_membership<Fd: AsFd>(
@@ -557,15 +557,15 @@ pub fn set_ip_drop_membership<Fd: AsFd>(
 ///  - [POSIX `netinet/in.h`]
 ///  - [Linux `setsockopt`]
 ///  - [Linux `ipv6`]
-///  - [Winsock `setsockopt`]
-///  - [Winsock `IPPROTO_IPV6` options]
+///  - [Winsock2 `setsockopt`]
+///  - [Winsock2 `IPPROTO_IPV6` options]
 ///
 /// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
 /// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `ipv6`]: https://man7.org/linux/man-pages/man7/ipv6.7.html
-/// [Winsock `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
-/// [Winsock `IPPROTO_IPV6` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
+/// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
+/// [Winsock2 `IPPROTO_IPV6` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
 #[inline]
 #[doc(alias = "IPV6_LEAVE_GROUP")]
 #[doc(alias = "IPV6_DROP_MEMBERSHIP")]
@@ -585,15 +585,15 @@ pub fn set_ipv6_drop_membership<Fd: AsFd>(
 ///  - [POSIX `netinet/tcp.h`]
 ///  - [Linux `setsockopt`]
 ///  - [Linux `tcp`]
-///  - [Winsock `setsockopt`]
-///  - [Winsock `IPPROTO_TCP` options]
+///  - [Winsock2 `setsockopt`]
+///  - [Winsock2 `IPPROTO_TCP` options]
 ///
 /// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
 /// [POSIX `netinet/tcp.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_tcp.h.html
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `tcp`]: https://man7.org/linux/man-pages/man7/tcp.7.html
-/// [Winsock `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
-/// [Winsock `IPPROTO_TCP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-tcp-socket-options
+/// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
+/// [Winsock2 `IPPROTO_TCP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-tcp-socket-options
 #[inline]
 #[doc(alias = "TCP_NODELAY")]
 pub fn set_tcp_nodelay<Fd: AsFd>(fd: &Fd, nodelay: bool) -> io::Result<()> {
@@ -608,15 +608,15 @@ pub fn set_tcp_nodelay<Fd: AsFd>(fd: &Fd, nodelay: bool) -> io::Result<()> {
 ///  - [POSIX `netinet/tcp.h`]
 ///  - [Linux `getsockopt`]
 ///  - [Linux `tcp`]
-///  - [Winsock `getsockopt`]
-///  - [Winsock `IPPROTO_TCP` options]
+///  - [Winsock2 `getsockopt`]
+///  - [Winsock2 `IPPROTO_TCP` options]
 ///
 /// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
 /// [POSIX `netinet/tcp.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_tcp.h.html
 /// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
 /// [Linux `tcp`]: https://man7.org/linux/man-pages/man7/tcp.7.html
-/// [Winsock `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
-/// [Winsock `IPPROTO_TCP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-tcp-socket-options
+/// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
+/// [Winsock2 `IPPROTO_TCP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-tcp-socket-options
 #[inline]
 #[doc(alias = "TCP_NODELAY")]
 pub fn get_tcp_nodelay<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {

--- a/src/net/wsa.rs
+++ b/src/net/wsa.rs
@@ -8,15 +8,15 @@ use winapi::um::winsock2::{WSACleanup, WSAGetLastError, WSAStartup, WSADATA};
 /// using sockets APIs. The function performs the necessary initialization.
 ///
 /// # References
-///  - [Winsock]
+///  - [Winsock2]
 ///
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsastartup
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsastartup
 pub fn wsa_startup() -> io::Result<WSADATA> {
     // Request version 2.2, which has been the latest version since far older
     // versions of Windows than we support here. For more information about
     // the version, see [here].
     //
-    // [here]: https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-wsastartup#remarks
+    // [here]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsastartup#remarks
     let version = 0x202;
     let mut data = MaybeUninit::uninit();
     unsafe {
@@ -35,9 +35,9 @@ pub fn wsa_startup() -> io::Result<WSADATA> {
 /// this function releases associated resources.
 ///
 /// # References
-///  - [Winsock]
+///  - [Winsock2]
 ///
-/// [Winsock]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsacleanup
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsacleanup
 pub fn wsa_cleanup() -> io::Result<()> {
     unsafe {
         if WSACleanup() == 0 {


### PR DESCRIPTION
And say "Winsock2" in documentation instead of "Winsock".