### PR TITLE
Implement `fcntl_add_seals` etc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ linux-raw-sys = { version = "0.0.37", default-features = false, features = ["gen
 # setting `errno`.
 [target.'cfg(any(rustix_use_libc, not(all(any(target_os = "linux"), any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64")))))'.dependencies]
 errno = { version = "0.2.8", default-features = false }
-libc = { version = "0.2.111", features = ["extra_traits"] }
+libc = { version = "0.2.114", features = ["extra_traits"] }
 
 # For the libc backend on Windows, use the Winsock2 API in winapi.
 [target.'cfg(windows)'.dependencies]
@@ -48,7 +48,7 @@ winapi = { version = "0.3.9", features = ["ws2ipdef", "ws2tcpip"] }
 [dev-dependencies]
 is-terminal = "0.0.0"
 tempfile = "3.2.0"
-libc = "0.2.106"
+libc = "0.2.114"
 serial_test = "0.5"
 
 [target.'cfg(not(target_os = "emscripten"))'.dev-dependencies]

--- a/src/fs/fcntl.rs
+++ b/src/fs/fcntl.rs
@@ -75,27 +75,43 @@ pub fn fcntl_setfl<Fd: AsFd>(fd: &Fd, flags: OFlags) -> io::Result<()> {
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/fcntl.2.html
 #[cfg(any(
-    linux_raw,
-    all(
-        libc,
-        not(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "illumos",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "redox",
-            target_os = "wasi",
-        ))
-    )
+    target_os = "android",
+    target_os = "linux",
+    target_os = "fuchsia",
+    target_os = "freebsd",
 ))]
 #[inline]
 #[doc(alias = "F_GET_SEALS")]
-pub fn fcntl_get_seals<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
+pub fn fcntl_get_seals<Fd: AsFd>(fd: &Fd) -> io::Result<SealFlags> {
     let fd = fd.as_fd();
     imp::syscalls::fcntl_get_seals(fd)
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "fuchsia",
+    target_os = "freebsd",
+))]
+pub use imp::fs::SealFlags;
+
+/// `fcntl(fd, F_ADD_SEALS)`
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/fcntl.2.html
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "fuchsia",
+    target_os = "freebsd",
+))]
+#[inline]
+#[doc(alias = "F_ADD_SEALS")]
+pub fn fcntl_add_seals<Fd: AsFd>(fd: &Fd, seals: SealFlags) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::fcntl_add_seals(fd, seals)
 }
 
 /// `fcntl(fd, F_DUPFD_CLOEXEC)`—Creates a new `OwnedFd` instance, with value

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -109,18 +109,13 @@ pub use dir::{Dir, DirEntry};
 pub use fadvise::{fadvise, Advice};
 #[cfg(not(target_os = "wasi"))]
 pub use fcntl::fcntl_dupfd_cloexec;
-#[cfg(not(any(
-    target_os = "dragonfly",
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "fuchsia",
     target_os = "freebsd",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "wasi",
-)))]
-pub use fcntl::fcntl_get_seals;
+))]
+pub use fcntl::{fcntl_add_seals, fcntl_get_seals, SealFlags};
 pub use fcntl::{fcntl_getfd, fcntl_getfl, fcntl_setfd, fcntl_setfl};
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 pub use fcntl_darwin::{fcntl_fullfsync, fcntl_rdadvise};

--- a/src/imp/libc/fs/mod.rs
+++ b/src/imp/libc/fs/mod.rs
@@ -50,6 +50,13 @@ pub use types::Advice;
 pub use types::FallocateFlags;
 #[cfg(not(target_os = "wasi"))]
 pub use types::FlockOperation;
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "fuchsia",
+    target_os = "freebsd"
+))]
+pub use types::SealFlags;
 #[cfg(not(any(
     target_os = "illumos",
     target_os = "netbsd",

--- a/src/imp/libc/fs/types.rs
+++ b/src/imp/libc/fs/types.rs
@@ -506,6 +506,61 @@ bitflags! {
 
         /// `MFD_ALLOW_SEALING`
         const ALLOW_SEALING = c::MFD_ALLOW_SEALING;
+
+        /// `MFD_HUGETLB` (since Linux 4.14)
+        const HUGETLB = c::MFD_HUGETLB;
+
+        /// `MFD_HUGE_64KB`
+        const HUGE_64KB = c::MFD_HUGE_64KB;
+        /// `MFD_HUGE_512JB`
+        const HUGE_512KB = c::MFD_HUGE_512KB;
+        /// `MFD_HUGE_1MB`
+        const HUGE_1MB = c::MFD_HUGE_1MB;
+        /// `MFD_HUGE_2MB`
+        const HUGE_2MB = c::MFD_HUGE_2MB;
+        /// `MFD_HUGE_8MB`
+        const HUGE_8MB = c::MFD_HUGE_8MB;
+        /// `MFD_HUGE_16MB`
+        const HUGE_16MB = c::MFD_HUGE_16MB;
+        /// `MFD_HUGE_32MB`
+        const HUGE_32MB = c::MFD_HUGE_32MB;
+        /// `MFD_HUGE_256MB`
+        const HUGE_256MB = c::MFD_HUGE_256MB;
+        /// `MFD_HUGE_512MB`
+        const HUGE_512MB = c::MFD_HUGE_512MB;
+        /// `MFD_HUGE_1GB`
+        const HUGE_1GB = c::MFD_HUGE_1GB;
+        /// `MFD_HUGE_2GB`
+        const HUGE_2GB = c::MFD_HUGE_2GB;
+        /// `MFD_HUGE_16GB`
+        const HUGE_16GB = c::MFD_HUGE_16GB;
+    }
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "fuchsia",
+    target_os = "freebsd"
+))]
+bitflags! {
+    /// `F_SEAL_*` constants for use with [`fcntl_add_seals`] and
+    /// [`fcntl_get_seals`].
+    ///
+    /// [`fcntl_add_seals`]: rustix::fs::fcntl_add_seals
+    /// [`fcntl_get_seals`]: rustix::fs::fcntl_get_seals
+    pub struct SealFlags: i32 {
+       /// `F_SEAL_SEAL`.
+       const SEAL = c::F_SEAL_SEAL;
+       /// `F_SEAL_SHRINK`.
+       const SHRINK = c::F_SEAL_SHRINK;
+       /// `F_SEAL_GROW`.
+       const GROW = c::F_SEAL_GROW;
+       /// `F_SEAL_WRITE`.
+       const WRITE = c::F_SEAL_WRITE;
+       /// `F_SEAL_FUTURE_WRITE` (since Linux 5.1)
+       #[cfg(target_os = "linux")]
+       const FUTURE_WRITE = c::F_SEAL_FUTURE_WRITE;
     }
 }
 

--- a/src/imp/linux_raw/fs/mod.rs
+++ b/src/imp/linux_raw/fs/mod.rs
@@ -8,6 +8,6 @@ pub use dir::{Dir, DirEntry};
 pub use makedev::{major, makedev, minor};
 pub use types::{
     Access, Advice, AtFlags, Dev, FallocateFlags, FdFlags, FileType, FlockOperation, FsWord,
-    MemfdFlags, Mode, OFlags, RawMode, RenameFlags, ResolveFlags, Stat, StatFs, Statx, StatxFlags,
-    NFS_SUPER_MAGIC, PROC_SUPER_MAGIC, UTIME_NOW, UTIME_OMIT,
+    MemfdFlags, Mode, OFlags, RawMode, RenameFlags, ResolveFlags, SealFlags, Stat, StatFs, Statx,
+    StatxFlags, NFS_SUPER_MAGIC, PROC_SUPER_MAGIC, UTIME_NOW, UTIME_OMIT,
 };

--- a/src/imp/linux_raw/fs/types.rs
+++ b/src/imp/linux_raw/fs/types.rs
@@ -365,6 +365,54 @@ bitflags! {
 
         /// `MFD_ALLOW_SEALING`
         const ALLOW_SEALING = linux_raw_sys::v5_4::general::MFD_ALLOW_SEALING;
+
+        /// `MFD_HUGETLB` (since Linux 4.14)
+        const HUGETLB = linux_raw_sys::v5_4::general::MFD_HUGETLB;
+
+        /// `MFD_HUGE_64KB`
+        const HUGE_64KB = linux_raw_sys::v5_4::general::MFD_HUGE_64KB;
+        /// `MFD_HUGE_512JB`
+        const HUGE_512KB = linux_raw_sys::v5_4::general::MFD_HUGE_512KB;
+        /// `MFD_HUGE_1MB`
+        const HUGE_1MB = linux_raw_sys::v5_4::general::MFD_HUGE_1MB;
+        /// `MFD_HUGE_2MB`
+        const HUGE_2MB = linux_raw_sys::v5_4::general::MFD_HUGE_2MB;
+        /// `MFD_HUGE_8MB`
+        const HUGE_8MB = linux_raw_sys::v5_4::general::MFD_HUGE_8MB;
+        /// `MFD_HUGE_16MB`
+        const HUGE_16MB = linux_raw_sys::v5_4::general::MFD_HUGE_16MB;
+        /// `MFD_HUGE_32MB`
+        const HUGE_32MB = linux_raw_sys::v5_4::general::MFD_HUGE_32MB;
+        /// `MFD_HUGE_256MB`
+        const HUGE_256MB = linux_raw_sys::v5_4::general::MFD_HUGE_256MB;
+        /// `MFD_HUGE_512MB`
+        const HUGE_512MB = linux_raw_sys::v5_4::general::MFD_HUGE_512MB;
+        /// `MFD_HUGE_1GB`
+        const HUGE_1GB = linux_raw_sys::v5_4::general::MFD_HUGE_1GB;
+        /// `MFD_HUGE_2GB`
+        const HUGE_2GB = linux_raw_sys::v5_4::general::MFD_HUGE_2GB;
+        /// `MFD_HUGE_16GB`
+        const HUGE_16GB = linux_raw_sys::v5_4::general::MFD_HUGE_16GB;
+    }
+}
+
+bitflags! {
+    /// `F_SEAL_*` constants for use with [`fcntl_add_seals`] and
+    /// [`fcntl_get_seals`].
+    ///
+    /// [`fcntl_add_seals`]: rustix::fs::fcntl_add_seals
+    /// [`fcntl_get_seals`]: rustix::fs::fcntl_get_seals
+    pub struct SealFlags: u32 {
+       /// `F_SEAL_SEAL`.
+       const SEAL = linux_raw_sys::v5_4::general::F_SEAL_SEAL;
+       /// `F_SEAL_SHRINK`.
+       const SHRINK = linux_raw_sys::v5_4::general::F_SEAL_SHRINK;
+       /// `F_SEAL_GROW`.
+       const GROW = linux_raw_sys::v5_4::general::F_SEAL_GROW;
+       /// `F_SEAL_WRITE`.
+       const WRITE = linux_raw_sys::v5_4::general::F_SEAL_WRITE;
+       /// `F_SEAL_FUTURE_WRITE` (since Linux 5.1)
+       const FUTURE_WRITE = linux_raw_sys::v5_4::general::F_SEAL_FUTURE_WRITE;
     }
 }
 

--- a/tests/io/main.rs
+++ b/tests/io/main.rs
@@ -28,3 +28,5 @@ mod prot;
 #[cfg(not(target_os = "redox"))] // redox doesn't have cwd/openat
 #[cfg(not(target_os = "wasi"))] // wasi support for S_IRUSR etc. submitted to libc in #2264
 mod read_write;
+#[cfg(any(target_os = "linux", target_os = "android"))]
+mod seals;

--- a/tests/io/seals.rs
+++ b/tests/io/seals.rs
@@ -1,0 +1,25 @@
+use rustix::fd::FromFd;
+use rustix::fs::{fcntl_add_seals, ftruncate, memfd_create, MemfdFlags, SealFlags};
+use std::fs::File;
+use std::io::Write;
+
+#[test]
+fn test_seals() {
+    let fd = memfd_create("test", MemfdFlags::CLOEXEC | MemfdFlags::ALLOW_SEALING).unwrap();
+    let mut file = File::from_fd(fd.into());
+
+    writeln!(&mut file, "Hello!").unwrap();
+
+    fcntl_add_seals(&file, SealFlags::GROW).unwrap();
+
+    // We sealed growing, so this should fail.
+    writeln!(&mut file, "World?").unwrap_err();
+
+    // We can still shrink for now.
+    ftruncate(&mut file, 1).unwrap();
+
+    fcntl_add_seals(&file, SealFlags::SHRINK).unwrap();
+
+    // We sealed shrinking, so this should fail.
+    ftruncate(&mut file, 0).unwrap_err();
+}


### PR DESCRIPTION
Implement `fcntl_add_seals`, and add a `SealFlags` to describe seal flag
values in `fcntl_add_seals` and `fcntl_get_seals`.

Also, add `MFD_HUGETLB` and accompanying flag values.