### PR TITLE
Update to io-lifetimes 0.5.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ cc = { version = "1.0.68", optional = true }
 [dependencies]
 bitflags = "1.2.1"
 itoa = { version = "1.0.1", default-features = false, optional = true }
-io-lifetimes = { version = "0.4.0", default-features = false, optional = true }
+io-lifetimes = { version = "0.5.1", default-features = false, optional = true }
 
 # Special dependencies used in rustc-dep-of-std mode.
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }


### PR DESCRIPTION
The only changes in io-lifetimes are in the Windows support, so there
are no changes for rustix here.