### PR TITLE
Cleanup: make an implicit lifetime parameter explicit.

### DIFF
--- a/src/imp/linux_raw/arch/inline/aarch64.rs
+++ b/src/imp/linux_raw/arch/inline/aarch64.rs
@@ -5,7 +5,7 @@ use core::arch::asm;
 
 #[inline]
 #[must_use]
-pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
+pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
     let r0;
     asm!(
         "svc 0",


### PR DESCRIPTION
All the other `SyscallNumber` arguments have an explicit lifetime
parameter, so fix this one that didn't, for consistency.