### PR TITLE
Add several features that are used in cargo

### DIFF
--- a/src/fs/abs.rs
+++ b/src/fs/abs.rs
@@ -1,0 +1,16 @@
+//! POSIX-style filesystem functions which operate on bare paths.
+
+use crate::{imp, io, path};
+use imp::fs::StatFs;
+
+/// `statfs`—Queries filesystem metadata.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/statfs.2.html
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[inline]
+pub fn statfs<P: path::Arg>(path: P) -> io::Result<StatFs> {
+    path.into_with_z_str(|path| imp::syscalls::statfs(path))
+}

--- a/src/fs/abs.rs
+++ b/src/fs/abs.rs
@@ -1,6 +1,8 @@
 //! POSIX-style filesystem functions which operate on bare paths.
 
+#[cfg(not(any(target_os = "netbsd", target_os = "redox", target_os = "wasi")))]
 use crate::{imp, io, path};
+#[cfg(not(any(target_os = "netbsd", target_os = "redox", target_os = "wasi")))]
 use imp::fs::StatFs;
 
 /// `statfs`—Queries filesystem metadata.
@@ -9,7 +11,7 @@ use imp::fs::StatFs;
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/statfs.2.html
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(not(any(target_os = "netbsd", target_os = "redox", target_os = "wasi")))]
 #[inline]
 pub fn statfs<P: path::Arg>(path: P) -> io::Result<StatFs> {
     path.into_with_z_str(|path| imp::syscalls::statfs(path))

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -192,6 +192,14 @@ pub use imp::fs::FsWord;
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 pub const PROC_SUPER_MAGIC: FsWord = imp::fs::PROC_SUPER_MAGIC;
 
+/// The filesystem magic number for NFS.
+///
+/// See [the `fstatfs` man page] for more information.
+///
+/// [the `fstatfs` man page]: https://man7.org/linux/man-pages/man2/fstatfs.2.html#DESCRIPTION
+#[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
+pub const NFS_SUPER_MAGIC: FsWord = imp::fs::NFS_SUPER_MAGIC;
+
 #[cfg(not(target_os = "wasi"))]
 pub use imp::fs::FlockOperation;
 pub use imp::fs::{Dev, RawMode};

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -3,6 +3,7 @@
 use crate::imp;
 use imp::time::Nsecs;
 
+mod abs;
 #[cfg(not(target_os = "redox"))]
 mod at;
 mod constants;
@@ -50,6 +51,8 @@ mod sendfile;
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 mod statx;
 
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub use abs::statfs;
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 pub use at::fclonefileat;
 #[cfg(not(any(

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -51,7 +51,7 @@ mod sendfile;
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 mod statx;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(not(any(target_os = "netbsd", target_os = "redox", target_os = "wasi")))]
 pub use abs::statfs;
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 pub use at::fclonefileat;

--- a/src/imp/libc/fs/mod.rs
+++ b/src/imp/libc/fs/mod.rs
@@ -50,6 +50,6 @@ pub use types::{Access, Dev, FdFlags, FileType, Mode, OFlags, RawMode, Stat};
 #[cfg(not(target_os = "redox"))]
 pub use types::{AtFlags, UTIME_NOW, UTIME_OMIT};
 #[cfg(any(target_os = "android", target_os = "linux"))]
-pub use types::{FsWord, MemfdFlags, RenameFlags, ResolveFlags, PROC_SUPER_MAGIC};
+pub use types::{FsWord, MemfdFlags, RenameFlags, ResolveFlags, NFS_SUPER_MAGIC, PROC_SUPER_MAGIC};
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 pub use types::{Statx, StatxFlags};

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -124,7 +124,7 @@ pub(crate) fn openat(
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "netbsd", target_os = "redox", target_os = "wasi")))]
 #[inline]
 pub(crate) fn statfs(filename: &ZStr) -> io::Result<StatFs> {
     unsafe {

--- a/src/imp/libc/fs/types.rs
+++ b/src/imp/libc/fs/types.rs
@@ -758,9 +758,20 @@ pub use c::{UTIME_NOW, UTIME_OMIT};
 ))]
 pub const PROC_SUPER_MAGIC: FsWord = c::PROC_SUPER_MAGIC as FsWord;
 
+/// `NFS_SUPER_MAGIC`—The magic number for the NFS filesystem.
+#[cfg(all(
+    any(target_os = "android", target_os = "linux"),
+    not(target_env = "musl")
+))]
+pub const NFS_SUPER_MAGIC: FsWord = c::NFS_SUPER_MAGIC as FsWord;
+
 /// `PROC_SUPER_MAGIC`—The magic number for the procfs filesystem.
 #[cfg(all(any(target_os = "android", target_os = "linux"), target_env = "musl"))]
 pub const PROC_SUPER_MAGIC: FsWord = 0x0000_9fa0;
+
+/// `NFS_SUPER_MAGIC`—The magic number for the NFS filesystem.
+#[cfg(all(any(target_os = "android", target_os = "linux"), target_env = "musl"))]
+pub const NFS_SUPER_MAGIC: FsWord = 0x0000_6969;
 
 /// `copyfile_state_t`—State for use with [`fcopyfile`].
 ///

--- a/src/imp/libc/offset.rs
+++ b/src/imp/libc/offset.rs
@@ -170,17 +170,6 @@ pub(super) use readwrite_pv::{preadv as libc_preadv, pwritev as libc_pwritev};
 #[cfg(not(any(
     windows,
     target_os = "android",
-    target_os = "linux",
-    target_os = "emscripten",
-    target_os = "l4re",
-    target_os = "netbsd",
-    target_os = "redox",
-    target_os = "wasi",
-)))]
-pub(super) use c::fstatfs as libc_fstatfs;
-#[cfg(not(any(
-    windows,
-    target_os = "android",
     target_os = "dragonfly",
     target_os = "fuchsia",
     target_os = "ios",
@@ -194,6 +183,17 @@ pub(super) use c::fstatfs as libc_fstatfs;
 pub(super) use c::posix_fallocate as libc_posix_fallocate;
 #[cfg(any(target_os = "l4re",))]
 pub(super) use c::posix_fallocate64 as libc_posix_fallocate;
+#[cfg(not(any(
+    windows,
+    target_os = "android",
+    target_os = "linux",
+    target_os = "emscripten",
+    target_os = "l4re",
+    target_os = "netbsd",
+    target_os = "redox",
+    target_os = "wasi",
+)))]
+pub(super) use {c::fstatfs as libc_fstatfs, c::statfs as libc_statfs};
 
 #[cfg(any(
     target_os = "android",
@@ -201,4 +201,4 @@ pub(super) use c::posix_fallocate64 as libc_posix_fallocate;
     target_os = "emscripten",
     target_os = "l4re",
 ))]
-pub(super) use c::fstatfs64 as libc_fstatfs;
+pub(super) use {c::fstatfs64 as libc_fstatfs, c::statfs64 as libc_statfs};

--- a/src/imp/libc/process/mod.rs
+++ b/src/imp/libc/process/mod.rs
@@ -37,5 +37,5 @@ pub(crate) use types::{raw_cpu_set_new, RawCpuSet, CPU_SETSIZE};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use types::{MembarrierCommand, RawCpuid};
 #[cfg(not(target_os = "wasi"))]
-pub use types::{RawGid, RawNonZeroPid, RawPid, RawUid, EXIT_SIGNALED_SIGABRT};
+pub use types::{RawGid, RawNonZeroPid, RawPid, RawUid, Signal, EXIT_SIGNALED_SIGABRT};
 pub use types::{EXIT_FAILURE, EXIT_SUCCESS};

--- a/src/imp/libc/process/syscalls.rs
+++ b/src/imp/libc/process/syscalls.rs
@@ -335,6 +335,7 @@ pub(crate) fn exit_group(code: c::c_int) -> ! {
     }
 }
 
+#[cfg(not(target_os = "wasi"))]
 #[inline]
 pub(crate) fn setsid() -> io::Result<Pid> {
     unsafe {
@@ -344,11 +345,13 @@ pub(crate) fn setsid() -> io::Result<Pid> {
     }
 }
 
+#[cfg(not(target_os = "wasi"))]
 #[inline]
 pub(crate) fn kill_process(pid: Pid, sig: Signal) -> io::Result<()> {
     unsafe { ret(libc::kill(pid.as_raw_nonzero().get(), sig as i32)) }
 }
 
+#[cfg(not(target_os = "wasi"))]
 #[inline]
 pub(crate) fn kill_process_group(pid: Pid, sig: Signal) -> io::Result<()> {
     unsafe {
@@ -359,6 +362,7 @@ pub(crate) fn kill_process_group(pid: Pid, sig: Signal) -> io::Result<()> {
     }
 }
 
+#[cfg(not(target_os = "wasi"))]
 #[inline]
 pub(crate) fn kill_current_process_group(sig: Signal) -> io::Result<()> {
     unsafe { ret(libc::kill(0, sig as i32)) }

--- a/src/imp/libc/process/types.rs
+++ b/src/imp/libc/process/types.rs
@@ -135,6 +135,121 @@ impl Resource {
     pub const Rss: Self = Self::As;
 }
 
+/// A signal number for use with [`kill`].
+///
+/// [`kill`]: crate::process::kill
+#[cfg(not(target_os = "wasi"))]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(i32)]
+pub enum Signal {
+    /// `SIGHUP`
+    Hup = c::SIGHUP,
+    /// `SIGINT`
+    Int = c::SIGINT,
+    /// `SIGQUIT`
+    Quit = c::SIGQUIT,
+    /// `SIGILL`
+    Ill = c::SIGILL,
+    /// `SIGTRAP`
+    Trap = c::SIGTRAP,
+    /// `SIGABRT`, aka `SIGIOT`
+    #[doc(alias = "Iot")]
+    Abrt = c::SIGABRT,
+    /// `SIGBUS`
+    Bus = c::SIGBUS,
+    /// `SIGFPE`
+    Fpe = c::SIGFPE,
+    /// `SIGKILL`
+    Kill = c::SIGKILL,
+    /// `SIGUSR1`
+    Usr1 = c::SIGUSR1,
+    /// `SIGSEGV`
+    Segv = c::SIGSEGV,
+    /// `SIGUSR2`
+    Usr2 = c::SIGUSR2,
+    /// `SIGPIPE`
+    Pipe = c::SIGPIPE,
+    /// `SIGALRM`
+    Alrm = c::SIGALRM,
+    /// `SIGTERM`
+    Term = c::SIGTERM,
+    /// `SIGSTKFLT`
+    Stkflt = c::SIGSTKFLT,
+    /// `SIGCHLD`
+    Chld = c::SIGCHLD,
+    /// `SIGCONT`
+    Cont = c::SIGCONT,
+    /// `SIGSTOP`
+    Stop = c::SIGSTOP,
+    /// `SIGTSTP`
+    Tstp = c::SIGTSTP,
+    /// `SIGTTIN`
+    Ttin = c::SIGTTIN,
+    /// `SIGTTOU`
+    Ttou = c::SIGTTOU,
+    /// `SIGURG`
+    Urg = c::SIGURG,
+    /// `SIGXCPU`
+    Xcpu = c::SIGXCPU,
+    /// `SIGXFSZ`
+    Xfsz = c::SIGXFSZ,
+    /// `SIGVTALRM`
+    Vtalrm = c::SIGVTALRM,
+    /// `SIGPROF`
+    Prof = c::SIGPROF,
+    /// `SIGWINCH`
+    Winch = c::SIGWINCH,
+    /// `SIGIO`, aka `SIGPOLL`
+    #[doc(alias = "Poll")]
+    Io = c::SIGIO,
+    /// `SIGPWR`
+    Pwr = c::SIGPWR,
+    /// `SIGSYS`, aka `SIGUNUSED`
+    #[doc(alias = "Unused")]
+    Sys = c::SIGSYS,
+}
+
+#[cfg(not(target_os = "wasi"))]
+impl Signal {
+    /// Convert a raw signal number into a `Signal`, if possible.
+    pub fn from_raw(sig: i32) -> Option<Self> {
+        match sig as _ {
+            c::SIGHUP => Some(Self::Hup),
+            c::SIGINT => Some(Self::Int),
+            c::SIGQUIT => Some(Self::Quit),
+            c::SIGILL => Some(Self::Ill),
+            c::SIGTRAP => Some(Self::Trap),
+            c::SIGABRT => Some(Self::Abrt),
+            c::SIGBUS => Some(Self::Bus),
+            c::SIGFPE => Some(Self::Fpe),
+            c::SIGKILL => Some(Self::Kill),
+            c::SIGUSR1 => Some(Self::Usr1),
+            c::SIGSEGV => Some(Self::Segv),
+            c::SIGUSR2 => Some(Self::Usr2),
+            c::SIGPIPE => Some(Self::Pipe),
+            c::SIGALRM => Some(Self::Alrm),
+            c::SIGTERM => Some(Self::Term),
+            c::SIGSTKFLT => Some(Self::Stkflt),
+            c::SIGCHLD => Some(Self::Chld),
+            c::SIGCONT => Some(Self::Cont),
+            c::SIGSTOP => Some(Self::Stop),
+            c::SIGTSTP => Some(Self::Tstp),
+            c::SIGTTIN => Some(Self::Ttin),
+            c::SIGTTOU => Some(Self::Ttou),
+            c::SIGURG => Some(Self::Urg),
+            c::SIGXCPU => Some(Self::Xcpu),
+            c::SIGXFSZ => Some(Self::Xfsz),
+            c::SIGVTALRM => Some(Self::Vtalrm),
+            c::SIGPROF => Some(Self::Prof),
+            c::SIGWINCH => Some(Self::Winch),
+            c::SIGIO => Some(Self::Io),
+            c::SIGPWR => Some(Self::Pwr),
+            c::SIGSYS => Some(Self::Sys),
+            _ => None,
+        }
+    }
+}
+
 pub const EXIT_SUCCESS: c::c_int = c::EXIT_SUCCESS;
 pub const EXIT_FAILURE: c::c_int = c::EXIT_FAILURE;
 #[cfg(not(target_os = "wasi"))]

--- a/src/imp/libc/process/types.rs
+++ b/src/imp/libc/process/types.rs
@@ -154,7 +154,8 @@ pub enum Signal {
     Trap = c::SIGTRAP,
     /// `SIGABRT`, aka `SIGIOT`
     #[doc(alias = "Iot")]
-    Abrt = c::SIGABRT,
+    #[doc(alias = "Abrt")]
+    Abort = c::SIGABRT,
     /// `SIGBUS`
     Bus = c::SIGBUS,
     /// `SIGFPE`
@@ -170,7 +171,8 @@ pub enum Signal {
     /// `SIGPIPE`
     Pipe = c::SIGPIPE,
     /// `SIGALRM`
-    Alrm = c::SIGALRM,
+    #[doc(alias = "Alrm")]
+    Alarm = c::SIGALRM,
     /// `SIGTERM`
     Term = c::SIGTERM,
     /// `SIGSTKFLT`
@@ -183,7 +185,8 @@ pub enum Signal {
     )))]
     Stkflt = c::SIGSTKFLT,
     /// `SIGCHLD`
-    Chld = c::SIGCHLD,
+    #[doc(alias = "Chld")]
+    Child = c::SIGCHLD,
     /// `SIGCONT`
     Cont = c::SIGCONT,
     /// `SIGSTOP`
@@ -201,7 +204,8 @@ pub enum Signal {
     /// `SIGXFSZ`
     Xfsz = c::SIGXFSZ,
     /// `SIGVTALRM`
-    Vtalrm = c::SIGVTALRM,
+    #[doc(alias = "Vtalrm")]
+    Vtalarm = c::SIGVTALRM,
     /// `SIGPROF`
     Prof = c::SIGPROF,
     /// `SIGWINCH`
@@ -217,7 +221,8 @@ pub enum Signal {
         target_os = "netbsd",
         target_os = "openbsd"
     )))]
-    Pwr = c::SIGPWR,
+    #[doc(alias = "Pwr")]
+    Power = c::SIGPWR,
     /// `SIGSYS`, aka `SIGUNUSED`
     #[doc(alias = "Unused")]
     Sys = c::SIGSYS,
@@ -233,7 +238,7 @@ impl Signal {
             c::SIGQUIT => Some(Self::Quit),
             c::SIGILL => Some(Self::Ill),
             c::SIGTRAP => Some(Self::Trap),
-            c::SIGABRT => Some(Self::Abrt),
+            c::SIGABRT => Some(Self::Abort),
             c::SIGBUS => Some(Self::Bus),
             c::SIGFPE => Some(Self::Fpe),
             c::SIGKILL => Some(Self::Kill),
@@ -241,7 +246,7 @@ impl Signal {
             c::SIGSEGV => Some(Self::Segv),
             c::SIGUSR2 => Some(Self::Usr2),
             c::SIGPIPE => Some(Self::Pipe),
-            c::SIGALRM => Some(Self::Alrm),
+            c::SIGALRM => Some(Self::Alarm),
             c::SIGTERM => Some(Self::Term),
             #[cfg(not(any(
                 target_os = "freebsd",
@@ -251,7 +256,7 @@ impl Signal {
                 target_os = "openbsd",
             )))]
             c::SIGSTKFLT => Some(Self::Stkflt),
-            c::SIGCHLD => Some(Self::Chld),
+            c::SIGCHLD => Some(Self::Child),
             c::SIGCONT => Some(Self::Cont),
             c::SIGSTOP => Some(Self::Stop),
             c::SIGTSTP => Some(Self::Tstp),
@@ -260,7 +265,7 @@ impl Signal {
             c::SIGURG => Some(Self::Urg),
             c::SIGXCPU => Some(Self::Xcpu),
             c::SIGXFSZ => Some(Self::Xfsz),
-            c::SIGVTALRM => Some(Self::Vtalrm),
+            c::SIGVTALRM => Some(Self::Vtalarm),
             c::SIGPROF => Some(Self::Prof),
             c::SIGWINCH => Some(Self::Winch),
             c::SIGIO => Some(Self::Io),
@@ -271,7 +276,7 @@ impl Signal {
                 target_os = "netbsd",
                 target_os = "openbsd",
             )))]
-            c::SIGPWR => Some(Self::Pwr),
+            c::SIGPWR => Some(Self::Power),
             c::SIGSYS => Some(Self::Sys),
             _ => None,
         }

--- a/src/imp/libc/process/types.rs
+++ b/src/imp/libc/process/types.rs
@@ -178,7 +178,8 @@ pub enum Signal {
         target_os = "freebsd",
         target_os = "ios",
         target_os = "macos",
-        target_os = "netbsd"
+        target_os = "netbsd",
+        target_os = "openbsd",
     )))]
     Stkflt = c::SIGSTKFLT,
     /// `SIGCHLD`
@@ -213,7 +214,8 @@ pub enum Signal {
         target_os = "freebsd",
         target_os = "ios",
         target_os = "macos",
-        target_os = "netbsd"
+        target_os = "netbsd",
+        target_os = "openbsd"
     )))]
     Pwr = c::SIGPWR,
     /// `SIGSYS`, aka `SIGUNUSED`
@@ -245,7 +247,8 @@ impl Signal {
                 target_os = "freebsd",
                 target_os = "ios",
                 target_os = "macos",
-                target_os = "netbsd"
+                target_os = "netbsd",
+                target_os = "openbsd",
             )))]
             c::SIGSTKFLT => Some(Self::Stkflt),
             c::SIGCHLD => Some(Self::Chld),
@@ -265,7 +268,8 @@ impl Signal {
                 target_os = "freebsd",
                 target_os = "ios",
                 target_os = "macos",
-                target_os = "netbsd"
+                target_os = "netbsd",
+                target_os = "openbsd",
             )))]
             c::SIGPWR => Some(Self::Pwr),
             c::SIGSYS => Some(Self::Sys),

--- a/src/imp/libc/process/types.rs
+++ b/src/imp/libc/process/types.rs
@@ -174,6 +174,12 @@ pub enum Signal {
     /// `SIGTERM`
     Term = c::SIGTERM,
     /// `SIGSTKFLT`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd"
+    )))]
     Stkflt = c::SIGSTKFLT,
     /// `SIGCHLD`
     Chld = c::SIGCHLD,
@@ -203,6 +209,12 @@ pub enum Signal {
     #[doc(alias = "Poll")]
     Io = c::SIGIO,
     /// `SIGPWR`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd"
+    )))]
     Pwr = c::SIGPWR,
     /// `SIGSYS`, aka `SIGUNUSED`
     #[doc(alias = "Unused")]
@@ -229,6 +241,12 @@ impl Signal {
             c::SIGPIPE => Some(Self::Pipe),
             c::SIGALRM => Some(Self::Alrm),
             c::SIGTERM => Some(Self::Term),
+            #[cfg(not(any(
+                target_os = "freebsd",
+                target_os = "ios",
+                target_os = "macos",
+                target_os = "netbsd"
+            )))]
             c::SIGSTKFLT => Some(Self::Stkflt),
             c::SIGCHLD => Some(Self::Chld),
             c::SIGCONT => Some(Self::Cont),
@@ -243,6 +261,12 @@ impl Signal {
             c::SIGPROF => Some(Self::Prof),
             c::SIGWINCH => Some(Self::Winch),
             c::SIGIO => Some(Self::Io),
+            #[cfg(not(any(
+                target_os = "freebsd",
+                target_os = "ios",
+                target_os = "macos",
+                target_os = "netbsd"
+            )))]
             c::SIGPWR => Some(Self::Pwr),
             c::SIGSYS => Some(Self::Sys),
             _ => None,

--- a/src/imp/linux_raw/fs/mod.rs
+++ b/src/imp/linux_raw/fs/mod.rs
@@ -9,5 +9,5 @@ pub use makedev::{major, makedev, minor};
 pub use types::{
     Access, Advice, AtFlags, Dev, FallocateFlags, FdFlags, FileType, FlockOperation, FsWord,
     MemfdFlags, Mode, OFlags, RawMode, RenameFlags, ResolveFlags, Stat, StatFs, Statx, StatxFlags,
-    PROC_SUPER_MAGIC, UTIME_NOW, UTIME_OMIT,
+    NFS_SUPER_MAGIC, PROC_SUPER_MAGIC, UTIME_NOW, UTIME_OMIT,
 };

--- a/src/imp/linux_raw/fs/types.rs
+++ b/src/imp/linux_raw/fs/types.rs
@@ -521,3 +521,6 @@ pub use linux_raw_sys::general::{UTIME_NOW, UTIME_OMIT};
 
 /// `PROC_SUPER_MAGIC`—The magic number for the procfs filesystem.
 pub const PROC_SUPER_MAGIC: FsWord = linux_raw_sys::general::PROC_SUPER_MAGIC as FsWord;
+
+/// `NFS_SUPER_MAGIC`—The magic number for the NFS filesystem.
+pub const NFS_SUPER_MAGIC: FsWord = linux_raw_sys::general::NFS_SUPER_MAGIC as FsWord;

--- a/src/imp/linux_raw/io/poll_fd.rs
+++ b/src/imp/linux_raw/io/poll_fd.rs
@@ -50,6 +50,12 @@ impl<'fd> PollFd<'fd> {
         Self::from_borrowed_fd(fd.as_fd(), events)
     }
 
+    /// Sets the contained file descriptor to `fd`.
+    #[inline]
+    pub fn set_fd<Fd: AsFd>(&mut self, fd: &'fd Fd) {
+        self.fd = fd.as_fd();
+    }
+
     /// Constructs a new `PollFd` holding `fd` and `events`.
     ///
     /// This is the same as `new`, but can be used to avoid borrowing the

--- a/src/imp/linux_raw/process/mod.rs
+++ b/src/imp/linux_raw/process/mod.rs
@@ -11,8 +11,8 @@ pub(crate) use auxv::{exe_phdrs, linux_execfn, linux_hwcap, page_size};
 pub(super) use auxv::{exe_phdrs_slice, sysinfo_ehdr};
 pub(crate) use types::{raw_cpu_set_new, RawCpuSet, RawUname, CPU_SETSIZE};
 pub use types::{
-    MembarrierCommand, RawCpuid, RawGid, RawNonZeroPid, RawPid, RawUid, Resource, EXIT_FAILURE,
-    EXIT_SIGNALED_SIGABRT, EXIT_SUCCESS,
+    MembarrierCommand, RawCpuid, RawGid, RawNonZeroPid, RawPid, RawUid, Resource, Signal,
+    EXIT_FAILURE, EXIT_SIGNALED_SIGABRT, EXIT_SUCCESS,
 };
 pub(crate) use wait::{
     WCONTINUED, WEXITSTATUS, WIFCONTINUED, WIFEXITED, WIFSIGNALED, WIFSTOPPED, WNOHANG, WSTOPSIG,

--- a/src/imp/linux_raw/process/types.rs
+++ b/src/imp/linux_raw/process/types.rs
@@ -93,7 +93,8 @@ pub enum Signal {
     Trap = linux_raw_sys::general::SIGTRAP,
     /// `SIGABRT`, aka `SIGIOT`
     #[doc(alias = "Iot")]
-    Abrt = linux_raw_sys::general::SIGABRT,
+    #[doc(alias = "Abrt")]
+    Abort = linux_raw_sys::general::SIGABRT,
     /// `SIGBUS`
     Bus = linux_raw_sys::general::SIGBUS,
     /// `SIGFPE`
@@ -109,13 +110,15 @@ pub enum Signal {
     /// `SIGPIPE`
     Pipe = linux_raw_sys::general::SIGPIPE,
     /// `SIGALRM`
-    Alrm = linux_raw_sys::general::SIGALRM,
+    #[doc(alias = "Alrm")]
+    Alarm = linux_raw_sys::general::SIGALRM,
     /// `SIGTERM`
     Term = linux_raw_sys::general::SIGTERM,
     /// `SIGSTKFLT`
     Stkflt = linux_raw_sys::general::SIGSTKFLT,
     /// `SIGCHLD`
-    Chld = linux_raw_sys::general::SIGCHLD,
+    #[doc(alias = "Chld")]
+    Child = linux_raw_sys::general::SIGCHLD,
     /// `SIGCONT`
     Cont = linux_raw_sys::general::SIGCONT,
     /// `SIGSTOP`
@@ -133,7 +136,8 @@ pub enum Signal {
     /// `SIGXFSZ`
     Xfsz = linux_raw_sys::general::SIGXFSZ,
     /// `SIGVTALRM`
-    Vtalrm = linux_raw_sys::general::SIGVTALRM,
+    #[doc(alias = "Vtalrm")]
+    Vtalarm = linux_raw_sys::general::SIGVTALRM,
     /// `SIGPROF`
     Prof = linux_raw_sys::general::SIGPROF,
     /// `SIGWINCH`
@@ -142,7 +146,8 @@ pub enum Signal {
     #[doc(alias = "Poll")]
     Io = linux_raw_sys::general::SIGIO,
     /// `SIGPWR`
-    Pwr = linux_raw_sys::general::SIGPWR,
+    #[doc(alias = "Pwr")]
+    Power = linux_raw_sys::general::SIGPWR,
     /// `SIGSYS`, aka `SIGUNUSED`
     #[doc(alias = "Unused")]
     Sys = linux_raw_sys::general::SIGSYS,
@@ -159,7 +164,7 @@ impl Signal {
             linux_raw_sys::general::SIGQUIT => Some(Self::Quit),
             linux_raw_sys::general::SIGILL => Some(Self::Ill),
             linux_raw_sys::general::SIGTRAP => Some(Self::Trap),
-            linux_raw_sys::general::SIGABRT => Some(Self::Abrt),
+            linux_raw_sys::general::SIGABRT => Some(Self::Abort),
             linux_raw_sys::general::SIGBUS => Some(Self::Bus),
             linux_raw_sys::general::SIGFPE => Some(Self::Fpe),
             linux_raw_sys::general::SIGKILL => Some(Self::Kill),
@@ -167,10 +172,10 @@ impl Signal {
             linux_raw_sys::general::SIGSEGV => Some(Self::Segv),
             linux_raw_sys::general::SIGUSR2 => Some(Self::Usr2),
             linux_raw_sys::general::SIGPIPE => Some(Self::Pipe),
-            linux_raw_sys::general::SIGALRM => Some(Self::Alrm),
+            linux_raw_sys::general::SIGALRM => Some(Self::Alarm),
             linux_raw_sys::general::SIGTERM => Some(Self::Term),
             linux_raw_sys::general::SIGSTKFLT => Some(Self::Stkflt),
-            linux_raw_sys::general::SIGCHLD => Some(Self::Chld),
+            linux_raw_sys::general::SIGCHLD => Some(Self::Child),
             linux_raw_sys::general::SIGCONT => Some(Self::Cont),
             linux_raw_sys::general::SIGSTOP => Some(Self::Stop),
             linux_raw_sys::general::SIGTSTP => Some(Self::Tstp),
@@ -179,11 +184,11 @@ impl Signal {
             linux_raw_sys::general::SIGURG => Some(Self::Urg),
             linux_raw_sys::general::SIGXCPU => Some(Self::Xcpu),
             linux_raw_sys::general::SIGXFSZ => Some(Self::Xfsz),
-            linux_raw_sys::general::SIGVTALRM => Some(Self::Vtalrm),
+            linux_raw_sys::general::SIGVTALRM => Some(Self::Vtalarm),
             linux_raw_sys::general::SIGPROF => Some(Self::Prof),
             linux_raw_sys::general::SIGWINCH => Some(Self::Winch),
             linux_raw_sys::general::SIGIO => Some(Self::Io),
-            linux_raw_sys::general::SIGPWR => Some(Self::Pwr),
+            linux_raw_sys::general::SIGPWR => Some(Self::Power),
             linux_raw_sys::general::SIGSYS => Some(Self::Sys),
             linux_raw_sys::general::SIGRTMIN => Some(Self::Rtmin),
             _ => None,

--- a/src/imp/linux_raw/process/types.rs
+++ b/src/imp/linux_raw/process/types.rs
@@ -74,6 +74,123 @@ pub enum Resource {
     Rttime = linux_raw_sys::general::RLIMIT_RTTIME,
 }
 
+/// A signal number for use with [`kill_process`] and [`kill_process_group`].
+///
+/// [`kill_process`]: crate::process::kill_process
+/// [`kill_process_group`]: crate::process::kill_process_group
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum Signal {
+    /// `SIGHUP`
+    Hup = linux_raw_sys::general::SIGHUP,
+    /// `SIGINT`
+    Int = linux_raw_sys::general::SIGINT,
+    /// `SIGQUIT`
+    Quit = linux_raw_sys::general::SIGQUIT,
+    /// `SIGILL`
+    Ill = linux_raw_sys::general::SIGILL,
+    /// `SIGTRAP`
+    Trap = linux_raw_sys::general::SIGTRAP,
+    /// `SIGABRT`, aka `SIGIOT`
+    #[doc(alias = "Iot")]
+    Abrt = linux_raw_sys::general::SIGABRT,
+    /// `SIGBUS`
+    Bus = linux_raw_sys::general::SIGBUS,
+    /// `SIGFPE`
+    Fpe = linux_raw_sys::general::SIGFPE,
+    /// `SIGKILL`
+    Kill = linux_raw_sys::general::SIGKILL,
+    /// `SIGUSR1`
+    Usr1 = linux_raw_sys::general::SIGUSR1,
+    /// `SIGSEGV`
+    Segv = linux_raw_sys::general::SIGSEGV,
+    /// `SIGUSR2`
+    Usr2 = linux_raw_sys::general::SIGUSR2,
+    /// `SIGPIPE`
+    Pipe = linux_raw_sys::general::SIGPIPE,
+    /// `SIGALRM`
+    Alrm = linux_raw_sys::general::SIGALRM,
+    /// `SIGTERM`
+    Term = linux_raw_sys::general::SIGTERM,
+    /// `SIGSTKFLT`
+    Stkflt = linux_raw_sys::general::SIGSTKFLT,
+    /// `SIGCHLD`
+    Chld = linux_raw_sys::general::SIGCHLD,
+    /// `SIGCONT`
+    Cont = linux_raw_sys::general::SIGCONT,
+    /// `SIGSTOP`
+    Stop = linux_raw_sys::general::SIGSTOP,
+    /// `SIGTSTP`
+    Tstp = linux_raw_sys::general::SIGTSTP,
+    /// `SIGTTIN`
+    Ttin = linux_raw_sys::general::SIGTTIN,
+    /// `SIGTTOU`
+    Ttou = linux_raw_sys::general::SIGTTOU,
+    /// `SIGURG`
+    Urg = linux_raw_sys::general::SIGURG,
+    /// `SIGXCPU`
+    Xcpu = linux_raw_sys::general::SIGXCPU,
+    /// `SIGXFSZ`
+    Xfsz = linux_raw_sys::general::SIGXFSZ,
+    /// `SIGVTALRM`
+    Vtalrm = linux_raw_sys::general::SIGVTALRM,
+    /// `SIGPROF`
+    Prof = linux_raw_sys::general::SIGPROF,
+    /// `SIGWINCH`
+    Winch = linux_raw_sys::general::SIGWINCH,
+    /// `SIGIO`, aka `SIGPOLL`
+    #[doc(alias = "Poll")]
+    Io = linux_raw_sys::general::SIGIO,
+    /// `SIGPWR`
+    Pwr = linux_raw_sys::general::SIGPWR,
+    /// `SIGSYS`, aka `SIGUNUSED`
+    #[doc(alias = "Unused")]
+    Sys = linux_raw_sys::general::SIGSYS,
+    /// `SIGRTMIN`
+    Rtmin = linux_raw_sys::general::SIGRTMIN,
+}
+
+impl Signal {
+    /// Convert a raw signal number into a `Signal`, if possible.
+    pub fn from_raw(sig: i32) -> Option<Self> {
+        match sig as _ {
+            linux_raw_sys::general::SIGHUP => Some(Self::Hup),
+            linux_raw_sys::general::SIGINT => Some(Self::Int),
+            linux_raw_sys::general::SIGQUIT => Some(Self::Quit),
+            linux_raw_sys::general::SIGILL => Some(Self::Ill),
+            linux_raw_sys::general::SIGTRAP => Some(Self::Trap),
+            linux_raw_sys::general::SIGABRT => Some(Self::Abrt),
+            linux_raw_sys::general::SIGBUS => Some(Self::Bus),
+            linux_raw_sys::general::SIGFPE => Some(Self::Fpe),
+            linux_raw_sys::general::SIGKILL => Some(Self::Kill),
+            linux_raw_sys::general::SIGUSR1 => Some(Self::Usr1),
+            linux_raw_sys::general::SIGSEGV => Some(Self::Segv),
+            linux_raw_sys::general::SIGUSR2 => Some(Self::Usr2),
+            linux_raw_sys::general::SIGPIPE => Some(Self::Pipe),
+            linux_raw_sys::general::SIGALRM => Some(Self::Alrm),
+            linux_raw_sys::general::SIGTERM => Some(Self::Term),
+            linux_raw_sys::general::SIGSTKFLT => Some(Self::Stkflt),
+            linux_raw_sys::general::SIGCHLD => Some(Self::Chld),
+            linux_raw_sys::general::SIGCONT => Some(Self::Cont),
+            linux_raw_sys::general::SIGSTOP => Some(Self::Stop),
+            linux_raw_sys::general::SIGTSTP => Some(Self::Tstp),
+            linux_raw_sys::general::SIGTTIN => Some(Self::Ttin),
+            linux_raw_sys::general::SIGTTOU => Some(Self::Ttou),
+            linux_raw_sys::general::SIGURG => Some(Self::Urg),
+            linux_raw_sys::general::SIGXCPU => Some(Self::Xcpu),
+            linux_raw_sys::general::SIGXFSZ => Some(Self::Xfsz),
+            linux_raw_sys::general::SIGVTALRM => Some(Self::Vtalrm),
+            linux_raw_sys::general::SIGPROF => Some(Self::Prof),
+            linux_raw_sys::general::SIGWINCH => Some(Self::Winch),
+            linux_raw_sys::general::SIGIO => Some(Self::Io),
+            linux_raw_sys::general::SIGPWR => Some(Self::Pwr),
+            linux_raw_sys::general::SIGSYS => Some(Self::Sys),
+            linux_raw_sys::general::SIGRTMIN => Some(Self::Rtmin),
+            _ => None,
+        }
+    }
+}
+
 /// `EXIT_SUCCESS`
 pub const EXIT_SUCCESS: c::c_int = 0;
 /// `EXIT_FAILURE`

--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -115,6 +115,19 @@ impl Pid {
         Self(raw)
     }
 
+    /// Creates a `Pid` holding the ID of the given child process.
+    #[cfg(feature = "std")]
+    #[inline]
+    pub fn from_child(child: &std::process::Child) -> Self {
+        // Safety
+        //
+        // We know the returned ID is valid because it came directly from
+        // an OS API.
+        let id = child.id();
+        debug_assert_ne!(id, 0);
+        unsafe { Self::from_raw_nonzero(RawNonZeroPid::new_unchecked(id as _)) }
+    }
+
     /// Converts a `Pid` into a `RawNonZeroPid`.
     #[inline]
     pub const fn as_raw_nonzero(self) -> RawNonZeroPid {

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -52,6 +52,7 @@ pub use id::{
     getegid, geteuid, getgid, getpid, getppid, getuid, Gid, Pid, RawGid, RawNonZeroPid, RawPid,
     RawUid, Uid,
 };
+#[cfg(not(target_os = "wasi"))]
 pub use imp::process::Signal;
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 pub use membarrier::{

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -52,6 +52,7 @@ pub use id::{
     getegid, geteuid, getgid, getpid, getppid, getuid, Gid, Pid, RawGid, RawNonZeroPid, RawPid,
     RawUid, Uid,
 };
+pub use imp::process::Signal;
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 pub use membarrier::{
     membarrier, membarrier_cpu, membarrier_query, MembarrierCommand, MembarrierQuery,
@@ -172,4 +173,68 @@ pub fn waitpid(pid: Option<Pid>, waitopts: WaitOptions) -> io::Result<Option<Wai
 #[inline]
 pub fn wait(waitopts: WaitOptions) -> io::Result<Option<(Pid, WaitStatus)>> {
     imp::syscalls::wait(waitopts)
+}
+
+/// `setsid()`—Create a new session.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/setsid.2.html
+#[cfg(not(target_os = "wasi"))]
+#[inline]
+pub fn setsid() -> io::Result<Pid> {
+    imp::syscalls::setsid()
+}
+
+/// `kill(pid, sig)`—Sends a signal to a process.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/kill.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/kill.2.html
+#[cfg(not(target_os = "wasi"))]
+#[inline]
+#[doc(alias = "kill")]
+pub fn kill_process(pid: Pid, sig: Signal) -> io::Result<()> {
+    imp::syscalls::kill_process(pid, sig)
+}
+
+/// `kill(-pid, sig)`—Sends a signal to all processes in a process group.
+///
+/// If `pid` is 1, this sends a signal to all processes the current process
+/// has permission to send signals to, except process process `1`, possibly
+/// other system-specific processes, and on some systems, the current process.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/kill.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/kill.2.html
+#[cfg(not(target_os = "wasi"))]
+#[inline]
+#[doc(alias = "kill")]
+pub fn kill_process_group(pid: Pid, sig: Signal) -> io::Result<()> {
+    imp::syscalls::kill_process_group(pid, sig)
+}
+
+/// `kill(0, sig)`—Sends a signal to all processes in the current process
+/// group.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/kill.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/kill.2.html
+#[cfg(not(target_os = "wasi"))]
+#[inline]
+#[doc(alias = "kill")]
+pub fn kill_current_process_group(sig: Signal) -> io::Result<()> {
+    imp::syscalls::kill_current_process_group(sig)
 }

--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -24,4 +24,6 @@ mod mknodat;
 mod openat2;
 mod readdir;
 mod renameat;
+#[cfg(not(any(target_os = "netbsd", target_os = "redox", target_os = "wasi")))]
+// not implemented in libc for netbsd yet
 mod statfs;

--- a/tests/fs/statfs.rs
+++ b/tests/fs/statfs.rs
@@ -1,6 +1,6 @@
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[test]
-fn test_statx() {
+fn test_statfs_abi() {
     use rustix::fs::{FsWord, StatFs, NFS_SUPER_MAGIC, PROC_SUPER_MAGIC};
 
     // Ensure these all have consistent types.
@@ -37,4 +37,11 @@ fn test_statx() {
 
     assert_eq!(PROC_SUPER_MAGIC, 0x0000_9fa0);
     assert_eq!(NFS_SUPER_MAGIC, 0x0000_6969);
+}
+
+#[test]
+fn test_statfs() {
+    let statfs = rustix::fs::statfs("Cargo.toml").unwrap();
+    assert_ne!(statfs.f_blocks, 0);
+    assert_ne!(statfs.f_files, 0);
 }

--- a/tests/fs/statfs.rs
+++ b/tests/fs/statfs.rs
@@ -1,12 +1,13 @@
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[test]
 fn test_statx() {
-    use rustix::fs::{FsWord, StatFs, PROC_SUPER_MAGIC};
+    use rustix::fs::{FsWord, StatFs, NFS_SUPER_MAGIC, PROC_SUPER_MAGIC};
 
     // Ensure these all have consistent types.
     let t: StatFs = unsafe { std::mem::zeroed() };
     let _s: FsWord = t.f_type;
     let _u: FsWord = PROC_SUPER_MAGIC;
+    let _v: FsWord = NFS_SUPER_MAGIC;
 
     // Ensure that after all the platform-specific dancing we have to do, this
     // constant comes out with the correct value.
@@ -16,6 +17,10 @@ fn test_statx() {
             i128::from(PROC_SUPER_MAGIC),
             i128::from(libc::PROC_SUPER_MAGIC)
         );
+        assert_eq!(
+            i128::from(NFS_SUPER_MAGIC),
+            i128::from(libc::NFS_SUPER_MAGIC)
+        );
     }
 
     #[cfg(linux_raw)]
@@ -24,7 +29,12 @@ fn test_statx() {
             i128::from(PROC_SUPER_MAGIC),
             i128::from(linux_raw_sys::general::PROC_SUPER_MAGIC)
         );
+        assert_eq!(
+            i128::from(NFS_SUPER_MAGIC),
+            i128::from(linux_raw_sys::general::NFS_SUPER_MAGIC)
+        );
     }
 
     assert_eq!(PROC_SUPER_MAGIC, 0x0000_9fa0);
+    assert_eq!(NFS_SUPER_MAGIC, 0x0000_6969);
 }


### PR DESCRIPTION
This adds `setsid`, `kill`, `statfs` system calls, and supporting types, constants, and utilities, which are things from libc that cargo currently uses explicitly. Cargo also uses libc transitively through std, but that's a [bigger project](https://blog.sunfishcode.online/port-std-to-rustix/).

This is based on #175.