### PR TITLE
Outline assembly code refactoring

### DIFF
--- a/src/imp/linux_raw/arch/outline/nr_last.rs
+++ b/src/imp/linux_raw/arch/outline/nr_last.rs
@@ -56,20 +56,12 @@ extern "C" {
 
 #[inline]
 #[must_use]
-pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
+pub(in crate::imp) unsafe fn syscall0(nr: SyscallNumber<'_>) -> RetReg<R0> {
     rustix_syscall0_nr_last(nr)
 }
 #[inline]
 #[must_use]
 pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
-    rustix_syscall1_nr_last(a0, nr)
-}
-#[inline]
-#[must_use]
-pub(in crate::imp) unsafe fn syscall1_readonly(
-    nr: SyscallNumber<'_>,
-    a0: ArgReg<'_, A0>,
-) -> RetReg<R0> {
     rustix_syscall1_nr_last(a0, nr)
 }
 #[inline]
@@ -88,15 +80,6 @@ pub(in crate::imp) unsafe fn syscall2(
 }
 #[inline]
 #[must_use]
-pub(in crate::imp) unsafe fn syscall2_readonly(
-    nr: SyscallNumber<'_>,
-    a0: ArgReg<'_, A0>,
-    a1: ArgReg<'_, A1>,
-) -> RetReg<R0> {
-    rustix_syscall2_nr_last(a0, a1, nr)
-}
-#[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -107,28 +90,7 @@ pub(in crate::imp) unsafe fn syscall3(
 }
 #[inline]
 #[must_use]
-pub(in crate::imp) unsafe fn syscall3_readonly(
-    nr: SyscallNumber<'_>,
-    a0: ArgReg<'_, A0>,
-    a1: ArgReg<'_, A1>,
-    a2: ArgReg<'_, A2>,
-) -> RetReg<R0> {
-    rustix_syscall3_nr_last(a0, a1, a2, nr)
-}
-#[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4(
-    nr: SyscallNumber<'_>,
-    a0: ArgReg<'_, A0>,
-    a1: ArgReg<'_, A1>,
-    a2: ArgReg<'_, A2>,
-    a3: ArgReg<'_, A3>,
-) -> RetReg<R0> {
-    rustix_syscall4_nr_last(a0, a1, a2, a3, nr)
-}
-#[inline]
-#[must_use]
-pub(in crate::imp) unsafe fn syscall4_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
     a1: ArgReg<'_, A1>,
@@ -151,18 +113,6 @@ pub(in crate::imp) unsafe fn syscall5(
 }
 #[inline]
 #[must_use]
-pub(in crate::imp) unsafe fn syscall5_readonly(
-    nr: SyscallNumber<'_>,
-    a0: ArgReg<'_, A0>,
-    a1: ArgReg<'_, A1>,
-    a2: ArgReg<'_, A2>,
-    a3: ArgReg<'_, A3>,
-    a4: ArgReg<'_, A4>,
-) -> RetReg<R0> {
-    rustix_syscall5_nr_last(a0, a1, a2, a3, a4, nr)
-}
-#[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -174,16 +124,11 @@ pub(in crate::imp) unsafe fn syscall6(
 ) -> RetReg<R0> {
     rustix_syscall6_nr_last(a0, a1, a2, a3, a4, a5, nr)
 }
-#[inline]
-#[must_use]
-pub(in crate::imp) unsafe fn syscall6_readonly(
-    nr: SyscallNumber<'_>,
-    a0: ArgReg<'_, A0>,
-    a1: ArgReg<'_, A1>,
-    a2: ArgReg<'_, A2>,
-    a3: ArgReg<'_, A3>,
-    a4: ArgReg<'_, A4>,
-    a5: ArgReg<'_, A5>,
-) -> RetReg<R0> {
-    rustix_syscall6_nr_last(a0, a1, a2, a3, a4, a5, nr)
-}
+
+// We don't have separate `_readonly` implementations, so these can just be
+// aliases to their non-`_readonly` counterparts.
+pub(in crate::imp) use {
+    syscall0 as syscall0_readonly, syscall1 as syscall1_readonly, syscall2 as syscall2_readonly,
+    syscall3 as syscall3_readonly, syscall4 as syscall4_readonly, syscall5 as syscall5_readonly,
+    syscall6 as syscall6_readonly,
+};

--- a/src/imp/linux_raw/arch/outline/nr_last.rs
+++ b/src/imp/linux_raw/arch/outline/nr_last.rs
@@ -53,142 +53,137 @@ extern "C" {
 }
 
 // Then we define inline wrapper functions that do the reordering.
-mod reorder {
-    use super::*;
 
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
-        rustix_syscall0_nr_last(nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
-        rustix_syscall1_nr_last(a0, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall1_readonly(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-    ) -> RetReg<R0> {
-        rustix_syscall1_nr_last(a0, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
-        rustix_syscall1_noreturn_nr_last(a0, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall2(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-    ) -> RetReg<R0> {
-        rustix_syscall2_nr_last(a0, a1, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall2_readonly(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-    ) -> RetReg<R0> {
-        rustix_syscall2_nr_last(a0, a1, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall3(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-    ) -> RetReg<R0> {
-        rustix_syscall3_nr_last(a0, a1, a2, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall3_readonly(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-    ) -> RetReg<R0> {
-        rustix_syscall3_nr_last(a0, a1, a2, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall4(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-        a3: ArgReg<'_, A3>,
-    ) -> RetReg<R0> {
-        rustix_syscall4_nr_last(a0, a1, a2, a3, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall4_readonly(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-        a3: ArgReg<'_, A3>,
-    ) -> RetReg<R0> {
-        rustix_syscall4_nr_last(a0, a1, a2, a3, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall5(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-        a3: ArgReg<'_, A3>,
-        a4: ArgReg<'_, A4>,
-    ) -> RetReg<R0> {
-        rustix_syscall5_nr_last(a0, a1, a2, a3, a4, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall5_readonly(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-        a3: ArgReg<'_, A3>,
-        a4: ArgReg<'_, A4>,
-    ) -> RetReg<R0> {
-        rustix_syscall5_nr_last(a0, a1, a2, a3, a4, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall6(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-        a3: ArgReg<'_, A3>,
-        a4: ArgReg<'_, A4>,
-        a5: ArgReg<'_, A5>,
-    ) -> RetReg<R0> {
-        rustix_syscall6_nr_last(a0, a1, a2, a3, a4, a5, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall6_readonly(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-        a3: ArgReg<'_, A3>,
-        a4: ArgReg<'_, A4>,
-        a5: ArgReg<'_, A5>,
-    ) -> RetReg<R0> {
-        rustix_syscall6_nr_last(a0, a1, a2, a3, a4, a5, nr)
-    }
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
+    rustix_syscall0_nr_last(nr)
 }
-
-pub(in crate::imp) use reorder::*;
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
+    rustix_syscall1_nr_last(a0, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall1_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> RetReg<R0> {
+    rustix_syscall1_nr_last(a0, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
+    rustix_syscall1_noreturn_nr_last(a0, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall2(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    rustix_syscall2_nr_last(a0, a1, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall2_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    rustix_syscall2_nr_last(a0, a1, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall3(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    rustix_syscall3_nr_last(a0, a1, a2, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall3_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    rustix_syscall3_nr_last(a0, a1, a2, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall4(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    rustix_syscall4_nr_last(a0, a1, a2, a3, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall4_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    rustix_syscall4_nr_last(a0, a1, a2, a3, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall5(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    rustix_syscall5_nr_last(a0, a1, a2, a3, a4, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall5_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    rustix_syscall5_nr_last(a0, a1, a2, a3, a4, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall6(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    rustix_syscall6_nr_last(a0, a1, a2, a3, a4, a5, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall6_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    rustix_syscall6_nr_last(a0, a1, a2, a3, a4, a5, nr)
+}

--- a/src/imp/linux_raw/arch/outline/nr_last.rs
+++ b/src/imp/linux_raw/arch/outline/nr_last.rs
@@ -1,9 +1,19 @@
+//! Syscall wrappers for platforms which pass the syscall number specially.
+//!
+//! Rustix aims to minimize the amount of assembly code it needs. To that end,
+//! this code reorders syscall arguments as close as feasible to the actual
+//! syscall convention before calling the assembly functions.
+//!
+//! Many architectures use a convention where the syscall number is passed in a
+//! special register, with the regular syscall arguments passed in either the
+//! same or similar registers as the platform C convention. This code
+//! approximates that order by passing the regular syscall arguments first, and
+//! the syscall number last. That way, the outline assembly code typically just
+//! needs to move the syscall number to its special register, and leave the
+//! other arguments mostly as they are.
+
 use crate::imp::reg::{ArgReg, RetReg, SyscallNumber, A0, A1, A2, A3, A4, A5, R0};
 
-// Some architectures' outline assembly code prefers to see the `nr` argument
-// last, as that lines up the syscall calling convention with the userspace
-// calling convention better.
-//
 // First we declare the actual assembly routines with `*_nr_last` names and
 // reordered arguments. If the signatures or calling conventions are ever
 // changed, the symbol names should also be updated accordingly, to avoid
@@ -125,8 +135,9 @@ pub(in crate::imp) unsafe fn syscall6(
     rustix_syscall6_nr_last(a0, a1, a2, a3, a4, a5, nr)
 }
 
-// We don't have separate `_readonly` implementations, so these can just be
-// aliases to their non-`_readonly` counterparts.
+// Then we define the `_readonly` versions of the wrappers. We don't have
+// separate `_readonly` implementations, so these can just be aliases to
+// their non-`_readonly` counterparts.
 pub(in crate::imp) use {
     syscall0 as syscall0_readonly, syscall1 as syscall1_readonly, syscall2 as syscall2_readonly,
     syscall3 as syscall3_readonly, syscall4 as syscall4_readonly, syscall5 as syscall5_readonly,

--- a/src/imp/linux_raw/arch/outline/x86.rs
+++ b/src/imp/linux_raw/arch/outline/x86.rs
@@ -1,12 +1,22 @@
+//! Syscall wrappers for 32-bit x86.
+//!
+//! This module is similar to the `nr_last` module, except specialized for
+//! 32-bit x86.
+//!
+//! The syscall convention passes all arguments in registers. The closest we
+//! can easily get to that from Rust is to use the fastcall convention which
+//! passes the first two arguments in `ecx` and `edx`, which are the second
+//! and third Linux syscall arguments. To line them up, this function passes
+//! the second and third syscall argument as the first and second argument to
+//! the outline assembly, followed by the first syscall argument, and then the
+//! rest of the syscall arguments. The assembly code still has to do some work,
+//! but at least we can get up to two arguments into the right place for it.
+
 #![allow(dead_code, unused_imports)]
 
 use crate::imp::reg::{ArgReg, RetReg, SyscallNumber, A0, A1, A2, A3, A4, A5, R0};
 use crate::imp::vdso_wrappers::SyscallType;
 
-// x86 (using fastcall) prefers to pass a1 and a2 first, before a0, because
-// fastcall passes the first two arguments in ecx and edx, which are the second
-// and third Linux syscall arguments.
-//
 // First we declare the actual assembly routines with `*_nr_last_fastcall`
 // names and reordered arguments. If the signatures or calling conventions are
 // ever changed, the symbol names should also be updated accordingly, to avoid
@@ -128,8 +138,9 @@ pub(in crate::imp) unsafe fn syscall6(
     rustix_syscall6_nr_last_fastcall(a1, a2, a0, a3, a4, a5, nr)
 }
 
-// We don't have separate `_readonly` implementations, so these can just be
-// aliases to their non-`_readonly` counterparts.
+// Then we define the `_readonly` versions of the wrappers. We don't have
+// separate `_readonly` implementations, so these can just be aliases to
+// their non-`_readonly` counterparts.
 pub(in crate::imp) use {
     syscall0 as syscall0_readonly, syscall1 as syscall1_readonly, syscall2 as syscall2_readonly,
     syscall3 as syscall3_readonly, syscall4 as syscall4_readonly, syscall5 as syscall5_readonly,

--- a/src/imp/linux_raw/arch/outline/x86.rs
+++ b/src/imp/linux_raw/arch/outline/x86.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 use crate::imp::reg::{ArgReg, RetReg, SyscallNumber, A0, A1, A2, A3, A4, A5, R0};
 use crate::imp::vdso_wrappers::SyscallType;
@@ -59,20 +59,12 @@ extern "fastcall" {
 
 #[inline]
 #[must_use]
-pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
+pub(in crate::imp) unsafe fn syscall0(nr: SyscallNumber<'_>) -> RetReg<R0> {
     rustix_syscall0_nr_last_fastcall(nr)
 }
 #[inline]
 #[must_use]
 pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
-    rustix_syscall1_nr_last_fastcall(a0, nr)
-}
-#[inline]
-#[must_use]
-pub(in crate::imp) unsafe fn syscall1_readonly(
-    nr: SyscallNumber<'_>,
-    a0: ArgReg<'_, A0>,
-) -> RetReg<R0> {
     rustix_syscall1_nr_last_fastcall(a0, nr)
 }
 #[inline]
@@ -91,15 +83,6 @@ pub(in crate::imp) unsafe fn syscall2(
 }
 #[inline]
 #[must_use]
-pub(in crate::imp) unsafe fn syscall2_readonly(
-    nr: SyscallNumber<'_>,
-    a0: ArgReg<'_, A0>,
-    a1: ArgReg<'_, A1>,
-) -> RetReg<R0> {
-    rustix_syscall2_nr_last_fastcall(a1, a0, nr)
-}
-#[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -110,28 +93,7 @@ pub(in crate::imp) unsafe fn syscall3(
 }
 #[inline]
 #[must_use]
-pub(in crate::imp) unsafe fn syscall3_readonly(
-    nr: SyscallNumber<'_>,
-    a0: ArgReg<'_, A0>,
-    a1: ArgReg<'_, A1>,
-    a2: ArgReg<'_, A2>,
-) -> RetReg<R0> {
-    rustix_syscall3_nr_last_fastcall(a1, a2, a0, nr)
-}
-#[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4(
-    nr: SyscallNumber<'_>,
-    a0: ArgReg<'_, A0>,
-    a1: ArgReg<'_, A1>,
-    a2: ArgReg<'_, A2>,
-    a3: ArgReg<'_, A3>,
-) -> RetReg<R0> {
-    rustix_syscall4_nr_last_fastcall(a1, a2, a0, a3, nr)
-}
-#[inline]
-#[must_use]
-pub(in crate::imp) unsafe fn syscall4_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
     a1: ArgReg<'_, A1>,
@@ -154,18 +116,6 @@ pub(in crate::imp) unsafe fn syscall5(
 }
 #[inline]
 #[must_use]
-pub(in crate::imp) unsafe fn syscall5_readonly(
-    nr: SyscallNumber<'_>,
-    a0: ArgReg<'_, A0>,
-    a1: ArgReg<'_, A1>,
-    a2: ArgReg<'_, A2>,
-    a3: ArgReg<'_, A3>,
-    a4: ArgReg<'_, A4>,
-) -> RetReg<R0> {
-    rustix_syscall5_nr_last_fastcall(a1, a2, a0, a3, a4, nr)
-}
-#[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -177,19 +127,14 @@ pub(in crate::imp) unsafe fn syscall6(
 ) -> RetReg<R0> {
     rustix_syscall6_nr_last_fastcall(a1, a2, a0, a3, a4, a5, nr)
 }
-#[inline]
-#[must_use]
-pub(in crate::imp) unsafe fn syscall6_readonly(
-    nr: SyscallNumber<'_>,
-    a0: ArgReg<'_, A0>,
-    a1: ArgReg<'_, A1>,
-    a2: ArgReg<'_, A2>,
-    a3: ArgReg<'_, A3>,
-    a4: ArgReg<'_, A4>,
-    a5: ArgReg<'_, A5>,
-) -> RetReg<R0> {
-    rustix_syscall6_nr_last_fastcall(a1, a2, a0, a3, a4, a5, nr)
-}
+
+// We don't have separate `_readonly` implementations, so these can just be
+// aliases to their non-`_readonly` counterparts.
+pub(in crate::imp) use {
+    syscall0 as syscall0_readonly, syscall1 as syscall1_readonly, syscall2 as syscall2_readonly,
+    syscall3 as syscall3_readonly, syscall4 as syscall4_readonly, syscall5 as syscall5_readonly,
+    syscall6 as syscall6_readonly,
+};
 
 // x86 prefers to route all syscalls through the vDSO, though this isn't
 // always possible, so it also has a special form for doing the dispatch.

--- a/src/imp/linux_raw/arch/outline/x86.rs
+++ b/src/imp/linux_raw/arch/outline/x86.rs
@@ -56,145 +56,140 @@ extern "fastcall" {
 }
 
 // Then we define inline wrapper functions that do the reordering.
-mod reorder {
-    use super::*;
 
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
-        rustix_syscall0_nr_last_fastcall(nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
-        rustix_syscall1_nr_last_fastcall(a0, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall1_readonly(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-    ) -> RetReg<R0> {
-        rustix_syscall1_nr_last_fastcall(a0, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
-        rustix_syscall1_noreturn_nr_last_fastcall(a0, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall2(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-    ) -> RetReg<R0> {
-        rustix_syscall2_nr_last_fastcall(a1, a0, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall2_readonly(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-    ) -> RetReg<R0> {
-        rustix_syscall2_nr_last_fastcall(a1, a0, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall3(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-    ) -> RetReg<R0> {
-        rustix_syscall3_nr_last_fastcall(a1, a2, a0, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall3_readonly(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-    ) -> RetReg<R0> {
-        rustix_syscall3_nr_last_fastcall(a1, a2, a0, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall4(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-        a3: ArgReg<'_, A3>,
-    ) -> RetReg<R0> {
-        rustix_syscall4_nr_last_fastcall(a1, a2, a0, a3, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall4_readonly(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-        a3: ArgReg<'_, A3>,
-    ) -> RetReg<R0> {
-        rustix_syscall4_nr_last_fastcall(a1, a2, a0, a3, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall5(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-        a3: ArgReg<'_, A3>,
-        a4: ArgReg<'_, A4>,
-    ) -> RetReg<R0> {
-        rustix_syscall5_nr_last_fastcall(a1, a2, a0, a3, a4, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall5_readonly(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-        a3: ArgReg<'_, A3>,
-        a4: ArgReg<'_, A4>,
-    ) -> RetReg<R0> {
-        rustix_syscall5_nr_last_fastcall(a1, a2, a0, a3, a4, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall6(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-        a3: ArgReg<'_, A3>,
-        a4: ArgReg<'_, A4>,
-        a5: ArgReg<'_, A5>,
-    ) -> RetReg<R0> {
-        rustix_syscall6_nr_last_fastcall(a1, a2, a0, a3, a4, a5, nr)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn syscall6_readonly(
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-        a3: ArgReg<'_, A3>,
-        a4: ArgReg<'_, A4>,
-        a5: ArgReg<'_, A5>,
-    ) -> RetReg<R0> {
-        rustix_syscall6_nr_last_fastcall(a1, a2, a0, a3, a4, a5, nr)
-    }
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
+    rustix_syscall0_nr_last_fastcall(nr)
 }
-
-pub(in crate::imp) use reorder::*;
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
+    rustix_syscall1_nr_last_fastcall(a0, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall1_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> RetReg<R0> {
+    rustix_syscall1_nr_last_fastcall(a0, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
+    rustix_syscall1_noreturn_nr_last_fastcall(a0, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall2(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    rustix_syscall2_nr_last_fastcall(a1, a0, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall2_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    rustix_syscall2_nr_last_fastcall(a1, a0, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall3(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    rustix_syscall3_nr_last_fastcall(a1, a2, a0, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall3_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    rustix_syscall3_nr_last_fastcall(a1, a2, a0, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall4(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    rustix_syscall4_nr_last_fastcall(a1, a2, a0, a3, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall4_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    rustix_syscall4_nr_last_fastcall(a1, a2, a0, a3, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall5(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    rustix_syscall5_nr_last_fastcall(a1, a2, a0, a3, a4, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall5_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    rustix_syscall5_nr_last_fastcall(a1, a2, a0, a3, a4, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall6(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    rustix_syscall6_nr_last_fastcall(a1, a2, a0, a3, a4, a5, nr)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn syscall6_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    rustix_syscall6_nr_last_fastcall(a1, a2, a0, a3, a4, a5, nr)
+}
 
 // x86 prefers to route all syscalls through the vDSO, though this isn't
 // always possible, so it also has a special form for doing the dispatch.
@@ -261,95 +256,90 @@ extern "fastcall" {
 }
 
 // Then we define inline wrapper functions that do the reordering.
-mod reorder_indirect {
-    use super::*;
 
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn indirect_syscall0(
-        callee: SyscallType,
-        nr: SyscallNumber<'_>,
-    ) -> RetReg<R0> {
-        rustix_indirect_syscall0_nr_last_fastcall(nr, callee)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn indirect_syscall1(
-        callee: SyscallType,
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-    ) -> RetReg<R0> {
-        rustix_indirect_syscall1_nr_last_fastcall(a0, nr, callee)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn indirect_syscall1_noreturn(
-        callee: SyscallType,
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-    ) -> ! {
-        rustix_indirect_syscall1_noreturn_nr_last_fastcall(a0, nr, callee)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn indirect_syscall2(
-        callee: SyscallType,
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-    ) -> RetReg<R0> {
-        rustix_indirect_syscall2_nr_last_fastcall(a1, a0, nr, callee)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn indirect_syscall3(
-        callee: SyscallType,
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-    ) -> RetReg<R0> {
-        rustix_indirect_syscall3_nr_last_fastcall(a1, a2, a0, nr, callee)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn indirect_syscall4(
-        callee: SyscallType,
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-        a3: ArgReg<'_, A3>,
-    ) -> RetReg<R0> {
-        rustix_indirect_syscall4_nr_last_fastcall(a1, a2, a0, a3, nr, callee)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn indirect_syscall5(
-        callee: SyscallType,
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-        a3: ArgReg<'_, A3>,
-        a4: ArgReg<'_, A4>,
-    ) -> RetReg<R0> {
-        rustix_indirect_syscall5_nr_last_fastcall(a1, a2, a0, a3, a4, nr, callee)
-    }
-    #[inline]
-    #[must_use]
-    pub(in crate::imp) unsafe fn indirect_syscall6(
-        callee: SyscallType,
-        nr: SyscallNumber<'_>,
-        a0: ArgReg<'_, A0>,
-        a1: ArgReg<'_, A1>,
-        a2: ArgReg<'_, A2>,
-        a3: ArgReg<'_, A3>,
-        a4: ArgReg<'_, A4>,
-        a5: ArgReg<'_, A5>,
-    ) -> RetReg<R0> {
-        rustix_indirect_syscall6_nr_last_fastcall(a1, a2, a0, a3, a4, a5, nr, callee)
-    }
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn indirect_syscall0(
+    callee: SyscallType,
+    nr: SyscallNumber<'_>,
+) -> RetReg<R0> {
+    rustix_indirect_syscall0_nr_last_fastcall(nr, callee)
 }
-
-pub(in crate::imp) use reorder_indirect::*;
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn indirect_syscall1(
+    callee: SyscallType,
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> RetReg<R0> {
+    rustix_indirect_syscall1_nr_last_fastcall(a0, nr, callee)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn indirect_syscall1_noreturn(
+    callee: SyscallType,
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> ! {
+    rustix_indirect_syscall1_noreturn_nr_last_fastcall(a0, nr, callee)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn indirect_syscall2(
+    callee: SyscallType,
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    rustix_indirect_syscall2_nr_last_fastcall(a1, a0, nr, callee)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn indirect_syscall3(
+    callee: SyscallType,
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    rustix_indirect_syscall3_nr_last_fastcall(a1, a2, a0, nr, callee)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn indirect_syscall4(
+    callee: SyscallType,
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    rustix_indirect_syscall4_nr_last_fastcall(a1, a2, a0, a3, nr, callee)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn indirect_syscall5(
+    callee: SyscallType,
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    rustix_indirect_syscall5_nr_last_fastcall(a1, a2, a0, a3, a4, nr, callee)
+}
+#[inline]
+#[must_use]
+pub(in crate::imp) unsafe fn indirect_syscall6(
+    callee: SyscallType,
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    rustix_indirect_syscall6_nr_last_fastcall(a1, a2, a0, a3, a4, a5, nr, callee)
+}


### PR DESCRIPTION
This PR contains three separate patches to rustix's Rust code wrapping its outline assembly code: two minor code simplifications, and expanded comments.
