### PR TITLE
Make the `times` elements in `utimensat` and `futimens` a struct.

### DIFF
--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -10,6 +10,7 @@ use crate::ffi::{ZStr, ZString};
 use crate::fs::CloneFlags;
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 use crate::fs::RenameFlags;
+use crate::fs::Timestamps;
 use crate::io::{self, OwnedFd};
 use crate::path::SMALL_PATH_BUFFER_SIZE;
 #[cfg(not(target_os = "wasi"))]
@@ -20,7 +21,6 @@ use imp::fd::{AsFd, BorrowedFd};
 #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi",)))]
 use imp::fs::Dev;
 use imp::fs::{Access, AtFlags, Mode, OFlags, Stat};
-use imp::time::Timespec;
 
 /// `openat(dirfd, path, oflags, mode)`—Opens a file.
 ///
@@ -266,7 +266,7 @@ pub fn accessat<P: path::Arg, Fd: AsFd>(
 pub fn utimensat<P: path::Arg, Fd: AsFd>(
     dirfd: &Fd,
     path: P,
-    times: &[Timespec; 2],
+    times: &Timestamps,
     flags: AtFlags,
 ) -> io::Result<()> {
     let dirfd = dirfd.as_fd();

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -1,5 +1,6 @@
 //! Functions which operate on file descriptors.
 
+use crate::fs::Timestamps;
 use crate::io::SeekFrom;
 #[cfg(not(target_os = "wasi"))]
 use crate::process::{Gid, Uid};
@@ -18,7 +19,6 @@ use imp::fs::Stat;
 use imp::fs::StatFs;
 #[cfg(not(target_os = "wasi"))]
 use imp::fs::{FlockOperation, Mode};
-use imp::time::Timespec;
 
 /// `lseek(fd, offset, whence)`—Repositions a file descriptor within a file.
 ///
@@ -121,7 +121,7 @@ pub fn fstatfs<Fd: AsFd>(fd: &Fd) -> io::Result<StatFs> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/futimens.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/utimensat.2.html
 #[inline]
-pub fn futimens<Fd: AsFd>(fd: &Fd, times: &[Timespec; 2]) -> io::Result<()> {
+pub fn futimens<Fd: AsFd>(fd: &Fd, times: &Timestamps) -> io::Result<()> {
     let fd = fd.as_fd();
     imp::syscalls::futimens(fd, times)
 }

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -196,6 +196,21 @@ pub const PROC_SUPER_MAGIC: FsWord = imp::fs::PROC_SUPER_MAGIC;
 pub use imp::fs::FlockOperation;
 pub use imp::fs::{Dev, RawMode};
 
+/// Timestamps used by [`utimensat`] and [`futimens`].
+//
+// This is `repr(c)` and specifically layed out to match the representation
+// used by `utimensat` and `futimens`, which expect 2-element arrays of
+// timestamps.
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub struct Timestamps {
+    /// The timestamp of the last access to a filesystem object.
+    pub last_access: crate::time::Timespec,
+
+    /// The timestamp of the last modification of a filesystem object.
+    pub last_modification: crate::time::Timespec,
+}
+
 /// Re-export types common to POSIX-ish platforms.
 #[cfg(feature = "std")]
 #[cfg(unix)]

--- a/src/imp/linux_raw/fs/syscalls.rs
+++ b/src/imp/linux_raw/fs/syscalls.rs
@@ -26,18 +26,18 @@ use super::super::conv::zero;
 use super::super::conv::{
     borrowed_fd, by_ref, c_int, c_str, c_uint, dev_t, mode_as, oflags, oflags_for_open_how,
     opt_c_str, opt_mut, out, pass_usize, raw_fd, ret, ret_c_int, ret_c_uint, ret_owned_fd,
-    ret_usize, size_of, slice_just_addr, slice_mut,
+    ret_usize, size_of, slice_mut,
 };
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use super::super::fd::AsFd;
 use super::super::fd::{BorrowedFd, RawFd};
 use super::super::reg::nr;
-use super::super::time::Timespec;
 use super::{
     Access, Advice as FsAdvice, AtFlags, FallocateFlags, FdFlags, FlockOperation, MemfdFlags, Mode,
     OFlags, RenameFlags, ResolveFlags, Stat, StatFs, StatxFlags,
 };
 use crate::ffi::ZStr;
+use crate::fs::Timestamps;
 use crate::io::{self, OwnedFd, SeekFrom};
 use crate::process::{Gid, Uid};
 use core::convert::TryInto;
@@ -1097,21 +1097,21 @@ pub(crate) fn getdents(fd: BorrowedFd<'_>, dirent: &mut [u8]) -> io::Result<usiz
 pub(crate) fn utimensat(
     dirfd: BorrowedFd<'_>,
     pathname: &ZStr,
-    utimes: &[Timespec; 2],
+    times: &Timestamps,
     flags: AtFlags,
 ) -> io::Result<()> {
-    _utimensat(dirfd, Some(pathname), utimes, flags)
+    _utimensat(dirfd, Some(pathname), times, flags)
 }
 
 #[inline]
 fn _utimensat(
     dirfd: BorrowedFd<'_>,
     pathname: Option<&ZStr>,
-    utimes: &[__kernel_timespec; 2],
+    times: &Timestamps,
     flags: AtFlags,
 ) -> io::Result<()> {
-    // The length of the array is fixed and not passed into the syscall.
-    let utimes_addr = slice_just_addr(utimes);
+    // Assert that `Timestamps` has the expected layout.
+    let _ = unsafe { core::mem::transmute::<Timestamps, [__kernel_timespec; 2]>(times.clone()) };
 
     #[cfg(target_pointer_width = "32")]
     unsafe {
@@ -1119,30 +1119,30 @@ fn _utimensat(
             nr(__NR_utimensat_time64),
             borrowed_fd(dirfd),
             opt_c_str(pathname),
-            utimes_addr,
+            by_ref(times),
             c_uint(flags.bits()),
         ))
         .or_else(|err| {
             // See the comments in `rustix_clock_gettime_via_syscall` about
             // emulation.
             if err == io::Error::NOSYS {
-                let old_utimes = [
+                let old_times = [
                     __kernel_old_timespec {
-                        tv_sec: utimes[0].tv_sec.try_into().map_err(|_| io::Error::INVAL)?,
-                        tv_nsec: utimes[0].tv_nsec.try_into().map_err(|_| io::Error::INVAL)?,
+                        tv_sec: times[0].tv_sec.try_into().map_err(|_| io::Error::INVAL)?,
+                        tv_nsec: times[0].tv_nsec.try_into().map_err(|_| io::Error::INVAL)?,
                     },
                     __kernel_old_timespec {
-                        tv_sec: utimes[1].tv_sec.try_into().map_err(|_| io::Error::INVAL)?,
-                        tv_nsec: utimes[1].tv_nsec.try_into().map_err(|_| io::Error::INVAL)?,
+                        tv_sec: times[1].tv_sec.try_into().map_err(|_| io::Error::INVAL)?,
+                        tv_nsec: times[1].tv_nsec.try_into().map_err(|_| io::Error::INVAL)?,
                     },
                 ];
                 // The length of the array is fixed and not passed into the syscall.
-                let old_utimes_addr = slice_just_addr(&old_utimes);
+                let old_times_addr = slice_just_addr(&old_times);
                 ret(syscall4_readonly(
                     nr(__NR_utimensat),
                     borrowed_fd(dirfd),
                     opt_c_str(pathname),
-                    old_utimes_addr,
+                    old_times_addr,
                     c_uint(flags.bits()),
                 ))
             } else {
@@ -1156,14 +1156,14 @@ fn _utimensat(
             nr(__NR_utimensat),
             borrowed_fd(dirfd),
             opt_c_str(pathname),
-            utimes_addr,
+            by_ref(times),
             c_uint(flags.bits()),
         ))
     }
 }
 
 #[inline]
-pub(crate) fn futimens(fd: BorrowedFd<'_>, times: &[Timespec; 2]) -> io::Result<()> {
+pub(crate) fn futimens(fd: BorrowedFd<'_>, times: &Timestamps) -> io::Result<()> {
     _utimensat(fd, None, times, AtFlags::empty())
 }
 


### PR DESCRIPTION
Instead of a 2-element array where users have to know which timestamp
goes at which index, use a `repr(C)` struct so that it has named
fields, while having the same layout.