### PR TITLE
Switch from atty to is-terminal.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ libc = { version = "0.2.111", features = ["extra_traits"] }
 winapi = { version = "0.3.9", features = ["ws2ipdef", "ws2tcpip"] }
 
 [dev-dependencies]
-atty = "0.2.14"
+is-terminal = "0.0.0"
 tempfile = "3.2.0"
 libc = "0.2.106"
 serial_test = "0.5"

--- a/tests/io/isatty.rs
+++ b/tests/io/isatty.rs
@@ -1,5 +1,6 @@
 use rustix::io::isatty;
 use tempfile::{tempdir, TempDir};
+use is_terminal::IsTerminal;
 
 #[allow(unused)]
 fn tmpdir() -> TempDir {
@@ -24,8 +25,8 @@ fn stdout_stderr_terminals() {
     {
         return;
     }
-    assert_eq!(isatty(&std::io::stdout()), atty::is(atty::Stream::Stdout));
-    assert_eq!(isatty(&std::io::stderr()), atty::is(atty::Stream::Stderr));
+    assert_eq!(isatty(&std::io::stdout()), std::io::stdout().is_terminal());
+    assert_eq!(isatty(&std::io::stderr()), std::io::stderr().is_terminal());
 }
 
 #[test]

--- a/tests/io/isatty.rs
+++ b/tests/io/isatty.rs
@@ -1,6 +1,6 @@
+use is_terminal::IsTerminal;
 use rustix::io::isatty;
 use tempfile::{tempdir, TempDir};
-use is_terminal::IsTerminal;
 
 #[allow(unused)]
 fn tmpdir() -> TempDir {


### PR DESCRIPTION
The atty crate doesn't support operating on arbitrary streams, and uses
a `Stream` enum which requires it to access stdio streams implicitly.
Begin migrating to a new is-terminal crate, which has an API that takes
an `AsFilelike` argument.