### PR TITLE
Add a `PollFd::clear_revents` function.

### DIFF
--- a/src/imp/libc/io/poll_fd.rs
+++ b/src/imp/libc/io/poll_fd.rs
@@ -67,6 +67,12 @@ impl<'fd> PollFd<'fd> {
         self.pollfd.fd = fd.as_fd().as_raw_fd();
     }
 
+    /// Clears the ready events.
+    #[inline]
+    pub fn clear_revents(&mut self) {
+        self.pollfd.revents = 0;
+    }
+
     /// Constructs a new `PollFd` holding `fd` and `events`.
     ///
     /// This is the same as `new`, but can be used to avoid borrowing the

--- a/src/imp/linux_raw/io/poll_fd.rs
+++ b/src/imp/linux_raw/io/poll_fd.rs
@@ -56,6 +56,12 @@ impl<'fd> PollFd<'fd> {
         self.fd = fd.as_fd();
     }
 
+    /// Clears the ready events.
+    #[inline]
+    pub fn clear_revents(&mut self) {
+        self.revents = 0;
+    }
+
     /// Constructs a new `PollFd` holding `fd` and `events`.
     ///
     /// This is the same as `new`, but can be used to avoid borrowing the

--- a/tests/io/poll.rs
+++ b/tests/io/poll.rs
@@ -23,6 +23,11 @@ fn test_poll() {
     assert_eq!(poll_fds[0].revents(), PollFlags::IN);
     assert_eq!(poll_fds[0].as_fd().as_raw_fd(), reader.as_fd().as_raw_fd());
 
+    let mut temp = poll_fds[0].clone();
+    assert_eq!(temp.revents(), PollFlags::IN);
+    temp.clear_revents();
+    assert!(temp.revents().is_empty());
+
     // Read the byte from the pipe.
     let mut buf = [b'\0'];
     assert_eq!(with_retrying(|| read(&reader, &mut buf)).unwrap(), 1);


### PR DESCRIPTION
Add a utility function to zero out the `revents` field of a `PollFd`.