### PR TITLE
Fix several issues in the test-users script.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,7 +193,8 @@ jobs:
             target: aarch64-unknown-linux-gnu
             gcc_package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
-            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu: qemu-aarch64
+            qemu_args: -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
           - build: powerpc64le-linux
             os: ubuntu-latest
@@ -201,7 +202,8 @@ jobs:
             target: powerpc64le-unknown-linux-gnu
             gcc_package: gcc-powerpc64le-linux-gnu
             gcc: powerpc64le-linux-gnu-gcc
-            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu: qemu-ppc64le
+            qemu_args: -L /usr/powerpc64le-linux-gnu
             qemu_target: ppc64le-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
@@ -209,7 +211,8 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
             gcc_package: gcc-riscv64-linux-gnu
             gcc: riscv64-linux-gnu-gcc
-            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu: qemu-riscv64
+            qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
           - build: arm-linux
             os: ubuntu-latest
@@ -217,7 +220,8 @@ jobs:
             target: armv5te-unknown-linux-gnueabi
             gcc_package: gcc-arm-linux-gnueabi
             gcc: arm-linux-gnueabi-gcc
-            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu: qemu-arm
+            qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
           - build: ubuntu-stable
             os: ubuntu-latest
@@ -235,7 +239,8 @@ jobs:
             target: aarch64-unknown-linux-gnu
             gcc_package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
-            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu: qemu-aarch64
+            qemu_args: -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
           - build: riscv64-linux-stable
             os: ubuntu-latest
@@ -243,7 +248,8 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
             gcc_package: gcc-riscv64-linux-gnu
             gcc: riscv64-linux-gnu-gcc
-            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu: qemu-riscv64
+            qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
           - build: arm-linux-stable
             os: ubuntu-latest
@@ -251,7 +257,8 @@ jobs:
             target: armv5te-unknown-linux-gnueabi
             gcc_package: gcc-arm-linux-gnueabi
             gcc: arm-linux-gnueabi-gcc
-            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu: qemu-arm
+            qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
           - build: macos
             os: macos-latest
@@ -308,8 +315,11 @@ jobs:
       run: |
         set -ex
 
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ${{ matrix.qemu_args }} >> $GITHUB_ENV
+
         # See if qemu is already in the cache
-        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+        if [ -f ${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ]; then
           exit 0
         fi
 
@@ -322,12 +332,6 @@ jobs:
         cd qemu-$QEMU_BUILD_VERSION
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         ninja -C build install
-        touch ${{ runner.tool_cache }}/qemu/built
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     - run: |
@@ -363,7 +367,8 @@ jobs:
             target: aarch64-unknown-linux-gnu
             gcc_package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
-            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu: qemu-aarch64
+            qemu_args: -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
           - build: powerpc64le-linux
             os: ubuntu-latest
@@ -371,7 +376,8 @@ jobs:
             target: powerpc64le-unknown-linux-gnu
             gcc_package: gcc-powerpc64le-linux-gnu
             gcc: powerpc64le-linux-gnu-gcc
-            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu: qemu-ppc64le
+            qemu_args: -L /usr/powerpc64le-linux-gnu
             qemu_target: ppc64le-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
@@ -379,7 +385,8 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
             gcc_package: gcc-riscv64-linux-gnu
             gcc: riscv64-linux-gnu-gcc
-            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu: qemu-riscv64
+            qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
           - build: arm-linux
             os: ubuntu-latest
@@ -387,7 +394,8 @@ jobs:
             target: armv7-unknown-linux-gnueabihf
             gcc_package: gcc-arm-linux-gnueabihf
             gcc: arm-linux-gnueabihf-gcc
-            qemu: qemu-arm -L /usr/arm-linux-gnueabihf
+            qemu: qemu-arm
+            qemu_args: -L /usr/arm-linux-gnueabihf
             qemu_target: arm-linux-user
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.
@@ -440,8 +448,11 @@ jobs:
       run: |
         set -ex
 
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ${{ matrix.qemu_args }} >> $GITHUB_ENV
+
         # See if qemu is already in the cache
-        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+        if [ -f ${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ]; then
           exit 0
         fi
 
@@ -454,12 +465,6 @@ jobs:
         cd qemu-$QEMU_BUILD_VERSION
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         ninja -C build install
-        touch ${{ runner.tool_cache }}/qemu/built
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     - run: |
@@ -480,7 +485,8 @@ jobs:
             target: powerpc64le-unknown-linux-gnu
             gcc_package: gcc-powerpc64le-linux-gnu
             gcc: powerpc64le-linux-gnu-gcc
-            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu: qemu-ppc64le
+            qemu_args: -L /usr/powerpc64le-linux-gnu
             qemu_target: ppc64le-linux-user
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.
@@ -528,8 +534,11 @@ jobs:
       run: |
         set -ex
 
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ${{ matrix.qemu_args }} >> $GITHUB_ENV
+
         # See if qemu is already in the cache
-        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+        if [ -f ${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ]; then
           exit 0
         fi
 
@@ -542,12 +551,6 @@ jobs:
         cd qemu-$QEMU_BUILD_VERSION
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         ninja -C build install
-        touch ${{ runner.tool_cache }}/qemu/built
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     - run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -273,21 +273,47 @@ jobs:
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: ./.github/workflows/cross.yml
-      with:
-        os: ${{ matrix.os }
-        target: ${{ matrix.target }}
-        libc_package: ${{ matrix.libc_package }}
-        gcc_package: ${{ matrix.gcc_package }}
-        gcc: ${{ matrix.gcc }}
-        qemu: ${{ matrix.qemu }}
-        qemu_target: ${{ matrix.qemu_target }}
 
     - name: Configure Cargo target
       run: |
         echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
+
+    - name: Install cross-compilation tools
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
+      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install cross-compilation libraries
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.libc_package }}
+      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install qemu
+      run: |
+        set -ex
+        # Download and build qemu from source since the most recent release is
+        # way faster at arm emulation than the current version github actions'
+        # ubuntu image uses. Disable as much as we can to get it to build
+        # quickly.
+        cd
+        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
+        cd qemu-6.1.0
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        make -j$(nproc) install
+
+        # Configure Cargo for cross compilation and tell it how it can run
+        # cross executables
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     - run: |
         # Run the tests, and check the prebuilt release libraries.
@@ -365,21 +391,47 @@ jobs:
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: ./.github/workflows/cross.yml
-      with:
-        os: ${{ matrix.os }
-        target: ${{ matrix.target }}
-        libc_package: ${{ matrix.libc_package }}
-        gcc_package: ${{ matrix.gcc_package }}
-        gcc: ${{ matrix.gcc }}
-        qemu: ${{ matrix.qemu }}
-        qemu_target: ${{ matrix.qemu_target }}
 
     - name: Configure Cargo target
       run: |
         echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
+
+    - name: Install cross-compilation tools
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
+      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install cross-compilation libraries
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.libc_package }}
+      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install qemu
+      run: |
+        set -ex
+        # Download and build qemu from source since the most recent release is
+        # way faster at arm emulation than the current version github actions'
+        # ubuntu image uses. Disable as much as we can to get it to build
+        # quickly.
+        cd
+        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
+        cd qemu-6.1.0
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        make -j$(nproc) install
+
+        # Configure Cargo for cross compilation and tell it how it can run
+        # cross executables
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     - run: |
         cargo test --verbose --features=all-impls,procfs --release --workspace -- --nocapture

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,6 +168,8 @@ jobs:
   test:
     name: Test
     runs-on: ${{ matrix.os }}
+    env:
+      QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
         build: [ubuntu, ubuntu-18.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux, ubuntu-stable, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, arm-linux-stable, macos, macos-11, windows, windows-2016, windows-2022]
@@ -280,6 +282,12 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
+    - uses: actions/cache@v2
+      with:
+        path: ${{ runner.tool_cache }}/qemu
+        key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}
+      if: matrix.target != '' && matrix.os == 'ubuntu-latest'
+
     - name: Install cross-compilation tools
       run: |
         set -ex
@@ -299,15 +307,22 @@ jobs:
     - name: Install qemu
       run: |
         set -ex
+
+        # See if qemu is already in the cache
+        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+          exit 0
+        fi
+
         # Download and build qemu from source since the most recent release is
         # way faster at arm emulation than the current version github actions'
         # ubuntu image uses. Disable as much as we can to get it to build
         # quickly.
         cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
+        curl https://download.qemu.org/qemu-$QEMU_BUILD_VERSION.tar.xz | tar xJf -
+        cd qemu-$QEMU_BUILD_VERSION
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        ninja -C build install
+        touch ${{ runner.tool_cache }}/qemu/built
 
         # Configure Cargo for cross compilation and tell it how it can run
         # cross executables
@@ -384,6 +399,7 @@ jobs:
       CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_libc
       CARGO_TARGET_RISCV64_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_libc
       CARGO_TARGET_ARM_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_libc
+      QEMU_BUILD_VERSION: 6.1.0
     steps:
     - uses: actions/checkout@v2
       with:
@@ -397,6 +413,12 @@ jobs:
         echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
+
+    - uses: actions/cache@v2
+      with:
+        path: ${{ runner.tool_cache }}/qemu
+        key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}
+      if: matrix.target != '' && matrix.os == 'ubuntu-latest'
 
     - name: Install cross-compilation tools
       run: |
@@ -417,15 +439,22 @@ jobs:
     - name: Install qemu
       run: |
         set -ex
+
+        # See if qemu is already in the cache
+        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+          exit 0
+        fi
+
         # Download and build qemu from source since the most recent release is
         # way faster at arm emulation than the current version github actions'
         # ubuntu image uses. Disable as much as we can to get it to build
         # quickly.
         cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
+        curl https://download.qemu.org/qemu-$QEMU_BUILD_VERSION.tar.xz | tar xJf -
+        cd qemu-$QEMU_BUILD_VERSION
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        ninja -C build install
+        touch ${{ runner.tool_cache }}/qemu/built
 
         # Configure Cargo for cross compilation and tell it how it can run
         # cross executables
@@ -458,6 +487,7 @@ jobs:
       RUSTFLAGS: --cfg rustix_use_experimental_asm -D warnings
       RUSTDOCFLAGS: --cfg rustix_use_experimental_asm
       CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_experimental_asm
+      QEMU_BUILD_VERSION: 6.1.0
     steps:
     - uses: actions/checkout@v2
       with:
@@ -471,6 +501,12 @@ jobs:
         echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
+
+    - uses: actions/cache@v2
+      with:
+        path: ${{ runner.tool_cache }}/qemu
+        key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}
+      if: matrix.target != '' && matrix.os == 'ubuntu-latest'
 
     - name: Install cross-compilation tools
       run: |
@@ -491,15 +527,22 @@ jobs:
     - name: Install qemu
       run: |
         set -ex
+
+        # See if qemu is already in the cache
+        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+          exit 0
+        fi
+
         # Download and build qemu from source since the most recent release is
         # way faster at arm emulation than the current version github actions'
         # ubuntu image uses. Disable as much as we can to get it to build
         # quickly.
         cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
+        curl https://download.qemu.org/qemu-$QEMU_BUILD_VERSION.tar.xz | tar xJf -
+        cd qemu-$QEMU_BUILD_VERSION
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        ninja -C build install
+        touch ${{ runner.tool_cache }}/qemu/built
 
         # Configure Cargo for cross compilation and tell it how it can run
         # cross executables

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -273,47 +273,21 @@ jobs:
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
+    - uses: ./.github/workflows/cross.yml
+      with:
+        os: ${{ matrix.os }
+        target: ${{ matrix.target }}
+        libc_package: ${{ matrix.libc_package }}
+        gcc_package: ${{ matrix.gcc_package }}
+        gcc: ${{ matrix.gcc }}
+        qemu: ${{ matrix.qemu }}
+        qemu_target: ${{ matrix.qemu_target }}
 
     - name: Configure Cargo target
       run: |
         echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
-
-    - name: Install cross-compilation tools
-      run: |
-        set -ex
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
-      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
-
-    - name: Install cross-compilation libraries
-      run: |
-        set -ex
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.libc_package }}
-      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
-
-    - name: Install qemu
-      run: |
-        set -ex
-        # Download and build qemu from source since the most recent release is
-        # way faster at arm emulation than the current version github actions'
-        # ubuntu image uses. Disable as much as we can to get it to build
-        # quickly.
-        cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
-      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     - run: |
         # Run the tests, and check the prebuilt release libraries.
@@ -391,47 +365,21 @@ jobs:
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
+    - uses: ./.github/workflows/cross.yml
+      with:
+        os: ${{ matrix.os }
+        target: ${{ matrix.target }}
+        libc_package: ${{ matrix.libc_package }}
+        gcc_package: ${{ matrix.gcc_package }}
+        gcc: ${{ matrix.gcc }}
+        qemu: ${{ matrix.qemu }}
+        qemu_target: ${{ matrix.qemu_target }}
 
     - name: Configure Cargo target
       run: |
         echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
-
-    - name: Install cross-compilation tools
-      run: |
-        set -ex
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
-      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
-
-    - name: Install cross-compilation libraries
-      run: |
-        set -ex
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.libc_package }}
-      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
-
-    - name: Install qemu
-      run: |
-        set -ex
-        # Download and build qemu from source since the most recent release is
-        # way faster at arm emulation than the current version github actions'
-        # ubuntu image uses. Disable as much as we can to get it to build
-        # quickly.
-        cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
-      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     - run: |
         cargo test --verbose --features=all-impls,procfs --release --workspace -- --nocapture

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -344,6 +344,8 @@ jobs:
         ref: rustix
         # Fetch enough to let the bootstrap script find an LLVM revision.
         fetch-depth: 2000
+    # Include the changes needed to support std.
+    - run: git rebase rustc-dep-of-std
     # Download a pre-built LLVM instead of building it from source.
     - run: cd rust && echo "[llvm]" >> config.toml
     - run: cd rust && echo "download-ci-llvm = true" >> config.toml

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -8,6 +8,8 @@ jobs:
   listenfd:
     name: listenfd ported to rustix
     runs-on: ${{ matrix.os }}
+    env:
+      QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
         build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux, macos-11]
@@ -77,6 +79,12 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
+    - uses: actions/cache@v2
+      with:
+        path: ${{ runner.tool_cache }}/qemu
+        key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}
+      if: matrix.target != '' && matrix.os == 'ubuntu-latest'
+
     - name: Install cross-compilation tools
       run: |
         set -ex
@@ -96,15 +104,22 @@ jobs:
     - name: Install qemu
       run: |
         set -ex
+
+        # See if qemu is already in the cache
+        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+          exit 0
+        fi
+
         # Download and build qemu from source since the most recent release is
         # way faster at arm emulation than the current version github actions'
         # ubuntu image uses. Disable as much as we can to get it to build
         # quickly.
         cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
+        curl https://download.qemu.org/qemu-$QEMU_BUILD_VERSION.tar.xz | tar xJf -
+        cd qemu-$QEMU_BUILD_VERSION
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        ninja -C build install
+        touch ${{ runner.tool_cache }}/qemu/built
 
         # Configure Cargo for cross compilation and tell it how it can run
         # cross executables
@@ -127,6 +142,8 @@ jobs:
   async-io:
     name: async-io ported to rustix
     runs-on: ${{ matrix.os }}
+    env:
+      QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
         build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux, macos-11]
@@ -192,6 +209,12 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
+    - uses: actions/cache@v2
+      with:
+        path: ${{ runner.tool_cache }}/qemu
+        key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}
+      if: matrix.target != '' && matrix.os == 'ubuntu-latest'
+
     - name: Install cross-compilation tools
       run: |
         set -ex
@@ -211,15 +234,22 @@ jobs:
     - name: Install qemu
       run: |
         set -ex
+
+        # See if qemu is already in the cache
+        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+          exit 0
+        fi
+
         # Download and build qemu from source since the most recent release is
         # way faster at arm emulation than the current version github actions'
         # ubuntu image uses. Disable as much as we can to get it to build
         # quickly.
         cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
+        curl https://download.qemu.org/qemu-$QEMU_BUILD_VERSION.tar.xz | tar xJf -
+        cd qemu-$QEMU_BUILD_VERSION
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        ninja -C build install
+        touch ${{ runner.tool_cache }}/qemu/built
 
         # Configure Cargo for cross compilation and tell it how it can run
         # cross executables
@@ -234,6 +264,8 @@ jobs:
   cap-std:
     name: cap-std
     runs-on: ${{ matrix.os }}
+    env:
+      QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
         build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux, macos-11]
@@ -299,6 +331,12 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
+    - uses: actions/cache@v2
+      with:
+        path: ${{ runner.tool_cache }}/qemu
+        key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}
+      if: matrix.target != '' && matrix.os == 'ubuntu-latest'
+
     - name: Install cross-compilation tools
       run: |
         set -ex
@@ -318,15 +356,22 @@ jobs:
     - name: Install qemu
       run: |
         set -ex
+
+        # See if qemu is already in the cache
+        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+          exit 0
+        fi
+
         # Download and build qemu from source since the most recent release is
         # way faster at arm emulation than the current version github actions'
         # ubuntu image uses. Disable as much as we can to get it to build
         # quickly.
         cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
+        curl https://download.qemu.org/qemu-$QEMU_BUILD_VERSION.tar.xz | tar xJf -
+        cd qemu-$QEMU_BUILD_VERSION
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        ninja -C build install
+        touch ${{ runner.tool_cache }}/qemu/built
 
         # Configure Cargo for cross compilation and tell it how it can run
         # cross executables
@@ -360,47 +405,6 @@ jobs:
         path: cargo
         ref: rustix
 
-    - name: Configure Cargo target
-      run: |
-        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
-        rustup target add ${{ matrix.target }}
-      if: matrix.target != ''
-
-    - name: Install cross-compilation tools
-      run: |
-        set -ex
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build pkg-config
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
-      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
-
-    - name: Install cross-compilation libraries
-      run: |
-        set -ex
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.libc_package }}
-      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
-
-    - name: Install qemu
-      run: |
-        set -ex
-        # Download and build qemu from source since the most recent release is
-        # way faster at arm emulation than the current version github actions'
-        # ubuntu image uses. Disable as much as we can to get it to build
-        # quickly.
-        cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
-      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
-
     - run: rustup component add rust-src rustc-dev llvm-tools-preview
     - run: cd cargo && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd cargo && echo 'rustix = { path = ".." }' >> Cargo.toml
@@ -412,6 +416,8 @@ jobs:
   memfd-rs:
     name: memfd-rs ported to rustix
     runs-on: ${{ matrix.os }}
+    env:
+      QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
         build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux]
@@ -474,6 +480,12 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
+    - uses: actions/cache@v2
+      with:
+        path: ${{ runner.tool_cache }}/qemu
+        key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}
+      if: matrix.target != '' && matrix.os == 'ubuntu-latest'
+
     - name: Install cross-compilation tools
       run: |
         set -ex
@@ -493,15 +505,22 @@ jobs:
     - name: Install qemu
       run: |
         set -ex
+
+        # See if qemu is already in the cache
+        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+          exit 0
+        fi
+
         # Download and build qemu from source since the most recent release is
         # way faster at arm emulation than the current version github actions'
         # ubuntu image uses. Disable as much as we can to get it to build
         # quickly.
         cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
+        curl https://download.qemu.org/qemu-$QEMU_BUILD_VERSION.tar.xz | tar xJf -
+        cd qemu-$QEMU_BUILD_VERSION
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        ninja -C build install
+        touch ${{ runner.tool_cache }}/qemu/built
 
         # Configure Cargo for cross compilation and tell it how it can run
         # cross executables
@@ -516,6 +535,8 @@ jobs:
   tempfile:
     name: tempfile ported to rustix
     runs-on: ${{ matrix.os }}
+    env:
+      QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
         build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux, macos-11]
@@ -581,6 +602,12 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
+    - uses: actions/cache@v2
+      with:
+        path: ${{ runner.tool_cache }}/qemu
+        key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}
+      if: matrix.target != '' && matrix.os == 'ubuntu-latest'
+
     - name: Install cross-compilation tools
       run: |
         set -ex
@@ -600,15 +627,22 @@ jobs:
     - name: Install qemu
       run: |
         set -ex
+
+        # See if qemu is already in the cache
+        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+          exit 0
+        fi
+
         # Download and build qemu from source since the most recent release is
         # way faster at arm emulation than the current version github actions'
         # ubuntu image uses. Disable as much as we can to get it to build
         # quickly.
         cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
+        curl https://download.qemu.org/qemu-$QEMU_BUILD_VERSION.tar.xz | tar xJf -
+        cd qemu-$QEMU_BUILD_VERSION
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        ninja -C build install
+        touch ${{ runner.tool_cache }}/qemu/built
 
         # Configure Cargo for cross compilation and tell it how it can run
         # cross executables
@@ -623,6 +657,8 @@ jobs:
   fd-lock:
     name: fd-lock
     runs-on: ${{ matrix.os }}
+    env:
+      QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
         build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux, macos-11]
@@ -688,6 +724,12 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
+    - uses: actions/cache@v2
+      with:
+        path: ${{ runner.tool_cache }}/qemu
+        key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}
+      if: matrix.target != '' && matrix.os == 'ubuntu-latest'
+
     - name: Install cross-compilation tools
       run: |
         set -ex
@@ -707,15 +749,22 @@ jobs:
     - name: Install qemu
       run: |
         set -ex
+
+        # See if qemu is already in the cache
+        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+          exit 0
+        fi
+
         # Download and build qemu from source since the most recent release is
         # way faster at arm emulation than the current version github actions'
         # ubuntu image uses. Disable as much as we can to get it to build
         # quickly.
         cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
+        curl https://download.qemu.org/qemu-$QEMU_BUILD_VERSION.tar.xz | tar xJf -
+        cd qemu-$QEMU_BUILD_VERSION
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        ninja -C build install
+        touch ${{ runner.tool_cache }}/qemu/built
 
         # Configure Cargo for cross compilation and tell it how it can run
         # cross executables
@@ -754,12 +803,6 @@ jobs:
         path: wasmtime
         submodules: true
 
-    - name: Configure Cargo target
-      run: |
-        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
-        rustup target add ${{ matrix.target }}
-      if: matrix.target != ''
-
     - run: rustup target add wasm32-wasi
     - run: cd wasmtime && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd wasmtime && echo 'rustix = { path = ".." }' >> Cargo.toml
@@ -787,47 +830,6 @@ jobs:
         repository: sunfishcode/nameless
         path: nameless
 
-    - name: Configure Cargo target
-      run: |
-        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
-        rustup target add ${{ matrix.target }}
-      if: matrix.target != ''
-
-    - name: Install cross-compilation tools
-      run: |
-        set -ex
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
-      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
-
-    - name: Install cross-compilation libraries
-      run: |
-        set -ex
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.libc_package }}
-      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
-
-    - name: Install qemu
-      run: |
-        set -ex
-        # Download and build qemu from source since the most recent release is
-        # way faster at arm emulation than the current version github actions'
-        # ubuntu image uses. Disable as much as we can to get it to build
-        # quickly.
-        cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
-      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
-
     - run: |
         set -ex
         sudo apt-get update
@@ -839,6 +841,8 @@ jobs:
   cap-std-ext:
     name: cap-std-ext
     runs-on: ${{ matrix.os }}
+    env:
+      QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
         # cap-std-ext only builds on Linux at the moment.
@@ -902,6 +906,12 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
+    - uses: actions/cache@v2
+      with:
+        path: ${{ runner.tool_cache }}/qemu
+        key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}
+      if: matrix.target != '' && matrix.os == 'ubuntu-latest'
+
     - name: Install cross-compilation tools
       run: |
         set -ex
@@ -921,15 +931,22 @@ jobs:
     - name: Install qemu
       run: |
         set -ex
+
+        # See if qemu is already in the cache
+        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+          exit 0
+        fi
+
         # Download and build qemu from source since the most recent release is
         # way faster at arm emulation than the current version github actions'
         # ubuntu image uses. Disable as much as we can to get it to build
         # quickly.
         cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
+        curl https://download.qemu.org/qemu-$QEMU_BUILD_VERSION.tar.xz | tar xJf -
+        cd qemu-$QEMU_BUILD_VERSION
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        ninja -C build install
+        touch ${{ runner.tool_cache }}/qemu/built
 
         # Configure Cargo for cross compilation and tell it how it can run
         # cross executables
@@ -963,47 +980,6 @@ jobs:
         repository: sunfishcode/dbus-rs
         path: dbus-rs
 
-    - name: Configure Cargo target
-      run: |
-        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
-        rustup target add ${{ matrix.target }}
-      if: matrix.target != ''
-
-    - name: Install cross-compilation tools
-      run: |
-        set -ex
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
-      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
-
-    - name: Install cross-compilation libraries
-      run: |
-        set -ex
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.libc_package }}
-      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
-
-    - name: Install qemu
-      run: |
-        set -ex
-        # Download and build qemu from source since the most recent release is
-        # way faster at arm emulation than the current version github actions'
-        # ubuntu image uses. Disable as much as we can to get it to build
-        # quickly.
-        cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
-      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
-
     - run: |
         set -ex
         sudo apt-get update
@@ -1031,47 +1007,6 @@ jobs:
       with:
         repository: sunfishcode/mustang
         path: mustang
-
-    - name: Configure Cargo target
-      run: |
-        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
-        rustup target add ${{ matrix.target }}
-      if: matrix.target != ''
-
-    - name: Install cross-compilation tools
-      run: |
-        set -ex
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
-      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
-
-    - name: Install cross-compilation libraries
-      run: |
-        set -ex
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.libc_package }}
-      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
-
-    - name: Install qemu
-      run: |
-        set -ex
-        # Download and build qemu from source since the most recent release is
-        # way faster at arm emulation than the current version github actions'
-        # ubuntu image uses. Disable as much as we can to get it to build
-        # quickly.
-        cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
-      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     - run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
     - run: cd mustang && echo '[patch.crates-io]' >> Cargo.toml

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -287,7 +287,7 @@ jobs:
         repository: sunfishcode/dbus-rs
         path: dbus-rs
     - run: sudo apt-get update
-    - run: sudo apt-get install -y libdbus-1-dev
+    - run: sudo apt-get install -y libdbus-1-dev at-spi2-core
     - run: cd dbus-rs && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd dbus-rs && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd dbus-rs && env DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --session --print-address --fork` cargo test --workspace
@@ -342,6 +342,8 @@ jobs:
         repository: sunfishcode/rust
         path: rust
         ref: rustix
+        # Fetch enough to let the bootstrap script find an LLVM revision.
+        fetch-depth: 2000
     # Download a pre-built LLVM instead of building it from source.
     - run: cd rust && echo "[llvm]" >> config.toml
     - run: cd rust && echo "download-ci-llvm = true" >> config.toml

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -30,7 +30,8 @@ jobs:
             target: aarch64-unknown-linux-gnu
             gcc_package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
-            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu: qemu-aarch64
+            qemu_args: -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
           - build: powerpc64le-linux
             os: ubuntu-latest
@@ -38,7 +39,8 @@ jobs:
             target: powerpc64le-unknown-linux-gnu
             gcc_package: gcc-powerpc64le-linux-gnu
             gcc: powerpc64le-linux-gnu-gcc
-            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu: qemu-ppc64le
+            qemu_args: -L /usr/powerpc64le-linux-gnu
             qemu_target: ppc64le-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
@@ -46,7 +48,8 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
             gcc_package: gcc-riscv64-linux-gnu
             gcc: riscv64-linux-gnu-gcc
-            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu: qemu-riscv64
+            qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
           - build: arm-linux
             os: ubuntu-latest
@@ -54,7 +57,8 @@ jobs:
             target: armv5te-unknown-linux-gnueabi
             gcc_package: gcc-arm-linux-gnueabi
             gcc: arm-linux-gnueabi-gcc
-            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu: qemu-arm
+            qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
           - build: macos-11
             os: macos-11
@@ -92,6 +96,7 @@ jobs:
         sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
         upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
         echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
+        echo CC_${{ matrix.target }}=${{ matrix.gcc }} >> $GITHUB_ENV
       if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
 
     - name: Install cross-compilation libraries
@@ -105,8 +110,11 @@ jobs:
       run: |
         set -ex
 
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ${{ matrix.qemu_args }} >> $GITHUB_ENV
+
         # See if qemu is already in the cache
-        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+        if [ -f ${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ]; then
           exit 0
         fi
 
@@ -119,12 +127,6 @@ jobs:
         cd qemu-$QEMU_BUILD_VERSION
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         ninja -C build install
-        touch ${{ runner.tool_cache }}/qemu/built
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     - run: cargo install systemfd
@@ -135,7 +137,9 @@ jobs:
     - run: cd thttp && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd thttp && echo 'listenfd = { path = "../rust-listenfd" }' >> Cargo.toml
 
+    - run: cd thttp && cargo build
     - run: cd thttp && systemfd --no-pid -s http::0.0.0.0:5052 -- cargo run &
+    - run: sleep 5
     - run: wget http://127.0.0.1:5052/Cargo.toml
     - run: diff -u Cargo.toml Cargo.toml.1
 
@@ -164,7 +168,8 @@ jobs:
             target: aarch64-unknown-linux-gnu
             gcc_package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
-            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu: qemu-aarch64
+            qemu_args: -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
           - build: powerpc64le-linux
             os: ubuntu-latest
@@ -172,7 +177,8 @@ jobs:
             target: powerpc64le-unknown-linux-gnu
             gcc_package: gcc-powerpc64le-linux-gnu
             gcc: powerpc64le-linux-gnu-gcc
-            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu: qemu-ppc64le
+            qemu_args: -L /usr/powerpc64le-linux-gnu
             qemu_target: ppc64le-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
@@ -180,7 +186,8 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
             gcc_package: gcc-riscv64-linux-gnu
             gcc: riscv64-linux-gnu-gcc
-            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu: qemu-riscv64
+            qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
           - build: arm-linux
             os: ubuntu-latest
@@ -188,7 +195,8 @@ jobs:
             target: armv5te-unknown-linux-gnueabi
             gcc_package: gcc-arm-linux-gnueabi
             gcc: arm-linux-gnueabi-gcc
-            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu: qemu-arm
+            qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
           - build: macos-11
             os: macos-11
@@ -235,8 +243,11 @@ jobs:
       run: |
         set -ex
 
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ${{ matrix.qemu_args }} >> $GITHUB_ENV
+
         # See if qemu is already in the cache
-        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+        if [ -f ${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ]; then
           exit 0
         fi
 
@@ -249,12 +260,6 @@ jobs:
         cd qemu-$QEMU_BUILD_VERSION
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         ninja -C build install
-        touch ${{ runner.tool_cache }}/qemu/built
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     - run: cd async-io && echo '[patch.crates-io]' >> Cargo.toml
@@ -286,7 +291,8 @@ jobs:
             target: aarch64-unknown-linux-gnu
             gcc_package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
-            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu: qemu-aarch64
+            qemu_args: -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
           - build: powerpc64le-linux
             os: ubuntu-latest
@@ -294,7 +300,8 @@ jobs:
             target: powerpc64le-unknown-linux-gnu
             gcc_package: gcc-powerpc64le-linux-gnu
             gcc: powerpc64le-linux-gnu-gcc
-            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu: qemu-ppc64le
+            qemu_args: -L /usr/powerpc64le-linux-gnu
             qemu_target: ppc64le-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
@@ -302,7 +309,8 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
             gcc_package: gcc-riscv64-linux-gnu
             gcc: riscv64-linux-gnu-gcc
-            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu: qemu-riscv64
+            qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
           - build: arm-linux
             os: ubuntu-latest
@@ -310,7 +318,8 @@ jobs:
             target: armv5te-unknown-linux-gnueabi
             gcc_package: gcc-arm-linux-gnueabi
             gcc: arm-linux-gnueabi-gcc
-            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu: qemu-arm
+            qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
           - build: macos-11
             os: macos-11
@@ -357,8 +366,11 @@ jobs:
       run: |
         set -ex
 
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ${{ matrix.qemu_args }} >> $GITHUB_ENV
+
         # See if qemu is already in the cache
-        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+        if [ -f ${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ]; then
           exit 0
         fi
 
@@ -371,12 +383,6 @@ jobs:
         cd qemu-$QEMU_BUILD_VERSION
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         ninja -C build install
-        touch ${{ runner.tool_cache }}/qemu/built
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     - run: cd cap-std && echo '[patch.crates-io]' >> Cargo.toml
@@ -438,7 +444,8 @@ jobs:
             target: aarch64-unknown-linux-gnu
             gcc_package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
-            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu: qemu-aarch64
+            qemu_args: -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
           - build: powerpc64le-linux
             os: ubuntu-latest
@@ -446,7 +453,8 @@ jobs:
             target: powerpc64le-unknown-linux-gnu
             gcc_package: gcc-powerpc64le-linux-gnu
             gcc: powerpc64le-linux-gnu-gcc
-            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu: qemu-ppc64le
+            qemu_args: -L /usr/powerpc64le-linux-gnu
             qemu_target: ppc64le-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
@@ -454,7 +462,8 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
             gcc_package: gcc-riscv64-linux-gnu
             gcc: riscv64-linux-gnu-gcc
-            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu: qemu-riscv64
+            qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
           - build: arm-linux
             os: ubuntu-latest
@@ -462,7 +471,8 @@ jobs:
             target: armv5te-unknown-linux-gnueabi
             gcc_package: gcc-arm-linux-gnueabi
             gcc: arm-linux-gnueabi-gcc
-            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu: qemu-arm
+            qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
     steps:
     - uses: actions/checkout@v2
@@ -506,8 +516,11 @@ jobs:
       run: |
         set -ex
 
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ${{ matrix.qemu_args }} >> $GITHUB_ENV
+
         # See if qemu is already in the cache
-        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+        if [ -f ${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ]; then
           exit 0
         fi
 
@@ -520,12 +533,6 @@ jobs:
         cd qemu-$QEMU_BUILD_VERSION
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         ninja -C build install
-        touch ${{ runner.tool_cache }}/qemu/built
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     - run: cd memfd-rs && echo '[patch.crates-io]' >> Cargo.toml
@@ -557,7 +564,8 @@ jobs:
             target: aarch64-unknown-linux-gnu
             gcc_package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
-            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu: qemu-aarch64
+            qemu_args: -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
           - build: powerpc64le-linux
             os: ubuntu-latest
@@ -565,7 +573,8 @@ jobs:
             target: powerpc64le-unknown-linux-gnu
             gcc_package: gcc-powerpc64le-linux-gnu
             gcc: powerpc64le-linux-gnu-gcc
-            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu: qemu-ppc64le
+            qemu_args: -L /usr/powerpc64le-linux-gnu
             qemu_target: ppc64le-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
@@ -573,7 +582,8 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
             gcc_package: gcc-riscv64-linux-gnu
             gcc: riscv64-linux-gnu-gcc
-            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu: qemu-riscv64
+            qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
           - build: arm-linux
             os: ubuntu-latest
@@ -581,7 +591,8 @@ jobs:
             target: armv5te-unknown-linux-gnueabi
             gcc_package: gcc-arm-linux-gnueabi
             gcc: arm-linux-gnueabi-gcc
-            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu: qemu-arm
+            qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
           - build: macos-11
             os: macos-11
@@ -628,8 +639,11 @@ jobs:
       run: |
         set -ex
 
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ${{ matrix.qemu_args }} >> $GITHUB_ENV
+
         # See if qemu is already in the cache
-        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+        if [ -f ${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ]; then
           exit 0
         fi
 
@@ -642,12 +656,6 @@ jobs:
         cd qemu-$QEMU_BUILD_VERSION
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         ninja -C build install
-        touch ${{ runner.tool_cache }}/qemu/built
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     - run: cd tempfile && echo '[patch.crates-io]' >> Cargo.toml
@@ -679,7 +687,8 @@ jobs:
             target: aarch64-unknown-linux-gnu
             gcc_package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
-            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu: qemu-aarch64
+            qemu_args: -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
           - build: powerpc64le-linux
             os: ubuntu-latest
@@ -687,7 +696,8 @@ jobs:
             target: powerpc64le-unknown-linux-gnu
             gcc_package: gcc-powerpc64le-linux-gnu
             gcc: powerpc64le-linux-gnu-gcc
-            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu: qemu-ppc64le
+            qemu_args: -L /usr/powerpc64le-linux-gnu
             qemu_target: ppc64le-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
@@ -695,7 +705,8 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
             gcc_package: gcc-riscv64-linux-gnu
             gcc: riscv64-linux-gnu-gcc
-            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu: qemu-riscv64
+            qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
           - build: arm-linux
             os: ubuntu-latest
@@ -703,7 +714,8 @@ jobs:
             target: armv5te-unknown-linux-gnueabi
             gcc_package: gcc-arm-linux-gnueabi
             gcc: arm-linux-gnueabi-gcc
-            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu: qemu-arm
+            qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
           - build: macos-11
             os: macos-11
@@ -750,8 +762,11 @@ jobs:
       run: |
         set -ex
 
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ${{ matrix.qemu_args }} >> $GITHUB_ENV
+
         # See if qemu is already in the cache
-        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+        if [ -f ${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ]; then
           exit 0
         fi
 
@@ -764,12 +779,6 @@ jobs:
         cd qemu-$QEMU_BUILD_VERSION
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         ninja -C build install
-        touch ${{ runner.tool_cache }}/qemu/built
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     # fd-lock currently uses rustix 0.32.
@@ -864,7 +873,8 @@ jobs:
             target: aarch64-unknown-linux-gnu
             gcc_package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
-            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu: qemu-aarch64
+            qemu_args: -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
           - build: powerpc64le-linux
             os: ubuntu-latest
@@ -872,7 +882,8 @@ jobs:
             target: powerpc64le-unknown-linux-gnu
             gcc_package: gcc-powerpc64le-linux-gnu
             gcc: powerpc64le-linux-gnu-gcc
-            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu: qemu-ppc64le
+            qemu_args: -L /usr/powerpc64le-linux-gnu
             qemu_target: ppc64le-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
@@ -880,7 +891,8 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
             gcc_package: gcc-riscv64-linux-gnu
             gcc: riscv64-linux-gnu-gcc
-            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu: qemu-riscv64
+            qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
           - build: arm-linux
             os: ubuntu-latest
@@ -888,7 +900,8 @@ jobs:
             target: armv5te-unknown-linux-gnueabi
             gcc_package: gcc-arm-linux-gnueabi
             gcc: arm-linux-gnueabi-gcc
-            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu: qemu-arm
+            qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
     steps:
     - uses: actions/checkout@v2
@@ -897,7 +910,8 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - uses: actions/checkout@v2
       with:
-        repository: coreos/cap-std-ext
+        #repository: coreos/cap-std-ext
+        repository: sunfishcode/cap-std-ext
         path: cap-std-ext
 
     - name: Configure Cargo target
@@ -932,8 +946,11 @@ jobs:
       run: |
         set -ex
 
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ${{ matrix.qemu_args }} >> $GITHUB_ENV
+
         # See if qemu is already in the cache
-        if [ -f ${{ runner.tool_cache }}/qemu/built ]; then
+        if [ -f ${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ]; then
           exit 0
         fi
 
@@ -946,12 +963,6 @@ jobs:
         cd qemu-$QEMU_BUILD_VERSION
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         ninja -C build install
-        touch ${{ runner.tool_cache }}/qemu/built
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     - run: cd cap-std-ext && echo '[patch.crates-io]' >> Cargo.toml
@@ -969,7 +980,8 @@ jobs:
         include:
           - build: ubuntu
             os: ubuntu-latest
-            rust: nightly
+            #rust: nightly
+            rust: stable
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/install-rust

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -345,6 +345,7 @@ jobs:
         # Fetch enough to let the bootstrap script find an LLVM revision.
         fetch-depth: 2000
     # Include the changes needed to support std.
+    - run: git fetch --depth=1 origin rustc-dep-of-std
     - run: git rebase rustc-dep-of-std
     # Download a pre-built LLVM instead of building it from source.
     - run: cd rust && echo "[llvm]" >> config.toml

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux, macos-11]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -30,6 +30,14 @@ jobs:
             gcc: aarch64-linux-gnu-gcc
             qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
+          - build: powerpc64le-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: powerpc64le-unknown-linux-gnu
+            gcc_package: gcc-powerpc64le-linux-gnu
+            gcc: powerpc64le-linux-gnu-gcc
+            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu_target: ppc64le-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
             rust: nightly
@@ -109,7 +117,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux, macos-11]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -129,6 +137,14 @@ jobs:
             gcc: aarch64-linux-gnu-gcc
             qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
+          - build: powerpc64le-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: powerpc64le-unknown-linux-gnu
+            gcc_package: gcc-powerpc64le-linux-gnu
+            gcc: powerpc64le-linux-gnu-gcc
+            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu_target: ppc64le-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
             rust: nightly
@@ -279,7 +295,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -299,6 +315,14 @@ jobs:
             gcc: aarch64-linux-gnu-gcc
             qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
+          - build: powerpc64le-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: powerpc64le-unknown-linux-gnu
+            gcc_package: gcc-powerpc64le-linux-gnu
+            gcc: powerpc64le-linux-gnu-gcc
+            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu_target: ppc64le-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
             rust: nightly
@@ -375,7 +399,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux, macos-11]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -395,6 +419,14 @@ jobs:
             gcc: aarch64-linux-gnu-gcc
             qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
+          - build: powerpc64le-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: powerpc64le-unknown-linux-gnu
+            gcc_package: gcc-powerpc64le-linux-gnu
+            gcc: powerpc64le-linux-gnu-gcc
+            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu_target: ppc64le-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
             rust: nightly
@@ -474,7 +506,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux, macos-11]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -494,6 +526,14 @@ jobs:
             gcc: aarch64-linux-gnu-gcc
             qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
+          - build: powerpc64le-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: powerpc64le-unknown-linux-gnu
+            gcc_package: gcc-powerpc64le-linux-gnu
+            gcc: powerpc64le-linux-gnu-gcc
+            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu_target: ppc64le-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
             rust: nightly
@@ -683,7 +723,7 @@ jobs:
     strategy:
       matrix:
         # cap-std-ext only builds on Linux at the moment.
-        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -703,6 +743,14 @@ jobs:
             gcc: aarch64-linux-gnu-gcc
             qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
+          - build: powerpc64le-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: powerpc64le-unknown-linux-gnu
+            gcc_package: gcc-powerpc64le-linux-gnu
+            gcc: powerpc64le-linux-gnu-gcc
+            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu_target: ppc64le-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
             rust: nightly

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -131,11 +131,15 @@ jobs:
 
     - run: cargo install systemfd
 
+    - run: cd rust-listenfd && cargo update
+    - run: sed -i'.bak' 's/^version = "\([[:digit:].-]*\)"$/version = '`grep -A1 '^name = "rustix"' rust-listenfd/Cargo.lock  |grep ^version |sed 's/^[^"]*//'`'/' Cargo.toml
+
     - run: cd rust-listenfd && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd rust-listenfd && echo 'rustix = { path = ".." }' >> Cargo.toml
 
     - run: cd thttp && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd thttp && echo 'listenfd = { path = "../rust-listenfd" }' >> Cargo.toml
+    - run: cd thttp && echo 'rustix = { path = ".." }' >> Cargo.toml
 
     - run: cd thttp && cargo build
     - run: cd thttp && systemfd --no-pid -s http::0.0.0.0:5052 -- cargo run &
@@ -262,6 +266,8 @@ jobs:
         ninja -C build install
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
+    - run: cd async-io && cargo update
+    - run: sed -i'.bak' 's/^version = "\([[:digit:].-]*\)"$/version = '`grep -A1 '^name = "rustix"' async-io/Cargo.lock  |grep ^version |sed 's/^[^"]*//'`'/' Cargo.toml
     - run: cd async-io && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd async-io && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd async-io && cargo test
@@ -385,6 +391,8 @@ jobs:
         ninja -C build install
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
+    - run: cd cap-std && cargo update
+    - run: sed -i'.bak' 's/^version = "\([[:digit:].-]*\)"$/version = '`grep -A1 '^name = "rustix"' cap-std/Cargo.lock  |grep ^version |sed 's/^[^"]*//'`'/' Cargo.toml
     - run: cd cap-std && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd cap-std && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd cap-std && cargo test
@@ -412,6 +420,8 @@ jobs:
         ref: rustix
 
     - run: rustup component add rust-src rustc-dev llvm-tools-preview
+    - run: cd cargo && cargo update
+    - run: sed -i'.bak' 's/^version = "\([[:digit:].-]*\)"$/version = '`grep -A1 '^name = "rustix"' cargo/Cargo.lock  |grep ^version |sed 's/^[^"]*//'`'/' Cargo.toml
     - run: cd cargo && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd cargo && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd cargo && cargo test --workspace
@@ -535,6 +545,8 @@ jobs:
         ninja -C build install
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
+    - run: cd memfd-rs && cargo update
+    - run: sed -i'.bak' 's/^version = "\([[:digit:].-]*\)"$/version = '`grep -A1 '^name = "rustix"' memfd-rs/Cargo.lock  |grep ^version |sed 's/^[^"]*//'`'/' Cargo.toml
     - run: cd memfd-rs && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd memfd-rs && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd memfd-rs && cargo test
@@ -658,6 +670,8 @@ jobs:
         ninja -C build install
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
+    - run: cd tempfile && cargo update
+    - run: sed -i'.bak' 's/^version = "\([[:digit:].-]*\)"$/version = '`grep -A1 '^name = "rustix"' tempfile/Cargo.lock  |grep ^version |sed 's/^[^"]*//'`'/' Cargo.toml
     - run: cd tempfile && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd tempfile && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd tempfile && cargo test
@@ -781,8 +795,8 @@ jobs:
         ninja -C build install
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
-    # fd-lock currently uses rustix 0.32.
-    - run: sed -i'.bak' 's/^version = "\([[:digit:].-]*\)"$/version = "0.32.0"/' Cargo.toml
+    - run: cd fd-lock && cargo update
+    - run: sed -i'.bak' 's/^version = "\([[:digit:].-]*\)"$/version = '`grep -A1 '^name = "rustix"' fd-lock/Cargo.lock  |grep ^version |sed 's/^[^"]*//'`'/' Cargo.toml
     - run: cd fd-lock && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd fd-lock && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd fd-lock && cargo test
@@ -813,6 +827,8 @@ jobs:
         submodules: true
 
     - run: rustup target add wasm32-wasi
+    - run: cd wasmtime && cargo update
+    - run: sed -i'.bak' 's/^version = "\([[:digit:].-]*\)"$/version = '`grep -A1 '^name = "rustix"' wasmtime/Cargo.lock  |grep ^version |sed 's/^[^"]*//'`'/' Cargo.toml
     - run: cd wasmtime && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd wasmtime && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd wasmtime && cargo test --features "test-programs/test_programs" --workspace --exclude 'wasmtime-wasi-*' --exclude wasi-crypto --exclude wasmtime-fuzzing
@@ -843,6 +859,8 @@ jobs:
         set -ex
         sudo apt-get update
         sudo apt-get install -y libssl-dev
+    - run: cd nameless && cargo update
+    - run: sed -i'.bak' 's/^version = "\([[:digit:].-]*\)"$/version = '`grep -A1 '^name = "rustix"' nameless/Cargo.lock  |grep ^version |sed 's/^[^"]*//'`'/' Cargo.toml
     - run: cd nameless && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd nameless && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd nameless && cargo test
@@ -965,6 +983,8 @@ jobs:
         ninja -C build install
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
+    - run: cd cap-std-ext && cargo update
+    - run: sed -i'.bak' 's/^version = "\([[:digit:].-]*\)"$/version = '`grep -A1 '^name = "rustix"' cap-std-ext/Cargo.lock  |grep ^version |sed 's/^[^"]*//'`'/' Cargo.toml
     - run: cd cap-std-ext && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd cap-std-ext && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd cap-std-ext && cargo test
@@ -996,6 +1016,8 @@ jobs:
         set -ex
         sudo apt-get update
         sudo apt-get install -y libdbus-1-dev at-spi2-core pkg-config
+    - run: cd dbus-rs && cargo update
+    - run: sed -i'.bak' 's/^version = "\([[:digit:].-]*\)"$/version = '`grep -A1 '^name = "rustix"' dbus-rs/Cargo.lock  |grep ^version |sed 's/^[^"]*//'`'/' Cargo.toml
     - run: cd dbus-rs && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd dbus-rs && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd dbus-rs && env DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --session --print-address --fork` cargo test --workspace
@@ -1021,6 +1043,8 @@ jobs:
         path: mustang
 
     - run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+    - run: cd mustang && cargo update
+    - run: sed -i'.bak' 's/^version = "\([[:digit:].-]*\)"$/version = '`grep -A1 '^name = "rustix"' mustang/Cargo.lock  |grep ^version |sed 's/^[^"]*//'`'/' Cargo.toml
     - run: cd mustang && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd mustang && echo 'rustix = { path = ".." }' >> Cargo.toml
     # This test takes too long.

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -238,8 +238,8 @@ jobs:
     - run: cd cap-std-ext && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd cap-std-ext && cargo test
 
-  ostree-ext:
-    name: ostree-ext
+  ostree-rs-ext:
+    name: ostree-rs-ext
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -257,11 +257,13 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - uses: actions/checkout@v2
       with:
-        repository: ostreedev/ostree-ext
-        path: ostree-ext
-    - run: cd ostree-ext && echo '[patch.crates-io]' >> Cargo.toml
-    - run: cd ostree-ext && echo 'rustix = { path = ".." }' >> Cargo.toml
-    - run: cd ostree-ext && cargo test
+        repository: ostreedev/ostree-rs-ext
+        path: ostree-rs-ext
+    - run: sudo apt-get update
+    - run: sudo apt-get install -y libostree-dev
+    - run: cd ostree-rs-ext && echo '[patch.crates-io]' >> Cargo.toml
+    - run: cd ostree-rs-ext && echo 'rustix = { path = ".." }' >> Cargo.toml
+    - run: cd ostree-rs-ext && cargo test
 
   dbus-rs:
     name: dbus-rs ported to rustix
@@ -288,7 +290,7 @@ jobs:
     - run: sudo apt-get install -y libdbus-1-dev
     - run: cd dbus-rs && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd dbus-rs && echo 'rustix = { path = ".." }' >> Cargo.toml
-    - run: cd dbus-rs && cargo test
+    - run: cd dbus-rs && env DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --session --print-address --fork` cargo test --workspace
 
   mustang:
     name: mustang
@@ -340,6 +342,9 @@ jobs:
         repository: sunfishcode/rust
         path: rust
         ref: rustix
+    # Download a pre-built LLVM instead of building it from source.
+    - run: cd rust && echo "[llvm]" >> config.toml
+    - run: cd rust && echo "download-ci-llvm = true" >> config.toml
     - run: cd rust && sed -i 's/\<git = "https:\/\/github\.com\/bytecodealliance\/rustix", branch = "rustc-dep-of-std"/path = "..\/..\/.."/' library/std/Cargo.toml
     - run: cd rust && ./x.py test library/std --stage=0
       # See <https://github.com/bytecodealliance/rustix/issues/76#issuecomment-962196433>

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -5,6 +5,125 @@ name: Test rustix's users
 on: workflow_dispatch
 
 jobs:
+  listenfd:
+    name: listenfd ported to rustix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux, macos-11]
+        include:
+          - build: ubuntu
+            os: ubuntu-latest
+            rust: nightly
+          - build: i686-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: i686-unknown-linux-gnu
+            gcc_package: gcc-i686-linux-gnu
+            gcc: i686-linux-gnu-gcc
+            libc_package: libc-dev-i386-cross
+          - build: aarch64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: aarch64-unknown-linux-gnu
+            gcc_package: gcc-aarch64-linux-gnu
+            gcc: aarch64-linux-gnu-gcc
+            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu_target: aarch64-linux-user
+          - build: powerpc64le-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: powerpc64le-unknown-linux-gnu
+            gcc_package: gcc-powerpc64le-linux-gnu
+            gcc: powerpc64le-linux-gnu-gcc
+            qemu: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
+            qemu_target: ppc64le-linux-user
+          - build: riscv64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: riscv64gc-unknown-linux-gnu
+            gcc_package: gcc-riscv64-linux-gnu
+            gcc: riscv64-linux-gnu-gcc
+            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu_target: riscv64-linux-user
+          - build: arm-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: armv5te-unknown-linux-gnueabi
+            gcc_package: gcc-arm-linux-gnueabi
+            gcc: arm-linux-gnueabi-gcc
+            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu_target: arm-linux-user
+          - build: macos-11
+            os: macos-11
+            rust: nightly
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: ${{ matrix.rust }}
+    - uses: actions/checkout@v2
+      with:
+        repository: sunfishcode/rust-listenfd
+        path: rust-listenfd
+    - uses: actions/checkout@v2
+      with:
+        repository: davidedelpapa/thttp
+        path: thttp
+
+    - name: Configure Cargo target
+      run: |
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+        rustup target add ${{ matrix.target }}
+      if: matrix.target != ''
+
+    - name: Install cross-compilation tools
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
+      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install cross-compilation libraries
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.libc_package }}
+      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install qemu
+      run: |
+        set -ex
+        # Download and build qemu from source since the most recent release is
+        # way faster at arm emulation than the current version github actions'
+        # ubuntu image uses. Disable as much as we can to get it to build
+        # quickly.
+        cd
+        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
+        cd qemu-6.1.0
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        make -j$(nproc) install
+
+        # Configure Cargo for cross compilation and tell it how it can run
+        # cross executables
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
+
+    - run: cargo install systemfd
+
+    - run: cd rust-listenfd && echo '[patch.crates-io]' >> Cargo.toml
+    - run: cd rust-listenfd && echo 'rustix = { path = ".." }' >> Cargo.toml
+
+    - run: cd thttp && echo '[patch.crates-io]' >> Cargo.toml
+    - run: cd thttp && echo 'listenfd = { path = "../rust-listenfd" }' >> Cargo.toml
+
+    - run: cd thttp && systemfd --no-pid -s http::0.0.0.0:5052 -- cargo run &
+    - run: wget http://127.0.0.1:5052/Cargo.toml
+    - run: diff -u Cargo.toml Cargo.toml.1
+
   async-io:
     name: async-io ported to rustix
     runs-on: ${{ matrix.os }}
@@ -774,7 +893,7 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - uses: actions/checkout@v2
       with:
-        repository: cgwalters/cap-std-ext
+        repository: coreos/cap-std-ext
         path: cap-std-ext
 
     - name: Configure Cargo target

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -143,9 +143,9 @@ jobs:
 
     - run: cd thttp && cargo build
     - run: cd thttp && systemfd --no-pid -s http::0.0.0.0:5052 -- cargo run &
-    - run: sleep 5
-    - run: wget http://127.0.0.1:5052/Cargo.toml
-    - run: diff -u Cargo.toml Cargo.toml.1
+    - run: cd thttp && sleep 5
+    - run: cd thttp && wget http://127.0.0.1:5052/Cargo.toml
+    - run: cd thttp && diff -u Cargo.toml Cargo.toml.1
 
   async-io:
     name: async-io ported to rustix

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -10,11 +10,45 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable]
+        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
         include:
-          - build: stable
+          - build: ubuntu
             os: ubuntu-latest
-            rust: stable
+            rust: nightly
+          - build: i686-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: i686-unknown-linux-gnu
+            gcc_package: gcc-i686-linux-gnu
+            gcc: i686-linux-gnu-gcc
+            libc_package: libc-dev-i386-cross
+          - build: aarch64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: aarch64-unknown-linux-gnu
+            gcc_package: gcc-aarch64-linux-gnu
+            gcc: aarch64-linux-gnu-gcc
+            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu_target: aarch64-linux-user
+          - build: riscv64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: riscv64gc-unknown-linux-gnu
+            gcc_package: gcc-riscv64-linux-gnu
+            gcc: riscv64-linux-gnu-gcc
+            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu_target: riscv64-linux-user
+          - build: arm-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: armv5te-unknown-linux-gnueabi
+            gcc_package: gcc-arm-linux-gnueabi
+            gcc: arm-linux-gnueabi-gcc
+            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu_target: arm-linux-user
+          - build: macos-11
+            os: macos-11
+            rust: nightly
     steps:
     - uses: actions/checkout@v2
       with:
@@ -26,6 +60,15 @@ jobs:
       with:
         repository: sunfishcode/async-io
         path: async-io
+    - uses: ./.github/workflows/cross.yml
+      with:
+        os: ${{ matrix.os }
+        target: ${{ matrix.target }}
+        libc_package: ${{ matrix.libc_package }}
+        gcc_package: ${{ matrix.gcc_package }}
+        gcc: ${{ matrix.gcc }}
+        qemu: ${{ matrix.qemu }}
+        qemu_target: ${{ matrix.qemu_target }}
     - run: cd async-io && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd async-io && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd async-io && cargo test
@@ -35,11 +78,45 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable]
+        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
         include:
-          - build: stable
+          - build: ubuntu
             os: ubuntu-latest
-            rust: stable
+            rust: nightly
+          - build: i686-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: i686-unknown-linux-gnu
+            gcc_package: gcc-i686-linux-gnu
+            gcc: i686-linux-gnu-gcc
+            libc_package: libc-dev-i386-cross
+          - build: aarch64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: aarch64-unknown-linux-gnu
+            gcc_package: gcc-aarch64-linux-gnu
+            gcc: aarch64-linux-gnu-gcc
+            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu_target: aarch64-linux-user
+          - build: riscv64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: riscv64gc-unknown-linux-gnu
+            gcc_package: gcc-riscv64-linux-gnu
+            gcc: riscv64-linux-gnu-gcc
+            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu_target: riscv64-linux-user
+          - build: arm-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: armv5te-unknown-linux-gnueabi
+            gcc_package: gcc-arm-linux-gnueabi
+            gcc: arm-linux-gnueabi-gcc
+            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu_target: arm-linux-user
+          - build: macos-11
+            os: macos-11
+            rust: nightly
     steps:
     - uses: actions/checkout@v2
       with:
@@ -51,6 +128,15 @@ jobs:
       with:
         repository: bytecodealliance/cap-std
         path: cap-std
+    - uses: ./.github/workflows/cross.yml
+      with:
+        os: ${{ matrix.os }
+        target: ${{ matrix.target }}
+        libc_package: ${{ matrix.libc_package }}
+        gcc_package: ${{ matrix.gcc_package }}
+        gcc: ${{ matrix.gcc }}
+        qemu: ${{ matrix.qemu }}
+        qemu_target: ${{ matrix.qemu_target }}
     - run: cd cap-std && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd cap-std && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd cap-std && cargo test
@@ -60,11 +146,45 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable]
+        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
         include:
-          - build: stable
+          - build: ubuntu
             os: ubuntu-latest
-            rust: stable
+            rust: nightly
+          - build: i686-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: i686-unknown-linux-gnu
+            gcc_package: gcc-i686-linux-gnu
+            gcc: i686-linux-gnu-gcc
+            libc_package: libc-dev-i386-cross
+          - build: aarch64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: aarch64-unknown-linux-gnu
+            gcc_package: gcc-aarch64-linux-gnu
+            gcc: aarch64-linux-gnu-gcc
+            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu_target: aarch64-linux-user
+          - build: riscv64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: riscv64gc-unknown-linux-gnu
+            gcc_package: gcc-riscv64-linux-gnu
+            gcc: riscv64-linux-gnu-gcc
+            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu_target: riscv64-linux-user
+          - build: arm-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: armv5te-unknown-linux-gnueabi
+            gcc_package: gcc-arm-linux-gnueabi
+            gcc: arm-linux-gnueabi-gcc
+            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu_target: arm-linux-user
+          - build: macos-11
+            os: macos-11
+            rust: nightly
     steps:
     - uses: actions/checkout@v2
       with:
@@ -77,6 +197,15 @@ jobs:
         repository: sunfishcode/cargo
         path: cargo
         ref: rustix
+    - uses: ./.github/workflows/cross.yml
+      with:
+        os: ${{ matrix.os }
+        target: ${{ matrix.target }}
+        libc_package: ${{ matrix.libc_package }}
+        gcc_package: ${{ matrix.gcc_package }}
+        gcc: ${{ matrix.gcc }}
+        qemu: ${{ matrix.qemu }}
+        qemu_target: ${{ matrix.qemu_target }}
     - run: cd cargo && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd cargo && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd cargo && cargo test --workspace
@@ -89,11 +218,45 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable]
+        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
         include:
-          - build: stable
+          - build: ubuntu
             os: ubuntu-latest
-            rust: stable
+            rust: nightly
+          - build: i686-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: i686-unknown-linux-gnu
+            gcc_package: gcc-i686-linux-gnu
+            gcc: i686-linux-gnu-gcc
+            libc_package: libc-dev-i386-cross
+          - build: aarch64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: aarch64-unknown-linux-gnu
+            gcc_package: gcc-aarch64-linux-gnu
+            gcc: aarch64-linux-gnu-gcc
+            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu_target: aarch64-linux-user
+          - build: riscv64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: riscv64gc-unknown-linux-gnu
+            gcc_package: gcc-riscv64-linux-gnu
+            gcc: riscv64-linux-gnu-gcc
+            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu_target: riscv64-linux-user
+          - build: arm-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: armv5te-unknown-linux-gnueabi
+            gcc_package: gcc-arm-linux-gnueabi
+            gcc: arm-linux-gnueabi-gcc
+            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu_target: arm-linux-user
+          - build: macos-11
+            os: macos-11
+            rust: nightly
     steps:
     - uses: actions/checkout@v2
       with:
@@ -105,6 +268,15 @@ jobs:
       with:
         repository: sunfishcode/memfd-rs
         path: memfd-rs
+    - uses: ./.github/workflows/cross.yml
+      with:
+        os: ${{ matrix.os }
+        target: ${{ matrix.target }}
+        libc_package: ${{ matrix.libc_package }}
+        gcc_package: ${{ matrix.gcc_package }}
+        gcc: ${{ matrix.gcc }}
+        qemu: ${{ matrix.qemu }}
+        qemu_target: ${{ matrix.qemu_target }}
     - run: cd memfd-rs && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd memfd-rs && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd memfd-rs && cargo test
@@ -114,11 +286,45 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable]
+        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
         include:
-          - build: stable
+          - build: ubuntu
             os: ubuntu-latest
-            rust: stable
+            rust: nightly
+          - build: i686-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: i686-unknown-linux-gnu
+            gcc_package: gcc-i686-linux-gnu
+            gcc: i686-linux-gnu-gcc
+            libc_package: libc-dev-i386-cross
+          - build: aarch64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: aarch64-unknown-linux-gnu
+            gcc_package: gcc-aarch64-linux-gnu
+            gcc: aarch64-linux-gnu-gcc
+            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu_target: aarch64-linux-user
+          - build: riscv64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: riscv64gc-unknown-linux-gnu
+            gcc_package: gcc-riscv64-linux-gnu
+            gcc: riscv64-linux-gnu-gcc
+            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu_target: riscv64-linux-user
+          - build: arm-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: armv5te-unknown-linux-gnueabi
+            gcc_package: gcc-arm-linux-gnueabi
+            gcc: arm-linux-gnueabi-gcc
+            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu_target: arm-linux-user
+          - build: macos-11
+            os: macos-11
+            rust: nightly
     steps:
     - uses: actions/checkout@v2
       with:
@@ -130,6 +336,15 @@ jobs:
       with:
         repository: sunfishcode/tempfile
         path: tempfile
+    - uses: ./.github/workflows/cross.yml
+      with:
+        os: ${{ matrix.os }
+        target: ${{ matrix.target }}
+        libc_package: ${{ matrix.libc_package }}
+        gcc_package: ${{ matrix.gcc_package }}
+        gcc: ${{ matrix.gcc }}
+        qemu: ${{ matrix.qemu }}
+        qemu_target: ${{ matrix.qemu_target }}
     - run: cd tempfile && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd tempfile && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd tempfile && cargo test
@@ -139,11 +354,45 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable]
+        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
         include:
-          - build: stable
+          - build: ubuntu
             os: ubuntu-latest
-            rust: stable
+            rust: nightly
+          - build: i686-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: i686-unknown-linux-gnu
+            gcc_package: gcc-i686-linux-gnu
+            gcc: i686-linux-gnu-gcc
+            libc_package: libc-dev-i386-cross
+          - build: aarch64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: aarch64-unknown-linux-gnu
+            gcc_package: gcc-aarch64-linux-gnu
+            gcc: aarch64-linux-gnu-gcc
+            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu_target: aarch64-linux-user
+          - build: riscv64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: riscv64gc-unknown-linux-gnu
+            gcc_package: gcc-riscv64-linux-gnu
+            gcc: riscv64-linux-gnu-gcc
+            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu_target: riscv64-linux-user
+          - build: arm-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: armv5te-unknown-linux-gnueabi
+            gcc_package: gcc-arm-linux-gnueabi
+            gcc: arm-linux-gnueabi-gcc
+            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu_target: arm-linux-user
+          - build: macos-11
+            os: macos-11
+            rust: nightly
     steps:
     - uses: actions/checkout@v2
       with:
@@ -155,6 +404,15 @@ jobs:
       with:
         repository: yoshuawuyts/fd-lock
         path: fd-lock
+    - uses: ./.github/workflows/cross.yml
+      with:
+        os: ${{ matrix.os }
+        target: ${{ matrix.target }}
+        libc_package: ${{ matrix.libc_package }}
+        gcc_package: ${{ matrix.gcc_package }}
+        gcc: ${{ matrix.gcc }}
+        qemu: ${{ matrix.qemu }}
+        qemu_target: ${{ matrix.qemu_target }}
     # fd-lock currently uses rustix 0.32.
     - run: sed -i 's/^version = "\([[:digit:].-]*\)"$/version = "0.32.0"/' Cargo.toml
     - run: cd fd-lock && echo '[patch.crates-io]' >> Cargo.toml
@@ -166,11 +424,45 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable]
+        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
         include:
-          - build: stable
+          - build: ubuntu
             os: ubuntu-latest
-            rust: stable
+            rust: nightly
+          - build: i686-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: i686-unknown-linux-gnu
+            gcc_package: gcc-i686-linux-gnu
+            gcc: i686-linux-gnu-gcc
+            libc_package: libc-dev-i386-cross
+          - build: aarch64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: aarch64-unknown-linux-gnu
+            gcc_package: gcc-aarch64-linux-gnu
+            gcc: aarch64-linux-gnu-gcc
+            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu_target: aarch64-linux-user
+          - build: riscv64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: riscv64gc-unknown-linux-gnu
+            gcc_package: gcc-riscv64-linux-gnu
+            gcc: riscv64-linux-gnu-gcc
+            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu_target: riscv64-linux-user
+          - build: arm-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: armv5te-unknown-linux-gnueabi
+            gcc_package: gcc-arm-linux-gnueabi
+            gcc: arm-linux-gnueabi-gcc
+            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu_target: arm-linux-user
+          - build: macos-11
+            os: macos-11
+            rust: nightly
     steps:
     - uses: actions/checkout@v2
       with:
@@ -183,6 +475,15 @@ jobs:
         repository: bytecodealliance/wasmtime
         path: wasmtime
         submodules: true
+    - uses: ./.github/workflows/cross.yml
+      with:
+        os: ${{ matrix.os }
+        target: ${{ matrix.target }}
+        libc_package: ${{ matrix.libc_package }}
+        gcc_package: ${{ matrix.gcc_package }}
+        gcc: ${{ matrix.gcc }}
+        qemu: ${{ matrix.qemu }}
+        qemu_target: ${{ matrix.qemu_target }}
     - run: rustup target add wasm32-wasi
     - run: cd wasmtime && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd wasmtime && echo 'rustix = { path = ".." }' >> Cargo.toml
@@ -193,11 +494,45 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable]
+        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
         include:
-          - build: stable
+          - build: ubuntu
             os: ubuntu-latest
-            rust: stable
+            rust: nightly
+          - build: i686-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: i686-unknown-linux-gnu
+            gcc_package: gcc-i686-linux-gnu
+            gcc: i686-linux-gnu-gcc
+            libc_package: libc-dev-i386-cross
+          - build: aarch64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: aarch64-unknown-linux-gnu
+            gcc_package: gcc-aarch64-linux-gnu
+            gcc: aarch64-linux-gnu-gcc
+            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu_target: aarch64-linux-user
+          - build: riscv64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: riscv64gc-unknown-linux-gnu
+            gcc_package: gcc-riscv64-linux-gnu
+            gcc: riscv64-linux-gnu-gcc
+            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu_target: riscv64-linux-user
+          - build: arm-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: armv5te-unknown-linux-gnueabi
+            gcc_package: gcc-arm-linux-gnueabi
+            gcc: arm-linux-gnueabi-gcc
+            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu_target: arm-linux-user
+          - build: macos-11
+            os: macos-11
+            rust: nightly
     steps:
     - uses: actions/checkout@v2
       with:
@@ -209,6 +544,15 @@ jobs:
       with:
         repository: sunfishcode/nameless
         path: nameless
+    - uses: ./.github/workflows/cross.yml
+      with:
+        os: ${{ matrix.os }
+        target: ${{ matrix.target }}
+        libc_package: ${{ matrix.libc_package }}
+        gcc_package: ${{ matrix.gcc_package }}
+        gcc: ${{ matrix.gcc }}
+        qemu: ${{ matrix.qemu }}
+        qemu_target: ${{ matrix.qemu_target }}
     - run: cd nameless && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd nameless && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd nameless && cargo test
@@ -218,11 +562,45 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable]
+        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
         include:
-          - build: stable
+          - build: ubuntu
             os: ubuntu-latest
-            rust: stable
+            rust: nightly
+          - build: i686-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: i686-unknown-linux-gnu
+            gcc_package: gcc-i686-linux-gnu
+            gcc: i686-linux-gnu-gcc
+            libc_package: libc-dev-i386-cross
+          - build: aarch64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: aarch64-unknown-linux-gnu
+            gcc_package: gcc-aarch64-linux-gnu
+            gcc: aarch64-linux-gnu-gcc
+            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu_target: aarch64-linux-user
+          - build: riscv64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: riscv64gc-unknown-linux-gnu
+            gcc_package: gcc-riscv64-linux-gnu
+            gcc: riscv64-linux-gnu-gcc
+            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu_target: riscv64-linux-user
+          - build: arm-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: armv5te-unknown-linux-gnueabi
+            gcc_package: gcc-arm-linux-gnueabi
+            gcc: arm-linux-gnueabi-gcc
+            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu_target: arm-linux-user
+          - build: macos-11
+            os: macos-11
+            rust: nightly
     steps:
     - uses: actions/checkout@v2
       with:
@@ -234,6 +612,15 @@ jobs:
       with:
         repository: cgwalters/cap-std-ext
         path: cap-std-ext
+    - uses: ./.github/workflows/cross.yml
+      with:
+        os: ${{ matrix.os }
+        target: ${{ matrix.target }}
+        libc_package: ${{ matrix.libc_package }}
+        gcc_package: ${{ matrix.gcc_package }}
+        gcc: ${{ matrix.gcc }}
+        qemu: ${{ matrix.qemu }}
+        qemu_target: ${{ matrix.qemu_target }}
     - run: cd cap-std-ext && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd cap-std-ext && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd cap-std-ext && cargo test
@@ -243,11 +630,45 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable]
+        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
         include:
-          - build: stable
+          - build: ubuntu
             os: ubuntu-latest
-            rust: stable
+            rust: nightly
+          - build: i686-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: i686-unknown-linux-gnu
+            gcc_package: gcc-i686-linux-gnu
+            gcc: i686-linux-gnu-gcc
+            libc_package: libc-dev-i386-cross
+          - build: aarch64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: aarch64-unknown-linux-gnu
+            gcc_package: gcc-aarch64-linux-gnu
+            gcc: aarch64-linux-gnu-gcc
+            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu_target: aarch64-linux-user
+          - build: riscv64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: riscv64gc-unknown-linux-gnu
+            gcc_package: gcc-riscv64-linux-gnu
+            gcc: riscv64-linux-gnu-gcc
+            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu_target: riscv64-linux-user
+          - build: arm-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: armv5te-unknown-linux-gnueabi
+            gcc_package: gcc-arm-linux-gnueabi
+            gcc: arm-linux-gnueabi-gcc
+            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu_target: arm-linux-user
+          - build: macos-11
+            os: macos-11
+            rust: nightly
     steps:
     - uses: actions/checkout@v2
       with:
@@ -259,6 +680,15 @@ jobs:
       with:
         repository: ostreedev/ostree-rs-ext
         path: ostree-rs-ext
+    - uses: ./.github/workflows/cross.yml
+      with:
+        os: ${{ matrix.os }
+        target: ${{ matrix.target }}
+        libc_package: ${{ matrix.libc_package }}
+        gcc_package: ${{ matrix.gcc_package }}
+        gcc: ${{ matrix.gcc }}
+        qemu: ${{ matrix.qemu }}
+        qemu_target: ${{ matrix.qemu_target }}
     - run: sudo apt-get update
     - run: sudo apt-get install -y libostree-dev
     - run: cd ostree-rs-ext && echo '[patch.crates-io]' >> Cargo.toml
@@ -270,12 +700,46 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable]
+        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
         include:
-          - build: stable
+          - build: ubuntu
             os: ubuntu-latest
-            rust: stable
-    steps:
+            rust: nightly
+          - build: i686-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: i686-unknown-linux-gnu
+            gcc_package: gcc-i686-linux-gnu
+            gcc: i686-linux-gnu-gcc
+            libc_package: libc-dev-i386-cross
+          - build: aarch64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: aarch64-unknown-linux-gnu
+            gcc_package: gcc-aarch64-linux-gnu
+            gcc: aarch64-linux-gnu-gcc
+            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu_target: aarch64-linux-user
+          - build: riscv64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: riscv64gc-unknown-linux-gnu
+            gcc_package: gcc-riscv64-linux-gnu
+            gcc: riscv64-linux-gnu-gcc
+            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu_target: riscv64-linux-user
+          - build: arm-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: armv5te-unknown-linux-gnueabi
+            gcc_package: gcc-arm-linux-gnueabi
+            gcc: arm-linux-gnueabi-gcc
+            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu_target: arm-linux-user
+          - build: macos-11
+            os: macos-11
+            rust: nightly
+  steps:
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -286,6 +750,15 @@ jobs:
       with:
         repository: sunfishcode/dbus-rs
         path: dbus-rs
+    - uses: ./.github/workflows/cross.yml
+      with:
+        os: ${{ matrix.os }
+        target: ${{ matrix.target }}
+        libc_package: ${{ matrix.libc_package }}
+        gcc_package: ${{ matrix.gcc_package }}
+        gcc: ${{ matrix.gcc }}
+        qemu: ${{ matrix.qemu }}
+        qemu_target: ${{ matrix.qemu_target }}
     - run: sudo apt-get update
     - run: sudo apt-get install -y libdbus-1-dev at-spi2-core
     - run: cd dbus-rs && echo '[patch.crates-io]' >> Cargo.toml
@@ -297,12 +770,46 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [nightly]
+        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
         include:
-          - build: nightly
+          - build: ubuntu
             os: ubuntu-latest
             rust: nightly
-    steps:
+          - build: i686-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: i686-unknown-linux-gnu
+            gcc_package: gcc-i686-linux-gnu
+            gcc: i686-linux-gnu-gcc
+            libc_package: libc-dev-i386-cross
+          - build: aarch64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: aarch64-unknown-linux-gnu
+            gcc_package: gcc-aarch64-linux-gnu
+            gcc: aarch64-linux-gnu-gcc
+            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+            qemu_target: aarch64-linux-user
+          - build: riscv64-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: riscv64gc-unknown-linux-gnu
+            gcc_package: gcc-riscv64-linux-gnu
+            gcc: riscv64-linux-gnu-gcc
+            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
+            qemu_target: riscv64-linux-user
+          - build: arm-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: armv5te-unknown-linux-gnueabi
+            gcc_package: gcc-arm-linux-gnueabi
+            gcc: arm-linux-gnueabi-gcc
+            qemu: qemu-arm -L /usr/arm-linux-gnueabi
+            qemu_target: arm-linux-user
+          - build: macos-11
+            os: macos-11
+            rust: nightly
+  steps:
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -313,9 +820,19 @@ jobs:
       with:
         repository: sunfishcode/mustang
         path: mustang
+    - uses: ./.github/workflows/cross.yml
+      with:
+        os: ${{ matrix.os }
+        target: ${{ matrix.target }}
+        libc_package: ${{ matrix.libc_package }}
+        gcc_package: ${{ matrix.gcc_package }}
+        gcc: ${{ matrix.gcc }}
+        qemu: ${{ matrix.qemu }}
+        qemu_target: ${{ matrix.qemu_target }}
     - run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
     - run: cd mustang && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd mustang && echo 'rustix = { path = ".." }' >> Cargo.toml
+    # This test takes too long.
     - run: cd mustang && sed -i 's/fn concurrent_recursive_mkdir()/#[ignore]\rfn concurrent_recursive_mkdir()/' tests/fs.rs
     # Use jobs=1 to hopefully avoid apparently oversubscribing the runner.
     - run: cd mustang && cargo test --target=specs/x86_64-mustang-linux-gnu.json -Zbuild-std --jobs=1
@@ -325,9 +842,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [nightly]
+        build: [ubuntu]
         include:
-          - build: nightly
+          - build: ubuntu
             os: ubuntu-latest
             rust: nightly
     steps:

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -51,8 +51,6 @@ jobs:
             rust: nightly
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
@@ -60,15 +58,48 @@ jobs:
       with:
         repository: sunfishcode/async-io
         path: async-io
-    - uses: ./.github/workflows/cross.yml
-      with:
-        os: ${{ matrix.os }
-        target: ${{ matrix.target }}
-        libc_package: ${{ matrix.libc_package }}
-        gcc_package: ${{ matrix.gcc_package }}
-        gcc: ${{ matrix.gcc }}
-        qemu: ${{ matrix.qemu }}
-        qemu_target: ${{ matrix.qemu_target }}
+
+    - name: Configure Cargo target
+      run: |
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+        rustup target add ${{ matrix.target }}
+      if: matrix.target != ''
+
+    - name: Install cross-compilation tools
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
+      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install cross-compilation libraries
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.libc_package }}
+      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install qemu
+      run: |
+        set -ex
+        # Download and build qemu from source since the most recent release is
+        # way faster at arm emulation than the current version github actions'
+        # ubuntu image uses. Disable as much as we can to get it to build
+        # quickly.
+        cd
+        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
+        cd qemu-6.1.0
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        make -j$(nproc) install
+
+        # Configure Cargo for cross compilation and tell it how it can run
+        # cross executables
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
+
     - run: cd async-io && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd async-io && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd async-io && cargo test
@@ -119,8 +150,6 @@ jobs:
             rust: nightly
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
@@ -128,15 +157,48 @@ jobs:
       with:
         repository: bytecodealliance/cap-std
         path: cap-std
-    - uses: ./.github/workflows/cross.yml
-      with:
-        os: ${{ matrix.os }
-        target: ${{ matrix.target }}
-        libc_package: ${{ matrix.libc_package }}
-        gcc_package: ${{ matrix.gcc_package }}
-        gcc: ${{ matrix.gcc }}
-        qemu: ${{ matrix.qemu }}
-        qemu_target: ${{ matrix.qemu_target }}
+
+    - name: Configure Cargo target
+      run: |
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+        rustup target add ${{ matrix.target }}
+      if: matrix.target != ''
+
+    - name: Install cross-compilation tools
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
+      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install cross-compilation libraries
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.libc_package }}
+      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install qemu
+      run: |
+        set -ex
+        # Download and build qemu from source since the most recent release is
+        # way faster at arm emulation than the current version github actions'
+        # ubuntu image uses. Disable as much as we can to get it to build
+        # quickly.
+        cd
+        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
+        cd qemu-6.1.0
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        make -j$(nproc) install
+
+        # Configure Cargo for cross compilation and tell it how it can run
+        # cross executables
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
+
     - run: cd cap-std && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd cap-std && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd cap-std && cargo test
@@ -146,49 +208,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
+        # Cargo depends on pkg-config which must be configured for cross-compilation.
+        build: [ubuntu]
         include:
           - build: ubuntu
             os: ubuntu-latest
             rust: nightly
-          - build: i686-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: i686-unknown-linux-gnu
-            gcc_package: gcc-i686-linux-gnu
-            gcc: i686-linux-gnu-gcc
-            libc_package: libc-dev-i386-cross
-          - build: aarch64-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: aarch64-unknown-linux-gnu
-            gcc_package: gcc-aarch64-linux-gnu
-            gcc: aarch64-linux-gnu-gcc
-            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
-            qemu_target: aarch64-linux-user
-          - build: riscv64-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: riscv64gc-unknown-linux-gnu
-            gcc_package: gcc-riscv64-linux-gnu
-            gcc: riscv64-linux-gnu-gcc
-            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
-            qemu_target: riscv64-linux-user
-          - build: arm-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: armv5te-unknown-linux-gnueabi
-            gcc_package: gcc-arm-linux-gnueabi
-            gcc: arm-linux-gnueabi-gcc
-            qemu: qemu-arm -L /usr/arm-linux-gnueabi
-            qemu_target: arm-linux-user
-          - build: macos-11
-            os: macos-11
-            rust: nightly
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
@@ -197,15 +224,49 @@ jobs:
         repository: sunfishcode/cargo
         path: cargo
         ref: rustix
-    - uses: ./.github/workflows/cross.yml
-      with:
-        os: ${{ matrix.os }
-        target: ${{ matrix.target }}
-        libc_package: ${{ matrix.libc_package }}
-        gcc_package: ${{ matrix.gcc_package }}
-        gcc: ${{ matrix.gcc }}
-        qemu: ${{ matrix.qemu }}
-        qemu_target: ${{ matrix.qemu_target }}
+
+    - name: Configure Cargo target
+      run: |
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+        rustup target add ${{ matrix.target }}
+      if: matrix.target != ''
+
+    - name: Install cross-compilation tools
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build pkg-config
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
+      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install cross-compilation libraries
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.libc_package }}
+      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install qemu
+      run: |
+        set -ex
+        # Download and build qemu from source since the most recent release is
+        # way faster at arm emulation than the current version github actions'
+        # ubuntu image uses. Disable as much as we can to get it to build
+        # quickly.
+        cd
+        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
+        cd qemu-6.1.0
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        make -j$(nproc) install
+
+        # Configure Cargo for cross compilation and tell it how it can run
+        # cross executables
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
+
+    - run: rustup component add rust-src rustc-dev llvm-tools-preview
     - run: cd cargo && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd cargo && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd cargo && cargo test --workspace
@@ -218,7 +279,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
+        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -254,13 +315,8 @@ jobs:
             gcc: arm-linux-gnueabi-gcc
             qemu: qemu-arm -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
-          - build: macos-11
-            os: macos-11
-            rust: nightly
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
@@ -268,15 +324,48 @@ jobs:
       with:
         repository: sunfishcode/memfd-rs
         path: memfd-rs
-    - uses: ./.github/workflows/cross.yml
-      with:
-        os: ${{ matrix.os }
-        target: ${{ matrix.target }}
-        libc_package: ${{ matrix.libc_package }}
-        gcc_package: ${{ matrix.gcc_package }}
-        gcc: ${{ matrix.gcc }}
-        qemu: ${{ matrix.qemu }}
-        qemu_target: ${{ matrix.qemu_target }}
+
+    - name: Configure Cargo target
+      run: |
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+        rustup target add ${{ matrix.target }}
+      if: matrix.target != ''
+
+    - name: Install cross-compilation tools
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
+      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install cross-compilation libraries
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.libc_package }}
+      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install qemu
+      run: |
+        set -ex
+        # Download and build qemu from source since the most recent release is
+        # way faster at arm emulation than the current version github actions'
+        # ubuntu image uses. Disable as much as we can to get it to build
+        # quickly.
+        cd
+        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
+        cd qemu-6.1.0
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        make -j$(nproc) install
+
+        # Configure Cargo for cross compilation and tell it how it can run
+        # cross executables
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
+
     - run: cd memfd-rs && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd memfd-rs && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd memfd-rs && cargo test
@@ -327,8 +416,6 @@ jobs:
             rust: nightly
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
@@ -336,15 +423,48 @@ jobs:
       with:
         repository: sunfishcode/tempfile
         path: tempfile
-    - uses: ./.github/workflows/cross.yml
-      with:
-        os: ${{ matrix.os }
-        target: ${{ matrix.target }}
-        libc_package: ${{ matrix.libc_package }}
-        gcc_package: ${{ matrix.gcc_package }}
-        gcc: ${{ matrix.gcc }}
-        qemu: ${{ matrix.qemu }}
-        qemu_target: ${{ matrix.qemu_target }}
+
+    - name: Configure Cargo target
+      run: |
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+        rustup target add ${{ matrix.target }}
+      if: matrix.target != ''
+
+    - name: Install cross-compilation tools
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
+      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install cross-compilation libraries
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.libc_package }}
+      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install qemu
+      run: |
+        set -ex
+        # Download and build qemu from source since the most recent release is
+        # way faster at arm emulation than the current version github actions'
+        # ubuntu image uses. Disable as much as we can to get it to build
+        # quickly.
+        cd
+        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
+        cd qemu-6.1.0
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        make -j$(nproc) install
+
+        # Configure Cargo for cross compilation and tell it how it can run
+        # cross executables
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
+
     - run: cd tempfile && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd tempfile && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd tempfile && cargo test
@@ -395,8 +515,6 @@ jobs:
             rust: nightly
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
@@ -404,17 +522,50 @@ jobs:
       with:
         repository: yoshuawuyts/fd-lock
         path: fd-lock
-    - uses: ./.github/workflows/cross.yml
-      with:
-        os: ${{ matrix.os }
-        target: ${{ matrix.target }}
-        libc_package: ${{ matrix.libc_package }}
-        gcc_package: ${{ matrix.gcc_package }}
-        gcc: ${{ matrix.gcc }}
-        qemu: ${{ matrix.qemu }}
-        qemu_target: ${{ matrix.qemu_target }}
+
+    - name: Configure Cargo target
+      run: |
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+        rustup target add ${{ matrix.target }}
+      if: matrix.target != ''
+
+    - name: Install cross-compilation tools
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
+      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install cross-compilation libraries
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.libc_package }}
+      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install qemu
+      run: |
+        set -ex
+        # Download and build qemu from source since the most recent release is
+        # way faster at arm emulation than the current version github actions'
+        # ubuntu image uses. Disable as much as we can to get it to build
+        # quickly.
+        cd
+        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
+        cd qemu-6.1.0
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        make -j$(nproc) install
+
+        # Configure Cargo for cross compilation and tell it how it can run
+        # cross executables
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
+
     # fd-lock currently uses rustix 0.32.
-    - run: sed -i 's/^version = "\([[:digit:].-]*\)"$/version = "0.32.0"/' Cargo.toml
+    - run: sed -i'.bak' 's/^version = "\([[:digit:].-]*\)"$/version = "0.32.0"/' Cargo.toml
     - run: cd fd-lock && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd fd-lock && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd fd-lock && cargo test
@@ -424,49 +575,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
+        # Qemu doesn't support running Wasmtime.
+        build: [ubuntu, macos-11]
         include:
           - build: ubuntu
             os: ubuntu-latest
             rust: nightly
-          - build: i686-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: i686-unknown-linux-gnu
-            gcc_package: gcc-i686-linux-gnu
-            gcc: i686-linux-gnu-gcc
-            libc_package: libc-dev-i386-cross
-          - build: aarch64-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: aarch64-unknown-linux-gnu
-            gcc_package: gcc-aarch64-linux-gnu
-            gcc: aarch64-linux-gnu-gcc
-            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
-            qemu_target: aarch64-linux-user
-          - build: riscv64-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: riscv64gc-unknown-linux-gnu
-            gcc_package: gcc-riscv64-linux-gnu
-            gcc: riscv64-linux-gnu-gcc
-            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
-            qemu_target: riscv64-linux-user
-          - build: arm-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: armv5te-unknown-linux-gnueabi
-            gcc_package: gcc-arm-linux-gnueabi
-            gcc: arm-linux-gnueabi-gcc
-            qemu: qemu-arm -L /usr/arm-linux-gnueabi
-            qemu_target: arm-linux-user
           - build: macos-11
             os: macos-11
             rust: nightly
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
@@ -475,68 +594,32 @@ jobs:
         repository: bytecodealliance/wasmtime
         path: wasmtime
         submodules: true
-    - uses: ./.github/workflows/cross.yml
-      with:
-        os: ${{ matrix.os }
-        target: ${{ matrix.target }}
-        libc_package: ${{ matrix.libc_package }}
-        gcc_package: ${{ matrix.gcc_package }}
-        gcc: ${{ matrix.gcc }}
-        qemu: ${{ matrix.qemu }}
-        qemu_target: ${{ matrix.qemu_target }}
+
+    - name: Configure Cargo target
+      run: |
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+        rustup target add ${{ matrix.target }}
+      if: matrix.target != ''
+
     - run: rustup target add wasm32-wasi
     - run: cd wasmtime && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd wasmtime && echo 'rustix = { path = ".." }' >> Cargo.toml
-    - run: cd wasmtime && cargo test
+    - run: cd wasmtime && cargo test --features "test-programs/test_programs" --workspace --exclude 'wasmtime-wasi-*' --exclude wasi-crypto --exclude wasmtime-fuzzing
 
   nameless:
     name: nameless
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
+        # Our build script below only runs on Linux at the moment.
+        # Our build script below doesn't support cross compilation at the moment.
+        build: [ubuntu]
         include:
           - build: ubuntu
             os: ubuntu-latest
             rust: nightly
-          - build: i686-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: i686-unknown-linux-gnu
-            gcc_package: gcc-i686-linux-gnu
-            gcc: i686-linux-gnu-gcc
-            libc_package: libc-dev-i386-cross
-          - build: aarch64-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: aarch64-unknown-linux-gnu
-            gcc_package: gcc-aarch64-linux-gnu
-            gcc: aarch64-linux-gnu-gcc
-            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
-            qemu_target: aarch64-linux-user
-          - build: riscv64-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: riscv64gc-unknown-linux-gnu
-            gcc_package: gcc-riscv64-linux-gnu
-            gcc: riscv64-linux-gnu-gcc
-            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
-            qemu_target: riscv64-linux-user
-          - build: arm-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: armv5te-unknown-linux-gnueabi
-            gcc_package: gcc-arm-linux-gnueabi
-            gcc: arm-linux-gnueabi-gcc
-            qemu: qemu-arm -L /usr/arm-linux-gnueabi
-            qemu_target: arm-linux-user
-          - build: macos-11
-            os: macos-11
-            rust: nightly
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
@@ -544,15 +627,52 @@ jobs:
       with:
         repository: sunfishcode/nameless
         path: nameless
-    - uses: ./.github/workflows/cross.yml
-      with:
-        os: ${{ matrix.os }
-        target: ${{ matrix.target }}
-        libc_package: ${{ matrix.libc_package }}
-        gcc_package: ${{ matrix.gcc_package }}
-        gcc: ${{ matrix.gcc }}
-        qemu: ${{ matrix.qemu }}
-        qemu_target: ${{ matrix.qemu_target }}
+
+    - name: Configure Cargo target
+      run: |
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+        rustup target add ${{ matrix.target }}
+      if: matrix.target != ''
+
+    - name: Install cross-compilation tools
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
+      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install cross-compilation libraries
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.libc_package }}
+      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install qemu
+      run: |
+        set -ex
+        # Download and build qemu from source since the most recent release is
+        # way faster at arm emulation than the current version github actions'
+        # ubuntu image uses. Disable as much as we can to get it to build
+        # quickly.
+        cd
+        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
+        cd qemu-6.1.0
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        make -j$(nproc) install
+
+        # Configure Cargo for cross compilation and tell it how it can run
+        # cross executables
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
+
+    - run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y libssl-dev
     - run: cd nameless && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd nameless && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd nameless && cargo test
@@ -562,7 +682,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
+        # cap-std-ext only builds on Linux at the moment.
+        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -598,13 +719,8 @@ jobs:
             gcc: arm-linux-gnueabi-gcc
             qemu: qemu-arm -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
-          - build: macos-11
-            os: macos-11
-            rust: nightly
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
@@ -612,137 +728,66 @@ jobs:
       with:
         repository: cgwalters/cap-std-ext
         path: cap-std-ext
-    - uses: ./.github/workflows/cross.yml
-      with:
-        os: ${{ matrix.os }
-        target: ${{ matrix.target }}
-        libc_package: ${{ matrix.libc_package }}
-        gcc_package: ${{ matrix.gcc_package }}
-        gcc: ${{ matrix.gcc }}
-        qemu: ${{ matrix.qemu }}
-        qemu_target: ${{ matrix.qemu_target }}
+
+    - name: Configure Cargo target
+      run: |
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+        rustup target add ${{ matrix.target }}
+      if: matrix.target != ''
+
+    - name: Install cross-compilation tools
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
+      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install cross-compilation libraries
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.libc_package }}
+      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install qemu
+      run: |
+        set -ex
+        # Download and build qemu from source since the most recent release is
+        # way faster at arm emulation than the current version github actions'
+        # ubuntu image uses. Disable as much as we can to get it to build
+        # quickly.
+        cd
+        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
+        cd qemu-6.1.0
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        make -j$(nproc) install
+
+        # Configure Cargo for cross compilation and tell it how it can run
+        # cross executables
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
+
     - run: cd cap-std-ext && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd cap-std-ext && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd cap-std-ext && cargo test
-
-  ostree-rs-ext:
-    name: ostree-rs-ext
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
-        include:
-          - build: ubuntu
-            os: ubuntu-latest
-            rust: nightly
-          - build: i686-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: i686-unknown-linux-gnu
-            gcc_package: gcc-i686-linux-gnu
-            gcc: i686-linux-gnu-gcc
-            libc_package: libc-dev-i386-cross
-          - build: aarch64-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: aarch64-unknown-linux-gnu
-            gcc_package: gcc-aarch64-linux-gnu
-            gcc: aarch64-linux-gnu-gcc
-            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
-            qemu_target: aarch64-linux-user
-          - build: riscv64-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: riscv64gc-unknown-linux-gnu
-            gcc_package: gcc-riscv64-linux-gnu
-            gcc: riscv64-linux-gnu-gcc
-            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
-            qemu_target: riscv64-linux-user
-          - build: arm-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: armv5te-unknown-linux-gnueabi
-            gcc_package: gcc-arm-linux-gnueabi
-            gcc: arm-linux-gnueabi-gcc
-            qemu: qemu-arm -L /usr/arm-linux-gnueabi
-            qemu_target: arm-linux-user
-          - build: macos-11
-            os: macos-11
-            rust: nightly
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: ./.github/actions/install-rust
-      with:
-        toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v2
-      with:
-        repository: ostreedev/ostree-rs-ext
-        path: ostree-rs-ext
-    - uses: ./.github/workflows/cross.yml
-      with:
-        os: ${{ matrix.os }
-        target: ${{ matrix.target }}
-        libc_package: ${{ matrix.libc_package }}
-        gcc_package: ${{ matrix.gcc_package }}
-        gcc: ${{ matrix.gcc }}
-        qemu: ${{ matrix.qemu }}
-        qemu_target: ${{ matrix.qemu_target }}
-    - run: sudo apt-get update
-    - run: sudo apt-get install -y libostree-dev
-    - run: cd ostree-rs-ext && echo '[patch.crates-io]' >> Cargo.toml
-    - run: cd ostree-rs-ext && echo 'rustix = { path = ".." }' >> Cargo.toml
-    - run: cd ostree-rs-ext && cargo test
 
   dbus-rs:
     name: dbus-rs ported to rustix
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
+        # Our build script below only runs on Linux at the moment.
+        # Our build script below doesn't support cross compilation at the moment.
+        build: [ubuntu]
         include:
           - build: ubuntu
             os: ubuntu-latest
             rust: nightly
-          - build: i686-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: i686-unknown-linux-gnu
-            gcc_package: gcc-i686-linux-gnu
-            gcc: i686-linux-gnu-gcc
-            libc_package: libc-dev-i386-cross
-          - build: aarch64-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: aarch64-unknown-linux-gnu
-            gcc_package: gcc-aarch64-linux-gnu
-            gcc: aarch64-linux-gnu-gcc
-            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
-            qemu_target: aarch64-linux-user
-          - build: riscv64-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: riscv64gc-unknown-linux-gnu
-            gcc_package: gcc-riscv64-linux-gnu
-            gcc: riscv64-linux-gnu-gcc
-            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
-            qemu_target: riscv64-linux-user
-          - build: arm-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: armv5te-unknown-linux-gnueabi
-            gcc_package: gcc-arm-linux-gnueabi
-            gcc: arm-linux-gnueabi-gcc
-            qemu: qemu-arm -L /usr/arm-linux-gnueabi
-            qemu_target: arm-linux-user
-          - build: macos-11
-            os: macos-11
-            rust: nightly
-  steps:
+    steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
@@ -750,17 +795,52 @@ jobs:
       with:
         repository: sunfishcode/dbus-rs
         path: dbus-rs
-    - uses: ./.github/workflows/cross.yml
-      with:
-        os: ${{ matrix.os }
-        target: ${{ matrix.target }}
-        libc_package: ${{ matrix.libc_package }}
-        gcc_package: ${{ matrix.gcc_package }}
-        gcc: ${{ matrix.gcc }}
-        qemu: ${{ matrix.qemu }}
-        qemu_target: ${{ matrix.qemu_target }}
-    - run: sudo apt-get update
-    - run: sudo apt-get install -y libdbus-1-dev at-spi2-core
+
+    - name: Configure Cargo target
+      run: |
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+        rustup target add ${{ matrix.target }}
+      if: matrix.target != ''
+
+    - name: Install cross-compilation tools
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
+      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install cross-compilation libraries
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.libc_package }}
+      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install qemu
+      run: |
+        set -ex
+        # Download and build qemu from source since the most recent release is
+        # way faster at arm emulation than the current version github actions'
+        # ubuntu image uses. Disable as much as we can to get it to build
+        # quickly.
+        cd
+        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
+        cd qemu-6.1.0
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        make -j$(nproc) install
+
+        # Configure Cargo for cross compilation and tell it how it can run
+        # cross executables
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
+
+    - run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y libdbus-1-dev at-spi2-core pkg-config
     - run: cd dbus-rs && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd dbus-rs && echo 'rustix = { path = ".." }' >> Cargo.toml
     - run: cd dbus-rs && env DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --session --print-address --fork` cargo test --workspace
@@ -770,49 +850,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux, arm-linux, macos-11]
+        build: [ubuntu]
         include:
           - build: ubuntu
             os: ubuntu-latest
             rust: nightly
-          - build: i686-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: i686-unknown-linux-gnu
-            gcc_package: gcc-i686-linux-gnu
-            gcc: i686-linux-gnu-gcc
-            libc_package: libc-dev-i386-cross
-          - build: aarch64-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: aarch64-unknown-linux-gnu
-            gcc_package: gcc-aarch64-linux-gnu
-            gcc: aarch64-linux-gnu-gcc
-            qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
-            qemu_target: aarch64-linux-user
-          - build: riscv64-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: riscv64gc-unknown-linux-gnu
-            gcc_package: gcc-riscv64-linux-gnu
-            gcc: riscv64-linux-gnu-gcc
-            qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
-            qemu_target: riscv64-linux-user
-          - build: arm-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: armv5te-unknown-linux-gnueabi
-            gcc_package: gcc-arm-linux-gnueabi
-            gcc: arm-linux-gnueabi-gcc
-            qemu: qemu-arm -L /usr/arm-linux-gnueabi
-            qemu_target: arm-linux-user
-          - build: macos-11
-            os: macos-11
-            rust: nightly
-  steps:
+    steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
@@ -820,20 +864,53 @@ jobs:
       with:
         repository: sunfishcode/mustang
         path: mustang
-    - uses: ./.github/workflows/cross.yml
-      with:
-        os: ${{ matrix.os }
-        target: ${{ matrix.target }}
-        libc_package: ${{ matrix.libc_package }}
-        gcc_package: ${{ matrix.gcc_package }}
-        gcc: ${{ matrix.gcc }}
-        qemu: ${{ matrix.qemu }}
-        qemu_target: ${{ matrix.qemu_target }}
+
+    - name: Configure Cargo target
+      run: |
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+        rustup target add ${{ matrix.target }}
+      if: matrix.target != ''
+
+    - name: Install cross-compilation tools
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
+      if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install cross-compilation libraries
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.libc_package }}
+      if: matrix.libc_package != '' && matrix.os == 'ubuntu-latest'
+
+    - name: Install qemu
+      run: |
+        set -ex
+        # Download and build qemu from source since the most recent release is
+        # way faster at arm emulation than the current version github actions'
+        # ubuntu image uses. Disable as much as we can to get it to build
+        # quickly.
+        cd
+        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
+        cd qemu-6.1.0
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        make -j$(nproc) install
+
+        # Configure Cargo for cross compilation and tell it how it can run
+        # cross executables
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+      if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
+
     - run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
     - run: cd mustang && echo '[patch.crates-io]' >> Cargo.toml
     - run: cd mustang && echo 'rustix = { path = ".." }' >> Cargo.toml
     # This test takes too long.
-    - run: cd mustang && sed -i 's/fn concurrent_recursive_mkdir()/#[ignore]\rfn concurrent_recursive_mkdir()/' tests/fs.rs
+    - run: cd mustang && sed -i'.bak' 's/fn concurrent_recursive_mkdir()/#[ignore]\rfn concurrent_recursive_mkdir()/' tests/fs.rs
     # Use jobs=1 to hopefully avoid apparently oversubscribing the runner.
     - run: cd mustang && cargo test --target=specs/x86_64-mustang-linux-gnu.json -Zbuild-std --jobs=1
 
@@ -850,7 +927,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: true
+        # Fetch everything to get rebase with rustc-dep-of-std.
+        fetch-depth: 0
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
@@ -859,15 +937,18 @@ jobs:
         repository: sunfishcode/rust
         path: rust
         ref: rustix
-        # Fetch enough to let the bootstrap script find an LLVM revision.
-        fetch-depth: 2000
+        submodules: true
+        # Fetch at least 200 to let the bootstrap script find an LLVM revision.
+        fetch-depth: 200
+    # Hack to get git rebase to work.
+    - run: git config --global user.email "you@example.com"
+    - run: git config --global user.name "Your Name"
     # Include the changes needed to support std.
-    - run: git fetch --depth=1 origin rustc-dep-of-std
-    - run: git rebase rustc-dep-of-std
+    - run: git rebase origin/rustc-dep-of-std
     # Download a pre-built LLVM instead of building it from source.
     - run: cd rust && echo "[llvm]" >> config.toml
     - run: cd rust && echo "download-ci-llvm = true" >> config.toml
-    - run: cd rust && sed -i 's/\<git = "https:\/\/github\.com\/bytecodealliance\/rustix", branch = "rustc-dep-of-std"/path = "..\/..\/.."/' library/std/Cargo.toml
+    - run: cd rust && sed -i'.bak' 's/\<git = "https:\/\/github\.com\/bytecodealliance\/rustix", branch = "rustc-dep-of-std"/path = "..\/..\/.."/' library/std/Cargo.toml
     - run: cd rust && ./x.py test library/std --stage=0
       # See <https://github.com/bytecodealliance/rustix/issues/76#issuecomment-962196433>
       env:

--- a/tests/net/poll.rs
+++ b/tests/net/poll.rs
@@ -94,7 +94,7 @@ fn client(ready: Arc<(Mutex<u16>, Condvar)>) {
 }
 
 #[test]
-fn test_v6() {
+fn test_poll() {
     #[cfg(windows)]
     rustix::net::wsa_startup().unwrap();
 


### PR DESCRIPTION
 - In the Rust build, use a downloaded LLVM to avoid needing the dependencies
   needed to build LLVM.
 - Fix the name of the ostree-rs-ext repository.
 - Install libostree-dev for the ostree-rs-ext build.
 - Launch a dbus-daemon for the dbus-rs tests to use.