### PR TITLE
Update to itoa 1.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ cc = { version = "1.0.68", optional = true }
 
 [dependencies]
 bitflags = "1.2.1"
-itoa = { version = "0.4.7", default-features = false, optional = true }
+itoa = { version = "1.0.1", default-features = false, optional = true }
 io-lifetimes = { version = "0.4.0", default-features = false, optional = true }
 
 # Special dependencies used in rustc-dep-of-std mode.

--- a/src/path/dec_int.rs
+++ b/src/path/dec_int.rs
@@ -6,7 +6,8 @@
 
 use crate::ffi::ZStr;
 use crate::imp::fd::{AsFd, AsRawFd};
-use itoa::{fmt, Integer};
+use core::fmt::Write;
+use itoa::{Buffer, Integer};
 #[cfg(feature = "std")]
 use std::ffi::{CStr, OsStr};
 #[cfg(feature = "std")]
@@ -49,7 +50,8 @@ impl DecInt {
             buf: [0; 20 + 1],
             len: 0,
         });
-        fmt(&mut me, i).unwrap();
+        let mut buf = Buffer::new();
+        me.write_str(buf.format(i)).unwrap();
         me.0
     }
 


### PR DESCRIPTION
itoa 1.0 removed the `fmt` function; use `Buffer` instead.