### PR TITLE
Implement `proc_self_maps`, `proc_self_pagemap`, and `proc_self_fdinfo`.

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -85,7 +85,7 @@ pub use pipe::{pipe_with, PipeFlags};
 #[cfg(not(windows))]
 pub use poll::{poll, PollFd, PollFlags};
 #[cfg(all(feature = "procfs", any(target_os = "android", target_os = "linux")))]
-pub use procfs::proc_self_fd;
+pub use procfs::{proc_self_fd, proc_self_fdinfo_fd, proc_self_maps, proc_self_pagemap};
 #[cfg(not(windows))]
 pub use read_write::{pread, pwrite, read, readv, write, writev};
 #[cfg(not(any(windows, target_os = "redox")))]

--- a/src/io/procfs.rs
+++ b/src/io/procfs.rs
@@ -463,6 +463,10 @@ fn open_and_check_file(dir: BorrowedFd, dir_stat: &Stat, name: &ZStr) -> io::Res
     // if we can find a regular file with an inode and name that matches the
     // file we just opened. If we can't find it, there could be a file bind
     // mount on top of the file we want.
+    //
+    // TODO: With Linux 5.8 we might be able to use `statx and
+    // `STATX_ATTR_MOUNT_ROOT` to detect mountpoints directly instead of doing
+    // this scanning.
     let dir = Dir::from(dot).map_err(|_err| io::Error::NOTSUP)?;
     for entry in dir {
         let entry = entry.map_err(|_err| io::Error::NOTSUP)?;

--- a/src/io/procfs.rs
+++ b/src/io/procfs.rs
@@ -5,6 +5,16 @@
 //! This module does a considerable amount of work to determine whether `/proc`
 //! is mounted, with actual `procfs`, and without any additional mount points
 //! on top of the paths we open.
+//!
+//! Why all the effort to detect bind mount points? People are doing all kinds
+//! of things with Linux containers these days, with many different privilege
+//! schemes, and we want to avoid making any unnecessary assumptions. Rustix
+//! and its users will sometimes use procfs *implicitly* (when Linux gives them
+//! no better options), in ways that aren't obvious from their public APIs.
+//! These filesystem accesses might not be visible to someone auditing the main
+//! code of an application for places which may be influenced by the filesystem
+//! namespace. So with the checking here, they may fail, but they won't be able
+//! to succeed with bogus results.
 
 use crate::fd::{AsFd, BorrowedFd};
 use crate::ffi::ZStr;

--- a/tests/process/proc.rs
+++ b/tests/process/proc.rs
@@ -1,0 +1,5 @@
+#[test]
+fn test_proc_funcs() {
+    let _maps = rustix::io::proc_self_maps().unwrap();
+    let _pagemap = rustix::io::proc_self_pagemap().unwrap();
+}


### PR DESCRIPTION
Add support for opening files within procfs, and add public APIs for
accessing `/proc/self/maps`, `/proc/self/pagemap`, and
`proc/self/<fd>/fdinfo`.