### PR TITLE
Avoid shared references to mutable state in `readv` et al.

### DIFF
--- a/src/imp/libc/io/syscalls.rs
+++ b/src/imp/libc/io/syscalls.rs
@@ -89,7 +89,7 @@ pub(crate) fn pwrite(fd: BorrowedFd<'_>, buf: &[u8], offset: u64) -> io::Result<
     Ok(nwritten as usize)
 }
 
-pub(crate) fn readv(fd: BorrowedFd<'_>, bufs: &[IoSliceMut]) -> io::Result<usize> {
+pub(crate) fn readv(fd: BorrowedFd<'_>, bufs: &mut [IoSliceMut]) -> io::Result<usize> {
     let nread = unsafe {
         ret_ssize_t(c::readv(
             borrowed_fd(fd),
@@ -112,7 +112,7 @@ pub(crate) fn writev(fd: BorrowedFd<'_>, bufs: &[IoSlice]) -> io::Result<usize> 
 }
 
 #[cfg(not(target_os = "redox"))]
-pub(crate) fn preadv(fd: BorrowedFd<'_>, bufs: &[IoSliceMut], offset: u64) -> io::Result<usize> {
+pub(crate) fn preadv(fd: BorrowedFd<'_>, bufs: &mut [IoSliceMut], offset: u64) -> io::Result<usize> {
     // Silently cast; we'll get `EINVAL` if the value is negative.
     let offset = offset as i64;
     let nread = unsafe {
@@ -144,7 +144,7 @@ pub(crate) fn pwritev(fd: BorrowedFd<'_>, bufs: &[IoSlice], offset: u64) -> io::
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 pub(crate) fn preadv2(
     fd: BorrowedFd<'_>,
-    bufs: &[IoSliceMut],
+    bufs: &mut [IoSliceMut],
     offset: u64,
     flags: ReadWriteFlags,
 ) -> io::Result<usize> {
@@ -171,7 +171,7 @@ pub(crate) fn preadv2(
 #[inline]
 pub(crate) fn preadv2(
     fd: BorrowedFd<'_>,
-    bufs: &[IoSliceMut],
+    bufs: &mut [IoSliceMut],
     offset: u64,
     flags: ReadWriteFlags,
 ) -> io::Result<usize> {

--- a/src/imp/libc/io/syscalls.rs
+++ b/src/imp/libc/io/syscalls.rs
@@ -112,7 +112,11 @@ pub(crate) fn writev(fd: BorrowedFd<'_>, bufs: &[IoSlice]) -> io::Result<usize> 
 }
 
 #[cfg(not(target_os = "redox"))]
-pub(crate) fn preadv(fd: BorrowedFd<'_>, bufs: &mut [IoSliceMut], offset: u64) -> io::Result<usize> {
+pub(crate) fn preadv(
+    fd: BorrowedFd<'_>,
+    bufs: &mut [IoSliceMut],
+    offset: u64,
+) -> io::Result<usize> {
     // Silently cast; we'll get `EINVAL` if the value is negative.
     let offset = offset as i64;
     let nread = unsafe {

--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -221,7 +221,7 @@ pub(crate) fn pread(fd: BorrowedFd<'_>, buf: &mut [u8], pos: u64) -> io::Result<
     }
 }
 
-pub(crate) fn readv(fd: BorrowedFd<'_>, bufs: &[IoSliceMut<'_>]) -> io::Result<usize> {
+pub(crate) fn readv(fd: BorrowedFd<'_>, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
     let (bufs_addr, bufs_len) = slice(&bufs[..cmp::min(bufs.len(), max_iov())]);
 
     unsafe {
@@ -234,7 +234,7 @@ pub(crate) fn readv(fd: BorrowedFd<'_>, bufs: &[IoSliceMut<'_>]) -> io::Result<u
     }
 }
 
-pub(crate) fn preadv(fd: BorrowedFd<'_>, bufs: &[IoSliceMut<'_>], pos: u64) -> io::Result<usize> {
+pub(crate) fn preadv(fd: BorrowedFd<'_>, bufs: &mut [IoSliceMut<'_>], pos: u64) -> io::Result<usize> {
     let (bufs_addr, bufs_len) = slice(&bufs[..cmp::min(bufs.len(), max_iov())]);
 
     #[cfg(target_pointer_width = "32")]
@@ -262,7 +262,7 @@ pub(crate) fn preadv(fd: BorrowedFd<'_>, bufs: &[IoSliceMut<'_>], pos: u64) -> i
 
 pub(crate) fn preadv2(
     fd: BorrowedFd<'_>,
-    bufs: &[IoSliceMut<'_>],
+    bufs: &mut [IoSliceMut<'_>],
     pos: u64,
     flags: ReadWriteFlags,
 ) -> io::Result<usize> {

--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -234,7 +234,11 @@ pub(crate) fn readv(fd: BorrowedFd<'_>, bufs: &mut [IoSliceMut<'_>]) -> io::Resu
     }
 }
 
-pub(crate) fn preadv(fd: BorrowedFd<'_>, bufs: &mut [IoSliceMut<'_>], pos: u64) -> io::Result<usize> {
+pub(crate) fn preadv(
+    fd: BorrowedFd<'_>,
+    bufs: &mut [IoSliceMut<'_>],
+    pos: u64,
+) -> io::Result<usize> {
     let (bufs_addr, bufs_len) = slice(&bufs[..cmp::min(bufs.len(), max_iov())]);
 
     #[cfg(target_pointer_width = "32")]

--- a/src/io/read_write.rs
+++ b/src/io/read_write.rs
@@ -73,7 +73,7 @@ pub fn pwrite<Fd: AsFd>(fd: &Fd, buf: &[u8], offset: u64) -> io::Result<usize> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/readv.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/readv.2.html
 #[inline]
-pub fn readv<Fd: AsFd>(fd: &Fd, bufs: &[IoSliceMut<'_>]) -> io::Result<usize> {
+pub fn readv<Fd: AsFd>(fd: &Fd, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
     let fd = fd.as_fd();
     imp::syscalls::readv(fd, bufs)
 }
@@ -101,7 +101,7 @@ pub fn writev<Fd: AsFd>(fd: &Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/preadv.2.html
 #[cfg(not(target_os = "redox"))]
 #[inline]
-pub fn preadv<Fd: AsFd>(fd: &Fd, bufs: &[IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
+pub fn preadv<Fd: AsFd>(fd: &Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
     let fd = fd.as_fd();
     imp::syscalls::preadv(fd, bufs, offset)
 }
@@ -132,7 +132,7 @@ pub fn pwritev<Fd: AsFd>(fd: &Fd, bufs: &[IoSlice<'_>], offset: u64) -> io::Resu
 #[inline]
 pub fn preadv2<Fd: AsFd>(
     fd: &Fd,
-    bufs: &[IoSliceMut<'_>],
+    bufs: &mut [IoSliceMut<'_>],
     offset: u64,
     flags: ReadWriteFlags,
 ) -> io::Result<usize> {

--- a/tests/io/readwrite.rs
+++ b/tests/io/readwrite.rs
@@ -31,9 +31,9 @@ fn test_readwrite_pv() {
     }
     pwritev(&foo, &[IoSlice::new(b"world")], 300).unwrap();
     let mut buf = [0_u8; 5];
-    preadv(&foo, &[IoSliceMut::new(&mut buf)], 200).unwrap();
+    preadv(&foo, &mut [IoSliceMut::new(&mut buf)], 200).unwrap();
     assert_eq!(&buf, b"hello");
-    preadv(&foo, &[IoSliceMut::new(&mut buf)], 300).unwrap();
+    preadv(&foo, &mut [IoSliceMut::new(&mut buf)], 300).unwrap();
     assert_eq!(&buf, b"world");
 }
 
@@ -80,9 +80,9 @@ fn test_readwrite_v() {
     writev(&foo, &[IoSlice::new(b"world")]).unwrap();
     seek(&foo, SeekFrom::Start(0)).unwrap();
     let mut buf = [0_u8; 5];
-    readv(&foo, &[IoSliceMut::new(&mut buf)]).unwrap();
+    readv(&foo, &mut [IoSliceMut::new(&mut buf)]).unwrap();
     assert_eq!(&buf, b"hello");
-    readv(&foo, &[IoSliceMut::new(&mut buf)]).unwrap();
+    readv(&foo, &mut [IoSliceMut::new(&mut buf)]).unwrap();
     assert_eq!(&buf, b"world");
 }
 


### PR DESCRIPTION
Change the signatures for `readv`, `writev`, `preadv`, `pwritev`, and
similar to use `&mut [IoSliceMut]` rather than `&[IoSliceMut]`.

If we were to write userspace implementations of these functions instead
of making system calls, using `&[IoSliceMut]` would lead to compile-time
errors. For example, code like this:

```rust
fn readv(bufs: &[IoSliceMut]) {
    if let Some(buf) = bufs.get(0) {
        if let Some(first) = buf.get_mut(0) {
            *first = 0;
        }
    }
}
```

would get this error:

```
error[E0596]: cannot borrow `*buf` as mutable, as it is behind a `&` reference
 --> test.rs:5:30
  |
4 |     if let Some(buf) = bufs.get(0) {
  |                 --- help: consider changing this to be a mutable reference: `&mut IoSliceMut<'_>`
5 |         if let Some(first) = buf.get_mut(0) {
  |                              ^^^^^^^^^^^^^^ `buf` is a `&` reference, so the data it refers to cannot be borrowed as mutable

```

Rustix API signatures shouldn't be defined in ways that would require
unsafe code in the implementation. Rustix does use unsafe code to make
actual system calls, but that's an implementation detail that shouldn't
be visible in the API.

This also matches how std's [`read_vectored`] et al are defined.

[`read_vectored`]: https://doc.rust-lang.org/stable/std/io/trait.Read.html#method.read_vectored