### PR TITLE
Make `Pid` a non-zero type.

### DIFF
--- a/examples/process.rs
+++ b/examples/process.rs
@@ -5,7 +5,8 @@ use rustix::process::*;
 
 #[cfg(not(windows))]
 fn main() -> io::Result<()> {
-    println!("Pid: {}", getpid().as_raw());
+    println!("Pid: {}", getpid().as_raw_nonzero());
+    println!("Parent Pid: {}", Pid::as_raw(getppid()));
     println!("Uid: {}", getuid().as_raw());
     println!("Gid: {}", getgid().as_raw());
     #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -15,8 +16,8 @@ fn main() -> io::Result<()> {
     }
     println!("Page size: {}", page_size());
     println!("Uname: {:?}", uname());
-    println!("Process group priority: {}", getpriority_pgrp(Pid::NONE)?);
-    println!("Process priority: {}", getpriority_process(Pid::NONE)?);
+    println!("Process group priority: {}", getpriority_pgrp(None)?);
+    println!("Process priority: {}", getpriority_process(None)?);
     println!("User priority: {}", getpriority_user(Uid::ROOT)?);
     println!(
         "Current working directory: {}",

--- a/src/imp/libc/process/mod.rs
+++ b/src/imp/libc/process/mod.rs
@@ -37,5 +37,5 @@ pub(crate) use types::{raw_cpu_set_new, RawCpuSet, CPU_SETSIZE};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use types::{MembarrierCommand, RawCpuid};
 #[cfg(not(target_os = "wasi"))]
-pub use types::{RawGid, RawPid, RawUid, EXIT_SIGNALED_SIGABRT};
+pub use types::{RawGid, RawNonZeroPid, RawPid, RawUid, EXIT_SIGNALED_SIGABRT};
 pub use types::{EXIT_FAILURE, EXIT_SUCCESS};

--- a/src/imp/libc/process/types.rs
+++ b/src/imp/libc/process/types.rs
@@ -143,6 +143,9 @@ pub const EXIT_SIGNALED_SIGABRT: c::c_int = 128 + c::SIGABRT;
 /// A process identifier as a raw integer.
 #[cfg(not(target_os = "wasi"))]
 pub type RawPid = c::pid_t;
+/// A non-zero process identifier as a raw non-zero integer.
+#[cfg(not(target_os = "wasi"))]
+pub type RawNonZeroPid = core::num::NonZeroI32;
 /// A group identifier as a raw integer.
 #[cfg(not(target_os = "wasi"))]
 pub type RawGid = c::gid_t;

--- a/src/imp/libc/syscalls.rs
+++ b/src/imp/libc/syscalls.rs
@@ -21,6 +21,8 @@ use super::conv::ret_ssize_t;
 use super::conv::{borrowed_fd, ret};
 #[cfg(windows)]
 use super::fd::{BorrowedFd, LibcFd, RawFd};
+#[cfg(any(target_os = "android", target_os = "linux"))]
+use super::process::RawNonZeroPid;
 #[cfg(target_os = "linux")]
 use super::rand::GetRandomFlags;
 #[cfg(any(windows, target_os = "linux"))]
@@ -46,7 +48,8 @@ pub(crate) fn getrandom(buf: &mut [u8], flags: GetRandomFlags) -> io::Result<usi
 pub(crate) fn gettid() -> Pid {
     unsafe {
         let tid: i32 = c::gettid();
-        Pid::from_raw(tid)
+        debug_assert_ne!(tid, 0);
+        Pid::from_raw_nonzero(RawNonZeroPid::new_unchecked(tid))
     }
 }
 

--- a/src/imp/linux_raw/process/mod.rs
+++ b/src/imp/linux_raw/process/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use auxv::{exe_phdrs, linux_execfn, linux_hwcap, page_size};
 pub(super) use auxv::{exe_phdrs_slice, sysinfo_ehdr};
 pub(crate) use types::{raw_cpu_set_new, RawCpuSet, RawUname, CPU_SETSIZE};
 pub use types::{
-    MembarrierCommand, RawCpuid, RawGid, RawPid, RawUid, Resource, EXIT_FAILURE,
+    MembarrierCommand, RawCpuid, RawGid, RawNonZeroPid, RawPid, RawUid, Resource, EXIT_FAILURE,
     EXIT_SIGNALED_SIGABRT, EXIT_SUCCESS,
 };
 pub(crate) use wait::{

--- a/src/imp/linux_raw/process/types.rs
+++ b/src/imp/linux_raw/process/types.rs
@@ -83,6 +83,8 @@ pub const EXIT_SIGNALED_SIGABRT: c::c_int = 128 + linux_raw_sys::general::SIGABR
 
 /// A process identifier as a raw integer.
 pub type RawPid = u32;
+/// A non-zero process identifier as a raw non-zero integer.
+pub type RawNonZeroPid = core::num::NonZeroU32;
 /// A group identifier as a raw integer.
 pub type RawGid = u32;
 /// A user identifier as a raw integer.

--- a/src/io/procfs.rs
+++ b/src/io/procfs.rs
@@ -237,8 +237,13 @@ fn proc_self() -> io::Result<(BorrowedFd<'static>, &'static Stat)> {
 
             // Open "/proc/self". Use our pid to compute the name rather than literally
             // using "self", as "self" is a symlink.
-            let proc_self = openat(&proc, DecInt::new(pid.as_raw()), oflags, Mode::empty())
-                .map_err(|_err| io::Error::NOTSUP)?;
+            let proc_self = openat(
+                &proc,
+                DecInt::new(pid.as_raw_nonzero().get()),
+                oflags,
+                Mode::empty(),
+            )
+            .map_err(|_err| io::Error::NOTSUP)?;
             let proc_self_stat = check_proc_entry(
                 Kind::Pid,
                 proc_self.as_fd(),

--- a/src/process/priority.rs
+++ b/src/process/priority.rs
@@ -35,6 +35,8 @@ pub fn getpriority_user(uid: Uid) -> io::Result<i32> {
 /// `getpriority(PRIO_PGRP, gid)`—Get the scheduling priority of the given
 /// process group.
 ///
+/// A `pgid` of `None` means the process group of the calling process.
+///
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
@@ -46,13 +48,15 @@ pub fn getpriority_user(uid: Uid) -> io::Result<i32> {
 #[cfg(not(target_os = "redox"))]
 #[inline]
 #[doc(alias = "getpriority")]
-pub fn getpriority_pgrp(pgid: Pid) -> io::Result<i32> {
+pub fn getpriority_pgrp(pgid: Option<Pid>) -> io::Result<i32> {
     imp::syscalls::getpriority_pgrp(pgid)
 }
 
 /// `getpriority(PRIO_PROCESS, pid)`—Get the scheduling priority of the given
 /// process.
 ///
+/// A `pid` of `None` means the calling process.
+///
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
@@ -64,7 +68,7 @@ pub fn getpriority_pgrp(pgid: Pid) -> io::Result<i32> {
 #[cfg(not(target_os = "redox"))]
 #[inline]
 #[doc(alias = "getpriority")]
-pub fn getpriority_process(pid: Pid) -> io::Result<i32> {
+pub fn getpriority_process(pid: Option<Pid>) -> io::Result<i32> {
     imp::syscalls::getpriority_process(pid)
 }
 
@@ -89,6 +93,8 @@ pub fn setpriority_user(uid: Uid, priority: i32) -> io::Result<()> {
 /// `setpriority(PRIO_PGRP, pgid)`—Get the scheduling priority of the given
 /// process group.
 ///
+/// A `pgid` of `None` means the process group of the calling process.
+///
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
@@ -100,13 +106,15 @@ pub fn setpriority_user(uid: Uid, priority: i32) -> io::Result<()> {
 #[cfg(not(target_os = "redox"))]
 #[inline]
 #[doc(alias = "setpriority")]
-pub fn setpriority_pgrp(pgid: Pid, priority: i32) -> io::Result<()> {
+pub fn setpriority_pgrp(pgid: Option<Pid>, priority: i32) -> io::Result<()> {
     imp::syscalls::setpriority_pgrp(pgid, priority)
 }
 
 /// `setpriority(PRIO_PROCESS, pid)`—Get the scheduling priority of the given
 /// process.
 ///
+/// A `pid` of `None` means the calling process.
+///
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
@@ -118,6 +126,6 @@ pub fn setpriority_pgrp(pgid: Pid, priority: i32) -> io::Result<()> {
 #[cfg(not(target_os = "redox"))]
 #[inline]
 #[doc(alias = "setpriority")]
-pub fn setpriority_process(pid: Pid, priority: i32) -> io::Result<()> {
+pub fn setpriority_process(pid: Option<Pid>, priority: i32) -> io::Result<()> {
     imp::syscalls::setpriority_process(pid, priority)
 }

--- a/src/process/sched.rs
+++ b/src/process/sched.rs
@@ -64,8 +64,8 @@ impl CpuSet {
 
 /// `sched_setaffinity(pid, cpuset)`—Set a thread's CPU affinity mask.
 ///
-/// `pid` is the thread ID to update. If pid is `Pid::NONE`, then the current
-/// thread is updated.
+/// `pid` is the thread ID to update. If pid is `None`, then the current thread
+/// is updated.
 ///
 /// The `CpuSet` argument specifies the set of CPUs on which the thread will
 /// be eligible to run.
@@ -75,14 +75,14 @@ impl CpuSet {
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html
 #[inline]
-pub fn sched_setaffinity(pid: Pid, cpuset: &CpuSet) -> io::Result<()> {
+pub fn sched_setaffinity(pid: Option<Pid>, cpuset: &CpuSet) -> io::Result<()> {
     imp::syscalls::sched_setaffinity(pid, &cpuset.cpu_set)
 }
 
 /// `sched_getaffinity(pid)`—Get a thread's CPU affinity mask.
 ///
-/// `pid` is the thread ID to check. If pid is `Pid::NONE`, then the current
-/// thread is checked.
+/// `pid` is the thread ID to check. If pid is `None`, then the current thread
+/// is checked.
 ///
 /// Returns the set of CPUs on which the thread is eligible to run.
 ///
@@ -91,7 +91,7 @@ pub fn sched_setaffinity(pid: Pid, cpuset: &CpuSet) -> io::Result<()> {
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/sched_getaffinity.2.html
 #[inline]
-pub fn sched_getaffinity(pid: Pid) -> io::Result<CpuSet> {
+pub fn sched_getaffinity(pid: Option<Pid>) -> io::Result<CpuSet> {
     let mut cpuset = CpuSet::new();
     imp::syscalls::sched_getaffinity(pid, &mut cpuset.cpu_set).and(Ok(cpuset))
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -136,7 +136,7 @@ pub use imp::thread::tls::StartupTlsInfo;
 /// `fork()`—Creates a new process by duplicating the calling process.
 ///
 /// On success, the PID of the child process is returned in the parent, and
-/// `Pid::NONE` is returned in the child.
+/// `None` is returned in the child.
 ///
 /// If the parent has multiple threads, fork creates a child process containing
 /// a copy of all the memory of all the threads, but with only one actual
@@ -165,7 +165,7 @@ pub use imp::thread::tls::StartupTlsInfo;
 /// [`pthread_atfork`]: https://man7.org/linux/man-pages/man3/pthread_atfork.3.html
 /// [rand]: https://crates.io/crates/rand
 #[cfg(linux_raw)]
-pub unsafe fn fork() -> io::Result<Pid> {
+pub unsafe fn fork() -> io::Result<Option<Pid>> {
     imp::syscalls::fork()
 }
 

--- a/tests/process/id.rs
+++ b/tests/process/id.rs
@@ -22,7 +22,6 @@ fn test_getegid() {
 
 #[test]
 fn test_getpid() {
-    assert_ne!(process::getpid(), process::Pid::NONE);
     assert_eq!(process::getpid(), process::getpid());
 }
 

--- a/tests/process/priority.rs
+++ b/tests/process/priority.rs
@@ -1,6 +1,6 @@
 use rustix::process::nice;
 #[cfg(not(target_os = "redox"))]
-use rustix::process::{getpriority_process, setpriority_process, Pid};
+use rustix::process::{getpriority_process, setpriority_process};
 
 #[cfg(not(target_os = "freebsd"))] // FreeBSD's nice(3) doesn't return the old value.
 #[test]
@@ -9,7 +9,7 @@ fn test_priorities() {
 
     #[cfg(not(target_os = "redox"))]
     {
-        let get_prio = getpriority_process(Pid::NONE).unwrap();
+        let get_prio = getpriority_process(None).unwrap();
         assert_eq!(get_prio, old);
     }
 
@@ -21,14 +21,14 @@ fn test_priorities() {
 
     #[cfg(not(target_os = "redox"))]
     {
-        let get_prio = getpriority_process(Pid::NONE).unwrap();
+        let get_prio = getpriority_process(None).unwrap();
         assert_eq!(get_prio, new);
 
-        setpriority_process(Pid::NONE, get + 1).unwrap();
-        let now = getpriority_process(Pid::NONE).unwrap();
+        setpriority_process(None, get + 1).unwrap();
+        let now = getpriority_process(None).unwrap();
         assert_eq!(get + 1, now);
-        setpriority_process(Pid::NONE, get + 10000).unwrap();
-        let now = getpriority_process(Pid::NONE).unwrap();
+        setpriority_process(None, get + 10000).unwrap();
+        let now = getpriority_process(None).unwrap();
         // Linux's max is 19; Darwin's max is 20.
         assert!(now >= 19 && now <= 20);
         // Darwin appears to return `EPERM` on an out of range `nice`.
@@ -43,30 +43,30 @@ fn test_priorities() {
 #[cfg(target_os = "freebsd")]
 #[test]
 fn test_priorities() {
-    let start = getpriority_process(Pid::NONE).unwrap();
+    let start = getpriority_process(None).unwrap();
 
     let _ = nice(0).unwrap();
 
-    let now = getpriority_process(Pid::NONE).unwrap();
+    let now = getpriority_process(None).unwrap();
     assert_eq!(start, now);
 
     let _ = nice(1).unwrap();
 
-    let now = getpriority_process(Pid::NONE).unwrap();
+    let now = getpriority_process(None).unwrap();
     assert_eq!(start + 1, now);
 
-    setpriority_process(Pid::NONE, start + 2).unwrap();
+    setpriority_process(None, start + 2).unwrap();
 
-    let now = getpriority_process(Pid::NONE).unwrap();
+    let now = getpriority_process(None).unwrap();
     assert_eq!(start + 2, now);
 
-    setpriority_process(Pid::NONE, 10000).unwrap();
+    setpriority_process(None, 10000).unwrap();
 
-    let now = getpriority_process(Pid::NONE).unwrap();
+    let now = getpriority_process(None).unwrap();
     assert_eq!(now, 20);
 
     let _ = nice(1).unwrap();
 
-    let now = getpriority_process(Pid::NONE).unwrap();
+    let now = getpriority_process(None).unwrap();
     assert_eq!(now, 20);
 }

--- a/tests/process/wait.rs
+++ b/tests/process/wait.rs
@@ -34,7 +34,7 @@ fn test_wait() {
         .expect("failed to execute child");
     unsafe { kill(child.id() as _, SIGSTOP) };
 
-    let pid = unsafe { process::Pid::from_raw(child.id() as _) };
+    let pid = unsafe { process::Pid::from_raw(child.id() as _) }.unwrap();
     let (child_pid, status) = process::wait(process::WaitOptions::UNTRACED)
         .expect("failed to wait")
         .unwrap();

--- a/tests/thread/id.rs
+++ b/tests/thread/id.rs
@@ -1,9 +1,7 @@
-use rustix::process::Pid;
 use rustix::thread;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[test]
 fn test_gettid() {
-    assert_ne!(thread::gettid(), Pid::NONE);
     assert_eq!(thread::gettid(), thread::gettid());
 }


### PR DESCRIPTION
Make `Pid` a non-zero type and use `Option<Pid>` in places where a pid
value can be zero.  This lets `fork`'s API use an `Option` instead of a
sentry value, which is cleaner.