### PR TITLE
Add ioctl_blksszget and ioctl_blkpbszget to android.

### DIFF
--- a/src/imp/libc/io/syscalls.rs
+++ b/src/imp/libc/io/syscalls.rs
@@ -323,7 +323,7 @@ pub(crate) fn eventfd(initval: u32, flags: EventfdFlags) -> io::Result<OwnedFd> 
     unsafe { syscall_ret_owned_fd(c::syscall(c::SYS_eventfd2, initval, flags.bits())) }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 pub(crate) fn ioctl_blksszget(fd: BorrowedFd) -> io::Result<u32> {
     let mut result = MaybeUninit::<c::c_uint>::uninit();
@@ -337,7 +337,7 @@ pub(crate) fn ioctl_blksszget(fd: BorrowedFd) -> io::Result<u32> {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 pub(crate) fn ioctl_blkpbszget(fd: BorrowedFd) -> io::Result<u32> {
     let mut result = MaybeUninit::<c::c_uint>::uninit();

--- a/src/imp/libc/io/syscalls.rs
+++ b/src/imp/libc/io/syscalls.rs
@@ -330,7 +330,7 @@ pub(crate) fn ioctl_blksszget(fd: BorrowedFd) -> io::Result<u32> {
     unsafe {
         ret(libc::ioctl(
             borrowed_fd(fd),
-            libc::BLKSSZGET as c::c_ulong,
+            libc::BLKSSZGET,
             result.as_mut_ptr(),
         ))?;
         Ok(result.assume_init() as u32)
@@ -344,7 +344,7 @@ pub(crate) fn ioctl_blkpbszget(fd: BorrowedFd) -> io::Result<u32> {
     unsafe {
         ret(libc::ioctl(
             borrowed_fd(fd),
-            libc::BLKPBSZGET as c::c_ulong,
+            libc::BLKPBSZGET,
             result.as_mut_ptr(),
         ))?;
         Ok(result.assume_init() as u32)

--- a/src/io/ioctl.rs
+++ b/src/io/ioctl.rs
@@ -117,7 +117,7 @@ pub fn ioctl_fionread<Fd: AsFd>(fd: &Fd) -> io::Result<u64> {
 }
 
 /// `ioctl(fd, BLKSSZGET)`—Returns the logical block size of a block device.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 #[doc(alias = "BLKSSZGET")]
 pub fn ioctl_blksszget<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
@@ -126,7 +126,7 @@ pub fn ioctl_blksszget<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
 }
 
 /// `ioctl(fd, BLKPBSZGET)`—Returns the physical block size of a block device.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 #[doc(alias = "BLKPBSZGET")]
 pub fn ioctl_blkpbszget<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -54,7 +54,7 @@ pub use ioctl::ioctl_fioclex;
 pub use ioctl::ioctl_fionbio;
 #[cfg(not(any(windows, target_os = "redox")))]
 pub use ioctl::ioctl_fionread;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 pub use ioctl::{ioctl_blkpbszget, ioctl_blksszget};
 #[cfg(not(any(windows, target_os = "wasi")))]
 pub use ioctl::{ioctl_tcgets, ioctl_tiocgwinsz};


### PR DESCRIPTION
In the previous pr (#99) I had to remove the syscalls form android because they weren't implemented in libc. Now with libc 0.2.113 they are: https://github.com/rust-lang/libc/pull/2626