### PR TITLE
Add support for abstract-name sockets.

### DIFF
--- a/src/imp/libc/net/addr.rs
+++ b/src/imp/libc/net/addr.rs
@@ -2,51 +2,125 @@
 
 use super::super::c;
 #[cfg(not(windows))]
-use crate::ffi::{ZStr, ZString};
+use super::offsetof_sun_path;
+#[cfg(not(windows))]
+use crate::ffi::ZStr;
 #[cfg(not(windows))]
 use crate::io;
 #[cfg(not(windows))]
 use crate::path;
+use core::convert::TryInto;
 #[cfg(not(windows))]
 use core::fmt;
+#[cfg(not(windows))]
+use core::mem::transmute;
 
 /// `struct sockaddr_un`
 #[cfg(not(windows))]
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone)]
 #[doc(alias = "sockaddr_un")]
 pub struct SocketAddrUnix {
-    path: ZString,
+    pub(crate) unix: libc::sockaddr_un,
+    #[cfg(not(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
+    len: libc::socklen_t,
 }
 
 #[cfg(not(windows))]
 impl SocketAddrUnix {
-    /// Construct a new Unix-domain address from a byte slice.
-    /// filesystem path.
+    /// Construct a new Unix-domain address from a filesystem path.
     #[inline]
     pub fn new<P: path::Arg>(path: P) -> io::Result<Self> {
-        let path = path.into_z_str()?.into_owned();
-        Self::_new(path)
+        path.into_with_z_str(|path| Self::_new(path))
     }
 
     #[inline]
-    fn _new(path: ZString) -> io::Result<Self> {
-        let bytes = path.as_bytes();
+    fn _new(path: &ZStr) -> io::Result<Self> {
+        let mut unix = Self::init();
+        let bytes = path.to_bytes_with_nul();
+        if bytes.len() > unix.sun_path.len() {
+            return Err(io::Error::NAMETOOLONG);
+        }
+        for (i, b) in bytes.iter().enumerate() {
+            unix.sun_path[i] = *b as c::c_char;
+        }
 
-        let z = c::sockaddr_un {
+        #[cfg(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ))]
+        {
+            unix.sun_len = (offsetof_sun_path() + bytes.len()).try_into().unwrap();
+        }
+
+        Ok(Self {
+            unix,
+            #[cfg(not(any(
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "ios",
+                target_os = "macos",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            )))]
+            len: (offsetof_sun_path() + bytes.len()).try_into().unwrap(),
+        })
+    }
+
+    /// Construct a new abstract Unix-domain address from a byte slice.
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[inline]
+    pub fn new_abstract_name(name: &[u8]) -> io::Result<Self> {
+        let mut unix = Self::init();
+        if 1 + name.len() > unix.sun_path.len() {
+            return Err(io::Error::NAMETOOLONG);
+        }
+        unix.sun_path[0] = b'\0' as c::c_char;
+        for (i, b) in name.iter().enumerate() {
+            unix.sun_path[1 + i] = *b as c::c_char;
+        }
+        let len = offsetof_sun_path() + 1 + name.len();
+        let len = len.try_into().unwrap();
+        Ok(Self {
+            unix,
+            #[cfg(not(any(
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "ios",
+                target_os = "macos",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            )))]
+            len,
+        })
+    }
+
+    fn init() -> c::sockaddr_un {
+        c::sockaddr_un {
             #[cfg(any(
                 target_os = "dragonfly",
-                target_os = "ios",
                 target_os = "freebsd",
+                target_os = "ios",
                 target_os = "macos",
                 target_os = "netbsd",
                 target_os = "openbsd"
             ))]
             sun_len: 0,
-            sun_family: 0,
+            sun_family: c::AF_UNIX as _,
             #[cfg(any(
                 target_os = "dragonfly",
-                target_os = "ios",
                 target_os = "freebsd",
+                target_os = "ios",
                 target_os = "macos",
                 target_os = "netbsd",
                 target_os = "openbsd"
@@ -54,31 +128,132 @@ impl SocketAddrUnix {
             sun_path: [0; 104],
             #[cfg(not(any(
                 target_os = "dragonfly",
-                target_os = "ios",
                 target_os = "freebsd",
+                target_os = "ios",
                 target_os = "macos",
                 target_os = "netbsd",
                 target_os = "openbsd"
             )))]
             sun_path: [0; 108],
-        };
-        if bytes.len() + 1 > z.sun_path.len() {
-            return Err(io::Error::NAMETOOLONG);
         }
-        Ok(Self { path })
     }
 
-    /// Returns a reference to the contained path.
+    /// For a filesystem path address, return the path.
     #[inline]
-    pub fn path(&self) -> &ZStr {
-        &self.path
+    pub fn path(&self) -> Option<&ZStr> {
+        let len = self.len();
+        if len != 0 && self.unix.sun_path[0] != b'\0' as c::c_char {
+            let end = len as usize - offsetof_sun_path();
+            // Safety: Transmuting between `&[c_char]` and `&[u8]`.
+            unsafe {
+                Some(ZStr::from_bytes_with_nul(transmute(&self.unix.sun_path[..end])).unwrap())
+            }
+        } else {
+            None
+        }
+    }
+
+    /// For an abstract address, return the identifier.
+    #[inline]
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    pub fn abstract_name(&self) -> Option<&[u8]> {
+        let len = self.len();
+        if len != 0 && self.unix.sun_path[0] == b'\0' as c::c_char {
+            let end = len as usize - offsetof_sun_path();
+            // Safety: Transmuting between `&[c_char]` and `&[u8]`.
+            unsafe { Some(transmute(&self.unix.sun_path[1..end])) }
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub(crate) fn addr_len(&self) -> c::socklen_t {
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        )))]
+        {
+            self.len
+        }
+        #[cfg(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ))]
+        {
+            c::socklen_t::from(self.unix.sun_len)
+        }
+    }
+
+    #[inline]
+    pub(crate) fn len(&self) -> usize {
+        self.addr_len() as usize
+    }
+}
+
+#[cfg(not(windows))]
+impl PartialEq for SocketAddrUnix {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        let self_len = self.len() - offsetof_sun_path();
+        let other_len = other.len() - offsetof_sun_path();
+        self.unix.sun_path[..self_len].eq(&other.unix.sun_path[..other_len])
+    }
+}
+
+#[cfg(not(windows))]
+impl Eq for SocketAddrUnix {}
+
+#[cfg(not(windows))]
+impl PartialOrd for SocketAddrUnix {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        let self_len = self.len() - offsetof_sun_path();
+        let other_len = other.len() - offsetof_sun_path();
+        self.unix.sun_path[..self_len].partial_cmp(&other.unix.sun_path[..other_len])
+    }
+}
+
+#[cfg(not(windows))]
+impl Ord for SocketAddrUnix {
+    #[inline]
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        let self_len = self.len() - offsetof_sun_path();
+        let other_len = other.len() - offsetof_sun_path();
+        self.unix.sun_path[..self_len].cmp(&other.unix.sun_path[..other_len])
+    }
+}
+
+#[cfg(not(windows))]
+impl core::hash::Hash for SocketAddrUnix {
+    #[inline]
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        let self_len = self.len() - offsetof_sun_path();
+        self.unix.sun_path[..self_len].hash(state)
     }
 }
 
 #[cfg(not(windows))]
 impl fmt::Debug for SocketAddrUnix {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.path.fmt(fmt)
+        if let Some(path) = self.path() {
+            path.fmt(fmt)
+        } else {
+            #[cfg(any(target_os = "android", target_os = "linux"))]
+            if let Some(name) = self.abstract_name() {
+                return name.fmt(fmt);
+            }
+
+            "(unnamed)".fmt(fmt)
+        }
     }
 }
 

--- a/src/imp/libc/net/mod.rs
+++ b/src/imp/libc/net/mod.rs
@@ -15,8 +15,6 @@ pub use addr::SocketAddrUnix;
 pub(crate) use read_sockaddr::{read_sockaddr, read_sockaddr_os};
 pub use send_recv::{RecvFlags, SendFlags};
 pub use types::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType, Timeout};
-#[cfg(not(windows))]
-pub(crate) use write_sockaddr::encode_sockaddr_unix;
 pub(crate) use write_sockaddr::{encode_sockaddr_v4, encode_sockaddr_v6, write_sockaddr};
 
 /// Return the offset of the `sun_path` field of `sockaddr_un`.

--- a/src/imp/libc/net/write_sockaddr.rs
+++ b/src/imp/libc/net/write_sockaddr.rs
@@ -91,48 +91,7 @@ unsafe fn write_sockaddr_v6(v6: &SocketAddrV6, storage: *mut SocketAddrStorage) 
 }
 
 #[cfg(not(windows))]
-pub(crate) unsafe fn encode_sockaddr_unix(unix: &SocketAddrUnix) -> c::sockaddr_un {
-    let mut encoded = c::sockaddr_un {
-        #[cfg(any(
-            target_os = "dragonfly",
-            target_os = "ios",
-            target_os = "freebsd",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))]
-        sun_len: size_of::<c::sockaddr_un>() as _,
-        sun_family: c::AF_UNIX as _,
-        #[cfg(any(
-            target_os = "dragonfly",
-            target_os = "ios",
-            target_os = "freebsd",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))]
-        sun_path: [0; 104],
-        #[cfg(not(any(
-            target_os = "dragonfly",
-            target_os = "ios",
-            target_os = "freebsd",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        )))]
-        sun_path: [0; 108],
-    };
-    let bytes = unix.path().to_bytes();
-    for (i, b) in bytes.iter().enumerate() {
-        encoded.sun_path[i] = *b as c::c_char;
-    }
-    encoded.sun_path[bytes.len()] = b'\0' as c::c_char;
-    encoded
-}
-
-#[cfg(not(windows))]
 unsafe fn write_sockaddr_unix(unix: &SocketAddrUnix, storage: *mut SocketAddrStorage) -> usize {
-    let encoded = encode_sockaddr_unix(unix);
-    core::ptr::write(storage.cast(), encoded);
-    super::offsetof_sun_path() + unix.path().to_bytes().len() + 1
+    core::ptr::write(storage.cast(), unix.unix);
+    unix.len()
 }

--- a/src/imp/linux_raw/net/addr.rs
+++ b/src/imp/linux_raw/net/addr.rs
@@ -5,49 +5,154 @@
 //! Linux's IPv6 type contains a union.
 #![allow(unsafe_code)]
 
-use crate::ffi::{ZStr, ZString};
+use super::super::c;
+use super::offsetof_sun_path;
+use crate::ffi::ZStr;
 use crate::{io, path};
+use core::convert::TryInto;
 use core::fmt;
+use core::mem::transmute;
 
 /// `struct sockaddr_un`
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone)]
 #[doc(alias = "sockaddr_un")]
 pub struct SocketAddrUnix {
-    path: ZString,
+    pub(crate) unix: linux_raw_sys::general::sockaddr_un,
+    len: linux_raw_sys::general::socklen_t,
 }
 
 impl SocketAddrUnix {
-    /// Construct a new Unix-domain address from a byte slice.
-    /// filesystem path.
+    /// Construct a new Unix-domain address from a filesystem path.
     #[inline]
     pub fn new<P: path::Arg>(path: P) -> io::Result<Self> {
-        let path = path.into_z_str()?.into_owned();
-        Self::_new(path)
+        path.into_with_z_str(|path| Self::_new(path))
     }
 
     #[inline]
-    fn _new(path: ZString) -> io::Result<Self> {
-        let bytes = path.as_bytes();
-        let z = linux_raw_sys::general::sockaddr_un {
-            sun_family: 0,
-            sun_path: [0; 108_usize],
-        };
-        if bytes.len() + 1 > z.sun_path.len() {
+    fn _new(path: &ZStr) -> io::Result<Self> {
+        let mut unix = Self::init();
+        let bytes = path.to_bytes_with_nul();
+        if bytes.len() > unix.sun_path.len() {
             return Err(io::Error::NAMETOOLONG);
         }
-        Ok(Self { path })
+        for (i, b) in bytes.iter().enumerate() {
+            unix.sun_path[i] = *b as c::c_char;
+        }
+        let len = offsetof_sun_path() + bytes.len();
+        let len = len.try_into().unwrap();
+        Ok(Self { unix, len })
     }
 
-    /// Returns a reference to the contained path.
+    /// Construct a new abstract Unix-domain address from a byte slice.
+    #[cfg(any(target_os = "android", target_os = "linux"))]
     #[inline]
-    pub fn path(&self) -> &ZStr {
-        &self.path
+    pub fn new_abstract_name(name: &[u8]) -> io::Result<Self> {
+        let mut unix = Self::init();
+        if 1 + name.len() > unix.sun_path.len() {
+            return Err(io::Error::NAMETOOLONG);
+        }
+        unix.sun_path[0] = b'\0' as c::c_char;
+        for (i, b) in name.iter().enumerate() {
+            unix.sun_path[1 + i] = *b as c::c_char;
+        }
+        let len = offsetof_sun_path() + 1 + name.len();
+        let len = len.try_into().unwrap();
+        Ok(Self { unix, len })
+    }
+
+    fn init() -> linux_raw_sys::general::sockaddr_un {
+        linux_raw_sys::general::sockaddr_un {
+            sun_family: linux_raw_sys::general::AF_UNIX as _,
+            sun_path: [0; 108],
+        }
+    }
+
+    /// For a filesystem path address, return the path.
+    #[inline]
+    pub fn path(&self) -> Option<&ZStr> {
+        let len = self.len();
+        if len != 0 && self.unix.sun_path[0] != b'\0' as c::c_char {
+            let end = len as usize - offsetof_sun_path();
+            // Safety: Transmuting between `&[c_char]` and `&[u8]`.
+            unsafe {
+                Some(ZStr::from_bytes_with_nul(transmute(&self.unix.sun_path[..end])).unwrap())
+            }
+        } else {
+            None
+        }
+    }
+
+    /// For an abstract address, return the identifier.
+    #[inline]
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    pub fn abstract_name(&self) -> Option<&[u8]> {
+        let len = self.len();
+        if len != 0 && self.unix.sun_path[0] == b'\0' as c::c_char {
+            let end = len as usize - offsetof_sun_path();
+            // Safety: Transmuting between `&[c_char]` and `&[u8]`.
+            unsafe { Some(transmute(&self.unix.sun_path[1..end])) }
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub(crate) fn addr_len(&self) -> linux_raw_sys::general::socklen_t {
+        self.len
+    }
+
+    #[inline]
+    pub(crate) fn len(&self) -> usize {
+        self.addr_len() as usize
+    }
+}
+
+impl PartialEq for SocketAddrUnix {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        let self_len = self.len() - offsetof_sun_path();
+        let other_len = other.len() - offsetof_sun_path();
+        self.unix.sun_path[..self_len].eq(&other.unix.sun_path[..other_len])
+    }
+}
+
+impl Eq for SocketAddrUnix {}
+
+impl PartialOrd for SocketAddrUnix {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        let self_len = self.len() - offsetof_sun_path();
+        let other_len = other.len() - offsetof_sun_path();
+        self.unix.sun_path[..self_len].partial_cmp(&other.unix.sun_path[..other_len])
+    }
+}
+
+impl Ord for SocketAddrUnix {
+    #[inline]
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        let self_len = self.len() - offsetof_sun_path();
+        let other_len = other.len() - offsetof_sun_path();
+        self.unix.sun_path[..self_len].cmp(&other.unix.sun_path[..other_len])
+    }
+}
+
+impl core::hash::Hash for SocketAddrUnix {
+    #[inline]
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        let self_len = self.len() - offsetof_sun_path();
+        self.unix.sun_path[..self_len].hash(state)
     }
 }
 
 impl fmt::Debug for SocketAddrUnix {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.path.fmt(fmt)
+        if let Some(path) = self.path() {
+            path.fmt(fmt)
+        } else if let Some(name) = self.abstract_name() {
+            name.fmt(fmt)
+        } else {
+            "(unnamed)".fmt(fmt)
+        }
     }
 }
 

--- a/src/imp/linux_raw/net/mod.rs
+++ b/src/imp/linux_raw/net/mod.rs
@@ -7,9 +7,7 @@ mod write_sockaddr;
 pub(crate) mod ext;
 pub(crate) mod syscalls;
 pub(crate) use read_sockaddr::{read_sockaddr, read_sockaddr_os};
-pub(crate) use write_sockaddr::{
-    encode_sockaddr_unix, encode_sockaddr_v4, encode_sockaddr_v6, write_sockaddr,
-};
+pub(crate) use write_sockaddr::{encode_sockaddr_v4, encode_sockaddr_v6, write_sockaddr};
 
 pub use addr::{SocketAddrStorage, SocketAddrUnix};
 pub use send_recv::{RecvFlags, SendFlags};

--- a/src/imp/linux_raw/net/syscalls.rs
+++ b/src/imp/linux_raw/net/syscalls.rs
@@ -14,8 +14,8 @@ use super::super::conv::{
 };
 use super::super::reg::nr;
 use super::{
-    encode_sockaddr_unix, encode_sockaddr_v4, encode_sockaddr_v6, read_sockaddr_os, AcceptFlags,
-    AddressFamily, Protocol, RecvFlags, SendFlags, Shutdown, SocketFlags, SocketType,
+    encode_sockaddr_v4, encode_sockaddr_v6, read_sockaddr_os, AcceptFlags, AddressFamily, Protocol,
+    RecvFlags, SendFlags, Shutdown, SocketFlags, SocketType,
 };
 use crate::fd::BorrowedFd;
 use crate::io::{self, OwnedFd};
@@ -29,7 +29,7 @@ use core::mem::MaybeUninit;
     target_arch = "riscv64"
 )))]
 use linux_raw_sys::general::{__NR_recv, __NR_send};
-use linux_raw_sys::general::{sockaddr, sockaddr_in, sockaddr_in6, sockaddr_un, socklen_t};
+use linux_raw_sys::general::{sockaddr, sockaddr_in, sockaddr_in6, socklen_t};
 #[cfg(target_arch = "x86")]
 use {
     super::super::arch::choose::syscall2,
@@ -450,8 +450,8 @@ pub(crate) fn sendto_unix(
             buf_addr,
             buf_len,
             c_uint(flags.bits()),
-            by_ref(&encode_sockaddr_unix(addr)),
-            size_of::<sockaddr_un, _>(),
+            by_ref(&addr.unix),
+            socklen_t(addr.addr_len()),
         ))
     }
     #[cfg(target_arch = "x86")]
@@ -464,8 +464,8 @@ pub(crate) fn sendto_unix(
                 buf_addr,
                 buf_len,
                 c_uint(flags.bits()),
-                by_ref(&encode_sockaddr_unix(addr)),
-                size_of::<sockaddr_un, _>(),
+                by_ref(&addr.unix),
+                socklen_t(addr.addr_len()),
             ]),
         ))
     }
@@ -701,8 +701,8 @@ pub(crate) fn bind_unix(fd: BorrowedFd<'_>, addr: &SocketAddrUnix) -> io::Result
         ret(syscall3_readonly(
             nr(__NR_bind),
             borrowed_fd(fd),
-            by_ref(&encode_sockaddr_unix(addr)),
-            size_of::<sockaddr_un, _>(),
+            by_ref(&addr.unix),
+            socklen_t(addr.addr_len()),
         ))
     }
     #[cfg(target_arch = "x86")]
@@ -712,8 +712,8 @@ pub(crate) fn bind_unix(fd: BorrowedFd<'_>, addr: &SocketAddrUnix) -> io::Result
             x86_sys(SYS_BIND),
             slice_just_addr::<ArgReg<SocketArg>, _>(&[
                 borrowed_fd(fd),
-                by_ref(&encode_sockaddr_unix(addr)),
-                size_of::<sockaddr_un, _>(),
+                by_ref(&addr.unix),
+                socklen_t(addr.addr_len()),
             ]),
         ))
     }
@@ -776,8 +776,8 @@ pub(crate) fn connect_unix(fd: BorrowedFd<'_>, addr: &SocketAddrUnix) -> io::Res
         ret(syscall3_readonly(
             nr(__NR_connect),
             borrowed_fd(fd),
-            by_ref(&encode_sockaddr_unix(addr)),
-            size_of::<sockaddr_un, _>(),
+            by_ref(&addr.unix),
+            socklen_t(addr.addr_len()),
         ))
     }
     #[cfg(target_arch = "x86")]
@@ -787,8 +787,8 @@ pub(crate) fn connect_unix(fd: BorrowedFd<'_>, addr: &SocketAddrUnix) -> io::Res
             x86_sys(SYS_CONNECT),
             slice_just_addr::<ArgReg<SocketArg>, _>(&[
                 borrowed_fd(fd),
-                by_ref(&encode_sockaddr_unix(addr)),
-                size_of::<sockaddr_un, _>(),
+                by_ref(&addr.unix),
+                socklen_t(addr.addr_len()),
             ]),
         ))
     }


### PR DESCRIPTION
In Linux, unix-domain sockets can have an "abstract" address which is
encoded with a leading NUL byte. Add support for constructing such
abstract addresses.

Since `SocketAddrUnix` previously held a `ZString`, which can't
accomodate leading NUL bytes, change `SocketAddrUnix` to hold a `sockaddr_un`
instead, and redo the encoding/decoding logic to work with it.