### PR TITLE
Sunfishcode/unsafe fork

### DIFF
--- a/src/imp/libc/process/syscalls.rs
+++ b/src/imp/libc/process/syscalls.rs
@@ -336,17 +336,3 @@ pub(crate) fn exit_group(code: c::c_int) -> ! {
         libc::_exit(code)
     }
 }
-
-#[cfg(not(target_os = "wasi"))]
-#[inline]
-pub(crate) unsafe fn execve(
-    path: &ZStr,
-    args: &[*const u8],
-    env_vars: &[*const u8],
-) -> io::Result<()> {
-    ret(libc::execve(
-        c_str(path),
-        args.as_ptr().cast(),
-        env_vars.as_ptr().cast(),
-    ))
-}

--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -15,8 +15,8 @@ use super::io::error::decode_usize_infallible;
 #[cfg(target_pointer_width = "64")]
 use super::io::error::try_decode_u64;
 use super::io::error::{
-    try_decode_c_int, try_decode_c_uint, try_decode_raw_fd, try_decode_usize, try_decode_void,
-    try_decode_void_star,
+    try_decode_c_int, try_decode_c_uint, try_decode_error, try_decode_raw_fd, try_decode_usize,
+    try_decode_void, try_decode_void_star,
 };
 use super::reg::{raw_arg, ArgNumber, ArgReg, RetReg, R0};
 use super::time::ClockId;
@@ -276,6 +276,17 @@ pub(super) fn out<'a, T: Sized, Num: ArgNumber>(t: &'a mut MaybeUninit<T>) -> Ar
 #[inline]
 pub(super) unsafe fn ret(raw: RetReg<R0>) -> io::Result<()> {
     try_decode_void(raw)
+}
+
+/// Convert a `usize` returned from a syscall that doesn't return on success.
+///
+/// # Safety
+///
+/// The caller must ensure that this is the return value of a syscall which
+/// doesn't return on success.
+#[inline]
+pub(super) unsafe fn ret_error(raw: RetReg<R0>) -> io::Error {
+    try_decode_error(raw)
 }
 
 /// Convert a `usize` returned from a syscall that effectively always returns

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -49,7 +49,8 @@ pub use chdir::getcwd;
 pub use id::Cpuid;
 #[cfg(not(target_os = "wasi"))]
 pub use id::{
-    getegid, geteuid, getgid, getpid, getppid, getuid, Gid, Pid, RawGid, RawPid, RawUid, Uid,
+    getegid, geteuid, getgid, getpid, getppid, getuid, Gid, Pid, RawGid, RawNonZeroPid, RawPid,
+    RawUid, Uid,
 };
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 pub use membarrier::{


### PR DESCRIPTION
As discussed in #137, switch from trying to provide a safe `execve` to providing a simpler raw unsafe one. This way, it won't need to allocate at all, which makes it easier to use after a `fork` in the presence of arbitrary `#[global_allocator]` implementations.

And as discussed in https://github.com/sunfishcode/mustang/pull/84 and elsewhere, document more safety and robustness hazards with `fork`.