### PR TITLE
Implement `setrlimit` and `prlimit`.

### DIFF
--- a/src/imp/libc/offset.rs
+++ b/src/imp/libc/offset.rs
@@ -57,7 +57,7 @@ pub(super) use c::{rlimit as libc_rlimit, RLIM_INFINITY as LIBC_RLIM_INFINITY};
     target_os = "linux",
     target_os = "wasi",
 )))]
-pub(super) use c::getrlimit as libc_getrlimit;
+pub(super) use c::{getrlimit as libc_getrlimit, setrlimit as libc_setrlimit};
 
 // TODO: Add `RLIM64_INFINITY` to upstream libc.
 #[cfg(any(
@@ -74,7 +74,12 @@ pub(super) const LIBC_RLIM_INFINITY: u64 = !0u64;
     target_os = "emscripten",
     target_os = "l4re",
 ))]
-pub(super) use c::{getrlimit64 as libc_getrlimit, mmap64 as libc_mmap};
+pub(super) use c::{
+    getrlimit64 as libc_getrlimit, mmap64 as libc_mmap, setrlimit64 as libc_setrlimit,
+};
+
+#[cfg(any(target_os = "android", target_os = "linux",))]
+pub(super) use c::prlimit64 as libc_prlimit;
 
 #[cfg(not(any(
     windows,

--- a/src/imp/libc/process/syscalls.rs
+++ b/src/imp/libc/process/syscalls.rs
@@ -295,16 +295,14 @@ pub(crate) fn getrlimit(limit: Resource) -> Rlimit {
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 #[inline]
 pub(crate) fn setrlimit(limit: Resource, new: Rlimit) -> io::Result<()> {
-    let rlim_cur: libc::rlim_t = match new.current {
+    let rlim_cur = match new.current {
         Some(r) => r.try_into().map_err(|_| io::Error::INVAL)?,
-        None => None,
-    }
-    .unwrap_or(LIBC_RLIM_INFINITY as _);
-    let rlim_max: libc::rlim_t = match new.maximum {
+        None => LIBC_RLIM_INFINITY as _,
+    };
+    let rlim_max = match new.maximum {
         Some(r) => r.try_into().map_err(|_| io::Error::INVAL)?,
-        None => None,
-    }
-    .unwrap_or(LIBC_RLIM_INFINITY as _);
+        None => LIBC_RLIM_INFINITY as _,
+    };
     let lim = libc_rlimit { rlim_cur, rlim_max };
     unsafe { ret(libc_setrlimit(limit as _, as_ptr(&lim))) }
 }

--- a/src/imp/libc/process/syscalls.rs
+++ b/src/imp/libc/process/syscalls.rs
@@ -21,12 +21,15 @@ use core::mem::MaybeUninit;
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 use {
     super::super::conv::ret_infallible,
-    super::super::offset::libc_prlimit,
     super::super::offset::{libc_getrlimit, libc_rlimit, libc_setrlimit, LIBC_RLIM_INFINITY},
     crate::as_ptr,
-    crate::process::{Cpuid, MembarrierCommand, MembarrierQuery},
     crate::process::{Resource, Rlimit},
     core::convert::TryInto,
+};
+#[cfg(any(target_os = "android", target_os = "linux"))]
+use {
+    super::super::offset::libc_prlimit,
+    crate::process::{Cpuid, MembarrierCommand, MembarrierQuery},
 };
 #[cfg(not(target_os = "wasi"))]
 use {

--- a/src/imp/libc/process/syscalls.rs
+++ b/src/imp/libc/process/syscalls.rs
@@ -295,12 +295,12 @@ pub(crate) fn getrlimit(limit: Resource) -> Rlimit {
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 #[inline]
 pub(crate) fn setrlimit(limit: Resource, new: Rlimit) -> io::Result<()> {
-    let rlim_cur = match new.current {
+    let rlim_cur: libc::rlim_t = match new.current {
         Some(r) => r.try_into().map_err(|_| io::Error::INVAL)?,
         None => None,
     }
     .unwrap_or(LIBC_RLIM_INFINITY as _);
-    let rlim_max = match new.maximum {
+    let rlim_max: libc::rlim_t = match new.maximum {
         Some(r) => r.try_into().map_err(|_| io::Error::INVAL)?,
         None => None,
     }

--- a/src/imp/libc/process/syscalls.rs
+++ b/src/imp/libc/process/syscalls.rs
@@ -296,8 +296,8 @@ pub(crate) fn getrlimit(limit: Resource) -> Rlimit {
 #[inline]
 pub(crate) fn setrlimit(limit: Resource, new: Rlimit) -> io::Result<()> {
     let lim = libc_rlimit {
-        rlim_cur: new.current.unwrap_or(LIBC_RLIM_INFINITY),
-        rlim_max: new.maximum.unwrap_or(LIBC_RLIM_INFINITY),
+        rlim_cur: new.current.unwrap_or(LIBC_RLIM_INFINITY as _),
+        rlim_max: new.maximum.unwrap_or(LIBC_RLIM_INFINITY as _),
     };
     unsafe { ret(libc_setrlimit(limit as _, as_ptr(&lim))) }
 }

--- a/src/imp/libc/process/syscalls.rs
+++ b/src/imp/libc/process/syscalls.rs
@@ -22,7 +22,6 @@ use core::mem::MaybeUninit;
 use {
     super::super::conv::ret_infallible,
     super::super::offset::{libc_getrlimit, libc_rlimit, libc_setrlimit, LIBC_RLIM_INFINITY},
-    crate::as_ptr,
     crate::process::{Resource, Rlimit},
     core::convert::TryInto,
 };
@@ -285,7 +284,7 @@ pub(crate) fn getrlimit(limit: Resource) -> Rlimit {
 #[inline]
 pub(crate) fn setrlimit(limit: Resource, new: Rlimit) -> io::Result<()> {
     let lim = rlimit_to_libc(new)?;
-    unsafe { ret(libc_setrlimit(limit as _, as_ptr(&lim))) }
+    unsafe { ret(libc_setrlimit(limit as _, &lim)) }
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -297,7 +296,7 @@ pub(crate) fn prlimit(pid: Option<Pid>, limit: Resource, new: Rlimit) -> io::Res
         ret_infallible(libc_prlimit(
             Pid::as_raw(pid),
             limit as _,
-            as_ptr(&lim),
+            &lim,
             result.as_mut_ptr(),
         ));
         Ok(rlimit_from_libc(result.assume_init()))

--- a/src/imp/libc/process/syscalls.rs
+++ b/src/imp/libc/process/syscalls.rs
@@ -309,12 +309,12 @@ fn rlimit_from_libc(lim: libc_rlimit) -> Rlimit {
     let current = if lim.rlim_cur == LIBC_RLIM_INFINITY {
         None
     } else {
-        lim.rlim_cur.try_into().unwrap()
+        Some(lim.rlim_cur.try_into().unwrap())
     };
     let maximum = if lim.rlim_max == LIBC_RLIM_INFINITY {
         None
     } else {
-        lim.rlim_max.try_into().unwrap()
+        Some(lim.rlim_max.try_into().unwrap())
     };
     Rlimit { current, maximum }
 }

--- a/src/imp/libc/process/syscalls.rs
+++ b/src/imp/libc/process/syscalls.rs
@@ -305,6 +305,7 @@ pub(crate) fn prlimit(pid: Option<Pid>, limit: Resource, new: Rlimit) -> io::Res
 }
 
 /// Convert a Rust [`Rlimit`] to a C `libc_rlimit`.
+#[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 fn rlimit_from_libc(lim: libc_rlimit) -> Rlimit {
     let current = if lim.rlim_cur == LIBC_RLIM_INFINITY {
         None
@@ -320,6 +321,7 @@ fn rlimit_from_libc(lim: libc_rlimit) -> Rlimit {
 }
 
 /// Convert a C `libc_rlimit` to a Rust `Rlimit`.
+#[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 fn rlimit_to_libc(lim: Rlimit) -> io::Result<libc_rlimit> {
     let rlim_cur = match lim.current {
         Some(r) => r.try_into().map_err(|_| io::Error::INVAL)?,

--- a/src/imp/libc/process/types.rs
+++ b/src/imp/libc/process/types.rs
@@ -35,9 +35,12 @@ pub enum MembarrierCommand {
     RegisterPrivateExpeditedRseq = 256,
 }
 
-/// A resource value for use with [`getrlimit`].
+/// A resource value for use with [`getrlimit`], [`setrlimit`], and
+/// [`prlimit`].
 ///
 /// [`getrlimit`]: crate::process::getrlimit
+/// [`setrlimit`]: crate::process::setrlimit
+/// [`prlimit`]: crate::process::prlimit
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(i32)]

--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -22,6 +22,7 @@ use super::reg::{raw_arg, ArgNumber, ArgReg, RetReg, R0};
 use super::time::ClockId;
 use crate::ffi::ZStr;
 use crate::io::{self, OwnedFd};
+use crate::process::Resource;
 use crate::{as_mut_ptr, as_ptr};
 use core::mem::{transmute, MaybeUninit};
 use core::ptr::null;
@@ -267,6 +268,11 @@ pub(super) fn oflags<'a, Num: ArgNumber>(oflags: OFlags) -> ArgReg<'a, Num> {
 #[inline]
 pub(super) fn oflags_for_open_how(oflags: OFlags) -> u64 {
     u64::from(oflags_bits(oflags))
+}
+
+#[inline]
+pub(super) fn resource<'a, Num: ArgNumber>(resource: Resource) -> ArgReg<'a, Num> {
+    c_uint(resource as c::c_uint)
 }
 
 #[inline]

--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -270,6 +270,7 @@ pub(super) fn oflags_for_open_how(oflags: OFlags) -> u64 {
     u64::from(oflags_bits(oflags))
 }
 
+/// Convert a `Resource` into a syscall argument.
 #[inline]
 pub(super) fn resource<'a, Num: ArgNumber>(resource: Resource) -> ArgReg<'a, Num> {
     c_uint(resource as c::c_uint)

--- a/src/imp/linux_raw/process/syscalls.rs
+++ b/src/imp/linux_raw/process/syscalls.rs
@@ -407,12 +407,12 @@ fn rlimit_from_linux(lim: linux_raw_sys::v5_4::general::rlimit64) -> Rlimit {
     let current = if lim.rlim_cur == linux_raw_sys::v5_4::general::RLIM64_INFINITY as _ {
         None
     } else {
-        lim.rlim_cur.try_into().unwrap()
+        Some(lim.rlim_cur.try_into().unwrap())
     };
     let maximum = if lim.rlim_max == linux_raw_sys::v5_4::general::RLIM64_INFINITY as _ {
         None
     } else {
-        lim.rlim_max.try_into().unwrap()
+        Some(lim.rlim_max.try_into().unwrap())
     };
     Rlimit { current, maximum }
 }

--- a/src/imp/linux_raw/process/syscalls.rs
+++ b/src/imp/linux_raw/process/syscalls.rs
@@ -40,7 +40,7 @@ use linux_raw_sys::v5_4::general::{__NR_membarrier, __NR_prlimit64};
 #[cfg(target_pointer_width = "32")]
 use {
     core::convert::TryInto,
-    linux_raw_sys::general::{__NR_getrlimit, __NR_prlimit, __NR_setrlimit},
+    linux_raw_sys::general::{__NR_getrlimit, __NR_setrlimit},
 };
 
 #[inline]

--- a/src/imp/linux_raw/process/syscalls.rs
+++ b/src/imp/linux_raw/process/syscalls.rs
@@ -411,14 +411,17 @@ pub(crate) fn setrlimit(limit: Resource, new: Rlimit) -> io::Result<()> {
         )) {
             Ok(()) => Ok(()),
             Err(io::Error::NOSYS) => {
-                let lim = linux_raw_sys::general::rlimit {
-                    rlim_cur: new
-                        .current
-                        .unwrap_or(linux_raw_sys::general::RLIM_INFINITY as _),
-                    rlim_max: new
-                        .maximum
-                        .unwrap_or(linux_raw_sys::general::RLIM_INFINITY as _),
-                };
+                let rlim_cur = match new.current {
+                    Some(r) => r.try_into().map_err(|_| io::Error::INVAL)?,
+                    None => None,
+                }
+                .unwrap_or(linux_raw_sys::general::RLIM_INFINITY as _);
+                let rlim_max = match new.maximum {
+                    Some(r) => r.try_into().map_err(|_| io::Error::INVAL)?,
+                    None => None,
+                }
+                .unwrap_or(linux_raw_sys::general::RLIM_INFINITY as _);
+                let lim = linux_raw_sys::general::rlimit { rlim_cur, rlim_max };
                 ret(syscall2(
                     nr(__NR_setrlimit),
                     c_uint(limit as c::c_uint),

--- a/src/imp/linux_raw/process/syscalls.rs
+++ b/src/imp/linux_raw/process/syscalls.rs
@@ -413,14 +413,12 @@ pub(crate) fn setrlimit(limit: Resource, new: Rlimit) -> io::Result<()> {
             Err(io::Error::NOSYS) => {
                 let rlim_cur = match new.current {
                     Some(r) => r.try_into().map_err(|_| io::Error::INVAL)?,
-                    None => None,
-                }
-                .unwrap_or(linux_raw_sys::general::RLIM_INFINITY as _);
+                    None => linux_raw_sys::general::RLIM_INFINITY as _,
+                };
                 let rlim_max = match new.maximum {
                     Some(r) => r.try_into().map_err(|_| io::Error::INVAL)?,
-                    None => None,
-                }
-                .unwrap_or(linux_raw_sys::general::RLIM_INFINITY as _);
+                    None => linux_raw_sys::general::RLIM_INFINITY as _,
+                };
                 let lim = linux_raw_sys::general::rlimit { rlim_cur, rlim_max };
                 ret(syscall2(
                     nr(__NR_setrlimit),

--- a/src/imp/linux_raw/process/types.rs
+++ b/src/imp/linux_raw/process/types.rs
@@ -34,9 +34,12 @@ pub enum MembarrierCommand {
         linux_raw_sys::v5_11::general::membarrier_cmd::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_RSEQ as _,
 }
 
-/// A resource value for use with [`getrlimit`].
+/// A resource value for use with [`getrlimit`], [`setrlimit`], and
+/// [`prlimit`].
 ///
 /// [`getrlimit`]: crate::process::getrlimit
+/// [`setrlimit`]: crate::process::setrlimit
+/// [`prlimit`]: crate::process::prlimit
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum Resource {

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -65,8 +65,10 @@ pub use priority::{
     getpriority_pgrp, getpriority_process, getpriority_user, setpriority_pgrp, setpriority_process,
     setpriority_user,
 };
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub use rlimit::prlimit;
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
-pub use rlimit::{getrlimit, Resource, Rlimit};
+pub use rlimit::{getrlimit, setrlimit, Resource, Rlimit};
 #[cfg(any(
     target_os = "linux",
     target_os = "android",

--- a/src/process/rlimit.rs
+++ b/src/process/rlimit.rs
@@ -27,20 +27,20 @@ pub fn getrlimit(resource: Resource) -> Rlimit {
     imp::syscalls::getrlimit(resource)
 }
 
-/// `setrlimit(resource, lim)`—Set a process resource limit value.
+/// `setrlimit(resource, new)`—Set a process resource limit value.
 ///
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
 ///
-/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getrlimit.html
-/// [Linux]: https://man7.org/linux/man-pages/man2/getrlimit.2.html
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setrlimit.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/setrlimit.2.html
 #[inline]
 pub fn setrlimit(resource: Resource, new: Rlimit) -> io::Result<()> {
     imp::syscalls::setrlimit(resource, new)
 }
 
-/// `prlimit(pid, resource, lim)`—Get and set a process resource limit value.
+/// `prlimit(pid, resource, new)`—Get and set a process resource limit value.
 ///
 /// # References
 ///  - [Linux]

--- a/src/process/rlimit.rs
+++ b/src/process/rlimit.rs
@@ -1,9 +1,12 @@
-use crate::imp;
+#[cfg(any(target_os = "android", target_os = "linux"))]
+use crate::process::Pid;
+use crate::{imp, io};
 
 pub use crate::imp::process::Resource;
 
-/// `struct rlimit`—Current and maximum values used in [`getrlimit`].
-#[derive(Debug)]
+/// `struct rlimit`—Current and maximum values used in [`getrlimit`],
+/// [`setrlimit`]`, and [`prlimit`].
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Rlimit {
     /// Current effective, "soft", limit.
     pub current: Option<u64>,
@@ -22,4 +25,29 @@ pub struct Rlimit {
 #[inline]
 pub fn getrlimit(resource: Resource) -> Rlimit {
     imp::syscalls::getrlimit(resource)
+}
+
+/// `setrlimit(resource, lim)`—Set a process resource limit value.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getrlimit.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/getrlimit.2.html
+#[inline]
+pub fn setrlimit(resource: Resource, new: Rlimit) -> io::Result<()> {
+    imp::syscalls::setrlimit(resource, new)
+}
+
+/// `prlimit(pid, resource, lim)`—Get and set a process resource limit value.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/prlimit.2.html
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[inline]
+pub fn prlimit(pid: Option<Pid>, resource: Resource, new: Rlimit) -> io::Result<Rlimit> {
+    imp::syscalls::prlimit(pid, resource, new)
 }

--- a/tests/process/main.rs
+++ b/tests/process/main.rs
@@ -11,6 +11,8 @@ mod id;
 mod membarrier;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))] // WASI doesn't have [gs]etpriority.
 mod priority;
+#[cfg(not(target_os = "wasi"))]
+mod rlimit;
 mod sched_yield;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have uname.
 mod uname;

--- a/tests/process/rlimit.rs
+++ b/tests/process/rlimit.rs
@@ -24,11 +24,19 @@ fn test_prlimit() {
         maximum: Some(0),
     };
 
-    let _old = rustix::process::prlimit(None, Resource::Core, new.clone()).unwrap();
+    let first = rustix::process::getrlimit(Resource::Core);
+
+    let old = rustix::process::prlimit(None, Resource::Core, new.clone()).unwrap();
+
+    assert_eq!(first, old);
+
+    let other = Rlimit {
+        current: Some(0),
+        maximum: Some(0),
+    };
 
     let again =
-        rustix::process::prlimit(Some(rustix::process::getpid()), Resource::Core, new.clone())
-            .unwrap();
+        rustix::process::prlimit(Some(rustix::process::getpid()), Resource::Core, other).unwrap();
 
     assert_eq!(again, new);
 }

--- a/tests/process/rlimit.rs
+++ b/tests/process/rlimit.rs
@@ -1,0 +1,34 @@
+use rustix::process::{Resource, Rlimit};
+
+#[test]
+fn test_getrlimit() {
+    let lim = rustix::process::getrlimit(Resource::Stack);
+    assert_ne!(lim.current, Some(0));
+    assert_ne!(lim.maximum, Some(0));
+}
+
+#[test]
+fn test_setrlimit() {
+    let new = Rlimit {
+        current: Some(0),
+        maximum: Some(0),
+    };
+    rustix::process::setrlimit(Resource::Core, new).unwrap();
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[test]
+fn test_prlimit() {
+    let new = Rlimit {
+        current: Some(0),
+        maximum: Some(0),
+    };
+
+    let _old = rustix::process::prlimit(None, Resource::Core, new.clone()).unwrap();
+
+    let again =
+        rustix::process::prlimit(Some(rustix::process::getpid()), Resource::Core, new.clone())
+            .unwrap();
+
+    assert_eq!(again, new);
+}


### PR DESCRIPTION
rustix already had the types defined for `getrlimit`, so this just adds
the new `setrlimit` and Linux-specific `prlimit`.