### PR TITLE
Update to linux-raw 0.0.39.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ once_cell = { version = "1.5.2", optional = true }
 
 # For the linux_raw backend, linux-raw-sys provides Linux ABI details.
 [target.'cfg(all(not(rustix_use_libc), any(target_os = "linux"), any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64")))'.dependencies]
-linux-raw-sys = { version = "0.0.37", default-features = false, features = ["general", "errno", "v5_4", "v5_11", "no_std"] }
+linux-raw-sys = { version = "0.0.39", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 
 # For the libc backend on Unix platforms, use the libc crate, and errno for
 # setting `errno`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ once_cell = { version = "1.5.2", optional = true }
 
 # For the linux_raw backend, linux-raw-sys provides Linux ABI details.
 [target.'cfg(all(not(rustix_use_libc), any(target_os = "linux"), any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64")))'.dependencies]
-linux-raw-sys = { version = "0.0.39", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
+linux-raw-sys = { version = "0.0.40", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 
 # For the libc backend on Unix platforms, use the libc crate, and errno for
 # setting `errno`.

--- a/src/imp/linux_raw/fs/syscalls.rs
+++ b/src/imp/linux_raw/fs/syscalls.rs
@@ -42,26 +42,23 @@ use linux_raw_sys::general::__NR_open;
 #[cfg(not(any(target_arch = "riscv64")))]
 use linux_raw_sys::general::__NR_renameat;
 use linux_raw_sys::general::{
-    __NR_faccessat, __NR_fallocate, __NR_fchmod, __NR_fchmodat, __NR_fchown, __NR_fchownat,
-    __NR_fdatasync, __NR_flock, __NR_fsync, __NR_getdents64, __NR_linkat, __NR_mkdirat,
-    __NR_mknodat, __NR_openat, __NR_readlinkat, __NR_symlinkat, __NR_unlinkat, __NR_utimensat,
-    __kernel_timespec, AT_FDCWD, AT_REMOVEDIR, AT_SYMLINK_NOFOLLOW, F_DUPFD, F_DUPFD_CLOEXEC,
-    F_GETFD, F_GETFL, F_GETLEASE, F_GETOWN, F_GETSIG, F_SETFD, F_SETFL,
-};
-use linux_raw_sys::v5_11::general::{__NR_openat2, open_how};
-use linux_raw_sys::v5_4::general::{
-    __NR_copy_file_range, __NR_memfd_create, __NR_renameat2, __NR_statx, statx, F_ADD_SEALS,
-    F_GETPIPE_SZ, F_GET_SEALS, F_SETPIPE_SZ,
+    __NR_copy_file_range, __NR_faccessat, __NR_fallocate, __NR_fchmod, __NR_fchmodat, __NR_fchown,
+    __NR_fchownat, __NR_fdatasync, __NR_flock, __NR_fsync, __NR_getdents64, __NR_linkat,
+    __NR_memfd_create, __NR_mkdirat, __NR_mknodat, __NR_openat, __NR_openat2, __NR_readlinkat,
+    __NR_renameat2, __NR_statx, __NR_symlinkat, __NR_unlinkat, __NR_utimensat, __kernel_timespec,
+    open_how, statx, AT_FDCWD, AT_REMOVEDIR, AT_SYMLINK_NOFOLLOW, F_ADD_SEALS, F_DUPFD,
+    F_DUPFD_CLOEXEC, F_GETFD, F_GETFL, F_GETLEASE, F_GETOWN, F_GETPIPE_SZ, F_GETSIG, F_GET_SEALS,
+    F_SETFD, F_SETFL, F_SETPIPE_SZ,
 };
 #[cfg(target_pointer_width = "32")]
 use {
     super::super::arch::choose::syscall6_readonly,
     super::super::conv::{hi, lo, slice_just_addr},
+    linux_raw_sys::general::__NR_utimensat_time64,
     linux_raw_sys::general::{
         __NR__llseek, __NR_fcntl64, __NR_fstat64, __NR_fstatat64, __NR_fstatfs64, __NR_ftruncate64,
         __NR_sendfile64, __NR_statfs64, timespec as __kernel_old_timespec,
     },
-    linux_raw_sys::v5_4::general::__NR_utimensat_time64,
 };
 #[cfg(target_pointer_width = "64")]
 use {
@@ -1223,14 +1220,14 @@ pub(crate) fn accessat(
     flags: AtFlags,
 ) -> io::Result<()> {
     if flags.is_empty()
-        || (flags.bits() == linux_raw_sys::v5_11::general::AT_EACCESS
+        || (flags.bits() == linux_raw_sys::general::AT_EACCESS
             && crate::process::getuid() == crate::process::geteuid()
             && crate::process::getgid() == crate::process::getegid())
     {
         return _accessat(dirfd, path, access.bits());
     }
 
-    if flags.bits() != linux_raw_sys::v5_11::general::AT_EACCESS {
+    if flags.bits() != linux_raw_sys::general::AT_EACCESS {
         return Err(io::Error::INVAL);
     }
 

--- a/src/imp/linux_raw/fs/types.rs
+++ b/src/imp/linux_raw/fs/types.rs
@@ -48,19 +48,19 @@ bitflags! {
         const SYMLINK_NOFOLLOW = linux_raw_sys::general::AT_SYMLINK_NOFOLLOW;
 
         /// `AT_EMPTY_PATH`
-        const EMPTY_PATH = linux_raw_sys::v5_4::general::AT_EMPTY_PATH;
+        const EMPTY_PATH = linux_raw_sys::general::AT_EMPTY_PATH;
 
         /// `AT_EACCESS`
-        const EACCESS = linux_raw_sys::v5_11::general::AT_EACCESS;
+        const EACCESS = linux_raw_sys::general::AT_EACCESS;
 
         /// `AT_STATX_SYNC_AS_STAT`
-        const STATX_SYNC_AS_STAT = linux_raw_sys::v5_4::general::AT_STATX_SYNC_AS_STAT;
+        const STATX_SYNC_AS_STAT = linux_raw_sys::general::AT_STATX_SYNC_AS_STAT;
 
         /// `AT_STATX_FORCE_SYNC`
-        const STATX_FORCE_SYNC = linux_raw_sys::v5_4::general::AT_STATX_FORCE_SYNC;
+        const STATX_FORCE_SYNC = linux_raw_sys::general::AT_STATX_FORCE_SYNC;
 
         /// `AT_STATX_DONT_SYNC`
-        const STATX_DONT_SYNC = linux_raw_sys::v5_4::general::AT_STATX_DONT_SYNC;
+        const STATX_DONT_SYNC = linux_raw_sys::general::AT_STATX_DONT_SYNC;
     }
 }
 
@@ -199,13 +199,13 @@ bitflags! {
         const TRUNC = linux_raw_sys::general::O_TRUNC;
 
         /// `O_PATH`
-        const PATH = linux_raw_sys::v5_4::general::O_PATH;
+        const PATH = linux_raw_sys::general::O_PATH;
 
         /// `O_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::O_CLOEXEC;
 
         /// `O_TMPFILE`
-        const TMPFILE = linux_raw_sys::v5_4::general::O_TMPFILE;
+        const TMPFILE = linux_raw_sys::general::O_TMPFILE;
 
         /// `O_NOATIME`
         const NOATIME = linux_raw_sys::general::O_NOATIME;
@@ -218,19 +218,19 @@ bitflags! {
     /// [`openat2`]: crate::fs::openat2
     pub struct ResolveFlags: u64 {
         /// `RESOLVE_NO_XDEV`
-        const NO_XDEV = linux_raw_sys::v5_11::general::RESOLVE_NO_XDEV as u64;
+        const NO_XDEV = linux_raw_sys::general::RESOLVE_NO_XDEV as u64;
 
         /// `RESOLVE_NO_MAGICLINKS`
-        const NO_MAGICLINKS = linux_raw_sys::v5_11::general::RESOLVE_NO_MAGICLINKS as u64;
+        const NO_MAGICLINKS = linux_raw_sys::general::RESOLVE_NO_MAGICLINKS as u64;
 
         /// `RESOLVE_NO_SYMLINKS`
-        const NO_SYMLINKS = linux_raw_sys::v5_11::general::RESOLVE_NO_SYMLINKS as u64;
+        const NO_SYMLINKS = linux_raw_sys::general::RESOLVE_NO_SYMLINKS as u64;
 
         /// `RESOLVE_BENEATH`
-        const BENEATH = linux_raw_sys::v5_11::general::RESOLVE_BENEATH as u64;
+        const BENEATH = linux_raw_sys::general::RESOLVE_BENEATH as u64;
 
         /// `RESOLVE_IN_ROOT`
-        const IN_ROOT = linux_raw_sys::v5_11::general::RESOLVE_IN_ROOT as u64;
+        const IN_ROOT = linux_raw_sys::general::RESOLVE_IN_ROOT as u64;
     }
 }
 
@@ -240,13 +240,13 @@ bitflags! {
     /// [`renameat_with`]: crate::fs::renameat_with
     pub struct RenameFlags: c::c_uint {
         /// `RENAME_EXCHANGE`
-        const EXCHANGE = linux_raw_sys::v5_4::general::RENAME_EXCHANGE;
+        const EXCHANGE = linux_raw_sys::general::RENAME_EXCHANGE;
 
         /// `RENAME_NOREPLACE`
-        const NOREPLACE = linux_raw_sys::v5_4::general::RENAME_NOREPLACE;
+        const NOREPLACE = linux_raw_sys::general::RENAME_NOREPLACE;
 
         /// `RENAME_WHITEOUT`
-        const WHITEOUT = linux_raw_sys::v5_4::general::RENAME_WHITEOUT;
+        const WHITEOUT = linux_raw_sys::general::RENAME_WHITEOUT;
     }
 }
 
@@ -361,38 +361,38 @@ bitflags! {
     /// [`memfd_create`]: crate::fs::memfd_create
     pub struct MemfdFlags: c::c_uint {
         /// `MFD_CLOEXEC`
-        const CLOEXEC = linux_raw_sys::v5_4::general::MFD_CLOEXEC;
+        const CLOEXEC = linux_raw_sys::general::MFD_CLOEXEC;
 
         /// `MFD_ALLOW_SEALING`
-        const ALLOW_SEALING = linux_raw_sys::v5_4::general::MFD_ALLOW_SEALING;
+        const ALLOW_SEALING = linux_raw_sys::general::MFD_ALLOW_SEALING;
 
         /// `MFD_HUGETLB` (since Linux 4.14)
-        const HUGETLB = linux_raw_sys::v5_4::general::MFD_HUGETLB;
+        const HUGETLB = linux_raw_sys::general::MFD_HUGETLB;
 
         /// `MFD_HUGE_64KB`
-        const HUGE_64KB = linux_raw_sys::v5_4::general::MFD_HUGE_64KB;
+        const HUGE_64KB = linux_raw_sys::general::MFD_HUGE_64KB;
         /// `MFD_HUGE_512JB`
-        const HUGE_512KB = linux_raw_sys::v5_4::general::MFD_HUGE_512KB;
+        const HUGE_512KB = linux_raw_sys::general::MFD_HUGE_512KB;
         /// `MFD_HUGE_1MB`
-        const HUGE_1MB = linux_raw_sys::v5_4::general::MFD_HUGE_1MB;
+        const HUGE_1MB = linux_raw_sys::general::MFD_HUGE_1MB;
         /// `MFD_HUGE_2MB`
-        const HUGE_2MB = linux_raw_sys::v5_4::general::MFD_HUGE_2MB;
+        const HUGE_2MB = linux_raw_sys::general::MFD_HUGE_2MB;
         /// `MFD_HUGE_8MB`
-        const HUGE_8MB = linux_raw_sys::v5_4::general::MFD_HUGE_8MB;
+        const HUGE_8MB = linux_raw_sys::general::MFD_HUGE_8MB;
         /// `MFD_HUGE_16MB`
-        const HUGE_16MB = linux_raw_sys::v5_4::general::MFD_HUGE_16MB;
+        const HUGE_16MB = linux_raw_sys::general::MFD_HUGE_16MB;
         /// `MFD_HUGE_32MB`
-        const HUGE_32MB = linux_raw_sys::v5_4::general::MFD_HUGE_32MB;
+        const HUGE_32MB = linux_raw_sys::general::MFD_HUGE_32MB;
         /// `MFD_HUGE_256MB`
-        const HUGE_256MB = linux_raw_sys::v5_4::general::MFD_HUGE_256MB;
+        const HUGE_256MB = linux_raw_sys::general::MFD_HUGE_256MB;
         /// `MFD_HUGE_512MB`
-        const HUGE_512MB = linux_raw_sys::v5_4::general::MFD_HUGE_512MB;
+        const HUGE_512MB = linux_raw_sys::general::MFD_HUGE_512MB;
         /// `MFD_HUGE_1GB`
-        const HUGE_1GB = linux_raw_sys::v5_4::general::MFD_HUGE_1GB;
+        const HUGE_1GB = linux_raw_sys::general::MFD_HUGE_1GB;
         /// `MFD_HUGE_2GB`
-        const HUGE_2GB = linux_raw_sys::v5_4::general::MFD_HUGE_2GB;
+        const HUGE_2GB = linux_raw_sys::general::MFD_HUGE_2GB;
         /// `MFD_HUGE_16GB`
-        const HUGE_16GB = linux_raw_sys::v5_4::general::MFD_HUGE_16GB;
+        const HUGE_16GB = linux_raw_sys::general::MFD_HUGE_16GB;
     }
 }
 
@@ -404,15 +404,15 @@ bitflags! {
     /// [`fcntl_get_seals`]: rustix::fs::fcntl_get_seals
     pub struct SealFlags: u32 {
        /// `F_SEAL_SEAL`.
-       const SEAL = linux_raw_sys::v5_4::general::F_SEAL_SEAL;
+       const SEAL = linux_raw_sys::general::F_SEAL_SEAL;
        /// `F_SEAL_SHRINK`.
-       const SHRINK = linux_raw_sys::v5_4::general::F_SEAL_SHRINK;
+       const SHRINK = linux_raw_sys::general::F_SEAL_SHRINK;
        /// `F_SEAL_GROW`.
-       const GROW = linux_raw_sys::v5_4::general::F_SEAL_GROW;
+       const GROW = linux_raw_sys::general::F_SEAL_GROW;
        /// `F_SEAL_WRITE`.
-       const WRITE = linux_raw_sys::v5_4::general::F_SEAL_WRITE;
+       const WRITE = linux_raw_sys::general::F_SEAL_WRITE;
        /// `F_SEAL_FUTURE_WRITE` (since Linux 5.1)
-       const FUTURE_WRITE = linux_raw_sys::v5_4::general::F_SEAL_FUTURE_WRITE;
+       const FUTURE_WRITE = linux_raw_sys::general::F_SEAL_FUTURE_WRITE;
     }
 }
 
@@ -422,46 +422,46 @@ bitflags! {
     /// [`statx`]: crate::fs::statx
     pub struct StatxFlags: u32 {
         /// `STATX_TYPE`
-        const TYPE = linux_raw_sys::v5_4::general::STATX_TYPE;
+        const TYPE = linux_raw_sys::general::STATX_TYPE;
 
         /// `STATX_MODE`
-        const MODE = linux_raw_sys::v5_4::general::STATX_MODE;
+        const MODE = linux_raw_sys::general::STATX_MODE;
 
         /// `STATX_NLINK`
-        const NLINK = linux_raw_sys::v5_4::general::STATX_NLINK;
+        const NLINK = linux_raw_sys::general::STATX_NLINK;
 
         /// `STATX_UID`
-        const UID = linux_raw_sys::v5_4::general::STATX_UID;
+        const UID = linux_raw_sys::general::STATX_UID;
 
         /// `STATX_GID`
-        const GID = linux_raw_sys::v5_4::general::STATX_GID;
+        const GID = linux_raw_sys::general::STATX_GID;
 
         /// `STATX_ATIME`
-        const ATIME = linux_raw_sys::v5_4::general::STATX_ATIME;
+        const ATIME = linux_raw_sys::general::STATX_ATIME;
 
         /// `STATX_MTIME`
-        const MTIME = linux_raw_sys::v5_4::general::STATX_MTIME;
+        const MTIME = linux_raw_sys::general::STATX_MTIME;
 
         /// `STATX_CTIME`
-        const CTIME = linux_raw_sys::v5_4::general::STATX_CTIME;
+        const CTIME = linux_raw_sys::general::STATX_CTIME;
 
         /// `STATX_INO`
-        const INO = linux_raw_sys::v5_4::general::STATX_INO;
+        const INO = linux_raw_sys::general::STATX_INO;
 
         /// `STATX_SIZE`
-        const SIZE = linux_raw_sys::v5_4::general::STATX_SIZE;
+        const SIZE = linux_raw_sys::general::STATX_SIZE;
 
         /// `STATX_BLOCKS`
-        const BLOCKS = linux_raw_sys::v5_4::general::STATX_BLOCKS;
+        const BLOCKS = linux_raw_sys::general::STATX_BLOCKS;
 
         /// `STATX_BASIC_STATS`
-        const BASIC_STATS = linux_raw_sys::v5_4::general::STATX_BASIC_STATS;
+        const BASIC_STATS = linux_raw_sys::general::STATX_BASIC_STATS;
 
         /// `STATX_BTIME`
-        const BTIME = linux_raw_sys::v5_4::general::STATX_BTIME;
+        const BTIME = linux_raw_sys::general::STATX_BTIME;
 
         /// `STATX_ALL`
-        const ALL = linux_raw_sys::v5_4::general::STATX_ALL;
+        const ALL = linux_raw_sys::general::STATX_ALL;
     }
 }
 
@@ -473,17 +473,17 @@ bitflags! {
         /// `FALLOC_FL_KEEP_SIZE`
         const KEEP_SIZE = linux_raw_sys::general::FALLOC_FL_KEEP_SIZE;
         /// `FALLOC_FL_PUNCH_HOLE`
-        const PUNCH_HOLE = linux_raw_sys::v5_4::general::FALLOC_FL_PUNCH_HOLE;
+        const PUNCH_HOLE = linux_raw_sys::general::FALLOC_FL_PUNCH_HOLE;
         /// `FALLOC_FL_NO_HIDE_STALE`
-        const NO_HIDE_STALE = linux_raw_sys::v5_4::general::FALLOC_FL_NO_HIDE_STALE;
+        const NO_HIDE_STALE = linux_raw_sys::general::FALLOC_FL_NO_HIDE_STALE;
         /// `FALLOC_FL_COLLAPSE_RANGE`
-        const COLLAPSE_RANGE = linux_raw_sys::v5_4::general::FALLOC_FL_COLLAPSE_RANGE;
+        const COLLAPSE_RANGE = linux_raw_sys::general::FALLOC_FL_COLLAPSE_RANGE;
         /// `FALLOC_FL_ZERO_RANGE`
-        const ZERO_RANGE = linux_raw_sys::v5_4::general::FALLOC_FL_ZERO_RANGE;
+        const ZERO_RANGE = linux_raw_sys::general::FALLOC_FL_ZERO_RANGE;
         /// `FALLOC_FL_INSERT_RANGE`
-        const INSERT_RANGE = linux_raw_sys::v5_4::general::FALLOC_FL_INSERT_RANGE;
+        const INSERT_RANGE = linux_raw_sys::general::FALLOC_FL_INSERT_RANGE;
         /// `FALLOC_FL_UNSHARE_RANGE`
-        const UNSHARE_RANGE = linux_raw_sys::v5_4::general::FALLOC_FL_UNSHARE_RANGE;
+        const UNSHARE_RANGE = linux_raw_sys::general::FALLOC_FL_UNSHARE_RANGE;
     }
 }
 
@@ -537,7 +537,7 @@ pub type StatFs = linux_raw_sys::general::statfs64;
 /// `struct statx` for use with [`statx`].
 ///
 /// [`statx`]: crate::fs::statx
-pub type Statx = linux_raw_sys::v5_4::general::statx;
+pub type Statx = linux_raw_sys::general::statx;
 
 /// `mode_t`
 #[cfg(not(any(

--- a/src/imp/linux_raw/io/error.rs
+++ b/src/imp/linux_raw/io/error.rs
@@ -14,7 +14,7 @@ use super::super::c;
 use crate::imp::fd::RawFd;
 use crate::imp::reg::{RetNumber, RetReg};
 use crate::io;
-use linux_raw_sys::{errno, v5_4};
+use linux_raw_sys::errno;
 
 /// The error type for `rustix` APIs.
 ///
@@ -301,7 +301,7 @@ impl Error {
     /// `EHOSTUNREACH`
     pub const HOSTUNREACH: Self = Self::from_errno(errno::EHOSTUNREACH);
     /// `EHWPOISON`
-    pub const HWPOISON: Self = Self::from_errno(v5_4::errno::EHWPOISON);
+    pub const HWPOISON: Self = Self::from_errno(errno::EHWPOISON);
     /// `EIDRM`
     pub const IDRM: Self = Self::from_errno(errno::EIDRM);
     /// `EILSEQ`

--- a/src/imp/linux_raw/io/syscalls.rs
+++ b/src/imp/linux_raw/io/syscalls.rs
@@ -39,14 +39,14 @@ use core::mem::MaybeUninit;
 #[cfg(any(target_arch = "arm", target_arch = "x86"))]
 use linux_raw_sys::general::__NR_mmap2;
 use linux_raw_sys::general::{
-    __NR_close, __NR_dup, __NR_dup3, __NR_epoll_create1, __NR_epoll_ctl, __NR_ioctl, __NR_madvise,
-    __NR_mlock, __NR_mprotect, __NR_mremap, __NR_msync, __NR_munlock, __NR_munmap, __NR_pipe2,
-    __NR_pread64, __NR_preadv, __NR_pwrite64, __NR_pwritev, __NR_read, __NR_readv, __NR_write,
-    __NR_writev, epoll_event, BLKPBSZGET, BLKSSZGET, EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD,
-    FIONBIO, FIONREAD, TCGETS, TIOCEXCL, TIOCGWINSZ, TIOCNXCL,
+    __NR_close, __NR_dup, __NR_dup3, __NR_epoll_create1, __NR_epoll_ctl, __NR_eventfd2, __NR_ioctl,
+    __NR_madvise, __NR_mlock, __NR_mlock2, __NR_mprotect, __NR_mremap, __NR_msync, __NR_munlock,
+    __NR_munmap, __NR_pipe2, __NR_pread64, __NR_preadv, __NR_preadv2, __NR_pwrite64, __NR_pwritev,
+    __NR_pwritev2, __NR_read, __NR_readv, __NR_userfaultfd, __NR_write, __NR_writev, epoll_event,
+    EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD,
 };
-use linux_raw_sys::v5_4::general::{
-    __NR_eventfd2, __NR_mlock2, __NR_preadv2, __NR_pwritev2, __NR_userfaultfd,
+use linux_raw_sys::ioctl::{
+    BLKPBSZGET, BLKSSZGET, FIONBIO, FIONREAD, TCGETS, TIOCEXCL, TIOCGWINSZ, TIOCNXCL,
 };
 #[cfg(target_pointer_width = "32")]
 use {

--- a/src/imp/linux_raw/io/types.rs
+++ b/src/imp/linux_raw/io/types.rs
@@ -77,7 +77,7 @@ bitflags! {
         /// `MAP_SHARED`
         const SHARED = linux_raw_sys::general::MAP_SHARED;
         /// `MAP_SHARED_VALIDATE` (since Linux 4.15)
-        const SHARED_VALIDATE = linux_raw_sys::v5_4::general::MAP_SHARED_VALIDATE;
+        const SHARED_VALIDATE = linux_raw_sys::general::MAP_SHARED_VALIDATE;
         /// `MAP_PRIVATE`
         const PRIVATE = linux_raw_sys::general::MAP_PRIVATE;
         /// `MAP_DENYWRITE`
@@ -85,15 +85,15 @@ bitflags! {
         /// `MAP_FIXED`
         const FIXED = linux_raw_sys::general::MAP_FIXED;
         /// `MAP_FIXED_NOREPLACE` (since Linux 4.17)
-        const FIXED_NOREPLACE = linux_raw_sys::v5_4::general::MAP_FIXED_NOREPLACE;
+        const FIXED_NOREPLACE = linux_raw_sys::general::MAP_FIXED_NOREPLACE;
         /// `MAP_GROWSDOWN`
         const GROWSDOWN = linux_raw_sys::general::MAP_GROWSDOWN;
         /// `MAP_HUGETLB`
         const HUGETLB = linux_raw_sys::general::MAP_HUGETLB;
         /// `MAP_HUGE_2MB` (since Linux 3.8)
-        const HUGE_2MB = linux_raw_sys::v5_4::general::MAP_HUGE_2MB;
+        const HUGE_2MB = linux_raw_sys::general::MAP_HUGE_2MB;
         /// `MAP_HUGE_1GB` (since Linux 3.8)
-        const HUGE_1GB = linux_raw_sys::v5_4::general::MAP_HUGE_1GB;
+        const HUGE_1GB = linux_raw_sys::general::MAP_HUGE_1GB;
         /// `MAP_LOCKED`
         const LOCKED = linux_raw_sys::general::MAP_LOCKED;
         /// `MAP_NORESERVE`
@@ -103,9 +103,9 @@ bitflags! {
         /// `MAP_STACK`
         const STACK = linux_raw_sys::general::MAP_STACK;
         /// `MAP_SYNC` (since Linux 4.15)
-        const SYNC = linux_raw_sys::v5_4::general::MAP_SYNC;
+        const SYNC = linux_raw_sys::general::MAP_SYNC;
         /// `MAP_UNINITIALIZED`
-        const UNINITIALIZED = linux_raw_sys::v5_4::general::MAP_UNINITIALIZED;
+        const UNINITIALIZED = linux_raw_sys::general::MAP_UNINITIALIZED;
     }
 }
 
@@ -120,7 +120,7 @@ bitflags! {
         /// `MREMAP_MAYMOVE`
         const MAYMOVE = linux_raw_sys::general::MREMAP_MAYMOVE;
         /// `MREMAP_DONTUNMAP` (since Linux 5.7)
-        const DONTUNMAP = linux_raw_sys::v5_11::general::MREMAP_DONTUNMAP;
+        const DONTUNMAP = linux_raw_sys::general::MREMAP_DONTUNMAP;
     }
 }
 
@@ -130,7 +130,7 @@ bitflags! {
     /// [`mlock_with`]: crate::io::mlock_with
     pub struct MlockFlags: u32 {
         /// `MLOCK_ONFAULT`
-        const ONFAULT = linux_raw_sys::v5_4::general::MLOCK_ONFAULT;
+        const ONFAULT = linux_raw_sys::general::MLOCK_ONFAULT;
     }
 }
 
@@ -212,7 +212,7 @@ pub enum Advice {
     LinuxDontNeed = linux_raw_sys::general::MADV_DONTNEED,
 
     /// `MADV_FREE` (since Linux 4.5)
-    LinuxFree = linux_raw_sys::v5_4::general::MADV_FREE,
+    LinuxFree = linux_raw_sys::general::MADV_FREE,
     /// `MADV_REMOVE`
     LinuxRemove = linux_raw_sys::general::MADV_REMOVE,
     /// `MADV_DONTFORK`
@@ -222,27 +222,27 @@ pub enum Advice {
     /// `MADV_HWPOISON`
     LinuxHwPoison = linux_raw_sys::general::MADV_HWPOISON,
     /// `MADV_SOFT_OFFLINE`
-    LinuxSoftOffline = linux_raw_sys::v5_4::general::MADV_SOFT_OFFLINE,
+    LinuxSoftOffline = linux_raw_sys::general::MADV_SOFT_OFFLINE,
     /// `MADV_MERGEABLE`
     LinuxMergeable = linux_raw_sys::general::MADV_MERGEABLE,
     /// `MADV_UNMERGEABLE`
     LinuxUnmergeable = linux_raw_sys::general::MADV_UNMERGEABLE,
     /// `MADV_HUGEPAGE` (since Linux 2.6.38)
-    LinuxHugepage = linux_raw_sys::v5_4::general::MADV_HUGEPAGE,
+    LinuxHugepage = linux_raw_sys::general::MADV_HUGEPAGE,
     /// `MADV_NOHUGEPAGE` (since Linux 2.6.38)
-    LinuxNoHugepage = linux_raw_sys::v5_4::general::MADV_NOHUGEPAGE,
+    LinuxNoHugepage = linux_raw_sys::general::MADV_NOHUGEPAGE,
     /// `MADV_DONTDUMP` (since Linux 3.4)
-    LinuxDontDump = linux_raw_sys::v5_4::general::MADV_DONTDUMP,
+    LinuxDontDump = linux_raw_sys::general::MADV_DONTDUMP,
     /// `MADV_DODUMP` (since Linux 3.4)
-    LinuxDoDump = linux_raw_sys::v5_4::general::MADV_DODUMP,
+    LinuxDoDump = linux_raw_sys::general::MADV_DODUMP,
     /// `MADV_WIPEONFORK` (since Linux 4.14)
-    LinuxWipeOnFork = linux_raw_sys::v5_4::general::MADV_WIPEONFORK,
+    LinuxWipeOnFork = linux_raw_sys::general::MADV_WIPEONFORK,
     /// `MADV_KEEPONFORK` (since Linux 4.14)
-    LinuxKeepOnFork = linux_raw_sys::v5_4::general::MADV_KEEPONFORK,
+    LinuxKeepOnFork = linux_raw_sys::general::MADV_KEEPONFORK,
     /// `MADV_COLD` (since Linux 5.4)
-    LinuxCold = linux_raw_sys::v5_4::general::MADV_COLD,
+    LinuxCold = linux_raw_sys::general::MADV_COLD,
     /// `MADV_PAGEOUT` (since Linux 5.4)
-    LinuxPageOut = linux_raw_sys::v5_4::general::MADV_PAGEOUT,
+    LinuxPageOut = linux_raw_sys::general::MADV_PAGEOUT,
 }
 
 impl Advice {

--- a/src/imp/linux_raw/net/read_sockaddr.rs
+++ b/src/imp/linux_raw/net/read_sockaddr.rs
@@ -25,8 +25,13 @@ unsafe fn read_ss_family(storage: *const sockaddr) -> u16 {
     // Assert that we know the layout of `sockaddr`.
     let _ = sockaddr {
         __storage: __kernel_sockaddr_storage {
-            ss_family: 0_u16,
-            __data: [0; 126_usize],
+            __bindgen_anon_1: linux_raw_sys::general::__kernel_sockaddr_storage__bindgen_ty_1 {
+                __bindgen_anon_1:
+                    linux_raw_sys::general::__kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
+                        ss_family: 0_u16,
+                        __data: [0; 126_usize],
+                    },
+            },
         },
     };
 

--- a/src/imp/linux_raw/net/types.rs
+++ b/src/imp/linux_raw/net/types.rs
@@ -169,7 +169,7 @@ impl Protocol {
     /// `IPPROTO_IDP`
     pub const IDP: Self = Self(linux_raw_sys::general::IPPROTO_IDP as _);
     /// `IPPROTO_TP`
-    pub const TP: Self = Self(linux_raw_sys::v5_4::general::IPPROTO_TP as _);
+    pub const TP: Self = Self(linux_raw_sys::general::IPPROTO_TP as _);
     /// `IPPROTO_DCCP`
     pub const DCCP: Self = Self(linux_raw_sys::general::IPPROTO_DCCP as _);
     /// `IPPROTO_IPV6`
@@ -183,11 +183,11 @@ impl Protocol {
     /// `IPPROTO_AH`
     pub const AH: Self = Self(linux_raw_sys::general::IPPROTO_AH as _);
     /// `IPPROTO_MTP`
-    pub const MTP: Self = Self(linux_raw_sys::v5_4::general::IPPROTO_MTP as _);
+    pub const MTP: Self = Self(linux_raw_sys::general::IPPROTO_MTP as _);
     /// `IPPROTO_BEETPH`
     pub const BEETPH: Self = Self(linux_raw_sys::general::IPPROTO_BEETPH as _);
     /// `IPPROTO_ENCAP`
-    pub const ENCAP: Self = Self(linux_raw_sys::v5_4::general::IPPROTO_ENCAP as _);
+    pub const ENCAP: Self = Self(linux_raw_sys::general::IPPROTO_ENCAP as _);
     /// `IPPROTO_PIM`
     pub const PIM: Self = Self(linux_raw_sys::general::IPPROTO_PIM as _);
     /// `IPPROTO_COMP`
@@ -197,13 +197,13 @@ impl Protocol {
     /// `IPPROTO_UDPLITE`
     pub const UDPLITE: Self = Self(linux_raw_sys::general::IPPROTO_UDPLITE as _);
     /// `IPPROTO_MPLS`
-    pub const MPLS: Self = Self(linux_raw_sys::v5_4::general::IPPROTO_MPLS as _);
+    pub const MPLS: Self = Self(linux_raw_sys::general::IPPROTO_MPLS as _);
     /// `IPPROTO_ETHERNET`
-    pub const ETHERNET: Self = Self(linux_raw_sys::v5_11::general::IPPROTO_ETHERNET as _);
+    pub const ETHERNET: Self = Self(linux_raw_sys::general::IPPROTO_ETHERNET as _);
     /// `IPPROTO_RAW`
     pub const RAW: Self = Self(linux_raw_sys::general::IPPROTO_RAW as _);
     /// `IPPROTO_MPTCP`
-    pub const MPTCP: Self = Self(linux_raw_sys::v5_11::general::IPPROTO_MPTCP as _);
+    pub const MPTCP: Self = Self(linux_raw_sys::general::IPPROTO_MPTCP as _);
     /// `IPPROTO_FRAGMENT`
     pub const FRAGMENT: Self = Self(linux_raw_sys::general::IPPROTO_FRAGMENT as _);
     /// `IPPROTO_ICMPV6`

--- a/src/imp/linux_raw/net/types.rs
+++ b/src/imp/linux_raw/net/types.rs
@@ -276,8 +276,8 @@ bitflags! {
 #[repr(u32)]
 pub enum Timeout {
     /// `SO_RCVTIMEO`—Timeout for receiving.
-    Recv = linux_raw_sys::general::SO_RCVTIMEO,
+    Recv = linux_raw_sys::general::SO_RCVTIMEO_NEW,
 
     /// `SO_SNDTIMEO`—Timeout for sending.
-    Send = linux_raw_sys::general::SO_SNDTIMEO,
+    Send = linux_raw_sys::general::SO_SNDTIMEO_NEW,
 }

--- a/src/imp/linux_raw/process/auxv.rs
+++ b/src/imp/linux_raw/process/auxv.rs
@@ -11,9 +11,9 @@ use crate::ffi::ZStr;
 use core::mem::size_of;
 use core::slice;
 use linux_raw_sys::general::{
-    AT_EXECFN, AT_HWCAP, AT_NULL, AT_PAGESZ, AT_PHDR, AT_PHENT, AT_PHNUM,
+    AT_EXECFN, AT_HWCAP, AT_HWCAP2, AT_NULL, AT_PAGESZ, AT_PHDR, AT_PHENT, AT_PHNUM,
+    AT_SYSINFO_EHDR,
 };
-use linux_raw_sys::v5_4::general::{AT_HWCAP2, AT_SYSINFO_EHDR};
 
 #[inline]
 pub(crate) fn page_size() -> usize {

--- a/src/imp/linux_raw/process/syscalls.rs
+++ b/src/imp/linux_raw/process/syscalls.rs
@@ -29,9 +29,9 @@ use core::convert::TryInto;
 use core::mem::MaybeUninit;
 use linux_raw_sys::general::{
     __NR_chdir, __NR_exit_group, __NR_fchdir, __NR_getcwd, __NR_getpid, __NR_getppid,
-    __NR_getpriority, __NR_kill, __NR_sched_getaffinity, __NR_sched_setaffinity, __NR_sched_yield,
-    __NR_setpriority, __NR_setsid, __NR_uname, __NR_wait4, __kernel_gid_t, __kernel_pid_t,
-    __kernel_uid_t,
+    __NR_getpriority, __NR_kill, __NR_membarrier, __NR_prlimit64, __NR_sched_getaffinity,
+    __NR_sched_setaffinity, __NR_sched_yield, __NR_setpriority, __NR_setsid, __NR_uname,
+    __NR_wait4, __kernel_gid_t, __kernel_pid_t, __kernel_uid_t,
 };
 #[cfg(not(any(target_arch = "x86", target_arch = "sparc", target_arch = "arm")))]
 use linux_raw_sys::general::{__NR_getegid, __NR_geteuid, __NR_getgid, __NR_getuid};
@@ -39,7 +39,6 @@ use linux_raw_sys::general::{__NR_getegid, __NR_geteuid, __NR_getgid, __NR_getui
 use linux_raw_sys::general::{__NR_getegid32, __NR_geteuid32, __NR_getgid32, __NR_getuid32};
 #[cfg(target_pointer_width = "32")]
 use linux_raw_sys::general::{__NR_getrlimit, __NR_setrlimit};
-use linux_raw_sys::v5_4::general::{__NR_membarrier, __NR_prlimit64};
 
 #[inline]
 pub(crate) fn chdir(filename: &ZStr) -> io::Result<()> {
@@ -61,7 +60,7 @@ pub(crate) fn membarrier_query() -> MembarrierQuery {
     unsafe {
         match ret_c_uint(syscall2(
             nr(__NR_membarrier),
-            c_int(linux_raw_sys::v5_4::general::membarrier_cmd::MEMBARRIER_CMD_QUERY as _),
+            c_int(linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_QUERY as _),
             c_uint(0),
         )) {
             Ok(query) => {
@@ -93,9 +92,7 @@ pub(crate) fn membarrier_cpu(cmd: MembarrierCommand, cpu: Cpuid) -> io::Result<(
         ret(syscall3(
             nr(__NR_membarrier),
             c_int(cmd as c::c_int),
-            c_uint(
-                linux_raw_sys::v5_11::general::membarrier_cmd_flag::MEMBARRIER_CMD_FLAG_CPU as _,
-            ),
+            c_uint(linux_raw_sys::general::membarrier_cmd_flag::MEMBARRIER_CMD_FLAG_CPU as _),
             c_uint(cpu.as_raw()),
         ))
     }
@@ -315,7 +312,7 @@ pub(crate) fn setpriority_process(pid: Option<Pid>, priority: i32) -> io::Result
 
 #[inline]
 pub(crate) fn getrlimit(limit: Resource) -> Rlimit {
-    let mut result = MaybeUninit::<linux_raw_sys::v5_4::general::rlimit64>::uninit();
+    let mut result = MaybeUninit::<linux_raw_sys::general::rlimit64>::uninit();
     #[cfg(target_pointer_width = "32")]
     unsafe {
         match ret(syscall4(
@@ -399,7 +396,7 @@ unsafe fn setrlimit_old(limit: Resource, new: Rlimit) -> io::Result<()> {
 #[inline]
 pub(crate) fn prlimit(pid: Option<Pid>, limit: Resource, new: Rlimit) -> io::Result<Rlimit> {
     let lim = rlimit_to_linux(new)?;
-    let mut result = MaybeUninit::<linux_raw_sys::v5_4::general::rlimit64>::uninit();
+    let mut result = MaybeUninit::<linux_raw_sys::general::rlimit64>::uninit();
     unsafe {
         match ret(syscall4(
             nr(__NR_prlimit64),
@@ -416,13 +413,13 @@ pub(crate) fn prlimit(pid: Option<Pid>, limit: Resource, new: Rlimit) -> io::Res
 
 /// Convert a Rust [`Rlimit`] to a C `rlimit64`.
 #[inline]
-fn rlimit_from_linux(lim: linux_raw_sys::v5_4::general::rlimit64) -> Rlimit {
-    let current = if lim.rlim_cur == linux_raw_sys::v5_4::general::RLIM64_INFINITY as _ {
+fn rlimit_from_linux(lim: linux_raw_sys::general::rlimit64) -> Rlimit {
+    let current = if lim.rlim_cur == linux_raw_sys::general::RLIM64_INFINITY as _ {
         None
     } else {
         Some(lim.rlim_cur)
     };
-    let maximum = if lim.rlim_max == linux_raw_sys::v5_4::general::RLIM64_INFINITY as _ {
+    let maximum = if lim.rlim_max == linux_raw_sys::general::RLIM64_INFINITY as _ {
         None
     } else {
         Some(lim.rlim_max)
@@ -432,16 +429,16 @@ fn rlimit_from_linux(lim: linux_raw_sys::v5_4::general::rlimit64) -> Rlimit {
 
 /// Convert a C `rlimit64` to a Rust `Rlimit`.
 #[inline]
-fn rlimit_to_linux(lim: Rlimit) -> io::Result<linux_raw_sys::v5_4::general::rlimit64> {
+fn rlimit_to_linux(lim: Rlimit) -> io::Result<linux_raw_sys::general::rlimit64> {
     let rlim_cur = match lim.current {
         Some(r) => r.try_into().map_err(|_| io::Error::INVAL)?,
-        None => linux_raw_sys::v5_4::general::RLIM64_INFINITY as _,
+        None => linux_raw_sys::general::RLIM64_INFINITY as _,
     };
     let rlim_max = match lim.maximum {
         Some(r) => r.try_into().map_err(|_| io::Error::INVAL)?,
-        None => linux_raw_sys::v5_4::general::RLIM64_INFINITY as _,
+        None => linux_raw_sys::general::RLIM64_INFINITY as _,
     };
-    Ok(linux_raw_sys::v5_4::general::rlimit64 { rlim_cur, rlim_max })
+    Ok(linux_raw_sys::general::rlimit64 { rlim_cur, rlim_max })
 }
 
 /// Like `rlimit_from_linux` but uses Linux's old 32-bit `rlimit`.

--- a/src/imp/linux_raw/process/syscalls.rs
+++ b/src/imp/linux_raw/process/syscalls.rs
@@ -27,6 +27,15 @@ use crate::process::{
 };
 use core::convert::TryInto;
 use core::mem::MaybeUninit;
+#[cfg(all(
+    not(any(target_arch = "arm", target_arch = "powerpc64", target_arch = "x86")),
+    target_pointer_width = "32"
+))]
+use linux_raw_sys::general::__NR_getrlimit;
+#[cfg(target_pointer_width = "32")]
+use linux_raw_sys::general::__NR_setrlimit;
+#[cfg(any(target_arch = "arm", target_arch = "powerpc64", target_arch = "x86"))]
+use linux_raw_sys::general::__NR_ugetrlimit as __NR_getrlimit;
 use linux_raw_sys::general::{
     __NR_chdir, __NR_exit_group, __NR_fchdir, __NR_getcwd, __NR_getpid, __NR_getppid,
     __NR_getpriority, __NR_kill, __NR_membarrier, __NR_prlimit64, __NR_sched_getaffinity,
@@ -37,8 +46,6 @@ use linux_raw_sys::general::{
 use linux_raw_sys::general::{__NR_getegid, __NR_geteuid, __NR_getgid, __NR_getuid};
 #[cfg(any(target_arch = "x86", target_arch = "sparc", target_arch = "arm"))]
 use linux_raw_sys::general::{__NR_getegid32, __NR_geteuid32, __NR_getgid32, __NR_getuid32};
-#[cfg(target_pointer_width = "32")]
-use linux_raw_sys::general::{__NR_getrlimit, __NR_setrlimit};
 
 #[inline]
 pub(crate) fn chdir(filename: &ZStr) -> io::Result<()> {

--- a/src/imp/linux_raw/process/types.rs
+++ b/src/imp/linux_raw/process/types.rs
@@ -13,25 +13,31 @@ pub enum MembarrierCommand {
     /// `MEMBARRIER_CMD_GLOBAL`
     #[doc(alias = "Shared")]
     #[doc(alias = "MEMBARRIER_CMD_SHARED")]
-    Global = linux_raw_sys::v5_4::general::membarrier_cmd::MEMBARRIER_CMD_GLOBAL as _,
+    Global = linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_GLOBAL as _,
     /// `MEMBARRIER_CMD_GLOBAL_EXPEDITED`
-    GlobalExpedited = linux_raw_sys::v5_4::general::membarrier_cmd::MEMBARRIER_CMD_GLOBAL_EXPEDITED as _,
+    GlobalExpedited = linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_GLOBAL_EXPEDITED as _,
     /// `MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED`
-    RegisterGlobalExpedited = linux_raw_sys::v5_4::general::membarrier_cmd::MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED as _,
+    RegisterGlobalExpedited =
+        linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED as _,
     /// `MEMBARRIER_CMD_PRIVATE_EXPEDITED`
-    PrivateExpedited = linux_raw_sys::v5_4::general::membarrier_cmd::MEMBARRIER_CMD_PRIVATE_EXPEDITED as _,
+    PrivateExpedited =
+        linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_PRIVATE_EXPEDITED as _,
     /// `MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED`
-    RegisterPrivateExpedited = linux_raw_sys::v5_4::general::membarrier_cmd::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED as _,
+    RegisterPrivateExpedited =
+        linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED as _,
     /// `MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE`
-    PrivateExpeditedSyncCore = linux_raw_sys::v5_4::general::membarrier_cmd::MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE as _,
+    PrivateExpeditedSyncCore =
+        linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE as _,
     /// `MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_SYNC_CORE`
     RegisterPrivateExpeditedSyncCore =
-        linux_raw_sys::v5_4::general::membarrier_cmd::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_SYNC_CORE as _,
+        linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_SYNC_CORE
+            as _,
     /// `MEMBARRIER_CMD_PRIVATE_EXPEDITED_RSEQ` (since Linux 5.10)
-    PrivateExpeditedRseq = linux_raw_sys::v5_11::general::membarrier_cmd::MEMBARRIER_CMD_PRIVATE_EXPEDITED_RSEQ as _,
+    PrivateExpeditedRseq =
+        linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_PRIVATE_EXPEDITED_RSEQ as _,
     /// `MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_RSEQ` (since Linux 5.10)
     RegisterPrivateExpeditedRseq =
-        linux_raw_sys::v5_11::general::membarrier_cmd::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_RSEQ as _,
+        linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_RSEQ as _,
 }
 
 /// A resource value for use with [`getrlimit`], [`setrlimit`], and

--- a/src/imp/linux_raw/rand/syscalls.rs
+++ b/src/imp/linux_raw/rand/syscalls.rs
@@ -11,7 +11,7 @@ use super::super::conv::{c_uint, ret_usize, slice_mut};
 use super::super::reg::nr;
 use crate::io;
 use crate::rand::GetRandomFlags;
-use linux_raw_sys::v5_4::general::__NR_getrandom;
+use linux_raw_sys::general::__NR_getrandom;
 
 #[inline]
 pub(crate) fn getrandom(buf: &mut [u8], flags: GetRandomFlags) -> io::Result<usize> {

--- a/src/imp/linux_raw/rand/types.rs
+++ b/src/imp/linux_raw/rand/types.rs
@@ -6,8 +6,8 @@ bitflags! {
     /// [`getrandom`]: crate::rand::getrandom
     pub struct GetRandomFlags: u32 {
         /// `GRND_RANDOM`
-        const RANDOM = linux_raw_sys::v5_4::general::GRND_RANDOM;
+        const RANDOM = linux_raw_sys::general::GRND_RANDOM;
         /// `GRND_NONBLOCK`
-        const NONBLOCK = linux_raw_sys::v5_4::general::GRND_NONBLOCK;
+        const NONBLOCK = linux_raw_sys::general::GRND_NONBLOCK;
     }
 }

--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -39,9 +39,9 @@ use crate::process::{Pid, RawNonZeroPid};
 #[cfg(target_arch = "arm")]
 use linux_raw_sys::general::__ARM_NR_set_tls;
 use linux_raw_sys::general::{
-    __NR_exit, __NR_prctl, __NR_set_tid_address, __kernel_pid_t, PR_SET_NAME, SIGCHLD,
+    __NR_clone, __NR_execve, __NR_execveat, __NR_exit, __NR_prctl, __NR_set_tid_address,
+    __kernel_pid_t, PR_SET_NAME, SIGCHLD,
 };
-use linux_raw_sys::v5_4::general::{__NR_clone, __NR_execve, __NR_execveat};
 #[cfg(target_arch = "x86")]
 use {super::conv::by_mut, linux_raw_sys::general::__NR_set_thread_area};
 #[cfg(target_arch = "x86_64")]

--- a/src/imp/linux_raw/thread/syscalls.rs
+++ b/src/imp/linux_raw/thread/syscalls.rs
@@ -28,7 +28,7 @@ use linux_raw_sys::general::{
 use {
     core::convert::TryInto,
     linux_raw_sys::general::timespec as __kernel_old_timespec,
-    linux_raw_sys::v5_4::general::{__NR_clock_nanosleep_time64, __NR_futex_time64},
+    linux_raw_sys::general::{__NR_clock_nanosleep_time64, __NR_futex_time64},
 };
 
 #[inline]

--- a/src/imp/linux_raw/time/syscalls.rs
+++ b/src/imp/linux_raw/time/syscalls.rs
@@ -14,8 +14,8 @@ use core::mem::MaybeUninit;
 use linux_raw_sys::general::{__NR_clock_getres, __kernel_timespec};
 #[cfg(target_pointer_width = "32")]
 use {
-    super::super::conv::ret, crate::io, linux_raw_sys::general::timespec as __kernel_old_timespec,
-    linux_raw_sys::v5_4::general::__NR_clock_getres_time64,
+    super::super::conv::ret, crate::io, linux_raw_sys::general::__NR_clock_getres_time64,
+    linux_raw_sys::general::timespec as __kernel_old_timespec,
 };
 
 #[inline]

--- a/src/imp/linux_raw/vdso_wrappers.rs
+++ b/src/imp/linux_raw/vdso_wrappers.rs
@@ -25,8 +25,8 @@ use core::sync::atomic::Ordering::Relaxed;
 use linux_raw_sys::general::{__NR_clock_gettime, __kernel_clockid_t, __kernel_timespec};
 #[cfg(target_pointer_width = "32")]
 use {
-    super::conv::out, linux_raw_sys::general::timespec as __kernel_old_timespec,
-    linux_raw_sys::v5_4::general::__NR_clock_gettime64,
+    super::conv::out, linux_raw_sys::general::__NR_clock_gettime64,
+    linux_raw_sys::general::timespec as __kernel_old_timespec,
 };
 
 #[inline]
@@ -56,14 +56,12 @@ pub(crate) fn clock_gettime_dynamic(which_clock: DynamicClockId<'_>) -> io::Resu
         }
 
         DynamicClockId::RealtimeAlarm => {
-            linux_raw_sys::v5_4::general::CLOCK_REALTIME_ALARM as __kernel_clockid_t
+            linux_raw_sys::general::CLOCK_REALTIME_ALARM as __kernel_clockid_t
         }
-        DynamicClockId::Tai => linux_raw_sys::v5_4::general::CLOCK_TAI as __kernel_clockid_t,
-        DynamicClockId::Boottime => {
-            linux_raw_sys::v5_4::general::CLOCK_BOOTTIME as __kernel_clockid_t
-        }
+        DynamicClockId::Tai => linux_raw_sys::general::CLOCK_TAI as __kernel_clockid_t,
+        DynamicClockId::Boottime => linux_raw_sys::general::CLOCK_BOOTTIME as __kernel_clockid_t,
         DynamicClockId::BoottimeAlarm => {
-            linux_raw_sys::v5_4::general::CLOCK_BOOTTIME_ALARM as __kernel_clockid_t
+            linux_raw_sys::general::CLOCK_BOOTTIME_ALARM as __kernel_clockid_t
         }
     };
 


### PR DESCRIPTION
This version drops support for multiple Linux API versions, so this drops
all the `v5_4::` and `v5_11::` qualifiers.