### PR TITLE
Fix `readlinkat` syscalls to not be `readonly`.

### DIFF
--- a/src/imp/linux_raw/fs/syscalls.rs
+++ b/src/imp/linux_raw/fs/syscalls.rs
@@ -1244,7 +1244,7 @@ fn _copy_file_range(
 #[inline]
 pub(crate) fn memfd_create(name: &ZStr, flags: MemfdFlags) -> io::Result<OwnedFd> {
     unsafe {
-        ret_owned_fd(syscall2(
+        ret_owned_fd(syscall2_readonly(
             nr(__NR_memfd_create),
             c_str(name),
             c_uint(flags.bits()),

--- a/src/imp/linux_raw/fs/syscalls.rs
+++ b/src/imp/linux_raw/fs/syscalls.rs
@@ -596,7 +596,7 @@ pub(crate) fn fstatfs(fd: BorrowedFd<'_>) -> io::Result<StatFs> {
 pub(crate) fn readlink(path: &ZStr, buf: &mut [u8]) -> io::Result<usize> {
     let (buf_addr_mut, buf_len) = slice_mut(buf);
     unsafe {
-        ret_usize(syscall4_readonly(
+        ret_usize(syscall4(
             nr(__NR_readlinkat),
             c_int(AT_FDCWD),
             c_str(path),
@@ -610,7 +610,7 @@ pub(crate) fn readlink(path: &ZStr, buf: &mut [u8]) -> io::Result<usize> {
 pub(crate) fn readlinkat(dirfd: BorrowedFd<'_>, path: &ZStr, buf: &mut [u8]) -> io::Result<usize> {
     let (buf_addr_mut, buf_len) = slice_mut(buf);
     unsafe {
-        ret_usize(syscall4_readonly(
+        ret_usize(syscall4(
             nr(__NR_readlinkat),
             borrowed_fd(dirfd),
             c_str(path),

--- a/src/imp/linux_raw/process/syscalls.rs
+++ b/src/imp/linux_raw/process/syscalls.rs
@@ -198,7 +198,7 @@ pub(crate) fn sched_getaffinity(pid: Option<Pid>, cpuset: &mut RawCpuSet) -> io:
 #[inline]
 pub(crate) fn sched_setaffinity(pid: Option<Pid>, cpuset: &RawCpuSet) -> io::Result<()> {
     unsafe {
-        ret(syscall3(
+        ret(syscall3_readonly(
             nr(__NR_sched_setaffinity),
             c_uint(Pid::as_raw(pid)),
             size_of::<RawCpuSet, _>(),


### PR DESCRIPTION
The `readlinkat` syscall writes into the output buffer, so it is not
`readonly`, so use a non-`readonly` syscall wrapper for it. I believe
this bug isn't observable outside the crate, due to the restricted
ways that the actual syscall wrapper is used.

Also, mark several more syscalls that don't mutate memory as
`readonly`.