### PR TITLE
Factor out several more type conversions in the syscalls code.

### DIFF
--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -22,7 +22,7 @@ use super::reg::{raw_arg, ArgNumber, ArgReg, RetReg, R0};
 use super::time::ClockId;
 use crate::ffi::ZStr;
 use crate::io::{self, OwnedFd};
-use crate::process::Resource;
+use crate::process::{Pid, Resource, Signal};
 use crate::{as_mut_ptr, as_ptr};
 use core::mem::{transmute, MaybeUninit};
 use core::ptr::null;
@@ -274,6 +274,26 @@ pub(super) fn oflags_for_open_how(oflags: OFlags) -> u64 {
 #[inline]
 pub(super) fn resource<'a, Num: ArgNumber>(resource: Resource) -> ArgReg<'a, Num> {
     c_uint(resource as c::c_uint)
+}
+
+#[inline]
+pub(super) fn regular_pid<'a, Num: ArgNumber>(pid: Pid) -> ArgReg<'a, Num> {
+    raw_arg(pid.as_raw_nonzero().get() as usize)
+}
+
+#[inline]
+pub(super) fn negative_pid<'a, Num: ArgNumber>(pid: Pid) -> ArgReg<'a, Num> {
+    raw_arg(pid.as_raw_nonzero().get().wrapping_neg() as usize)
+}
+
+#[inline]
+pub(super) fn signal<'a, Num: ArgNumber>(sig: Signal) -> ArgReg<'a, Num> {
+    raw_arg(sig as usize)
+}
+
+#[inline]
+pub(super) fn fs_advice<'a, Num: ArgNumber>(advice: crate::fs::Advice) -> ArgReg<'a, Num> {
+    c_uint(advice as c::c_uint)
 }
 
 #[inline]

--- a/src/imp/linux_raw/fs/syscalls.rs
+++ b/src/imp/linux_raw/fs/syscalls.rs
@@ -15,7 +15,7 @@ use super::super::c;
 #[cfg(all(target_pointer_width = "32", target_arch = "arm"))]
 use super::super::conv::zero;
 use super::super::conv::{
-    borrowed_fd, by_ref, c_int, c_str, c_uint, dev_t, mode_and_type_as, mode_as, oflags,
+    borrowed_fd, by_ref, c_int, c_str, c_uint, dev_t, fs_advice, mode_and_type_as, mode_as, oflags,
     oflags_for_open_how, opt_c_str, opt_mut, out, pass_usize, raw_fd, ret, ret_c_int, ret_c_uint,
     ret_owned_fd, ret_usize, size_of, slice_mut,
 };
@@ -387,7 +387,7 @@ pub(crate) fn fadvise(fd: BorrowedFd<'_>, pos: u64, len: u64, advice: Advice) ->
         ret(syscall6_readonly(
             nr(__NR_fadvise64_64),
             borrowed_fd(fd),
-            c_uint(advice as c::c_uint),
+            fs_advice(advice),
             hi(pos),
             lo(pos),
             hi(len),
@@ -406,7 +406,7 @@ pub(crate) fn fadvise(fd: BorrowedFd<'_>, pos: u64, len: u64, advice: Advice) ->
             lo(pos),
             hi(len),
             lo(len),
-            c_uint(advice as c::c_uint),
+            fs_advice(advice),
         ))
     }
     #[cfg(target_pointer_width = "64")]
@@ -416,7 +416,7 @@ pub(crate) fn fadvise(fd: BorrowedFd<'_>, pos: u64, len: u64, advice: Advice) ->
             borrowed_fd(fd),
             loff_t_from_u64(pos),
             loff_t_from_u64(len),
-            c_uint(advice as c::c_uint),
+            fs_advice(advice),
         ))
     }
 }

--- a/src/imp/linux_raw/process/syscalls.rs
+++ b/src/imp/linux_raw/process/syscalls.rs
@@ -12,9 +12,9 @@ use super::super::arch::choose::{
 };
 use super::super::c;
 use super::super::conv::{
-    borrowed_fd, by_mut, by_ref, c_int, c_str, c_uint, const_void_star, out, pass_usize, resource,
-    ret, ret_c_int, ret_c_uint, ret_infallible, ret_usize, ret_usize_infallible, size_of,
-    slice_just_addr, slice_mut, void_star, zero,
+    borrowed_fd, by_mut, by_ref, c_int, c_str, c_uint, const_void_star, negative_pid, out,
+    pass_usize, regular_pid, resource, ret, ret_c_int, ret_c_uint, ret_infallible, ret_usize,
+    ret_usize_infallible, signal, size_of, slice_just_addr, slice_mut, void_star, zero,
 };
 use super::super::reg::nr;
 use super::{RawCpuSet, RawUname};
@@ -527,8 +527,8 @@ pub(crate) fn kill_process(pid: Pid, sig: Signal) -> io::Result<()> {
     unsafe {
         ret(syscall2_readonly(
             nr(__NR_kill),
-            pass_usize(pid.as_raw_nonzero().get() as usize),
-            pass_usize(sig as usize),
+            regular_pid(pid),
+            signal(sig),
         ))
     }
 }
@@ -538,19 +538,13 @@ pub(crate) fn kill_process_group(pid: Pid, sig: Signal) -> io::Result<()> {
     unsafe {
         ret(syscall2_readonly(
             nr(__NR_kill),
-            pass_usize((pid.as_raw_nonzero().get() as usize).wrapping_neg()),
-            pass_usize(sig as usize),
+            negative_pid(pid),
+            signal(sig),
         ))
     }
 }
 
 #[inline]
 pub(crate) fn kill_current_process_group(sig: Signal) -> io::Result<()> {
-    unsafe {
-        ret(syscall2_readonly(
-            nr(__NR_kill),
-            pass_usize(0),
-            pass_usize(sig as usize),
-        ))
-    }
+    unsafe { ret(syscall2_readonly(nr(__NR_kill), pass_usize(0), signal(sig))) }
 }


### PR DESCRIPTION
This adds conversion functions for converting `Pid`, `Signal`, and
`Advice` values into syscall argument registers.