### PR TITLE
Add 'use core::arch::asm' declarations, as needed on Rust nightly.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -115,7 +115,12 @@ fn has_feature(feature: &str) -> bool {
         .spawn()
         .unwrap();
 
-    writeln!(child.stdin.take().unwrap(), "#![feature({})]", feature).unwrap();
+    writeln!(
+        child.stdin.take().unwrap(),
+        "#![allow(stable_features)]\n#![feature({})]",
+        feature
+    )
+    .unwrap();
 
     child.wait().unwrap().success()
 }

--- a/src/imp/linux_raw/arch/inline/aarch64.rs
+++ b/src/imp/linux_raw/arch/inline/aarch64.rs
@@ -1,4 +1,5 @@
 use crate::imp::reg::{ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0};
+use core::arch::asm;
 
 #[inline]
 #[must_use]

--- a/src/imp/linux_raw/arch/inline/arm.rs
+++ b/src/imp/linux_raw/arch/inline/arm.rs
@@ -1,4 +1,5 @@
 use crate::imp::reg::{ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0};
+use core::arch::asm;
 
 #[inline]
 #[must_use]

--- a/src/imp/linux_raw/arch/inline/riscv64.rs
+++ b/src/imp/linux_raw/arch/inline/riscv64.rs
@@ -1,4 +1,5 @@
 use crate::imp::reg::{ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0};
+use core::arch::asm;
 
 #[inline]
 #[must_use]

--- a/src/imp/linux_raw/arch/inline/x86.rs
+++ b/src/imp/linux_raw/arch/inline/x86.rs
@@ -11,6 +11,7 @@
 
 use crate::imp::reg::{ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0};
 use crate::imp::vdso_wrappers::SyscallType;
+use core::arch::asm;
 
 #[inline]
 #[must_use]

--- a/src/imp/linux_raw/arch/inline/x86_64.rs
+++ b/src/imp/linux_raw/arch/inline/x86_64.rs
@@ -1,4 +1,5 @@
 use crate::imp::reg::{ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0};
+use core::arch::asm;
 
 #[cfg(target_pointer_width = "32")]
 compile_error!("x32 is not yet supported");

--- a/src/imp/linux_raw/vdso_wrappers.rs
+++ b/src/imp/linux_raw/vdso_wrappers.rs
@@ -17,6 +17,8 @@ use super::reg::{ArgReg, RetReg, SyscallNumber, A0, A1, A2, A3, A4, A5, R0};
 use super::time::{ClockId, DynamicClockId, Timespec};
 use super::{c, vdso};
 use crate::io;
+#[cfg(all(asm, target_arch = "x86"))]
+use core::arch::asm;
 use core::mem::{transmute, MaybeUninit};
 use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering::Relaxed;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@
 //! [`Arg`]: https://docs.rs/rustix/latest/rustix/path/trait.Arg.html
 
 #![deny(missing_docs)]
+#![allow(stable_features)]
 #![cfg_attr(linux_raw, deny(unsafe_code))]
 #![cfg_attr(asm, feature(asm))]
 #![cfg_attr(any(rustc_attrs, not(feature = "std")), feature(rustc_attrs))]


### PR DESCRIPTION
Fixes #142.