### PR TITLE
Refactor the `Mode` and `FileType` types.

### DIFF
--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -87,12 +87,17 @@ pub fn fchown<Fd: AsFd>(fd: &Fd, owner: Uid, group: Gid) -> io::Result<()> {
 
 /// `fstat(fd)`—Queries metadata for an open file or directory.
 ///
+/// [`Mode::from_raw_mode`] and [`FileType::from_raw_mode`] may be used to
+/// interpret the `st_mode` field.
+///
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/fstat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/fstat.2.html
+/// [`Mode::from_raw_mode`]: crate::fs::Mode::from_raw_mode
+/// [`FileType::from_raw_mode`]: crate::fs::FileType::from_raw_mode
 #[inline]
 pub fn fstat<Fd: AsFd>(fd: &Fd) -> io::Result<Stat> {
     let fd = fd.as_fd();

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -54,13 +54,6 @@ use super::super::offset::{libc_fstat, libc_fstatat, libc_ftruncate, libc_lseek,
 )))]
 use super::Advice as FsAdvice;
 #[cfg(not(any(
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "redox",
-    target_os = "wasi",
-)))]
-use super::Dev;
-#[cfg(not(any(
     target_os = "dragonfly",
     target_os = "netbsd",
     target_os = "openbsd",
@@ -75,6 +68,13 @@ use super::MemfdFlags;
 // not implemented in libc for netbsd yet
 use super::StatFs;
 use super::{Access, FdFlags, Mode, OFlags, Stat};
+#[cfg(not(any(
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "redox",
+    target_os = "wasi",
+)))]
+use super::{Dev, FileType};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use super::{RenameFlags, ResolveFlags};
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
@@ -366,12 +366,18 @@ pub(crate) fn chownat(
     target_os = "redox",
     target_os = "wasi",
 )))]
-pub(crate) fn mknodat(dirfd: BorrowedFd<'_>, path: &ZStr, mode: Mode, dev: Dev) -> io::Result<()> {
+pub(crate) fn mknodat(
+    dirfd: BorrowedFd<'_>,
+    path: &ZStr,
+    file_type: FileType,
+    mode: Mode,
+    dev: Dev,
+) -> io::Result<()> {
     unsafe {
         ret(c::mknodat(
             borrowed_fd(dirfd),
             c_str(path),
-            mode.bits(),
+            mode.bits() | file_type.as_raw_mode(),
             dev,
         ))
     }

--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -9,7 +9,7 @@
 
 use super::c;
 use super::fd::{AsRawFd, BorrowedFd, FromRawFd};
-use super::fs::{Mode, OFlags};
+use super::fs::{FileType, Mode, OFlags};
 #[cfg(not(debug_assertions))]
 use super::io::error::decode_usize_infallible;
 #[cfg(target_pointer_width = "64")]
@@ -218,6 +218,14 @@ pub(super) fn socklen_t<'a, Num: ArgNumber>(i: socklen_t) -> ArgReg<'a, Num> {
 #[inline]
 pub(super) fn mode_as<'a, Num: ArgNumber>(mode: Mode) -> ArgReg<'a, Num> {
     raw_arg(mode.bits() as usize)
+}
+
+#[inline]
+pub(super) fn mode_and_type_as<'a, Num: ArgNumber>(
+    mode: Mode,
+    file_type: FileType,
+) -> ArgReg<'a, Num> {
+    raw_arg(mode.as_raw_mode() as usize | file_type.as_raw_mode() as usize)
 }
 
 #[cfg(target_pointer_width = "64")]

--- a/src/imp/linux_raw/fs/syscalls.rs
+++ b/src/imp/linux_raw/fs/syscalls.rs
@@ -24,13 +24,14 @@ use super::super::c;
 #[cfg(all(target_pointer_width = "32", target_arch = "arm"))]
 use super::super::conv::zero;
 use super::super::conv::{
-    borrowed_fd, by_ref, c_int, c_str, c_uint, dev_t, mode_as, oflags, oflags_for_open_how,
-    opt_c_str, opt_mut, out, pass_usize, raw_fd, ret, ret_c_int, ret_c_uint, ret_owned_fd,
-    ret_usize, size_of, slice_mut,
+    borrowed_fd, by_ref, c_int, c_str, c_uint, dev_t, mode_and_type_as, mode_as, oflags,
+    oflags_for_open_how, opt_c_str, opt_mut, out, pass_usize, raw_fd, ret, ret_c_int, ret_c_uint,
+    ret_owned_fd, ret_usize, size_of, slice_mut,
 };
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use super::super::fd::AsFd;
 use super::super::fd::{BorrowedFd, RawFd};
+use super::super::fs::FileType;
 use super::super::reg::nr;
 use super::{
     Access, Advice as FsAdvice, AtFlags, FallocateFlags, FdFlags, FlockOperation, MemfdFlags, Mode,
@@ -253,6 +254,7 @@ pub(crate) fn fchown(fd: BorrowedFd<'_>, owner: Uid, group: Gid) -> io::Result<(
 pub(crate) fn mknodat(
     dirfd: BorrowedFd<'_>,
     filename: &ZStr,
+    file_type: FileType,
     mode: Mode,
     dev: u64,
 ) -> io::Result<()> {
@@ -262,7 +264,7 @@ pub(crate) fn mknodat(
             nr(__NR_mknodat),
             borrowed_fd(dirfd),
             c_str(filename),
-            mode_as(mode),
+            mode_and_type_as(mode, file_type),
             dev_t(dev)?,
         ))
     }
@@ -272,7 +274,7 @@ pub(crate) fn mknodat(
             nr(__NR_mknodat),
             borrowed_fd(dirfd),
             c_str(filename),
-            mode_as(mode),
+            mode_and_type_as(mode, file_type),
             dev_t(dev),
         ))
     }

--- a/src/imp/linux_raw/fs/types.rs
+++ b/src/imp/linux_raw/fs/types.rs
@@ -65,78 +65,71 @@ bitflags! {
 }
 
 bitflags! {
-    /// `S_I*` constants for use with [`openat`].
+    /// `S_I*` constants for use with [`openat`], [`chmodat`], and [`fchmod`].
     ///
     /// [`openat`]: crate::fs::openat
+    /// [`chmodat`]: crate::fs::chmodat
+    /// [`fchmod`]: crate::fs::fchmod
     pub struct Mode: RawMode {
         /// `S_IRWXU`
-        const IRWXU = linux_raw_sys::general::S_IRWXU;
+        const RWXU = linux_raw_sys::general::S_IRWXU;
 
         /// `S_IRUSR`
-        const IRUSR = linux_raw_sys::general::S_IRUSR;
+        const RUSR = linux_raw_sys::general::S_IRUSR;
 
         /// `S_IWUSR`
-        const IWUSR = linux_raw_sys::general::S_IWUSR;
+        const WUSR = linux_raw_sys::general::S_IWUSR;
 
         /// `S_IXUSR`
-        const IXUSR = linux_raw_sys::general::S_IXUSR;
+        const XUSR = linux_raw_sys::general::S_IXUSR;
 
         /// `S_IRWXG`
-        const IRWXG = linux_raw_sys::general::S_IRWXG;
+        const RWXG = linux_raw_sys::general::S_IRWXG;
 
         /// `S_IRGRP`
-        const IRGRP = linux_raw_sys::general::S_IRGRP;
+        const RGRP = linux_raw_sys::general::S_IRGRP;
 
         /// `S_IWGRP`
-        const IWGRP = linux_raw_sys::general::S_IWGRP;
+        const WGRP = linux_raw_sys::general::S_IWGRP;
 
         /// `S_IXGRP`
-        const IXGRP = linux_raw_sys::general::S_IXGRP;
+        const XGRP = linux_raw_sys::general::S_IXGRP;
 
         /// `S_IRWXO`
-        const IRWXO = linux_raw_sys::general::S_IRWXO;
+        const RWXO = linux_raw_sys::general::S_IRWXO;
 
         /// `S_IROTH`
-        const IROTH = linux_raw_sys::general::S_IROTH;
+        const ROTH = linux_raw_sys::general::S_IROTH;
 
         /// `S_IWOTH`
-        const IWOTH = linux_raw_sys::general::S_IWOTH;
+        const WOTH = linux_raw_sys::general::S_IWOTH;
 
         /// `S_IXOTH`
-        const IXOTH = linux_raw_sys::general::S_IXOTH;
+        const XOTH = linux_raw_sys::general::S_IXOTH;
 
         /// `S_ISUID`
-        const ISUID = linux_raw_sys::general::S_ISUID;
+        const SUID = linux_raw_sys::general::S_ISUID;
 
         /// `S_ISGID`
-        const ISGID = linux_raw_sys::general::S_ISGID;
+        const SGID = linux_raw_sys::general::S_ISGID;
 
         /// `S_ISVTX`
-        const ISVTX = linux_raw_sys::general::S_ISVTX;
+        const SVTX = linux_raw_sys::general::S_ISVTX;
+    }
+}
 
-        /// `S_IFREG`
-        const IFREG = linux_raw_sys::general::S_IFREG;
+impl Mode {
+    /// Construct a `Mode` from the mode bits of the `st_mode` field of
+    /// a `Stat`.
+    #[inline]
+    pub const fn from_raw_mode(st_mode: RawMode) -> Self {
+        Self::from_bits_truncate(st_mode)
+    }
 
-        /// `S_IFDIR`
-        const IFDIR = linux_raw_sys::general::S_IFDIR;
-
-        /// `S_IFLNK`
-        const IFLNK = linux_raw_sys::general::S_IFLNK;
-
-        /// `S_IFIFO`
-        const IFIFO = linux_raw_sys::general::S_IFIFO;
-
-        /// `S_IFSOCK`
-        const IFSOCK = linux_raw_sys::general::S_IFSOCK;
-
-        /// `S_IFCHR`
-        const IFCHR = linux_raw_sys::general::S_IFCHR;
-
-        /// `S_IFBLK`
-        const IFBLK = linux_raw_sys::general::S_IFBLK;
-
-        /// `S_IFMT`
-        const IFMT = linux_raw_sys::general::S_IFMT;
+    /// Construct an `st_mode` value from `Stat`.
+    #[inline]
+    pub const fn as_raw_mode(self) -> RawMode {
+        self.bits()
     }
 }
 
@@ -257,36 +250,40 @@ bitflags! {
     }
 }
 
-/// `S_IF*` constants.
+/// `S_IF*` constants for use with [`mknodat`] and [`Stat`]'s `st_mode` field.
+///
+/// [`mknodat`]: crate::fs::mknodat
+/// [`Stat`]: crate::fs::Stat
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FileType {
     /// `S_IFREG`
-    RegularFile,
+    RegularFile = linux_raw_sys::general::S_IFREG as isize,
 
     /// `S_IFDIR`
-    Directory,
+    Directory = linux_raw_sys::general::S_IFDIR as isize,
 
     /// `S_IFLNK`
-    Symlink,
+    Symlink = linux_raw_sys::general::S_IFLNK as isize,
 
     /// `S_IFIFO`
-    Fifo,
+    Fifo = linux_raw_sys::general::S_IFIFO as isize,
 
     /// `S_IFSOCK`
-    Socket,
+    Socket = linux_raw_sys::general::S_IFSOCK as isize,
 
     /// `S_IFCHR`
-    CharacterDevice,
+    CharacterDevice = linux_raw_sys::general::S_IFCHR as isize,
 
     /// `S_IFBLK`
-    BlockDevice,
+    BlockDevice = linux_raw_sys::general::S_IFBLK as isize,
 
     /// An unknown filesystem object.
     Unknown,
 }
 
 impl FileType {
-    /// Construct a `FileType` from the `st_mode` field of a `Stat`.
+    /// Construct a `FileType` from the `S_IFMT` bits of the `st_mode` field of
+    /// a `Stat`.
     #[inline]
     pub const fn from_raw_mode(st_mode: RawMode) -> Self {
         match st_mode & linux_raw_sys::general::S_IFMT {
@@ -301,10 +298,19 @@ impl FileType {
         }
     }
 
-    /// Construct a `FileType` from the `st_mode` field of a `Stat`.
+    /// Construct an `st_mode` value from `Stat`.
     #[inline]
-    pub const fn from_mode(st_mode: Mode) -> Self {
-        Self::from_raw_mode(st_mode.bits())
+    pub const fn as_raw_mode(self) -> RawMode {
+        match self {
+            Self::RegularFile => linux_raw_sys::general::S_IFREG,
+            Self::Directory => linux_raw_sys::general::S_IFDIR,
+            Self::Symlink => linux_raw_sys::general::S_IFLNK,
+            Self::Fifo => linux_raw_sys::general::S_IFIFO,
+            Self::Socket => linux_raw_sys::general::S_IFSOCK,
+            Self::CharacterDevice => linux_raw_sys::general::S_IFCHR,
+            Self::BlockDevice => linux_raw_sys::general::S_IFBLK,
+            Self::Unknown => linux_raw_sys::general::S_IFMT,
+        }
     }
 
     /// Construct a `FileType` from the `d_type` field of a `dirent`.

--- a/src/io/procfs.rs
+++ b/src/io/procfs.rs
@@ -7,7 +7,7 @@
 //! on top of the paths we open.
 
 use crate::fs::{
-    cwd, fstat, fstatfs, major, openat, renameat, Mode, OFlags, Stat, PROC_SUPER_MAGIC,
+    cwd, fstat, fstatfs, major, openat, renameat, FileType, Mode, OFlags, Stat, PROC_SUPER_MAGIC,
 };
 use crate::imp::fd::{AsFd, BorrowedFd};
 use crate::io::{self, OwnedFd};
@@ -93,7 +93,7 @@ fn check_proc_entry_with_stat(
 fn check_proc_root(entry: BorrowedFd<'_>, stat: &Stat) -> io::Result<()> {
     // We use `O_DIRECTORY` for proc directories, so open should fail if we
     // don't get a directory when we expect one.
-    assert_eq!(stat.st_mode & Mode::IFMT.bits(), Mode::IFDIR.bits());
+    assert_eq!(FileType::from_raw_mode(stat.st_mode), FileType::Directory);
 
     // Check the root inode number.
     if stat.st_ino != PROC_ROOT_INO {
@@ -121,7 +121,7 @@ fn check_proc_subdir(
 ) -> io::Result<()> {
     // We use `O_DIRECTORY` for proc directories, so open should fail if we
     // don't get a directory when we expect one.
-    assert_eq!(stat.st_mode & Mode::IFMT.bits(), Mode::IFDIR.bits());
+    assert_eq!(FileType::from_raw_mode(stat.st_mode), FileType::Directory);
 
     check_proc_nonroot(stat, proc_stat)?;
 

--- a/tests/fs/invalid_offset.rs
+++ b/tests/fs/invalid_offset.rs
@@ -18,7 +18,7 @@ fn invalid_offset_seek() {
         &dir,
         "foo",
         OFlags::WRONLY | OFlags::TRUNC | OFlags::CREATE,
-        Mode::IRUSR | Mode::IWUSR,
+        Mode::RUSR | Mode::WUSR,
     )
     .unwrap();
 
@@ -45,7 +45,7 @@ fn invalid_offset_fallocate() {
         &dir,
         "foo",
         OFlags::WRONLY | OFlags::TRUNC | OFlags::CREATE,
-        Mode::IRUSR | Mode::IWUSR,
+        Mode::RUSR | Mode::WUSR,
     )
     .unwrap();
 
@@ -70,7 +70,7 @@ fn invalid_offset_fadvise() {
         &dir,
         "foo",
         OFlags::WRONLY | OFlags::TRUNC | OFlags::CREATE,
-        Mode::IRUSR | Mode::IWUSR,
+        Mode::RUSR | Mode::WUSR,
     )
     .unwrap();
 
@@ -102,7 +102,7 @@ fn invalid_offset_pread() {
         &dir,
         "foo",
         OFlags::RDWR | OFlags::TRUNC | OFlags::CREATE,
-        Mode::IRUSR | Mode::IWUSR,
+        Mode::RUSR | Mode::WUSR,
     )
     .unwrap();
 
@@ -122,7 +122,7 @@ fn invalid_offset_pwrite() {
         &dir,
         "foo",
         OFlags::WRONLY | OFlags::TRUNC | OFlags::CREATE,
-        Mode::IRUSR | Mode::IWUSR,
+        Mode::RUSR | Mode::WUSR,
     )
     .unwrap();
 
@@ -142,14 +142,14 @@ fn invalid_offset_copy_file_range() {
         &dir,
         "foo",
         OFlags::RDWR | OFlags::TRUNC | OFlags::CREATE,
-        Mode::IRUSR | Mode::IWUSR,
+        Mode::RUSR | Mode::WUSR,
     )
     .unwrap();
     let bar = openat(
         &dir,
         "bar",
         OFlags::WRONLY | OFlags::TRUNC | OFlags::CREATE,
-        Mode::IRUSR | Mode::IWUSR,
+        Mode::RUSR | Mode::WUSR,
     )
     .unwrap();
     write(&foo, b"a").unwrap();

--- a/tests/fs/long_paths.rs
+++ b/tests/fs/long_paths.rs
@@ -11,7 +11,7 @@ fn test_long_paths() {
     #[cfg(linux_raw)]
     const PATH_MAX: usize = linux_raw_sys::general::PATH_MAX as usize;
 
-    mkdirat(&dir, "a", Mode::IRUSR | Mode::IXUSR | Mode::IWUSR).unwrap();
+    mkdirat(&dir, "a", Mode::RUSR | Mode::XUSR | Mode::WUSR).unwrap();
 
     let mut long_path = String::new();
     for _ in 0..PATH_MAX / 5 {

--- a/tests/fs/mkdirat.rs
+++ b/tests/fs/mkdirat.rs
@@ -6,7 +6,7 @@ fn test_mkdirat() {
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
 
-    mkdirat(&dir, "foo", Mode::IRWXU).unwrap();
+    mkdirat(&dir, "foo", Mode::RWXU).unwrap();
     let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();
     assert_eq!(FileType::from_raw_mode(stat.st_mode), FileType::Directory);
     unlinkat(&dir, "foo", AtFlags::REMOVEDIR).unwrap();
@@ -26,7 +26,7 @@ fn test_mkdirat_with_o_path() {
     )
     .unwrap();
 
-    mkdirat(&dir, "foo", Mode::IRWXU).unwrap();
+    mkdirat(&dir, "foo", Mode::RWXU).unwrap();
     let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();
     assert_eq!(FileType::from_raw_mode(stat.st_mode), FileType::Directory);
     unlinkat(&dir, "foo", AtFlags::REMOVEDIR).unwrap();

--- a/tests/fs/mknodat.rs
+++ b/tests/fs/mknodat.rs
@@ -14,13 +14,13 @@ fn test_mknodat() {
     // Create a regular file. Not supported on FreeBSD or OpenBSD.
     #[cfg(not(any(target_os = "freebsd", target_os = "openbsd")))]
     {
-        mknodat(&dir, "foo", Mode::IFREG, 0).unwrap();
+        mknodat(&dir, "foo", FileType::RegularFile, Mode::empty(), 0).unwrap();
         let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();
         assert_eq!(FileType::from_raw_mode(stat.st_mode), FileType::RegularFile);
         unlinkat(&dir, "foo", AtFlags::empty()).unwrap();
     }
 
-    mknodat(&dir, "foo", Mode::IFIFO, 0).unwrap();
+    mknodat(&dir, "foo", FileType::Fifo, Mode::empty(), 0).unwrap();
     let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();
     assert_eq!(FileType::from_raw_mode(stat.st_mode), FileType::Fifo);
     unlinkat(&dir, "foo", AtFlags::empty()).unwrap();

--- a/tests/fs/openat2.rs
+++ b/tests/fs/openat2.rs
@@ -45,7 +45,7 @@ fn test_openat2() {
         &dir,
         "test.txt",
         OFlags::WRONLY | OFlags::CREATE | OFlags::TRUNC,
-        Mode::IRUSR,
+        Mode::RUSR,
         ResolveFlags::empty(),
     )
     .unwrap();
@@ -172,7 +172,7 @@ fn test_openat2() {
         ResolveFlags::IN_ROOT,
     )
     .unwrap_err();
-    mkdirat(&dir, "proc", Mode::IRUSR | Mode::IXUSR).unwrap();
+    mkdirat(&dir, "proc", Mode::RUSR | Mode::XUSR).unwrap();
     let _ = openat2_more(
         &dir,
         "/proc",

--- a/tests/io/mmap.rs
+++ b/tests/io/mmap.rs
@@ -15,7 +15,7 @@ fn test_mmap() {
         &dir,
         "foo",
         OFlags::CREATE | OFlags::WRONLY | OFlags::TRUNC,
-        Mode::IRUSR,
+        Mode::RUSR,
     )
     .unwrap();
     write(&file, &[b'a'; 8192]).unwrap();

--- a/tests/io/readwrite.rs
+++ b/tests/io/readwrite.rs
@@ -11,7 +11,7 @@ fn test_readwrite_pv() {
         &dir,
         "foo",
         OFlags::RDWR | OFlags::CREATE | OFlags::TRUNC,
-        Mode::IRUSR | Mode::IWUSR,
+        Mode::RUSR | Mode::WUSR,
     )
     .unwrap();
 
@@ -48,7 +48,7 @@ fn test_readwrite_p() {
         &dir,
         "foo",
         OFlags::RDWR | OFlags::CREATE | OFlags::TRUNC,
-        Mode::IRUSR | Mode::IWUSR,
+        Mode::RUSR | Mode::WUSR,
     )
     .unwrap();
 
@@ -72,7 +72,7 @@ fn test_readwrite_v() {
         &dir,
         "foo",
         OFlags::RDWR | OFlags::CREATE | OFlags::TRUNC,
-        Mode::IRUSR | Mode::IWUSR,
+        Mode::RUSR | Mode::WUSR,
     )
     .unwrap();
 
@@ -98,7 +98,7 @@ fn test_readwrite() {
         &dir,
         "foo",
         OFlags::RDWR | OFlags::CREATE | OFlags::TRUNC,
-        Mode::IRUSR | Mode::IWUSR,
+        Mode::RUSR | Mode::WUSR,
     )
     .unwrap();
 


### PR DESCRIPTION
This makes several changes to the `Mode` and `FileType` API, based on
experience porting code to rustix.

 - Remove the file-type `S_IF*` constants (eg. `S_IFREG`) from the `Mode`
   bitflags type. This way, `Mode` is just for permission modes, and the
   fact that Unix packs the permissions mode bits with the file type
   bits is just an implementation detail.

 - Also, remove the leading `I` from the `Mode` arm names, as `S_I` is
   the common prefix in the C API.

 - Make `mknodat` take an explicit `FileType` argument, now that the mode
   doesn't include the file type.

And add documentation advertising `Mode::from_raw_mode` and
`FileType::from_raw_mode` to users of `statat` and `fstat`.