### PR TITLE
Remove the `test_wait` test.

### DIFF
--- a/tests/process/wait.rs
+++ b/tests/process/wait.rs
@@ -23,21 +23,3 @@ fn test_waitpid() {
         .unwrap();
     assert!(status.stopped());
 }
-
-#[test]
-#[serial]
-fn test_wait() {
-    let child = Command::new("yes")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("failed to execute child");
-    unsafe { kill(child.id() as _, SIGSTOP) };
-
-    let pid = unsafe { process::Pid::from_raw(child.id() as _) }.unwrap();
-    let (child_pid, status) = process::wait(process::WaitOptions::UNTRACED)
-        .expect("failed to wait")
-        .unwrap();
-    assert!(status.stopped());
-    assert_eq!(child_pid, pid);
-}


### PR DESCRIPTION
This test is dangerous as it can end up waiting for unrelated child
processes. In theory, we could fix this by spawning a separate process
that we completely control and running the test within that process,
but for now, just disable the test.
