### PR TITLE
Exclude all dotfiles from the crates.io package.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/bytecodealliance/rustix"
 edition = "2018"
 keywords = ["api", "file", "network", "safe", "syscall"]
 categories = ["os::unix-apis", "date-and-time", "filesystem", "network-programming"]
-exclude = ["/.github"]
+exclude = ["/.*"]
 
 [build-dependencies]
 cc = { version = "1.0.68", optional = true }


### PR DESCRIPTION
.gitignore, .cirrus.yml, and .rustfmt.toml don't need to be shipped in
the crates.io package, so exclude them.