### PR TITLE
Re-export io-lifetimes' `OwnedFd` as `rustix::fd::OwnedFd`.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -263,6 +263,7 @@ jobs:
         # way faster at arm emulation than the current version github actions'
         # ubuntu image uses. Disable as much as we can to get it to build
         # quickly.
+        cd
         curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
         cd qemu-6.1.0
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
@@ -366,6 +367,7 @@ jobs:
         # way faster at arm emulation than the current version github actions'
         # ubuntu image uses. Disable as much as we can to get it to build
         # quickly.
+        cd
         curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
         cd qemu-6.1.0
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs

--- a/src/imp/libc/io_lifetimes.rs
+++ b/src/imp/libc/io_lifetimes.rs
@@ -3,8 +3,7 @@
 //! We can make this assumption since `rustix` supports only `std::net` on
 //! Windows.
 
-pub use io_lifetimes::BorrowedSocket as BorrowedFd;
-pub(crate) use io_lifetimes::OwnedSocket as OwnedFd;
+pub use io_lifetimes::{BorrowedSocket as BorrowedFd, OwnedSocket as OwnedFd};
 #[cfg(feature = "std")]
 pub use std::os::windows::io::RawSocket as RawFd;
 pub(crate) use winapi::um::winsock2::SOCKET as LibcFd;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,12 +109,13 @@ extern crate alloc;
 /// Users can use this to avoid needing to import anything else to use the same
 /// versions of these types and traits.
 ///
-/// Note that `OwnedFd` lives at [`rustix::io::OwnedFd`].
+/// Note that rustix APIs that use `OwnedFd` use [`rustix::io::OwnedFd`]
+/// instead, which allows rustix to implement `close` for them.
 ///
 /// [`rustix::io::OwnedFd`]: crate::io::OwnedFd
 pub mod fd {
     use super::imp;
-    pub use imp::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
+    pub use imp::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
     #[cfg(feature = "std")]
     pub use imp::fd::{FromFd, IntoFd};
 }


### PR DESCRIPTION
The io-lifetimes traits use io-lifetimes' `OwnedFd`, rather than
`rustix::io::OwnedFd`, so some users need the io-lifetime's version to
be exported.