### PR TITLE
Update to is-terminal 0.1.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ libc = { version = "0.2.114", features = ["extra_traits"] }
 winapi = { version = "0.3.9", features = ["ws2ipdef", "ws2tcpip"] }
 
 [dev-dependencies]
-is-terminal = "0.0.0"
+is-terminal = "0.1.0"
 tempfile = "3.2.0"
 libc = "0.2.114"
 serial_test = "0.5"


### PR DESCRIPTION
This version uses io-lifetimes 0.5 and rustix 0.33. This is just a
dev-dependency, but updating it will fix the test build on Linux 2.6.32
where the old is-terminal depended on rustix 0.32 which doesn't have
the Linux 2.6.32 fixes.