### PR TITLE
procfs: Don't try to validate the uid/gid of `/proc`

### DIFF
--- a/tests/io/main.rs
+++ b/tests/io/main.rs
@@ -20,6 +20,8 @@ mod isatty;
 mod mmap;
 #[cfg(not(windows))]
 mod poll;
+#[cfg(all(feature = "procfs", any(target_os = "android", target_os = "linux")))]
+mod procfs;
 #[cfg(not(windows))]
 mod prot;
 #[cfg(not(windows))]

--- a/tests/io/procfs.rs
+++ b/tests/io/procfs.rs
@@ -1,0 +1,8 @@
+use io_lifetimes::raw::AsRawFilelike;
+
+#[test]
+fn test_proc_self() {
+    // Verify that this API works at all
+    let fd = rustix::io::proc_self_fd().unwrap();
+    assert_ne!(fd.as_raw_filelike(), 0);
+}


### PR DESCRIPTION
I typically develop inside a https://github.com/containers/toolbox/
container.  In this scenario:

```
$ ls -ald /proc
dr-xr-xr-x. 526 nobody nobody 0 Jan 12 14:47 /proc
$
```

And that's expected and normal; the real root uid from outside
the user namespace is mapped to `nobody`; distinct from the uid 0
inside the userns.

Honestly, I am still somewhat skeptical of the value of all of
these checks.  We're already validating that `/proc`'s filesystem
magic is `PROC_SUPER_MAGIC` - that seems really more than sufficient.