### PR TITLE
Add a `to_str` method to `DecInt`.

### DIFF
--- a/src/path/arg.rs
+++ b/src/path/arg.rs
@@ -911,19 +911,18 @@ impl Arg for Vec<u8> {
 impl Arg for DecInt {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        self.as_ref().as_os_str().to_str().ok_or(io::Error::INVAL)
+        Ok(self.as_str())
     }
 
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
-        Path::to_string_lossy(self.as_ref())
+        Cow::Borrowed(self.as_str())
     }
 
     #[inline]
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
-            ZString::new(self.as_ref().as_os_str().as_bytes())
-                .map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
     }
 
@@ -933,8 +932,7 @@ impl Arg for DecInt {
         Self: 'b,
     {
         Ok(Cow::Owned(
-            ZString::new(self.as_ref().as_os_str().as_bytes())
-                .map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
     }
 

--- a/src/path/dec_int.rs
+++ b/src/path/dec_int.rs
@@ -1,7 +1,7 @@
 //! # Safety
 //!
-//! This uses `CStr::from_bytes_with_nul_unchecked` on the buffer that
-//! it filled itself.
+//! This uses `CStr::from_bytes_with_nul_unchecked` and
+//! `str::from_utf8_unchecked`on the buffer that it filled itself.
 #![allow(unsafe_code)]
 
 use crate::ffi::ZStr;
@@ -67,7 +67,17 @@ impl DecInt {
         &self.buf[..self.len]
     }
 
-    /// Return the raw byte buffer.
+    /// Return the raw byte buffer as a `&str`.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        // # Safety
+        //
+        // `DecInt` always holds a formatted decimal number, so it's always
+        // valid UTF-8.
+        unsafe { core::str::from_utf8_unchecked(self.as_bytes()) }
+    }
+
+    /// Return the raw byte buffer as a `&ZStr`.
     #[inline]
     pub fn as_z_str(&self) -> &ZStr {
         let bytes_with_nul = &self.buf[..=self.len];
@@ -77,7 +87,7 @@ impl DecInt {
         unsafe { ZStr::from_bytes_with_nul_unchecked(bytes_with_nul) }
     }
 
-    /// Return the raw byte buffer.
+    /// Return the raw byte buffer as a `&CStr`.
     #[cfg(not(feature = "rustc-dep-of-std"))]
     #[inline]
     pub fn as_c_str(&self) -> &CStr {

--- a/tests/path/arg.rs
+++ b/tests/path/arg.rs
@@ -171,7 +171,7 @@ fn test_arg() {
     #[cfg(feature = "itoa")]
     {
         let t: DecInt = DecInt::new(43110);
-        assert_eq!("43110", t.as_str().unwrap());
+        assert_eq!("43110", t.as_str());
         assert_eq!("43110".to_owned(), Arg::to_string_lossy(&t));
         assert_eq!(zstr!("43110"), Borrow::borrow(&t.as_cow_z_str().unwrap()));
         assert_eq!(zstr!("43110"), t.as_c_str());


### PR DESCRIPTION
This avoids having `DecInt`'s `Arg` implementation depend on `Path`.