### PR TITLE
Spell ACCESS correctly.

### DIFF
--- a/src/imp/libc/fs/types.rs
+++ b/src/imp/libc/fs/types.rs
@@ -186,6 +186,7 @@ bitflags! {
         const APPEND = c::O_APPEND;
 
         /// `O_CREAT`
+        #[doc(alias = "CREAT")]
         const CREATE = c::O_CREAT;
 
         /// `O_DIRECTORY`

--- a/src/imp/libc/io/error.rs
+++ b/src/imp/libc/io/error.rs
@@ -17,7 +17,8 @@ use errno::errno;
 pub struct Error(pub(crate) c::c_int);
 
 impl Error {
-    pub const ACCES: Self = Self(c::EACCES);
+    #[doc(alias = "ACCES")]
+    pub const ACCESS: Self = Self(c::EACCES);
     pub const ADDRINUSE: Self = Self(c::EADDRINUSE);
     pub const ADDRNOTAVAIL: Self = Self(c::EADDRNOTAVAIL);
     #[cfg(not(any(

--- a/src/imp/linux_raw/fs/types.rs
+++ b/src/imp/linux_raw/fs/types.rs
@@ -163,6 +163,7 @@ bitflags! {
         const APPEND = linux_raw_sys::general::O_APPEND;
 
         /// `O_CREAT`
+        #[doc(alias = "CREAT")]
         const CREATE = linux_raw_sys::general::O_CREAT;
 
         /// `O_DIRECTORY`

--- a/src/imp/linux_raw/io/error.rs
+++ b/src/imp/linux_raw/io/error.rs
@@ -231,7 +231,8 @@ pub(in crate::imp) fn decode_usize_infallible<Num: RetNumber>(raw: RetReg<Num>) 
 }
 
 impl Error {
-    pub const ACCES: Self = Self::from_errno(errno::EACCES);
+    #[doc(alias = "ACCES")]
+    pub const ACCESS: Self = Self::from_errno(errno::EACCES);
     pub const ADDRINUSE: Self = Self::from_errno(errno::EADDRINUSE);
     pub const ADDRNOTAVAIL: Self = Self::from_errno(errno::EADDRNOTAVAIL);
     pub const ADV: Self = Self::from_errno(errno::EADV);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,8 @@
 //!    are presented as `i64` and `u64`.
 //!  - Behaviors that depend on the sizes of C types like `long` are hidden.
 //!  - In some places, more human-friendly and less historical-accident names
-//!    are used.
+//!    are used (and documentation aliases are used so that the original names
+//!    can still be searched for).
 //!
 //! Things they don't do include:
 //!  - Detecting whether functions are supported at runtime.


### PR DESCRIPTION
And add documentation aliases for ACCESS and CREATE.

As lib.rs says, rustix uses names which are "more human-friendly
and less historical-accident".