### PR TITLE
Update to libc 0.2.106.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ linux-raw-sys = { version = "0.0.36", default-features = false, features = ["gen
 # setting `errno`.
 [target.'cfg(any(rustix_use_libc, not(all(any(target_os = "linux"), any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64")))))'.dependencies]
 errno = { version = "0.2.8", default-features = false }
-libc = { version = "0.2.98", features = ["extra_traits"] }
+libc = { version = "0.2.106", features = ["extra_traits"] }
 
 # For the libc backend on Windows, use the Winsock2 API in winapi.
 [target.'cfg(windows)'.dependencies]
@@ -48,7 +48,7 @@ winapi = { version = "0.3.9", features = ["ws2ipdef", "ws2tcpip"] }
 [dev-dependencies]
 atty = "0.2.14"
 tempfile = "3.2.0"
-libc = "0.2.98"
+libc = "0.2.106"
 serial_test = "0.5"
 
 [target.'cfg(not(target_os = "emscripten"))'.dev-dependencies]


### PR DESCRIPTION
This ensures that we pull in the fix for the `POLLRDHUP` issue.