### PR TITLE
Enable `CpuSet::count` on Android

### DIFF
--- a/src/imp/libc/process/cpu_set.rs
+++ b/src/imp/libc/process/cpu_set.rs
@@ -40,7 +40,7 @@ pub(crate) fn CPU_ISSET(cpu: usize, cpuset: &RawCpuSet) -> bool {
     unsafe { libc::CPU_ISSET(cpu, cpuset) }
 }
 
-#[cfg(any(target_os = "linux"))]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 pub(crate) fn CPU_COUNT(cpuset: &RawCpuSet) -> u32 {
     use core::convert::TryInto;

--- a/src/process/sched.rs
+++ b/src/process/sched.rs
@@ -55,7 +55,7 @@ impl CpuSet {
     }
 
     /// Count the number of CPUs set in the `CpuSet`.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "android", target_os = "linux"))]
     #[inline]
     pub fn count(&self) -> u32 {
         imp::process::cpu_set::CPU_COUNT(&self.cpu_set)

--- a/tests/process/cpu_set.rs
+++ b/tests/process/cpu_set.rs
@@ -1,0 +1,14 @@
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[test]
+fn test_cpu_set() {
+    let set = rustix::process::sched_getaffinity(None).unwrap();
+
+    let mut count = 0;
+    for i in 0..rustix::process::CpuSet::MAX_CPU {
+        if set.is_set(i) {
+            count += 1;
+        }
+    }
+
+    assert_eq!(count, set.count());
+}

--- a/tests/process/main.rs
+++ b/tests/process/main.rs
@@ -5,6 +5,7 @@
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 
 mod auxv;
+mod cpu_set;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have get[gpu]id.
 mod id;
 #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -20,4 +21,3 @@ mod uname;
 mod wait;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 mod working_directory;
-mod cpu_set;

--- a/tests/process/main.rs
+++ b/tests/process/main.rs
@@ -20,3 +20,4 @@ mod uname;
 mod wait;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 mod working_directory;
+mod cpu_set;


### PR DESCRIPTION
Enable `CpuSet::count` on Android, and add a basic test for it.