### PR TITLE
Remove internal usage of `use ...::syscalls::*`.

### DIFF
--- a/src/fs/abs.rs
+++ b/src/fs/abs.rs
@@ -29,5 +29,5 @@ use imp::fs::StatFs;
 )))]
 #[inline]
 pub fn statfs<P: path::Arg>(path: P) -> io::Result<StatFs> {
-    path.into_with_z_str(|path| imp::syscalls::statfs(path))
+    path.into_with_z_str(|path| imp::fs::syscalls::statfs(path))
 }

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -46,7 +46,7 @@ pub fn openat<P: path::Arg, Fd: AsFd>(
     create_mode: Mode,
 ) -> io::Result<OwnedFd> {
     let dirfd = dirfd.as_fd();
-    path.into_with_z_str(|path| imp::syscalls::openat(dirfd, path, oflags, create_mode))
+    path.into_with_z_str(|path| imp::fs::syscalls::openat(dirfd, path, oflags, create_mode))
 }
 
 /// `readlinkat(fd, path)`—Reads the contents of a symlink.
@@ -78,7 +78,7 @@ fn _readlinkat(dirfd: BorrowedFd<'_>, path: &ZStr, mut buffer: Vec<u8>) -> io::R
     buffer.resize(buffer.capacity(), 0_u8);
 
     loop {
-        let nread = imp::syscalls::readlinkat(dirfd, path, &mut buffer)?;
+        let nread = imp::fs::syscalls::readlinkat(dirfd, path, &mut buffer)?;
 
         let nread = nread as usize;
         assert!(nread <= buffer.len());
@@ -102,7 +102,7 @@ fn _readlinkat(dirfd: BorrowedFd<'_>, path: &ZStr, mut buffer: Vec<u8>) -> io::R
 #[inline]
 pub fn mkdirat<P: path::Arg, Fd: AsFd>(dirfd: &Fd, path: P, mode: Mode) -> io::Result<()> {
     let dirfd = dirfd.as_fd();
-    path.into_with_z_str(|path| imp::syscalls::mkdirat(dirfd, path, mode))
+    path.into_with_z_str(|path| imp::fs::syscalls::mkdirat(dirfd, path, mode))
 }
 
 /// `linkat(old_dirfd, old_path, new_dirfd, new_path, flags)`—Creates a hard
@@ -126,7 +126,7 @@ pub fn linkat<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(
     let new_dirfd = new_dirfd.as_fd();
     old_path.into_with_z_str(|old_path| {
         new_path.into_with_z_str(|new_path| {
-            imp::syscalls::linkat(old_dirfd, old_path, new_dirfd, new_path, flags)
+            imp::fs::syscalls::linkat(old_dirfd, old_path, new_dirfd, new_path, flags)
         })
     })
 }
@@ -146,7 +146,7 @@ pub fn linkat<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(
 #[inline]
 pub fn unlinkat<P: path::Arg, Fd: AsFd>(dirfd: &Fd, path: P, flags: AtFlags) -> io::Result<()> {
     let dirfd = dirfd.as_fd();
-    path.into_with_z_str(|path| imp::syscalls::unlinkat(dirfd, path, flags))
+    path.into_with_z_str(|path| imp::fs::syscalls::unlinkat(dirfd, path, flags))
 }
 
 /// `renameat(old_dirfd, old_path, new_dirfd, new_path)`—Renames a file or
@@ -169,7 +169,7 @@ pub fn renameat<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(
     let new_dirfd = new_dirfd.as_fd();
     old_path.into_with_z_str(|old_path| {
         new_path.into_with_z_str(|new_path| {
-            imp::syscalls::renameat(old_dirfd, old_path, new_dirfd, new_path)
+            imp::fs::syscalls::renameat(old_dirfd, old_path, new_dirfd, new_path)
         })
     })
 }
@@ -195,7 +195,7 @@ pub fn renameat_with<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(
     let new_dirfd = new_dirfd.as_fd();
     old_path.into_with_z_str(|old_path| {
         new_path.into_with_z_str(|new_path| {
-            imp::syscalls::renameat2(old_dirfd, old_path, new_dirfd, new_path, flags)
+            imp::fs::syscalls::renameat2(old_dirfd, old_path, new_dirfd, new_path, flags)
         })
     })
 }
@@ -216,7 +216,8 @@ pub fn symlinkat<P: path::Arg, Q: path::Arg, Fd: AsFd>(
 ) -> io::Result<()> {
     let new_dirfd = new_dirfd.as_fd();
     old_path.into_with_z_str(|old_path| {
-        new_path.into_with_z_str(|new_path| imp::syscalls::symlinkat(old_path, new_dirfd, new_path))
+        new_path
+            .into_with_z_str(|new_path| imp::fs::syscalls::symlinkat(old_path, new_dirfd, new_path))
     })
 }
 
@@ -237,7 +238,7 @@ pub fn symlinkat<P: path::Arg, Q: path::Arg, Fd: AsFd>(
 #[doc(alias = "fstatat")]
 pub fn statat<P: path::Arg, Fd: AsFd>(dirfd: &Fd, path: P, flags: AtFlags) -> io::Result<Stat> {
     let dirfd = dirfd.as_fd();
-    path.into_with_z_str(|path| imp::syscalls::statat(dirfd, path, flags))
+    path.into_with_z_str(|path| imp::fs::syscalls::statat(dirfd, path, flags))
 }
 
 /// `faccessat(dirfd, path, access, flags)`—Tests permissions for a file or
@@ -259,7 +260,7 @@ pub fn accessat<P: path::Arg, Fd: AsFd>(
     flags: AtFlags,
 ) -> io::Result<()> {
     let dirfd = dirfd.as_fd();
-    path.into_with_z_str(|path| imp::syscalls::accessat(dirfd, path, access, flags))
+    path.into_with_z_str(|path| imp::fs::syscalls::accessat(dirfd, path, access, flags))
 }
 
 /// `utimensat(dirfd, path, times, flags)`—Sets file or directory timestamps.
@@ -278,7 +279,7 @@ pub fn utimensat<P: path::Arg, Fd: AsFd>(
     flags: AtFlags,
 ) -> io::Result<()> {
     let dirfd = dirfd.as_fd();
-    path.into_with_z_str(|path| imp::syscalls::utimensat(dirfd, path, times, flags))
+    path.into_with_z_str(|path| imp::fs::syscalls::utimensat(dirfd, path, times, flags))
 }
 
 /// `fchmodat(dirfd, path, mode, 0)`—Sets file or directory permissions.
@@ -300,7 +301,7 @@ pub fn utimensat<P: path::Arg, Fd: AsFd>(
 #[doc(alias = "fchmodat")]
 pub fn chmodat<P: path::Arg, Fd: AsFd>(dirfd: &Fd, path: P, mode: Mode) -> io::Result<()> {
     let dirfd = dirfd.as_fd();
-    path.into_with_z_str(|path| imp::syscalls::chmodat(dirfd, path, mode))
+    path.into_with_z_str(|path| imp::fs::syscalls::chmodat(dirfd, path, mode))
 }
 
 /// `fclonefileat(src, dst_dir, dst, flags)`—Efficiently copies between files.
@@ -320,7 +321,7 @@ pub fn fclonefileat<Fd: AsFd, DstFd: AsFd, P: path::Arg>(
     let srcfd = src.as_fd();
     let dst_dirfd = dst_dir.as_fd();
     dst.into_with_z_str(|dst| {
-        imp::syscalls::fclonefileat(srcfd.as_fd(), dst_dirfd.as_fd(), &dst, flags)
+        imp::fs::syscalls::fclonefileat(srcfd.as_fd(), dst_dirfd.as_fd(), &dst, flags)
     })
 }
 
@@ -342,7 +343,7 @@ pub fn mknodat<P: path::Arg, Fd: AsFd>(
     dev: Dev,
 ) -> io::Result<()> {
     let dirfd = dirfd.as_fd();
-    path.into_with_z_str(|path| imp::syscalls::mknodat(dirfd, path, file_type, mode, dev))
+    path.into_with_z_str(|path| imp::fs::syscalls::mknodat(dirfd, path, file_type, mode, dev))
 }
 
 /// `fchownat(dirfd, path, owner, group, flags)`—Sets file or directory
@@ -364,5 +365,5 @@ pub fn chownat<P: path::Arg, Fd: AsFd>(
     flags: AtFlags,
 ) -> io::Result<()> {
     let dirfd = dirfd.as_fd();
-    path.into_with_z_str(|path| imp::syscalls::chownat(dirfd, path, owner, group, flags))
+    path.into_with_z_str(|path| imp::fs::syscalls::chownat(dirfd, path, owner, group, flags))
 }

--- a/src/fs/copy_file_range.rs
+++ b/src/fs/copy_file_range.rs
@@ -18,5 +18,5 @@ pub fn copy_file_range<InFd: AsFd, OutFd: AsFd>(
 ) -> io::Result<u64> {
     let fd_in = fd_in.as_fd();
     let fd_out = fd_out.as_fd();
-    imp::syscalls::copy_file_range(fd_in, off_in, fd_out, off_out, len)
+    imp::fs::syscalls::copy_file_range(fd_in, off_in, fd_out, off_out, len)
 }

--- a/src/fs/fadvise.rs
+++ b/src/fs/fadvise.rs
@@ -16,5 +16,5 @@ pub use imp::fs::Advice;
 #[doc(alias = "posix_fadvise")]
 pub fn fadvise<Fd: AsFd>(fd: &Fd, offset: u64, len: u64, advice: Advice) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::fadvise(fd, offset, len, advice)
+    imp::fs::syscalls::fadvise(fd, offset, len, advice)
 }

--- a/src/fs/fcntl.rs
+++ b/src/fs/fcntl.rs
@@ -20,7 +20,7 @@ use imp::fs::{FdFlags, OFlags};
 #[doc(alias = "F_GETFD")]
 pub fn fcntl_getfd<Fd: AsFd>(fd: &Fd) -> io::Result<FdFlags> {
     let fd = fd.as_fd();
-    imp::syscalls::fcntl_getfd(fd)
+    imp::fs::syscalls::fcntl_getfd(fd)
 }
 
 /// `fcntl(fd, F_SETFD, flags)`—Sets a file descriptor's flags.
@@ -35,7 +35,7 @@ pub fn fcntl_getfd<Fd: AsFd>(fd: &Fd) -> io::Result<FdFlags> {
 #[doc(alias = "F_SETFD")]
 pub fn fcntl_setfd<Fd: AsFd>(fd: &Fd, flags: FdFlags) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::fcntl_setfd(fd, flags)
+    imp::fs::syscalls::fcntl_setfd(fd, flags)
 }
 
 /// `fcntl(fd, F_GETFL)`—Returns a file descriptor's access mode and status.
@@ -50,7 +50,7 @@ pub fn fcntl_setfd<Fd: AsFd>(fd: &Fd, flags: FdFlags) -> io::Result<()> {
 #[doc(alias = "F_GETFL")]
 pub fn fcntl_getfl<Fd: AsFd>(fd: &Fd) -> io::Result<OFlags> {
     let fd = fd.as_fd();
-    imp::syscalls::fcntl_getfl(fd)
+    imp::fs::syscalls::fcntl_getfl(fd)
 }
 
 /// `fcntl(fd, F_SETFL, flags)`—Sets a file descriptor's status.
@@ -65,7 +65,7 @@ pub fn fcntl_getfl<Fd: AsFd>(fd: &Fd) -> io::Result<OFlags> {
 #[doc(alias = "F_SETFL")]
 pub fn fcntl_setfl<Fd: AsFd>(fd: &Fd, flags: OFlags) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::fcntl_setfl(fd, flags)
+    imp::fs::syscalls::fcntl_setfl(fd, flags)
 }
 
 /// `fcntl(fd, F_GET_SEALS)`
@@ -84,7 +84,7 @@ pub fn fcntl_setfl<Fd: AsFd>(fd: &Fd, flags: OFlags) -> io::Result<()> {
 #[doc(alias = "F_GET_SEALS")]
 pub fn fcntl_get_seals<Fd: AsFd>(fd: &Fd) -> io::Result<SealFlags> {
     let fd = fd.as_fd();
-    imp::syscalls::fcntl_get_seals(fd)
+    imp::fs::syscalls::fcntl_get_seals(fd)
 }
 
 #[cfg(any(
@@ -111,7 +111,7 @@ pub use imp::fs::SealFlags;
 #[doc(alias = "F_ADD_SEALS")]
 pub fn fcntl_add_seals<Fd: AsFd>(fd: &Fd, seals: SealFlags) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::fcntl_add_seals(fd, seals)
+    imp::fs::syscalls::fcntl_add_seals(fd, seals)
 }
 
 /// `fcntl(fd, F_DUPFD_CLOEXEC)`—Creates a new `OwnedFd` instance, with value
@@ -134,5 +134,5 @@ pub fn fcntl_add_seals<Fd: AsFd>(fd: &Fd, seals: SealFlags) -> io::Result<()> {
 #[doc(alias = "F_DUPFD_CLOEXEC")]
 pub fn fcntl_dupfd_cloexec<Fd: AsFd>(fd: &Fd, min: RawFd) -> io::Result<OwnedFd> {
     let fd = fd.as_fd();
-    imp::syscalls::fcntl_dupfd_cloexec(fd, min)
+    imp::fs::syscalls::fcntl_dupfd_cloexec(fd, min)
 }

--- a/src/fs/fcntl_darwin.rs
+++ b/src/fs/fcntl_darwin.rs
@@ -10,7 +10,7 @@ use imp::fd::AsFd;
 #[inline]
 pub fn fcntl_rdadvise<Fd: AsFd>(fd: &Fd, offset: u64, len: u64) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::fcntl_rdadvise(fd, offset, len)
+    imp::fs::syscalls::fcntl_rdadvise(fd, offset, len)
 }
 
 /// `fcntl(fd, F_FULLFSYNC)`
@@ -22,5 +22,5 @@ pub fn fcntl_rdadvise<Fd: AsFd>(fd: &Fd, offset: u64, len: u64) -> io::Result<()
 #[inline]
 pub fn fcntl_fullfsync<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::fcntl_fullfsync(fd)
+    imp::fs::syscalls::fcntl_fullfsync(fd)
 }

--- a/src/fs/fcopyfile.rs
+++ b/src/fs/fcopyfile.rs
@@ -25,7 +25,7 @@ pub unsafe fn fcopyfile<FromFd: AsFd, ToFd: AsFd>(
 ) -> io::Result<()> {
     let from = from.as_fd();
     let to = to.as_fd();
-    imp::syscalls::fcopyfile(from, to, state, flags)
+    imp::fs::syscalls::fcopyfile(from, to, state, flags)
 }
 
 /// `copyfile_state_alloc()`
@@ -36,7 +36,7 @@ pub unsafe fn fcopyfile<FromFd: AsFd, ToFd: AsFd>(
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/fcopyfile.3.html
 #[inline]
 pub fn copyfile_state_alloc() -> io::Result<copyfile_state_t> {
-    imp::syscalls::copyfile_state_alloc()
+    imp::fs::syscalls::copyfile_state_alloc()
 }
 
 /// `copyfile_state_free(state)`
@@ -52,7 +52,7 @@ pub fn copyfile_state_alloc() -> io::Result<copyfile_state_t> {
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/fcopyfile.3.html
 #[inline]
 pub unsafe fn copyfile_state_free(state: copyfile_state_t) -> io::Result<()> {
-    imp::syscalls::copyfile_state_free(state)
+    imp::fs::syscalls::copyfile_state_free(state)
 }
 
 /// `copyfile_state_get(state, COPYFILE_STATE_COPIED)`
@@ -68,7 +68,7 @@ pub unsafe fn copyfile_state_free(state: copyfile_state_t) -> io::Result<()> {
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/fcopyfile.3.html
 #[inline]
 pub unsafe fn copyfile_state_get_copied(state: copyfile_state_t) -> io::Result<u64> {
-    imp::syscalls::copyfile_state_get_copied(state)
+    imp::fs::syscalls::copyfile_state_get_copied(state)
 }
 
 /// `copyfile_state_get(state, flags, dst)`
@@ -88,5 +88,5 @@ pub unsafe fn copyfile_state_get(
     flag: u32,
     dst: *mut core::ffi::c_void,
 ) -> io::Result<()> {
-    imp::syscalls::copyfile_state_get(state, flag, dst)
+    imp::fs::syscalls::copyfile_state_get(state, flag, dst)
 }

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -37,7 +37,7 @@ use imp::fs::{FlockOperation, Mode};
 #[inline]
 pub fn seek<Fd: AsFd>(fd: &Fd, pos: SeekFrom) -> io::Result<u64> {
     let fd = fd.as_fd();
-    imp::syscalls::seek(fd, pos)
+    imp::fs::syscalls::seek(fd, pos)
 }
 
 /// `lseek(fd, 0, SEEK_CUR)`—Returns the current position within a file.
@@ -55,7 +55,7 @@ pub fn seek<Fd: AsFd>(fd: &Fd, pos: SeekFrom) -> io::Result<u64> {
 #[inline]
 pub fn tell<Fd: AsFd>(fd: &Fd) -> io::Result<u64> {
     let fd = fd.as_fd();
-    imp::syscalls::tell(fd)
+    imp::fs::syscalls::tell(fd)
 }
 
 /// `fchmod(fd)`—Sets open file or directory permissions.
@@ -73,7 +73,7 @@ pub fn tell<Fd: AsFd>(fd: &Fd) -> io::Result<u64> {
 #[inline]
 pub fn fchmod<Fd: AsFd>(fd: &Fd, mode: Mode) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::fchmod(fd, mode)
+    imp::fs::syscalls::fchmod(fd, mode)
 }
 
 /// `fchown(fd)`—Sets open file or directory ownership.
@@ -88,7 +88,7 @@ pub fn fchmod<Fd: AsFd>(fd: &Fd, mode: Mode) -> io::Result<()> {
 #[inline]
 pub fn fchown<Fd: AsFd>(fd: &Fd, owner: Uid, group: Gid) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::fchown(fd, owner, group)
+    imp::fs::syscalls::fchown(fd, owner, group)
 }
 
 /// `fstat(fd)`—Queries metadata for an open file or directory.
@@ -107,7 +107,7 @@ pub fn fchown<Fd: AsFd>(fd: &Fd, owner: Uid, group: Gid) -> io::Result<()> {
 #[inline]
 pub fn fstat<Fd: AsFd>(fd: &Fd) -> io::Result<Stat> {
     let fd = fd.as_fd();
-    imp::syscalls::fstat(fd)
+    imp::fs::syscalls::fstat(fd)
 }
 
 /// `fstatfs(fd)`—Queries filesystem statistics for an open file or directory.
@@ -125,7 +125,7 @@ pub fn fstat<Fd: AsFd>(fd: &Fd) -> io::Result<Stat> {
 #[inline]
 pub fn fstatfs<Fd: AsFd>(fd: &Fd) -> io::Result<StatFs> {
     let fd = fd.as_fd();
-    imp::syscalls::fstatfs(fd)
+    imp::fs::syscalls::fstatfs(fd)
 }
 
 /// `futimens(fd, times)`—Sets timestamps for an open file or directory.
@@ -139,7 +139,7 @@ pub fn fstatfs<Fd: AsFd>(fd: &Fd) -> io::Result<StatFs> {
 #[inline]
 pub fn futimens<Fd: AsFd>(fd: &Fd, times: &Timestamps) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::futimens(fd, times)
+    imp::fs::syscalls::futimens(fd, times)
 }
 
 /// `fallocate(fd, mode, offset, len)`—Adjusts file allocation.
@@ -168,7 +168,7 @@ pub fn futimens<Fd: AsFd>(fd: &Fd, times: &Timestamps) -> io::Result<()> {
 #[doc(alias = "posix_fallocate")]
 pub fn fallocate<Fd: AsFd>(fd: &Fd, mode: FallocateFlags, offset: u64, len: u64) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::fallocate(fd, mode, offset, len)
+    imp::fs::syscalls::fallocate(fd, mode, offset, len)
 }
 
 /// `fcntl(fd, F_GETFL) & O_ACCMODE`
@@ -184,7 +184,7 @@ pub fn is_file_read_write<Fd: AsFd>(fd: &Fd) -> io::Result<(bool, bool)> {
 }
 
 pub(crate) fn _is_file_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
-    let mode = imp::syscalls::fcntl_getfl(fd)?;
+    let mode = imp::fs::syscalls::fcntl_getfl(fd)?;
 
     // Check for `O_PATH`.
     #[cfg(any(
@@ -223,7 +223,7 @@ pub(crate) fn _is_file_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)
 #[inline]
 pub fn fsync<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::fsync(fd)
+    imp::fs::syscalls::fsync(fd)
 }
 
 /// `fdatasync(fd)`—Ensures that file data is written to the underlying
@@ -244,7 +244,7 @@ pub fn fsync<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
 #[inline]
 pub fn fdatasync<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::fdatasync(fd)
+    imp::fs::syscalls::fdatasync(fd)
 }
 
 /// `ftruncate(fd, length)`—Sets the length of a file.
@@ -258,7 +258,7 @@ pub fn fdatasync<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
 #[inline]
 pub fn ftruncate<Fd: AsFd>(fd: &Fd, length: u64) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::ftruncate(fd, length)
+    imp::fs::syscalls::ftruncate(fd, length)
 }
 
 /// `flock(fd, operation)`—Acquire or release an advisory lock on an open file.
@@ -271,5 +271,5 @@ pub fn ftruncate<Fd: AsFd>(fd: &Fd, length: u64) -> io::Result<()> {
 #[inline]
 pub fn flock<Fd: AsFd>(fd: &Fd, operation: FlockOperation) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::flock(fd, operation)
+    imp::fs::syscalls::flock(fd, operation)
 }

--- a/src/fs/getpath.rs
+++ b/src/fs/getpath.rs
@@ -11,5 +11,5 @@ use imp::fd::AsFd;
 #[inline]
 pub fn getpath<Fd: AsFd>(fd: &Fd) -> io::Result<ZString> {
     let fd = fd.as_fd();
-    imp::syscalls::getpath(fd)
+    imp::fs::syscalls::getpath(fd)
 }

--- a/src/fs/memfd_create.rs
+++ b/src/fs/memfd_create.rs
@@ -11,5 +11,5 @@ pub use imp::fs::MemfdFlags;
 /// [Linux]: https://man7.org/linux/man-pages/man2/memfd_create.2.html
 #[inline]
 pub fn memfd_create<P: path::Arg>(path: P, flags: MemfdFlags) -> io::Result<OwnedFd> {
-    path.into_with_z_str(|path| imp::syscalls::memfd_create(path, flags))
+    path.into_with_z_str(|path| imp::fs::syscalls::memfd_create(path, flags))
 }

--- a/src/fs/openat2.rs
+++ b/src/fs/openat2.rs
@@ -18,5 +18,5 @@ pub fn openat2<Fd: AsFd, P: path::Arg>(
     resolve: ResolveFlags,
 ) -> io::Result<OwnedFd> {
     let dirfd = dirfd.as_fd();
-    path.into_with_z_str(|path| imp::syscalls::openat2(dirfd, path, oflags, mode, resolve))
+    path.into_with_z_str(|path| imp::fs::syscalls::openat2(dirfd, path, oflags, mode, resolve))
 }

--- a/src/fs/sendfile.rs
+++ b/src/fs/sendfile.rs
@@ -17,5 +17,5 @@ pub fn sendfile<OutFd: AsFd, InFd: AsFd>(
 ) -> io::Result<usize> {
     let out_fd = out_fd.as_fd();
     let in_fd = in_fd.as_fd();
-    imp::syscalls::sendfile(out_fd, in_fd, offset, count)
+    imp::fs::syscalls::sendfile(out_fd, in_fd, offset, count)
 }

--- a/src/fs/statx.rs
+++ b/src/fs/statx.rs
@@ -24,5 +24,5 @@ pub fn statx<P: path::Arg, Fd: AsFd>(
     mask: StatxFlags,
 ) -> io::Result<Statx> {
     let dirfd = dirfd.as_fd();
-    path.into_with_z_str(|path| imp::syscalls::statx(dirfd, path, flags, mask))
+    path.into_with_z_str(|path| imp::fs::syscalls::statx(dirfd, path, flags, mask))
 }

--- a/src/imp/libc/syscalls.rs
+++ b/src/imp/libc/syscalls.rs
@@ -10,22 +10,6 @@
 //! slices, out parameters, or in-out parameters, which integers are owned or
 //! borrowed file descriptors, etc.
 
-// There are a lot of system calls, so they're split out into separate files.
-#[cfg(not(windows))]
-pub(crate) use super::fs::syscalls::*;
-#[cfg(not(windows))]
-pub(crate) use super::io::syscalls::*;
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
-pub(crate) use super::net::syscalls::*;
-#[cfg(not(windows))]
-pub(crate) use super::process::syscalls::*;
-#[cfg(target_os = "linux")]
-pub(crate) use super::rand::syscalls::*;
-#[cfg(not(windows))]
-pub(crate) use super::thread::syscalls::*;
-#[cfg(not(windows))]
-pub(crate) use super::time::syscalls::*;
-
 #[cfg(windows)]
 use super::c;
 #[cfg(windows)]

--- a/src/imp/linux_raw/fs/dir.rs
+++ b/src/imp/linux_raw/fs/dir.rs
@@ -57,7 +57,7 @@ impl Dir {
     /// `readdir(self)`, where `None` means the end of the directory.
     pub fn read(&mut self) -> Option<io::Result<DirEntry>> {
         if let Some(next) = self.next.take() {
-            match crate::imp::syscalls::_seek(
+            match crate::imp::fs::syscalls::_seek(
                 self.fd.as_fd(),
                 next as i64,
                 linux_raw_sys::general::SEEK_SET,
@@ -148,7 +148,7 @@ impl Dir {
         self.buf
             .resize(self.buf.capacity() + 32 * size_of::<linux_dirent64>(), 0);
         self.pos = 0;
-        let nread = match crate::imp::syscalls::getdents(self.fd.as_fd(), &mut self.buf) {
+        let nread = match crate::imp::fs::syscalls::getdents(self.fd.as_fd(), &mut self.buf) {
             Ok(nread) => nread,
             Err(err) => return Some(Err(err)),
         };

--- a/src/imp/linux_raw/io/epoll.rs
+++ b/src/imp/linux_raw/io/epoll.rs
@@ -60,7 +60,7 @@ use super::super::c;
 use crate::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 #[cfg(feature = "std")]
 use crate::fd::{FromFd, FromRawFd, IntoFd, IntoRawFd};
-use crate::imp::syscalls::{epoll_add, epoll_create, epoll_del, epoll_mod, epoll_wait};
+use crate::imp::io::syscalls::{epoll_add, epoll_create, epoll_del, epoll_mod, epoll_wait};
 use crate::io::{self, OwnedFd};
 use alloc::vec::Vec;
 use bitflags::bitflags;

--- a/src/imp/linux_raw/io/syscalls.rs
+++ b/src/imp/linux_raw/io/syscalls.rs
@@ -496,7 +496,8 @@ pub(crate) fn is_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
         // TODO: This code would benefit from having a better way to read into
         // uninitialized memory.
         let mut buf = [0];
-        match super::super::syscalls::recv(fd, &mut buf, RecvFlags::PEEK | RecvFlags::DONTWAIT) {
+        match super::super::net::syscalls::recv(fd, &mut buf, RecvFlags::PEEK | RecvFlags::DONTWAIT)
+        {
             Ok(0) => read = false,
             Err(err) => {
                 #[allow(unreachable_patterns)] // `EAGAIN` may equal `EWOULDBLOCK`
@@ -513,7 +514,7 @@ pub(crate) fn is_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
         // Do a `send` with `DONTWAIT` for 0 bytes. An `EPIPE` indicates
         // the write side is shut down.
         #[allow(unreachable_patterns)] // `EAGAIN` equals `EWOULDBLOCK`
-        match super::super::syscalls::send(fd, &[], SendFlags::DONTWAIT) {
+        match super::super::net::syscalls::send(fd, &[], SendFlags::DONTWAIT) {
             // TODO or-patterns when we don't need 1.51
             Err(io::Error::AGAIN) => (),
             Err(io::Error::WOULDBLOCK) => (),

--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -13,15 +13,6 @@
 //! parameters, which integers are owned or borrowed file descriptors, etc.
 #![allow(unsafe_code)]
 
-// There are a lot of system calls, so they're split out into separate files.
-pub(crate) use super::fs::syscalls::*;
-pub(crate) use super::io::syscalls::*;
-pub(crate) use super::net::syscalls::*;
-pub(crate) use super::process::syscalls::*;
-pub(crate) use super::rand::syscalls::*;
-pub(crate) use super::thread::syscalls::*;
-pub(crate) use super::time::syscalls::*;
-
 use super::arch::choose::{
     syscall1_noreturn, syscall1_readonly, syscall2_readonly, syscall3_readonly, syscall5_readonly,
 };

--- a/src/io/close.rs
+++ b/src/io/close.rs
@@ -36,5 +36,5 @@ use imp::fd::RawFd;
 /// not valid after the call.
 #[inline]
 pub unsafe fn close(raw_fd: RawFd) {
-    imp::syscalls::close(raw_fd)
+    imp::io::syscalls::close(raw_fd)
 }

--- a/src/io/dup.rs
+++ b/src/io/dup.rs
@@ -29,7 +29,7 @@ pub use imp::io::DupFlags;
 #[inline]
 pub fn dup<Fd: AsFd>(fd: &Fd) -> io::Result<OwnedFd> {
     let fd = fd.as_fd();
-    imp::syscalls::dup(fd)
+    imp::io::syscalls::dup(fd)
 }
 
 /// `dup2(fd, new)`—Creates a new `OwnedFd` instance that shares the
@@ -51,7 +51,7 @@ pub fn dup<Fd: AsFd>(fd: &Fd) -> io::Result<OwnedFd> {
 #[inline]
 pub fn dup2<Fd: AsFd>(fd: &Fd, new: &OwnedFd) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::dup2(fd, new)
+    imp::io::syscalls::dup2(fd, new)
 }
 
 /// `dup3(fd, new, flags)`—Creates a new `OwnedFd` instance that shares the
@@ -72,5 +72,5 @@ pub fn dup2<Fd: AsFd>(fd: &Fd, new: &OwnedFd) -> io::Result<()> {
 #[doc(alias = "dup3")]
 pub fn dup2_with<Fd: AsFd>(fd: &Fd, new: &OwnedFd, flags: DupFlags) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::dup2_with(fd, new, flags)
+    imp::io::syscalls::dup2_with(fd, new, flags)
 }

--- a/src/io/eventfd.rs
+++ b/src/io/eventfd.rs
@@ -12,5 +12,5 @@ pub use imp::io::EventfdFlags;
 /// [Linux]: https://man7.org/linux/man-pages/man2/eventfd.2.html
 #[inline]
 pub fn eventfd(initval: u32, flags: EventfdFlags) -> io::Result<OwnedFd> {
-    imp::syscalls::eventfd(initval, flags)
+    imp::io::syscalls::eventfd(initval, flags)
 }

--- a/src/io/ioctl.rs
+++ b/src/io/ioctl.rs
@@ -28,7 +28,7 @@ use imp::fd::AsSocketAsFd;
 #[doc(alias = "TCGETS")]
 pub fn ioctl_tcgets<Fd: AsFd>(fd: &Fd) -> io::Result<Termios> {
     let fd = fd.as_fd();
-    imp::syscalls::ioctl_tcgets(fd)
+    imp::io::syscalls::ioctl_tcgets(fd)
 }
 
 /// `ioctl(fd, FIOCLEX)`—Set the close-on-exec flag.
@@ -40,7 +40,7 @@ pub fn ioctl_tcgets<Fd: AsFd>(fd: &Fd) -> io::Result<Termios> {
 #[doc(alias = "FD_CLOEXEC")]
 pub fn ioctl_fioclex<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::ioctl_fioclex(fd)
+    imp::io::syscalls::ioctl_fioclex(fd)
 }
 
 /// `ioctl(fd, TIOCGWINSZ)`—Get the current terminal window size.
@@ -54,7 +54,7 @@ pub fn ioctl_fioclex<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
 #[doc(alias = "TIOCGWINSZ")]
 pub fn ioctl_tiocgwinsz<Fd: AsFd>(fd: &Fd) -> io::Result<Winsize> {
     let fd = fd.as_fd();
-    imp::syscalls::ioctl_tiocgwinsz(fd)
+    imp::io::syscalls::ioctl_tiocgwinsz(fd)
 }
 
 /// `ioctl(fd, FIONBIO, &value)`—Enables or disables non-blocking mode.
@@ -62,7 +62,7 @@ pub fn ioctl_tiocgwinsz<Fd: AsFd>(fd: &Fd) -> io::Result<Winsize> {
 #[doc(alias = "FIONBIO")]
 pub fn ioctl_fionbio<Fd: AsFd>(fd: &Fd, value: bool) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::ioctl_fionbio(fd, value)
+    imp::io::syscalls::ioctl_fionbio(fd, value)
 }
 
 /// `ioctl(fd, TIOCEXCL)`—Enables exclusive mode on a terminal.
@@ -79,7 +79,7 @@ pub fn ioctl_fionbio<Fd: AsFd>(fd: &Fd, value: bool) -> io::Result<()> {
 #[doc(alias = "TIOCEXCL")]
 pub fn ioctl_tiocexcl<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::ioctl_tiocexcl(fd)
+    imp::io::syscalls::ioctl_tiocexcl(fd)
 }
 
 /// `ioctl(fd, TIOCNXCL)`—Disables exclusive mode on a terminal.
@@ -96,7 +96,7 @@ pub fn ioctl_tiocexcl<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
 #[doc(alias = "TIOCNXCL")]
 pub fn ioctl_tiocnxcl<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::ioctl_tiocnxcl(fd)
+    imp::io::syscalls::ioctl_tiocnxcl(fd)
 }
 
 /// `ioctl(fd, FIONREAD)`—Returns the number of bytes ready to be read.
@@ -113,7 +113,7 @@ pub fn ioctl_tiocnxcl<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
 #[doc(alias = "FIONREAD")]
 pub fn ioctl_fionread<Fd: AsFd>(fd: &Fd) -> io::Result<u64> {
     let fd = fd.as_fd();
-    imp::syscalls::ioctl_fionread(fd)
+    imp::io::syscalls::ioctl_fionread(fd)
 }
 
 /// `ioctl(fd, BLKSSZGET)`—Returns the logical block size of a block device.
@@ -122,7 +122,7 @@ pub fn ioctl_fionread<Fd: AsFd>(fd: &Fd) -> io::Result<u64> {
 #[doc(alias = "BLKSSZGET")]
 pub fn ioctl_blksszget<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
     let fd = fd.as_fd();
-    imp::syscalls::ioctl_blksszget(fd)
+    imp::io::syscalls::ioctl_blksszget(fd)
 }
 
 /// `ioctl(fd, BLKPBSZGET)`—Returns the physical block size of a block device.
@@ -131,5 +131,5 @@ pub fn ioctl_blksszget<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
 #[doc(alias = "BLKPBSZGET")]
 pub fn ioctl_blkpbszget<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
     let fd = fd.as_fd();
-    imp::syscalls::ioctl_blkpbszget(fd)
+    imp::io::syscalls::ioctl_blkpbszget(fd)
 }

--- a/src/io/is_read_write.rs
+++ b/src/io/is_read_write.rs
@@ -13,5 +13,5 @@ use imp::fd::AsFd;
 #[inline]
 pub fn is_read_write<Fd: AsFd>(fd: &Fd) -> io::Result<(bool, bool)> {
     let fd = fd.as_fd();
-    imp::syscalls::is_read_write(fd)
+    imp::io::syscalls::is_read_write(fd)
 }

--- a/src/io/madvise.rs
+++ b/src/io/madvise.rs
@@ -31,5 +31,5 @@ pub use imp::io::Advice;
 #[inline]
 #[doc(alias = "posix_madvise")]
 pub unsafe fn madvise(addr: *mut c_void, len: usize, advice: Advice) -> io::Result<()> {
-    imp::syscalls::madvise(addr, len, advice)
+    imp::io::syscalls::madvise(addr, len, advice)
 }

--- a/src/io/mmap.rs
+++ b/src/io/mmap.rs
@@ -42,7 +42,7 @@ pub unsafe fn mmap<Fd: AsFd>(
     offset: u64,
 ) -> io::Result<*mut c_void> {
     let fd = fd.as_fd();
-    imp::syscalls::mmap(ptr, len, prot, flags, fd, offset)
+    imp::io::syscalls::mmap(ptr, len, prot, flags, fd, offset)
 }
 
 /// `mmap(ptr, len, prot, MAP_ANONYMOUS | flags, -1, 0)`—Create an anonymous
@@ -68,7 +68,7 @@ pub unsafe fn mmap_anonymous(
     prot: ProtFlags,
     flags: MapFlags,
 ) -> io::Result<*mut c_void> {
-    imp::syscalls::mmap_anonymous(ptr, len, prot, flags)
+    imp::io::syscalls::mmap_anonymous(ptr, len, prot, flags)
 }
 
 /// `munmap(ptr, len)`
@@ -85,7 +85,7 @@ pub unsafe fn mmap_anonymous(
 /// [Linux]: https://man7.org/linux/man-pages/man2/munmap.2.html
 #[inline]
 pub unsafe fn munmap(ptr: *mut c_void, len: usize) -> io::Result<()> {
-    imp::syscalls::munmap(ptr, len)
+    imp::io::syscalls::munmap(ptr, len)
 }
 
 /// `mremap(old_address, old_size, new_size, flags)`—Resize, modify,
@@ -110,7 +110,7 @@ pub unsafe fn mremap(
     new_size: usize,
     flags: MremapFlags,
 ) -> io::Result<*mut c_void> {
-    imp::syscalls::mremap(old_address, old_size, new_size, flags)
+    imp::io::syscalls::mremap(old_address, old_size, new_size, flags)
 }
 
 /// `mremap(old_address, old_size, new_size, MREMAP_FIXED | flags)`—Resize,
@@ -137,7 +137,7 @@ pub unsafe fn mremap_fixed(
     flags: MremapFlags,
     new_address: *mut c_void,
 ) -> io::Result<*mut c_void> {
-    imp::syscalls::mremap_fixed(old_address, old_size, new_size, flags, new_address)
+    imp::io::syscalls::mremap_fixed(old_address, old_size, new_size, flags, new_address)
 }
 
 /// `mprotect(ptr, len, flags)`
@@ -154,7 +154,7 @@ pub unsafe fn mremap_fixed(
 /// [Linux]: https://man7.org/linux/man-pages/man2/mprotect.2.html
 #[inline]
 pub unsafe fn mprotect(ptr: *mut c_void, len: usize, flags: MprotectFlags) -> io::Result<()> {
-    imp::syscalls::mprotect(ptr, len, flags)
+    imp::io::syscalls::mprotect(ptr, len, flags)
 }
 
 /// `mlock(ptr, len)`—Lock memory into RAM.
@@ -178,7 +178,7 @@ pub unsafe fn mprotect(ptr: *mut c_void, len: usize, flags: MprotectFlags) -> io
 /// [Linux]: https://man7.org/linux/man-pages/man2/mlock.2.html
 #[inline]
 pub unsafe fn mlock(ptr: *mut c_void, len: usize) -> io::Result<()> {
-    imp::syscalls::mlock(ptr, len)
+    imp::io::syscalls::mlock(ptr, len)
 }
 
 /// `mlock2(ptr, len, flags)`—Lock memory into RAM, with
@@ -205,7 +205,7 @@ pub unsafe fn mlock(ptr: *mut c_void, len: usize) -> io::Result<()> {
 #[inline]
 #[doc(alias = "mlock2")]
 pub unsafe fn mlock_with(ptr: *mut c_void, len: usize, flags: MlockFlags) -> io::Result<()> {
-    imp::syscalls::mlock_with(ptr, len, flags)
+    imp::io::syscalls::mlock_with(ptr, len, flags)
 }
 
 /// `munlock(ptr, len)`—Unlock memory.
@@ -228,5 +228,5 @@ pub unsafe fn mlock_with(ptr: *mut c_void, len: usize, flags: MlockFlags) -> io:
 /// [Linux]: https://man7.org/linux/man-pages/man2/munlock.2.html
 #[inline]
 pub unsafe fn munlock(ptr: *mut c_void, len: usize) -> io::Result<()> {
-    imp::syscalls::munlock(ptr, len)
+    imp::io::syscalls::munlock(ptr, len)
 }

--- a/src/io/msync.rs
+++ b/src/io/msync.rs
@@ -28,5 +28,5 @@ pub use imp::io::MsyncFlags;
 /// [Linux `msync`]: https://man7.org/linux/man-pages/man2/msync.2.html
 #[inline]
 pub unsafe fn msync(addr: *mut c_void, len: usize, flags: MsyncFlags) -> io::Result<()> {
-    imp::syscalls::msync(addr, len, flags)
+    imp::io::syscalls::msync(addr, len, flags)
 }

--- a/src/io/pipe.rs
+++ b/src/io/pipe.rs
@@ -17,7 +17,7 @@ pub use imp::io::PipeFlags;
 /// [Linux]: https://man7.org/linux/man-pages/man2/pipe.2.html
 #[inline]
 pub fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
-    imp::syscalls::pipe()
+    imp::io::syscalls::pipe()
 }
 
 /// `pipe2(flags)`—Creates a pipe, with flags.
@@ -33,5 +33,5 @@ pub fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
 #[inline]
 #[doc(alias = "pipe2")]
 pub fn pipe_with(flags: PipeFlags) -> io::Result<(OwnedFd, OwnedFd)> {
-    imp::syscalls::pipe_with(flags)
+    imp::io::syscalls::pipe_with(flags)
 }

--- a/src/io/poll.rs
+++ b/src/io/poll.rs
@@ -12,5 +12,5 @@ pub use imp::io::{PollFd, PollFlags};
 /// [Linux]: https://man7.org/linux/man-pages/man2/poll.2.html
 #[inline]
 pub fn poll(fds: &mut [PollFd<'_>], timeout: i32) -> io::Result<usize> {
-    imp::syscalls::poll(fds, timeout)
+    imp::io::syscalls::poll(fds, timeout)
 }

--- a/src/io/read_write.rs
+++ b/src/io/read_write.rs
@@ -19,7 +19,7 @@ pub use imp::io::ReadWriteFlags;
 #[inline]
 pub fn read<Fd: AsFd>(fd: &Fd, buf: &mut [u8]) -> io::Result<usize> {
     let fd = fd.as_fd();
-    imp::syscalls::read(fd, buf)
+    imp::io::syscalls::read(fd, buf)
 }
 
 /// `write(fd, buf)`—Writes to a stream.
@@ -33,7 +33,7 @@ pub fn read<Fd: AsFd>(fd: &Fd, buf: &mut [u8]) -> io::Result<usize> {
 #[inline]
 pub fn write<Fd: AsFd>(fd: &Fd, buf: &[u8]) -> io::Result<usize> {
     let fd = fd.as_fd();
-    imp::syscalls::write(fd, buf)
+    imp::io::syscalls::write(fd, buf)
 }
 
 /// `pread(fd, buf, offset)`—Reads from a file at a given position.
@@ -47,7 +47,7 @@ pub fn write<Fd: AsFd>(fd: &Fd, buf: &[u8]) -> io::Result<usize> {
 #[inline]
 pub fn pread<Fd: AsFd>(fd: &Fd, buf: &mut [u8], offset: u64) -> io::Result<usize> {
     let fd = fd.as_fd();
-    imp::syscalls::pread(fd, buf, offset)
+    imp::io::syscalls::pread(fd, buf, offset)
 }
 
 /// `pwrite(fd, bufs)`—Writes to a file at a given position.
@@ -61,7 +61,7 @@ pub fn pread<Fd: AsFd>(fd: &Fd, buf: &mut [u8], offset: u64) -> io::Result<usize
 #[inline]
 pub fn pwrite<Fd: AsFd>(fd: &Fd, buf: &[u8], offset: u64) -> io::Result<usize> {
     let fd = fd.as_fd();
-    imp::syscalls::pwrite(fd, buf, offset)
+    imp::io::syscalls::pwrite(fd, buf, offset)
 }
 
 /// `readv(fd, bufs)`—Reads from a stream into multiple buffers.
@@ -75,7 +75,7 @@ pub fn pwrite<Fd: AsFd>(fd: &Fd, buf: &[u8], offset: u64) -> io::Result<usize> {
 #[inline]
 pub fn readv<Fd: AsFd>(fd: &Fd, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
     let fd = fd.as_fd();
-    imp::syscalls::readv(fd, bufs)
+    imp::io::syscalls::readv(fd, bufs)
 }
 
 /// `writev(fd, bufs)`—Writes to a stream from multiple buffers.
@@ -89,7 +89,7 @@ pub fn readv<Fd: AsFd>(fd: &Fd, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize
 #[inline]
 pub fn writev<Fd: AsFd>(fd: &Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
     let fd = fd.as_fd();
-    imp::syscalls::writev(fd, bufs)
+    imp::io::syscalls::writev(fd, bufs)
 }
 
 /// `preadv(fd, bufs, offset)`—Reads from a file at a given position into
@@ -103,7 +103,7 @@ pub fn writev<Fd: AsFd>(fd: &Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
 #[inline]
 pub fn preadv<Fd: AsFd>(fd: &Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
     let fd = fd.as_fd();
-    imp::syscalls::preadv(fd, bufs, offset)
+    imp::io::syscalls::preadv(fd, bufs, offset)
 }
 
 /// `pwritev(fd, bufs, offset)`—Writes to a file at a given position from
@@ -117,7 +117,7 @@ pub fn preadv<Fd: AsFd>(fd: &Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io
 #[inline]
 pub fn pwritev<Fd: AsFd>(fd: &Fd, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
     let fd = fd.as_fd();
-    imp::syscalls::pwritev(fd, bufs, offset)
+    imp::io::syscalls::pwritev(fd, bufs, offset)
 }
 
 /// `preadv2(fd, bufs, offset, flags)`—Reads data, with several options.
@@ -137,7 +137,7 @@ pub fn preadv2<Fd: AsFd>(
     flags: ReadWriteFlags,
 ) -> io::Result<usize> {
     let fd = fd.as_fd();
-    imp::syscalls::preadv2(fd, bufs, offset, flags)
+    imp::io::syscalls::preadv2(fd, bufs, offset, flags)
 }
 
 /// `pwritev2(fd, bufs, offset, flags)`—Writes data, with several options.
@@ -157,5 +157,5 @@ pub fn pwritev2<Fd: AsFd>(
     flags: ReadWriteFlags,
 ) -> io::Result<usize> {
     let fd = fd.as_fd();
-    imp::syscalls::pwritev2(fd, bufs, offset, flags)
+    imp::io::syscalls::pwritev2(fd, bufs, offset, flags)
 }

--- a/src/io/tty.rs
+++ b/src/io/tty.rs
@@ -27,7 +27,7 @@ use {
 #[inline]
 pub fn isatty<Fd: AsFd>(fd: &Fd) -> bool {
     let fd = fd.as_fd();
-    imp::syscalls::isatty(fd)
+    imp::io::syscalls::isatty(fd)
 }
 
 /// `ttyname_r(fd)`
@@ -63,7 +63,7 @@ fn _ttyname(dirfd: BorrowedFd<'_>, mut buffer: Vec<u8>) -> io::Result<ZString> {
     buffer.resize(buffer.capacity(), 0_u8);
 
     loop {
-        match imp::syscalls::ttyname(dirfd, &mut buffer) {
+        match imp::io::syscalls::ttyname(dirfd, &mut buffer) {
             Err(imp::io::Error::RANGE) => {
                 buffer.reserve(1); // use `Vec` reallocation strategy to grow capacity exponentially
                 buffer.resize(buffer.capacity(), 0_u8);

--- a/src/io/userfaultfd.rs
+++ b/src/io/userfaultfd.rs
@@ -26,5 +26,5 @@ pub use imp::io::UserfaultfdFlags;
 /// [Linux userfaultfd]: https://www.kernel.org/doc/Documentation/vm/userfaultfd.txt
 #[inline]
 pub unsafe fn userfaultfd(flags: UserfaultfdFlags) -> io::Result<OwnedFd> {
-    imp::syscalls::userfaultfd(flags)
+    imp::io::syscalls::userfaultfd(flags)
 }

--- a/src/net/send_recv.rs
+++ b/src/net/send_recv.rs
@@ -23,7 +23,7 @@ pub use imp::net::{RecvFlags, SendFlags};
 #[inline]
 pub fn recv<Fd: AsFd>(fd: &Fd, buf: &mut [u8], flags: RecvFlags) -> io::Result<usize> {
     let fd = fd.as_fd();
-    imp::syscalls::recv(fd, buf, flags)
+    imp::net::syscalls::recv(fd, buf, flags)
 }
 
 /// `send(fd, buf, flags)`—Writes data to a socket.
@@ -39,7 +39,7 @@ pub fn recv<Fd: AsFd>(fd: &Fd, buf: &mut [u8], flags: RecvFlags) -> io::Result<u
 #[inline]
 pub fn send<Fd: AsFd>(fd: &Fd, buf: &[u8], flags: SendFlags) -> io::Result<usize> {
     let fd = fd.as_fd();
-    imp::syscalls::send(fd, buf, flags)
+    imp::net::syscalls::send(fd, buf, flags)
 }
 
 /// `recvfrom(fd, buf, flags, addr, len)`—Reads data from a socket and
@@ -60,7 +60,7 @@ pub fn recvfrom<Fd: AsFd>(
     flags: RecvFlags,
 ) -> io::Result<(usize, SocketAddrAny)> {
     let fd = fd.as_fd();
-    imp::syscalls::recvfrom(fd, buf, flags)
+    imp::net::syscalls::recvfrom(fd, buf, flags)
 }
 
 /// `sendto(fd, buf, flags, addr, sizeof(struct sockaddr_in))`—Writes data to
@@ -83,7 +83,7 @@ pub fn sendto_v4<Fd: AsFd>(
     addr: &SocketAddrV4,
 ) -> io::Result<usize> {
     let fd = fd.as_fd();
-    imp::syscalls::sendto_v4(fd, buf, flags, addr)
+    imp::net::syscalls::sendto_v4(fd, buf, flags, addr)
 }
 
 /// `sendto(fd, buf, flags, addr, sizeof(struct sockaddr_in6))`—Writes data
@@ -106,7 +106,7 @@ pub fn sendto_v6<Fd: AsFd>(
     addr: &SocketAddrV6,
 ) -> io::Result<usize> {
     let fd = fd.as_fd();
-    imp::syscalls::sendto_v6(fd, buf, flags, addr)
+    imp::net::syscalls::sendto_v6(fd, buf, flags, addr)
 }
 
 /// `sendto(fd, buf, flags, addr, sizeof(struct sockaddr_un))`—Writes data to
@@ -130,7 +130,7 @@ pub fn sendto_unix<Fd: AsFd>(
     addr: &SocketAddrUnix,
 ) -> io::Result<usize> {
     let fd = fd.as_fd();
-    imp::syscalls::sendto_unix(fd, buf, flags, addr)
+    imp::net::syscalls::sendto_unix(fd, buf, flags, addr)
 }
 
 // TODO: `recvmsg`, `sendmsg`

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -32,7 +32,7 @@ impl Default for Protocol {
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-socket
 #[inline]
 pub fn socket(domain: AddressFamily, type_: SocketType, protocol: Protocol) -> io::Result<OwnedFd> {
-    imp::syscalls::socket(domain, type_, protocol)
+    imp::net::syscalls::socket(domain, type_, protocol)
 }
 
 /// `socket_with(domain, type_ | flags, protocol)`—Creates a socket, with
@@ -60,7 +60,7 @@ pub fn socket_with(
     flags: SocketFlags,
     protocol: Protocol,
 ) -> io::Result<OwnedFd> {
-    imp::syscalls::socket_with(domain, type_, flags, protocol)
+    imp::net::syscalls::socket_with(domain, type_, flags, protocol)
 }
 
 /// `bind(sockfd, addr, sizeof(struct sockaddr_in))`—Binds a socket to an
@@ -78,7 +78,7 @@ pub fn socket_with(
 #[doc(alias = "bind")]
 pub fn bind_v4<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV4) -> io::Result<()> {
     let sockfd = sockfd.as_fd();
-    imp::syscalls::bind_v4(sockfd, addr)
+    imp::net::syscalls::bind_v4(sockfd, addr)
 }
 
 /// `bind(sockfd, addr, sizeof(struct sockaddr_in6))`—Binds a socket to an
@@ -96,7 +96,7 @@ pub fn bind_v4<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV4) -> io::Result<()> {
 #[doc(alias = "bind")]
 pub fn bind_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> {
     let sockfd = sockfd.as_fd();
-    imp::syscalls::bind_v6(sockfd, addr)
+    imp::net::syscalls::bind_v6(sockfd, addr)
 }
 
 /// `bind(sockfd, addr, sizeof(struct sockaddr_un))`—Binds a socket to an
@@ -115,7 +115,7 @@ pub fn bind_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> {
 #[cfg(not(windows))]
 pub fn bind_unix<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrUnix) -> io::Result<()> {
     let sockfd = sockfd.as_fd();
-    imp::syscalls::bind_unix(sockfd, addr)
+    imp::net::syscalls::bind_unix(sockfd, addr)
 }
 
 /// `connect(sockfd, addr, sizeof(struct sockaddr_in))`—Initiates a
@@ -133,7 +133,7 @@ pub fn bind_unix<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrUnix) -> io::Result<()>
 #[doc(alias = "connect")]
 pub fn connect_v4<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV4) -> io::Result<()> {
     let sockfd = sockfd.as_fd();
-    imp::syscalls::connect_v4(sockfd, addr)
+    imp::net::syscalls::connect_v4(sockfd, addr)
 }
 
 /// `connect(sockfd, addr, sizeof(struct sockaddr_in6))`—Initiates a
@@ -151,7 +151,7 @@ pub fn connect_v4<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV4) -> io::Result<()> 
 #[doc(alias = "connect")]
 pub fn connect_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> {
     let sockfd = sockfd.as_fd();
-    imp::syscalls::connect_v6(sockfd, addr)
+    imp::net::syscalls::connect_v6(sockfd, addr)
 }
 
 /// `connect(sockfd, addr, sizeof(struct sockaddr_un))`—Initiates a
@@ -168,7 +168,7 @@ pub fn connect_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> 
 #[cfg(not(windows))]
 pub fn connect_unix<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrUnix) -> io::Result<()> {
     let sockfd = sockfd.as_fd();
-    imp::syscalls::connect_unix(sockfd, addr)
+    imp::net::syscalls::connect_unix(sockfd, addr)
 }
 
 /// `listen(fd, backlog)`—Enables listening for incoming connections.
@@ -184,7 +184,7 @@ pub fn connect_unix<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrUnix) -> io::Result<
 #[inline]
 pub fn listen<Fd: AsFd>(sockfd: &Fd, backlog: i32) -> io::Result<()> {
     let sockfd = sockfd.as_fd();
-    imp::syscalls::listen(sockfd, backlog)
+    imp::net::syscalls::listen(sockfd, backlog)
 }
 
 /// `accept(fd, NULL, NULL)`—Accepts an incoming connection.
@@ -207,7 +207,7 @@ pub fn listen<Fd: AsFd>(sockfd: &Fd, backlog: i32) -> io::Result<()> {
 #[doc(alias = "accept4")]
 pub fn accept<Fd: AsFd>(sockfd: &Fd) -> io::Result<OwnedFd> {
     let sockfd = sockfd.as_fd();
-    imp::syscalls::accept(sockfd)
+    imp::net::syscalls::accept(sockfd)
 }
 
 /// `accept4(fd, NULL, NULL, flags)`—Accepts an incoming connection, with
@@ -234,7 +234,7 @@ pub fn accept<Fd: AsFd>(sockfd: &Fd) -> io::Result<OwnedFd> {
 #[doc(alias = "accept4")]
 pub fn accept_with<Fd: AsFd>(sockfd: &Fd, flags: AcceptFlags) -> io::Result<OwnedFd> {
     let sockfd = sockfd.as_fd();
-    imp::syscalls::accept_with(sockfd, flags)
+    imp::net::syscalls::accept_with(sockfd, flags)
 }
 
 /// `accept(fd, &addr, &len)`—Accepts an incoming connection and returns the
@@ -254,7 +254,7 @@ pub fn accept_with<Fd: AsFd>(sockfd: &Fd, flags: AcceptFlags) -> io::Result<Owne
 #[doc(alias = "accept4")]
 pub fn acceptfrom<Fd: AsFd>(sockfd: &Fd) -> io::Result<(OwnedFd, SocketAddrAny)> {
     let sockfd = sockfd.as_fd();
-    imp::syscalls::acceptfrom(sockfd)
+    imp::net::syscalls::acceptfrom(sockfd)
 }
 
 /// `accept4(fd, &addr, &len, flags)`—Accepts an incoming connection and
@@ -280,7 +280,7 @@ pub fn acceptfrom_with<Fd: AsFd>(
     flags: AcceptFlags,
 ) -> io::Result<(OwnedFd, SocketAddrAny)> {
     let sockfd = sockfd.as_fd();
-    imp::syscalls::acceptfrom_with(sockfd, flags)
+    imp::net::syscalls::acceptfrom_with(sockfd, flags)
 }
 
 /// `shutdown(fd, how)`—Closes the read and/or write sides of a stream.
@@ -296,7 +296,7 @@ pub fn acceptfrom_with<Fd: AsFd>(
 #[inline]
 pub fn shutdown<Fd: AsFd>(sockfd: &Fd, how: Shutdown) -> io::Result<()> {
     let sockfd = sockfd.as_fd();
-    imp::syscalls::shutdown(sockfd, how)
+    imp::net::syscalls::shutdown(sockfd, how)
 }
 
 /// `getsockname(fd, addr, len)`—Returns the address a socket is bound to.
@@ -312,7 +312,7 @@ pub fn shutdown<Fd: AsFd>(sockfd: &Fd, how: Shutdown) -> io::Result<()> {
 #[inline]
 pub fn getsockname<Fd: AsFd>(sockfd: &Fd) -> io::Result<SocketAddrAny> {
     let sockfd = sockfd.as_fd();
-    imp::syscalls::getsockname(sockfd)
+    imp::net::syscalls::getsockname(sockfd)
 }
 
 /// `getpeername(fd, addr, len)`—Returns the address a socket is connected
@@ -329,5 +329,5 @@ pub fn getsockname<Fd: AsFd>(sockfd: &Fd) -> io::Result<SocketAddrAny> {
 #[inline]
 pub fn getpeername<Fd: AsFd>(sockfd: &Fd) -> io::Result<SocketAddrAny> {
     let sockfd = sockfd.as_fd();
-    imp::syscalls::getpeername(sockfd)
+    imp::net::syscalls::getpeername(sockfd)
 }

--- a/src/net/socketpair.rs
+++ b/src/net/socketpair.rs
@@ -17,5 +17,5 @@ pub fn socketpair(
     flags: SocketFlags,
     protocol: Protocol,
 ) -> io::Result<(OwnedFd, OwnedFd)> {
-    imp::syscalls::socketpair(domain, type_, flags, protocol)
+    imp::net::syscalls::socketpair(domain, type_, flags, protocol)
 }

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -35,7 +35,7 @@ pub use imp::net::Timeout;
 #[doc(alias = "SO_TYPE")]
 pub fn get_socket_type<Fd: AsFd>(fd: &Fd) -> io::Result<SocketType> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::get_socket_type(fd)
+    imp::net::syscalls::sockopt::get_socket_type(fd)
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, value)`
@@ -58,7 +58,7 @@ pub fn get_socket_type<Fd: AsFd>(fd: &Fd) -> io::Result<SocketType> {
 #[doc(alias = "SO_REUSEADDR")]
 pub fn set_socket_reuseaddr<Fd: AsFd>(fd: &Fd, value: bool) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_socket_reuseaddr(fd, value)
+    imp::net::syscalls::sockopt::set_socket_reuseaddr(fd, value)
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_BROADCAST, broadcast)`
@@ -81,7 +81,7 @@ pub fn set_socket_reuseaddr<Fd: AsFd>(fd: &Fd, value: bool) -> io::Result<()> {
 #[doc(alias = "SO_BROADCAST")]
 pub fn set_socket_broadcast<Fd: AsFd>(fd: &Fd, broadcast: bool) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_socket_broadcast(fd, broadcast)
+    imp::net::syscalls::sockopt::set_socket_broadcast(fd, broadcast)
 }
 
 /// `getsockopt(fd, SOL_SOCKET, SO_BROADCAST)`
@@ -104,7 +104,7 @@ pub fn set_socket_broadcast<Fd: AsFd>(fd: &Fd, broadcast: bool) -> io::Result<()
 #[doc(alias = "SO_BROADCAST")]
 pub fn get_socket_broadcast<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::get_socket_broadcast(fd)
+    imp::net::syscalls::sockopt::get_socket_broadcast(fd)
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_LINGER, linger)`
@@ -127,7 +127,7 @@ pub fn get_socket_broadcast<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
 #[doc(alias = "SO_LINGER")]
 pub fn set_socket_linger<Fd: AsFd>(fd: &Fd, linger: Option<Duration>) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_socket_linger(fd, linger)
+    imp::net::syscalls::sockopt::set_socket_linger(fd, linger)
 }
 
 /// `getsockopt(fd, SOL_SOCKET, SO_LINGER)`
@@ -150,7 +150,7 @@ pub fn set_socket_linger<Fd: AsFd>(fd: &Fd, linger: Option<Duration>) -> io::Res
 #[doc(alias = "SO_LINGER")]
 pub fn get_socket_linger<Fd: AsFd>(fd: &Fd) -> io::Result<Option<Duration>> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::get_socket_linger(fd)
+    imp::net::syscalls::sockopt::get_socket_linger(fd)
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_PASSCRED, passcred)`
@@ -166,7 +166,7 @@ pub fn get_socket_linger<Fd: AsFd>(fd: &Fd) -> io::Result<Option<Duration>> {
 #[doc(alias = "SO_PASSCRED")]
 pub fn set_socket_passcred<Fd: AsFd>(fd: &Fd, passcred: bool) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_socket_passcred(fd, passcred)
+    imp::net::syscalls::sockopt::set_socket_passcred(fd, passcred)
 }
 
 /// `getsockopt(fd, SOL_SOCKET, SO_PASSCRED)`
@@ -182,7 +182,7 @@ pub fn set_socket_passcred<Fd: AsFd>(fd: &Fd, passcred: bool) -> io::Result<()> 
 #[doc(alias = "SO_PASSCRED")]
 pub fn get_socket_passcred<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::get_socket_passcred(fd)
+    imp::net::syscalls::sockopt::get_socket_passcred(fd)
 }
 
 /// `setsockopt(fd, SOL_SOCKET, id, timeout)`—Set the sending
@@ -211,7 +211,7 @@ pub fn set_socket_timeout<Fd: AsFd>(
     timeout: Option<Duration>,
 ) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_socket_timeout(fd, id, timeout)
+    imp::net::syscalls::sockopt::set_socket_timeout(fd, id, timeout)
 }
 
 /// `getsockopt(fd, SOL_SOCKET, id)`—Get the sending or receiving timeout.
@@ -235,7 +235,7 @@ pub fn set_socket_timeout<Fd: AsFd>(
 #[doc(alias = "SO_SNDTIMEO")]
 pub fn get_socket_timeout<Fd: AsFd>(fd: &Fd, id: Timeout) -> io::Result<Option<Duration>> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::get_socket_timeout(fd, id)
+    imp::net::syscalls::sockopt::get_socket_timeout(fd, id)
 }
 
 /// `setsockopt(fd, IPPROTO_IP, IP_TTL, ttl)`
@@ -257,7 +257,7 @@ pub fn get_socket_timeout<Fd: AsFd>(fd: &Fd, id: Timeout) -> io::Result<Option<D
 #[doc(alias = "IP_TTL")]
 pub fn set_ip_ttl<Fd: AsFd>(fd: &Fd, ttl: u32) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_ip_ttl(fd, ttl)
+    imp::net::syscalls::sockopt::set_ip_ttl(fd, ttl)
 }
 
 /// `getsockopt(fd, IPPROTO_IP, IP_TTL)`
@@ -280,7 +280,7 @@ pub fn set_ip_ttl<Fd: AsFd>(fd: &Fd, ttl: u32) -> io::Result<()> {
 #[doc(alias = "IP_TTL")]
 pub fn get_ip_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::get_ip_ttl(fd)
+    imp::net::syscalls::sockopt::get_ip_ttl(fd)
 }
 
 /// `setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, only_v6)`
@@ -303,7 +303,7 @@ pub fn get_ip_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
 #[doc(alias = "IPV6_V6ONLY")]
 pub fn set_ipv6_v6only<Fd: AsFd>(fd: &Fd, only_v6: bool) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_ipv6_v6only(fd, only_v6)
+    imp::net::syscalls::sockopt::set_ipv6_v6only(fd, only_v6)
 }
 
 /// `getsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY)`
@@ -326,7 +326,7 @@ pub fn set_ipv6_v6only<Fd: AsFd>(fd: &Fd, only_v6: bool) -> io::Result<()> {
 #[doc(alias = "IPV6_V6ONLY")]
 pub fn get_ipv6_v6only<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::get_ipv6_v6only(fd)
+    imp::net::syscalls::sockopt::get_ipv6_v6only(fd)
 }
 
 /// `setsockopt(fd, IPPROTO_IP, IP_MULTICAST_LOOP, multicast_loop)`
@@ -349,7 +349,7 @@ pub fn get_ipv6_v6only<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
 #[doc(alias = "IP_MULTICAST_LOOP")]
 pub fn set_ip_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_ip_multicast_loop(fd, multicast_loop)
+    imp::net::syscalls::sockopt::set_ip_multicast_loop(fd, multicast_loop)
 }
 
 /// `getsockopt(fd, IPPROTO_IP, IP_MULTICAST_LOOP)`
@@ -372,7 +372,7 @@ pub fn set_ip_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::Res
 #[doc(alias = "IP_MULTICAST_LOOP")]
 pub fn get_ip_multicast_loop<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::get_ip_multicast_loop(fd)
+    imp::net::syscalls::sockopt::get_ip_multicast_loop(fd)
 }
 
 /// `setsockopt(fd, IPPROTO_IP, IP_MULTICAST_TTL, multicast_ttl)`
@@ -395,7 +395,7 @@ pub fn get_ip_multicast_loop<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
 #[doc(alias = "IP_MULTICAST_TTL")]
 pub fn set_ip_multicast_ttl<Fd: AsFd>(fd: &Fd, multicast_ttl: u32) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_ip_multicast_ttl(fd, multicast_ttl)
+    imp::net::syscalls::sockopt::set_ip_multicast_ttl(fd, multicast_ttl)
 }
 
 /// `getsockopt(fd, IPPROTO_IP, IP_MULTICAST_TTL)`
@@ -418,7 +418,7 @@ pub fn set_ip_multicast_ttl<Fd: AsFd>(fd: &Fd, multicast_ttl: u32) -> io::Result
 #[doc(alias = "IP_MULTICAST_TTL")]
 pub fn get_ip_multicast_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::get_ip_multicast_ttl(fd)
+    imp::net::syscalls::sockopt::get_ip_multicast_ttl(fd)
 }
 
 /// `setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, multicast_loop)`
@@ -441,7 +441,7 @@ pub fn get_ip_multicast_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
 #[doc(alias = "IPV6_MULTICAST_LOOP")]
 pub fn set_ipv6_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_ipv6_multicast_loop(fd, multicast_loop)
+    imp::net::syscalls::sockopt::set_ipv6_multicast_loop(fd, multicast_loop)
 }
 
 /// `getsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP)`
@@ -464,7 +464,7 @@ pub fn set_ipv6_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::R
 #[doc(alias = "IPV6_MULTICAST_LOOP")]
 pub fn get_ipv6_multicast_loop<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::get_ipv6_multicast_loop(fd)
+    imp::net::syscalls::sockopt::get_ipv6_multicast_loop(fd)
 }
 
 /// `setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, multiaddr, interface)`
@@ -491,7 +491,7 @@ pub fn set_ip_add_membership<Fd: AsFd>(
     interface: &Ipv4Addr,
 ) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_ip_add_membership(fd, multiaddr, interface)
+    imp::net::syscalls::sockopt::set_ip_add_membership(fd, multiaddr, interface)
 }
 
 /// `setsockopt(fd, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, multiaddr, interface)`
@@ -521,7 +521,7 @@ pub fn set_ipv6_add_membership<Fd: AsFd>(
     interface: u32,
 ) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_ipv6_add_membership(fd, multiaddr, interface)
+    imp::net::syscalls::sockopt::set_ipv6_add_membership(fd, multiaddr, interface)
 }
 
 /// `setsockopt(fd, IPPROTO_IP, IP_DROP_MEMBERSHIP, multiaddr, interface)`
@@ -548,7 +548,7 @@ pub fn set_ip_drop_membership<Fd: AsFd>(
     interface: &Ipv4Addr,
 ) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_ip_drop_membership(fd, multiaddr, interface)
+    imp::net::syscalls::sockopt::set_ip_drop_membership(fd, multiaddr, interface)
 }
 
 /// `setsockopt(fd, IPPROTO_IPV6, IPV6_DROP_MEMBERSHIP, multiaddr, interface)`
@@ -578,7 +578,7 @@ pub fn set_ipv6_drop_membership<Fd: AsFd>(
     interface: u32,
 ) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_ipv6_drop_membership(fd, multiaddr, interface)
+    imp::net::syscalls::sockopt::set_ipv6_drop_membership(fd, multiaddr, interface)
 }
 
 /// `setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, nodelay)`
@@ -601,7 +601,7 @@ pub fn set_ipv6_drop_membership<Fd: AsFd>(
 #[doc(alias = "TCP_NODELAY")]
 pub fn set_tcp_nodelay<Fd: AsFd>(fd: &Fd, nodelay: bool) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::set_tcp_nodelay(fd, nodelay)
+    imp::net::syscalls::sockopt::set_tcp_nodelay(fd, nodelay)
 }
 
 /// `getsockopt(fd, IPPROTO_TCP, TCP_NODELAY)`
@@ -624,5 +624,5 @@ pub fn set_tcp_nodelay<Fd: AsFd>(fd: &Fd, nodelay: bool) -> io::Result<()> {
 #[doc(alias = "TCP_NODELAY")]
 pub fn get_tcp_nodelay<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
     let fd = fd.as_fd();
-    imp::syscalls::sockopt::get_tcp_nodelay(fd)
+    imp::net::syscalls::sockopt::get_tcp_nodelay(fd)
 }

--- a/src/process/chdir.rs
+++ b/src/process/chdir.rs
@@ -15,7 +15,7 @@ use imp::fd::AsFd;
 /// [Linux]: https://man7.org/linux/man-pages/man2/chdir.2.html
 #[inline]
 pub fn chdir<P: path::Arg>(path: P) -> io::Result<()> {
-    path.into_with_z_str(imp::syscalls::chdir)
+    path.into_with_z_str(imp::process::syscalls::chdir)
 }
 
 /// `fchdir(fd)`—Change the working directory.
@@ -30,7 +30,7 @@ pub fn chdir<P: path::Arg>(path: P) -> io::Result<()> {
 #[inline]
 pub fn fchdir<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     let fd = fd.as_fd();
-    imp::syscalls::fchdir(fd)
+    imp::process::syscalls::fchdir(fd)
 }
 
 /// `getcwd()`
@@ -57,7 +57,7 @@ fn _getcwd(mut buffer: Vec<u8>) -> io::Result<ZString> {
     buffer.resize(buffer.capacity(), 0_u8);
 
     loop {
-        match imp::syscalls::getcwd(&mut buffer) {
+        match imp::process::syscalls::getcwd(&mut buffer) {
             Err(imp::io::Error::RANGE) => {
                 buffer.reserve(1); // use `Vec` reallocation strategy to grow capacity exponentially
                 buffer.resize(buffer.capacity(), 0_u8);

--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -170,7 +170,7 @@ impl Cpuid {
 #[inline]
 #[must_use]
 pub fn getuid() -> Uid {
-    imp::syscalls::getuid()
+    imp::process::syscalls::getuid()
 }
 
 /// `geteuid()`—Returns the process' effective user ID.
@@ -184,7 +184,7 @@ pub fn getuid() -> Uid {
 #[inline]
 #[must_use]
 pub fn geteuid() -> Uid {
-    imp::syscalls::geteuid()
+    imp::process::syscalls::geteuid()
 }
 
 /// `getgid()`—Returns the process' real group ID.
@@ -198,7 +198,7 @@ pub fn geteuid() -> Uid {
 #[inline]
 #[must_use]
 pub fn getgid() -> Gid {
-    imp::syscalls::getgid()
+    imp::process::syscalls::getgid()
 }
 
 /// `getegid()`—Returns the process' effective group ID.
@@ -212,7 +212,7 @@ pub fn getgid() -> Gid {
 #[inline]
 #[must_use]
 pub fn getegid() -> Gid {
-    imp::syscalls::getegid()
+    imp::process::syscalls::getegid()
 }
 
 /// `getpid()`—Returns the process' ID.
@@ -226,7 +226,7 @@ pub fn getegid() -> Gid {
 #[inline]
 #[must_use]
 pub fn getpid() -> Pid {
-    imp::syscalls::getpid()
+    imp::process::syscalls::getpid()
 }
 
 /// `getppid()`—Returns the parent process' ID.
@@ -240,5 +240,5 @@ pub fn getpid() -> Pid {
 #[inline]
 #[must_use]
 pub fn getppid() -> Option<Pid> {
-    imp::syscalls::getppid()
+    imp::process::syscalls::getppid()
 }

--- a/src/process/membarrier.rs
+++ b/src/process/membarrier.rs
@@ -66,7 +66,7 @@ impl MembarrierQuery {
 #[inline]
 #[doc(alias = "MEMBARRIER_CMD_QUERY")]
 pub fn membarrier_query() -> MembarrierQuery {
-    imp::syscalls::membarrier_query()
+    imp::process::syscalls::membarrier_query()
 }
 
 /// `membarrier(cmd, 0, 0)`—Perform a memory barrier.
@@ -77,7 +77,7 @@ pub fn membarrier_query() -> MembarrierQuery {
 /// [Linux]: https://man7.org/linux/man-pages/man2/membarrier.2.html
 #[inline]
 pub fn membarrier(cmd: MembarrierCommand) -> io::Result<()> {
-    imp::syscalls::membarrier(cmd)
+    imp::process::syscalls::membarrier(cmd)
 }
 
 /// `membarrier(cmd, MEMBARRIER_CMD_FLAG_CPU, cpu)`—Perform a memory barrier
@@ -89,5 +89,5 @@ pub fn membarrier(cmd: MembarrierCommand) -> io::Result<()> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/membarrier.2.html
 #[inline]
 pub fn membarrier_cpu(cmd: MembarrierCommand, cpu: Cpuid) -> io::Result<()> {
-    imp::syscalls::membarrier_cpu(cmd, cpu)
+    imp::process::syscalls::membarrier_cpu(cmd, cpu)
 }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -126,7 +126,7 @@ pub const EXIT_SIGNALED_SIGABRT: i32 = imp::process::EXIT_SIGNALED_SIGABRT;
 /// [Linux]: https://man7.org/linux/man-pages/man2/sched_yield.2.html
 #[inline]
 pub fn sched_yield() {
-    imp::syscalls::sched_yield()
+    imp::process::syscalls::sched_yield()
 }
 
 /// `waitpid(pid, waitopts)`—Wait for a specific process to change state.
@@ -156,7 +156,7 @@ pub fn sched_yield() {
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 pub fn waitpid(pid: Option<Pid>, waitopts: WaitOptions) -> io::Result<Option<WaitStatus>> {
-    Ok(imp::syscalls::waitpid(pid, waitopts)?.map(|(_, status)| status))
+    Ok(imp::process::syscalls::waitpid(pid, waitopts)?.map(|(_, status)| status))
 }
 
 /// `wait(waitopts)`—Wait for any of the children of calling process to
@@ -177,7 +177,7 @@ pub fn waitpid(pid: Option<Pid>, waitopts: WaitOptions) -> io::Result<Option<Wai
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 pub fn wait(waitopts: WaitOptions) -> io::Result<Option<(Pid, WaitStatus)>> {
-    imp::syscalls::wait(waitopts)
+    imp::process::syscalls::wait(waitopts)
 }
 
 /// `setsid()`—Create a new session.
@@ -191,7 +191,7 @@ pub fn wait(waitopts: WaitOptions) -> io::Result<Option<(Pid, WaitStatus)>> {
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 pub fn setsid() -> io::Result<Pid> {
-    imp::syscalls::setsid()
+    imp::process::syscalls::setsid()
 }
 
 /// `kill(pid, sig)`—Sends a signal to a process.
@@ -206,7 +206,7 @@ pub fn setsid() -> io::Result<Pid> {
 #[inline]
 #[doc(alias = "kill")]
 pub fn kill_process(pid: Pid, sig: Signal) -> io::Result<()> {
-    imp::syscalls::kill_process(pid, sig)
+    imp::process::syscalls::kill_process(pid, sig)
 }
 
 /// `kill(-pid, sig)`—Sends a signal to all processes in a process group.
@@ -225,7 +225,7 @@ pub fn kill_process(pid: Pid, sig: Signal) -> io::Result<()> {
 #[inline]
 #[doc(alias = "kill")]
 pub fn kill_process_group(pid: Pid, sig: Signal) -> io::Result<()> {
-    imp::syscalls::kill_process_group(pid, sig)
+    imp::process::syscalls::kill_process_group(pid, sig)
 }
 
 /// `kill(0, sig)`—Sends a signal to all processes in the current process
@@ -241,5 +241,5 @@ pub fn kill_process_group(pid: Pid, sig: Signal) -> io::Result<()> {
 #[inline]
 #[doc(alias = "kill")]
 pub fn kill_current_process_group(sig: Signal) -> io::Result<()> {
-    imp::syscalls::kill_current_process_group(sig)
+    imp::process::syscalls::kill_current_process_group(sig)
 }

--- a/src/process/priority.rs
+++ b/src/process/priority.rs
@@ -11,7 +11,7 @@ use crate::{imp, io};
 /// [Linux]: https://man7.org/linux/man-pages/man2/nice.2.html
 #[inline]
 pub fn nice(inc: i32) -> io::Result<i32> {
-    imp::syscalls::nice(inc)
+    imp::process::syscalls::nice(inc)
 }
 
 /// `getpriority(PRIO_USER, uid)`—Get the scheduling priority of the given
@@ -29,7 +29,7 @@ pub fn nice(inc: i32) -> io::Result<i32> {
 #[inline]
 #[doc(alias = "getpriority")]
 pub fn getpriority_user(uid: Uid) -> io::Result<i32> {
-    imp::syscalls::getpriority_user(uid)
+    imp::process::syscalls::getpriority_user(uid)
 }
 
 /// `getpriority(PRIO_PGRP, gid)`—Get the scheduling priority of the given
@@ -49,7 +49,7 @@ pub fn getpriority_user(uid: Uid) -> io::Result<i32> {
 #[inline]
 #[doc(alias = "getpriority")]
 pub fn getpriority_pgrp(pgid: Option<Pid>) -> io::Result<i32> {
-    imp::syscalls::getpriority_pgrp(pgid)
+    imp::process::syscalls::getpriority_pgrp(pgid)
 }
 
 /// `getpriority(PRIO_PROCESS, pid)`—Get the scheduling priority of the given
@@ -69,7 +69,7 @@ pub fn getpriority_pgrp(pgid: Option<Pid>) -> io::Result<i32> {
 #[inline]
 #[doc(alias = "getpriority")]
 pub fn getpriority_process(pid: Option<Pid>) -> io::Result<i32> {
-    imp::syscalls::getpriority_process(pid)
+    imp::process::syscalls::getpriority_process(pid)
 }
 
 /// `setpriority(PRIO_USER, uid)`—Get the scheduling priority of the given
@@ -87,7 +87,7 @@ pub fn getpriority_process(pid: Option<Pid>) -> io::Result<i32> {
 #[inline]
 #[doc(alias = "setpriority")]
 pub fn setpriority_user(uid: Uid, priority: i32) -> io::Result<()> {
-    imp::syscalls::setpriority_user(uid, priority)
+    imp::process::syscalls::setpriority_user(uid, priority)
 }
 
 /// `setpriority(PRIO_PGRP, pgid)`—Get the scheduling priority of the given
@@ -107,7 +107,7 @@ pub fn setpriority_user(uid: Uid, priority: i32) -> io::Result<()> {
 #[inline]
 #[doc(alias = "setpriority")]
 pub fn setpriority_pgrp(pgid: Option<Pid>, priority: i32) -> io::Result<()> {
-    imp::syscalls::setpriority_pgrp(pgid, priority)
+    imp::process::syscalls::setpriority_pgrp(pgid, priority)
 }
 
 /// `setpriority(PRIO_PROCESS, pid)`—Get the scheduling priority of the given
@@ -127,5 +127,5 @@ pub fn setpriority_pgrp(pgid: Option<Pid>, priority: i32) -> io::Result<()> {
 #[inline]
 #[doc(alias = "setpriority")]
 pub fn setpriority_process(pid: Option<Pid>, priority: i32) -> io::Result<()> {
-    imp::syscalls::setpriority_process(pid, priority)
+    imp::process::syscalls::setpriority_process(pid, priority)
 }

--- a/src/process/rlimit.rs
+++ b/src/process/rlimit.rs
@@ -24,7 +24,7 @@ pub struct Rlimit {
 /// [Linux]: https://man7.org/linux/man-pages/man2/getrlimit.2.html
 #[inline]
 pub fn getrlimit(resource: Resource) -> Rlimit {
-    imp::syscalls::getrlimit(resource)
+    imp::process::syscalls::getrlimit(resource)
 }
 
 /// `setrlimit(resource, new)`—Set a process resource limit value.
@@ -37,7 +37,7 @@ pub fn getrlimit(resource: Resource) -> Rlimit {
 /// [Linux]: https://man7.org/linux/man-pages/man2/setrlimit.2.html
 #[inline]
 pub fn setrlimit(resource: Resource, new: Rlimit) -> io::Result<()> {
-    imp::syscalls::setrlimit(resource, new)
+    imp::process::syscalls::setrlimit(resource, new)
 }
 
 /// `prlimit(pid, resource, new)`—Get and set a process resource limit value.
@@ -49,5 +49,5 @@ pub fn setrlimit(resource: Resource, new: Rlimit) -> io::Result<()> {
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 pub fn prlimit(pid: Option<Pid>, resource: Resource, new: Rlimit) -> io::Result<Rlimit> {
-    imp::syscalls::prlimit(pid, resource, new)
+    imp::process::syscalls::prlimit(pid, resource, new)
 }

--- a/src/process/sched.rs
+++ b/src/process/sched.rs
@@ -82,7 +82,7 @@ impl CpuSet {
 /// [Linux]: https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html
 #[inline]
 pub fn sched_setaffinity(pid: Option<Pid>, cpuset: &CpuSet) -> io::Result<()> {
-    imp::syscalls::sched_setaffinity(pid, &cpuset.cpu_set)
+    imp::process::syscalls::sched_setaffinity(pid, &cpuset.cpu_set)
 }
 
 /// `sched_getaffinity(pid)`—Get a thread's CPU affinity mask.
@@ -99,5 +99,5 @@ pub fn sched_setaffinity(pid: Option<Pid>, cpuset: &CpuSet) -> io::Result<()> {
 #[inline]
 pub fn sched_getaffinity(pid: Option<Pid>) -> io::Result<CpuSet> {
     let mut cpuset = CpuSet::new();
-    imp::syscalls::sched_getaffinity(pid, &mut cpuset.cpu_set).and(Ok(cpuset))
+    imp::process::syscalls::sched_getaffinity(pid, &mut cpuset.cpu_set).and(Ok(cpuset))
 }

--- a/src/process/uname.rs
+++ b/src/process/uname.rs
@@ -14,7 +14,7 @@ use core::fmt;
 /// hardware.
 #[inline]
 pub fn uname() -> Uname {
-    Uname(imp::syscalls::uname())
+    Uname(imp::process::syscalls::uname())
 }
 
 /// `struct utsname`—Return type for [`uname`].

--- a/src/rand/getrandom.rs
+++ b/src/rand/getrandom.rs
@@ -11,5 +11,5 @@ pub use imp::rand::GetRandomFlags;
 /// [Linux]: https://man7.org/linux/man-pages/man2/getrandom.2.html
 #[inline]
 pub fn getrandom(buf: &mut [u8], flags: GetRandomFlags) -> io::Result<usize> {
-    imp::syscalls::getrandom(buf, flags)
+    imp::rand::syscalls::getrandom(buf, flags)
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -113,7 +113,7 @@ pub unsafe fn exit_thread(status: i32) -> ! {
 #[doc(alias = "_Exit")]
 #[inline]
 pub fn exit_group(status: i32) -> ! {
-    imp::syscalls::exit_group(status)
+    imp::process::syscalls::exit_group(status)
 }
 
 /// Return fields from the main executable segment headers ("phdrs") relevant

--- a/src/thread/clock.rs
+++ b/src/thread/clock.rs
@@ -38,7 +38,7 @@ use imp::time::ClockId;
 )))))]
 #[inline]
 pub fn clock_nanosleep_relative(id: ClockId, request: &Timespec) -> NanosleepRelativeResult {
-    imp::syscalls::clock_nanosleep_relative(id, request)
+    imp::thread::syscalls::clock_nanosleep_relative(id, request)
 }
 
 /// `clock_nanosleep(id, TIMER_ABSTIME, request, NULL)`—Sleeps until an
@@ -65,7 +65,7 @@ pub fn clock_nanosleep_relative(id: ClockId, request: &Timespec) -> NanosleepRel
 )))))]
 #[inline]
 pub fn clock_nanosleep_absolute(id: ClockId, request: &Timespec) -> io::Result<()> {
-    imp::syscalls::clock_nanosleep_absolute(id, request)
+    imp::thread::syscalls::clock_nanosleep_absolute(id, request)
 }
 
 /// `nanosleep(request, remain)`—Sleeps for a duration.
@@ -80,7 +80,7 @@ pub fn clock_nanosleep_absolute(id: ClockId, request: &Timespec) -> io::Result<(
 /// [Linux]: https://man7.org/linux/man-pages/man2/nanosleep.2.html
 #[inline]
 pub fn nanosleep(request: &Timespec) -> NanosleepRelativeResult {
-    imp::syscalls::nanosleep(request)
+    imp::thread::syscalls::nanosleep(request)
 }
 
 /// A return type for `nanosleep` and `clock_nanosleep_relative`.

--- a/src/thread/futex.rs
+++ b/src/thread/futex.rs
@@ -35,5 +35,5 @@ pub unsafe fn futex(
     uaddr2: *mut u32,
     val3: u32,
 ) -> io::Result<usize> {
-    imp::syscalls::futex(uaddr, op, flags, val, utime, uaddr2, val3)
+    imp::thread::syscalls::futex(uaddr, op, flags, val, utime, uaddr2, val3)
 }

--- a/src/thread/id.rs
+++ b/src/thread/id.rs
@@ -10,5 +10,5 @@ use crate::process::Pid;
 #[inline]
 #[must_use]
 pub fn gettid() -> Pid {
-    imp::syscalls::gettid()
+    imp::thread::syscalls::gettid()
 }

--- a/src/time/clock.rs
+++ b/src/time/clock.rs
@@ -20,7 +20,7 @@ pub use imp::time::{ClockId, DynamicClockId};
 #[inline]
 #[must_use]
 pub fn clock_getres(id: ClockId) -> Timespec {
-    imp::syscalls::clock_getres(id)
+    imp::time::syscalls::clock_getres(id)
 }
 
 /// `clock_gettime(id)`—Returns the current value of a clock.


### PR DESCRIPTION
Remove lines like

> pub(crate) use super::fs::syscalls::*;

from the top-level syscalls.rs files, and just have code reference the
specific modules they need.