### PR TITLE
tests/statfs: Don't check `f_files != 0`

### DIFF
--- a/tests/fs/statfs.rs
+++ b/tests/fs/statfs.rs
@@ -43,5 +43,5 @@ fn test_statfs_abi() {
 fn test_statfs() {
     let statfs = rustix::fs::statfs("Cargo.toml").unwrap();
     assert_ne!(statfs.f_blocks, 0);
-    assert_ne!(statfs.f_files, 0);
+    // Previously we checked f_files != 0 here, but at least btrfs doesn't set that.
 }


### PR DESCRIPTION
At least as far as I can tell, the Linux btrfs code does not
set `f_files`.  I think likely because inode allocations are fully
dynamic.

Testing the block count should be sufficient.