### PR TITLE
Add network operations that operate on `SocketAddr`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ serial_test = "0.5"
 [target.'cfg(not(target_os = "emscripten"))'.dev-dependencies]
 criterion = "0.3"
 
+[target.'cfg(windows)'.dev-dependencies]
+ctor = "0.1.21"
+
 [features]
 default = ["std"]
 std = ["io-lifetimes", "linux-raw-sys/std"]

--- a/src/fs/copy_file_range.rs
+++ b/src/fs/copy_file_range.rs
@@ -16,7 +16,5 @@ pub fn copy_file_range<InFd: AsFd, OutFd: AsFd>(
     off_out: Option<&mut u64>,
     len: u64,
 ) -> io::Result<u64> {
-    let fd_in = fd_in.as_fd();
-    let fd_out = fd_out.as_fd();
-    imp::fs::syscalls::copy_file_range(fd_in, off_in, fd_out, off_out, len)
+    imp::fs::syscalls::copy_file_range(fd_in.as_fd(), off_in, fd_out.as_fd(), off_out, len)
 }

--- a/src/fs/fadvise.rs
+++ b/src/fs/fadvise.rs
@@ -15,6 +15,5 @@ pub use imp::fs::Advice;
 #[inline]
 #[doc(alias = "posix_fadvise")]
 pub fn fadvise<Fd: AsFd>(fd: &Fd, offset: u64, len: u64, advice: Advice) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fadvise(fd, offset, len, advice)
+    imp::fs::syscalls::fadvise(fd.as_fd(), offset, len, advice)
 }

--- a/src/fs/fcntl.rs
+++ b/src/fs/fcntl.rs
@@ -19,8 +19,7 @@ use imp::fs::{FdFlags, OFlags};
 #[inline]
 #[doc(alias = "F_GETFD")]
 pub fn fcntl_getfd<Fd: AsFd>(fd: &Fd) -> io::Result<FdFlags> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fcntl_getfd(fd)
+    imp::fs::syscalls::fcntl_getfd(fd.as_fd())
 }
 
 /// `fcntl(fd, F_SETFD, flags)`—Sets a file descriptor's flags.
@@ -34,8 +33,7 @@ pub fn fcntl_getfd<Fd: AsFd>(fd: &Fd) -> io::Result<FdFlags> {
 #[inline]
 #[doc(alias = "F_SETFD")]
 pub fn fcntl_setfd<Fd: AsFd>(fd: &Fd, flags: FdFlags) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fcntl_setfd(fd, flags)
+    imp::fs::syscalls::fcntl_setfd(fd.as_fd(), flags)
 }
 
 /// `fcntl(fd, F_GETFL)`—Returns a file descriptor's access mode and status.
@@ -49,8 +47,7 @@ pub fn fcntl_setfd<Fd: AsFd>(fd: &Fd, flags: FdFlags) -> io::Result<()> {
 #[inline]
 #[doc(alias = "F_GETFL")]
 pub fn fcntl_getfl<Fd: AsFd>(fd: &Fd) -> io::Result<OFlags> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fcntl_getfl(fd)
+    imp::fs::syscalls::fcntl_getfl(fd.as_fd())
 }
 
 /// `fcntl(fd, F_SETFL, flags)`—Sets a file descriptor's status.
@@ -64,8 +61,7 @@ pub fn fcntl_getfl<Fd: AsFd>(fd: &Fd) -> io::Result<OFlags> {
 #[inline]
 #[doc(alias = "F_SETFL")]
 pub fn fcntl_setfl<Fd: AsFd>(fd: &Fd, flags: OFlags) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fcntl_setfl(fd, flags)
+    imp::fs::syscalls::fcntl_setfl(fd.as_fd(), flags)
 }
 
 /// `fcntl(fd, F_GET_SEALS)`
@@ -83,8 +79,7 @@ pub fn fcntl_setfl<Fd: AsFd>(fd: &Fd, flags: OFlags) -> io::Result<()> {
 #[inline]
 #[doc(alias = "F_GET_SEALS")]
 pub fn fcntl_get_seals<Fd: AsFd>(fd: &Fd) -> io::Result<SealFlags> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fcntl_get_seals(fd)
+    imp::fs::syscalls::fcntl_get_seals(fd.as_fd())
 }
 
 #[cfg(any(
@@ -110,8 +105,7 @@ pub use imp::fs::SealFlags;
 #[inline]
 #[doc(alias = "F_ADD_SEALS")]
 pub fn fcntl_add_seals<Fd: AsFd>(fd: &Fd, seals: SealFlags) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fcntl_add_seals(fd, seals)
+    imp::fs::syscalls::fcntl_add_seals(fd.as_fd(), seals)
 }
 
 /// `fcntl(fd, F_DUPFD_CLOEXEC)`—Creates a new `OwnedFd` instance, with value
@@ -133,6 +127,5 @@ pub fn fcntl_add_seals<Fd: AsFd>(fd: &Fd, seals: SealFlags) -> io::Result<()> {
 #[inline]
 #[doc(alias = "F_DUPFD_CLOEXEC")]
 pub fn fcntl_dupfd_cloexec<Fd: AsFd>(fd: &Fd, min: RawFd) -> io::Result<OwnedFd> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fcntl_dupfd_cloexec(fd, min)
+    imp::fs::syscalls::fcntl_dupfd_cloexec(fd.as_fd(), min)
 }

--- a/src/fs/fcntl_darwin.rs
+++ b/src/fs/fcntl_darwin.rs
@@ -9,8 +9,7 @@ use imp::fd::AsFd;
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html
 #[inline]
 pub fn fcntl_rdadvise<Fd: AsFd>(fd: &Fd, offset: u64, len: u64) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fcntl_rdadvise(fd, offset, len)
+    imp::fs::syscalls::fcntl_rdadvise(fd.as_fd(), offset, len)
 }
 
 /// `fcntl(fd, F_FULLFSYNC)`
@@ -21,6 +20,5 @@ pub fn fcntl_rdadvise<Fd: AsFd>(fd: &Fd, offset: u64, len: u64) -> io::Result<()
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html
 #[inline]
 pub fn fcntl_fullfsync<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fcntl_fullfsync(fd)
+    imp::fs::syscalls::fcntl_fullfsync(fd.as_fd())
 }

--- a/src/fs/fcopyfile.rs
+++ b/src/fs/fcopyfile.rs
@@ -23,9 +23,7 @@ pub unsafe fn fcopyfile<FromFd: AsFd, ToFd: AsFd>(
     state: copyfile_state_t,
     flags: CopyfileFlags,
 ) -> io::Result<()> {
-    let from = from.as_fd();
-    let to = to.as_fd();
-    imp::fs::syscalls::fcopyfile(from, to, state, flags)
+    imp::fs::syscalls::fcopyfile(from.as_fd(), to.as_fd(), state, flags)
 }
 
 /// `copyfile_state_alloc()`

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -36,8 +36,7 @@ use imp::fs::{FlockOperation, Mode};
 /// [Linux]: https://man7.org/linux/man-pages/man2/lseek.2.html
 #[inline]
 pub fn seek<Fd: AsFd>(fd: &Fd, pos: SeekFrom) -> io::Result<u64> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::seek(fd, pos)
+    imp::fs::syscalls::seek(fd.as_fd(), pos)
 }
 
 /// `lseek(fd, 0, SEEK_CUR)`—Returns the current position within a file.
@@ -54,8 +53,7 @@ pub fn seek<Fd: AsFd>(fd: &Fd, pos: SeekFrom) -> io::Result<u64> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/lseek.2.html
 #[inline]
 pub fn tell<Fd: AsFd>(fd: &Fd) -> io::Result<u64> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::tell(fd)
+    imp::fs::syscalls::tell(fd.as_fd())
 }
 
 /// `fchmod(fd)`—Sets open file or directory permissions.
@@ -72,8 +70,7 @@ pub fn tell<Fd: AsFd>(fd: &Fd) -> io::Result<u64> {
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 pub fn fchmod<Fd: AsFd>(fd: &Fd, mode: Mode) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fchmod(fd, mode)
+    imp::fs::syscalls::fchmod(fd.as_fd(), mode)
 }
 
 /// `fchown(fd)`—Sets open file or directory ownership.
@@ -87,8 +84,7 @@ pub fn fchmod<Fd: AsFd>(fd: &Fd, mode: Mode) -> io::Result<()> {
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 pub fn fchown<Fd: AsFd>(fd: &Fd, owner: Uid, group: Gid) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fchown(fd, owner, group)
+    imp::fs::syscalls::fchown(fd.as_fd(), owner, group)
 }
 
 /// `fstat(fd)`—Queries metadata for an open file or directory.
@@ -106,8 +102,7 @@ pub fn fchown<Fd: AsFd>(fd: &Fd, owner: Uid, group: Gid) -> io::Result<()> {
 /// [`FileType::from_raw_mode`]: crate::fs::FileType::from_raw_mode
 #[inline]
 pub fn fstat<Fd: AsFd>(fd: &Fd) -> io::Result<Stat> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fstat(fd)
+    imp::fs::syscalls::fstat(fd.as_fd())
 }
 
 /// `fstatfs(fd)`—Queries filesystem statistics for an open file or directory.
@@ -124,8 +119,7 @@ pub fn fstat<Fd: AsFd>(fd: &Fd) -> io::Result<Stat> {
 )))] // not implemented in libc for netbsd yet
 #[inline]
 pub fn fstatfs<Fd: AsFd>(fd: &Fd) -> io::Result<StatFs> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fstatfs(fd)
+    imp::fs::syscalls::fstatfs(fd.as_fd())
 }
 
 /// `futimens(fd, times)`—Sets timestamps for an open file or directory.
@@ -138,8 +132,7 @@ pub fn fstatfs<Fd: AsFd>(fd: &Fd) -> io::Result<StatFs> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/utimensat.2.html
 #[inline]
 pub fn futimens<Fd: AsFd>(fd: &Fd, times: &Timestamps) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::futimens(fd, times)
+    imp::fs::syscalls::futimens(fd.as_fd(), times)
 }
 
 /// `fallocate(fd, mode, offset, len)`—Adjusts file allocation.
@@ -167,8 +160,7 @@ pub fn futimens<Fd: AsFd>(fd: &Fd, times: &Timestamps) -> io::Result<()> {
 #[inline]
 #[doc(alias = "posix_fallocate")]
 pub fn fallocate<Fd: AsFd>(fd: &Fd, mode: FallocateFlags, offset: u64, len: u64) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fallocate(fd, mode, offset, len)
+    imp::fs::syscalls::fallocate(fd.as_fd(), mode, offset, len)
 }
 
 /// `fcntl(fd, F_GETFL) & O_ACCMODE`
@@ -179,8 +171,7 @@ pub fn fallocate<Fd: AsFd>(fd: &Fd, mode: FallocateFlags, offset: u64, len: u64)
 /// general I/O handle support, use [`io::is_read_write`].
 #[inline]
 pub fn is_file_read_write<Fd: AsFd>(fd: &Fd) -> io::Result<(bool, bool)> {
-    let fd = fd.as_fd();
-    _is_file_read_write(fd)
+    _is_file_read_write(fd.as_fd())
 }
 
 pub(crate) fn _is_file_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
@@ -222,8 +213,7 @@ pub(crate) fn _is_file_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)
 /// [`fcntl_fullfsync`]: https://docs.rs/rustix/*/x86_64-apple-darwin/rustix/fs/fn.fcntl_fullfsync.html
 #[inline]
 pub fn fsync<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fsync(fd)
+    imp::fs::syscalls::fsync(fd.as_fd())
 }
 
 /// `fdatasync(fd)`—Ensures that file data is written to the underlying
@@ -243,8 +233,7 @@ pub fn fsync<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
 )))]
 #[inline]
 pub fn fdatasync<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::fdatasync(fd)
+    imp::fs::syscalls::fdatasync(fd.as_fd())
 }
 
 /// `ftruncate(fd, length)`—Sets the length of a file.
@@ -257,8 +246,7 @@ pub fn fdatasync<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/ftruncate.2.html
 #[inline]
 pub fn ftruncate<Fd: AsFd>(fd: &Fd, length: u64) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::ftruncate(fd, length)
+    imp::fs::syscalls::ftruncate(fd.as_fd(), length)
 }
 
 /// `flock(fd, operation)`—Acquire or release an advisory lock on an open file.
@@ -270,6 +258,5 @@ pub fn ftruncate<Fd: AsFd>(fd: &Fd, length: u64) -> io::Result<()> {
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 pub fn flock<Fd: AsFd>(fd: &Fd, operation: FlockOperation) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::flock(fd, operation)
+    imp::fs::syscalls::flock(fd.as_fd(), operation)
 }

--- a/src/fs/getpath.rs
+++ b/src/fs/getpath.rs
@@ -10,6 +10,5 @@ use imp::fd::AsFd;
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html
 #[inline]
 pub fn getpath<Fd: AsFd>(fd: &Fd) -> io::Result<ZString> {
-    let fd = fd.as_fd();
-    imp::fs::syscalls::getpath(fd)
+    imp::fs::syscalls::getpath(fd.as_fd())
 }

--- a/src/fs/openat2.rs
+++ b/src/fs/openat2.rs
@@ -17,6 +17,7 @@ pub fn openat2<Fd: AsFd, P: path::Arg>(
     mode: Mode,
     resolve: ResolveFlags,
 ) -> io::Result<OwnedFd> {
-    let dirfd = dirfd.as_fd();
-    path.into_with_z_str(|path| imp::fs::syscalls::openat2(dirfd, path, oflags, mode, resolve))
+    path.into_with_z_str(|path| {
+        imp::fs::syscalls::openat2(dirfd.as_fd(), path, oflags, mode, resolve)
+    })
 }

--- a/src/fs/sendfile.rs
+++ b/src/fs/sendfile.rs
@@ -15,7 +15,5 @@ pub fn sendfile<OutFd: AsFd, InFd: AsFd>(
     offset: Option<&mut u64>,
     count: usize,
 ) -> io::Result<usize> {
-    let out_fd = out_fd.as_fd();
-    let in_fd = in_fd.as_fd();
-    imp::fs::syscalls::sendfile(out_fd, in_fd, offset, count)
+    imp::fs::syscalls::sendfile(out_fd.as_fd(), in_fd.as_fd(), offset, count)
 }

--- a/src/fs/statx.rs
+++ b/src/fs/statx.rs
@@ -23,6 +23,5 @@ pub fn statx<P: path::Arg, Fd: AsFd>(
     flags: AtFlags,
     mask: StatxFlags,
 ) -> io::Result<Statx> {
-    let dirfd = dirfd.as_fd();
-    path.into_with_z_str(|path| imp::fs::syscalls::statx(dirfd, path, flags, mask))
+    path.into_with_z_str(|path| imp::fs::syscalls::statx(dirfd.as_fd(), path, flags, mask))
 }

--- a/src/imp/libc/net/addr.rs
+++ b/src/imp/libc/net/addr.rs
@@ -9,6 +9,7 @@ use crate::ffi::ZStr;
 use crate::io;
 #[cfg(not(windows))]
 use crate::path;
+#[cfg(not(windows))]
 use core::convert::TryInto;
 #[cfg(not(windows))]
 use core::fmt;

--- a/src/imp/libc/net/mod.rs
+++ b/src/imp/libc/net/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod syscalls;
 pub use addr::SocketAddrStorage;
 #[cfg(not(windows))]
 pub use addr::SocketAddrUnix;
-pub(crate) use read_sockaddr::{read_sockaddr, read_sockaddr_os};
+pub(crate) use read_sockaddr::{maybe_read_sockaddr_os, read_sockaddr, read_sockaddr_os};
 pub use send_recv::{RecvFlags, SendFlags};
 pub use types::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType, Timeout};
 pub(crate) use write_sockaddr::{encode_sockaddr_v4, encode_sockaddr_v6, write_sockaddr};

--- a/src/imp/libc/net/mod.rs
+++ b/src/imp/libc/net/mod.rs
@@ -12,7 +12,9 @@ pub(crate) mod syscalls;
 pub use addr::SocketAddrStorage;
 #[cfg(not(windows))]
 pub use addr::SocketAddrUnix;
-pub(crate) use read_sockaddr::{maybe_read_sockaddr_os, read_sockaddr, read_sockaddr_os};
+pub(crate) use read_sockaddr::{
+    initialize_family_to_unspec, maybe_read_sockaddr_os, read_sockaddr, read_sockaddr_os,
+};
 pub use send_recv::{RecvFlags, SendFlags};
 pub use types::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType, Timeout};
 pub(crate) use write_sockaddr::{encode_sockaddr_v4, encode_sockaddr_v6, write_sockaddr};

--- a/src/imp/libc/net/read_sockaddr.rs
+++ b/src/imp/libc/net/read_sockaddr.rs
@@ -160,6 +160,17 @@ pub(crate) unsafe fn read_sockaddr(
     }
 }
 
+pub(crate) unsafe fn maybe_read_sockaddr_os(
+    storage: *const c::sockaddr_storage,
+    len: usize,
+) -> Option<SocketAddrAny> {
+    if len == 0 {
+        None
+    } else {
+        Some(read_sockaddr_os(storage, len))
+    }
+}
+
 pub(crate) unsafe fn read_sockaddr_os(
     storage: *const c::sockaddr_storage,
     len: usize,

--- a/src/imp/libc/net/read_sockaddr.rs
+++ b/src/imp/libc/net/read_sockaddr.rs
@@ -81,6 +81,12 @@ unsafe fn read_ss_family(storage: *const c::sockaddr_storage) -> u16 {
     (*storage.cast::<sockaddr_header>()).ss_family.into()
 }
 
+/// Set the `ss_family` field of a socket address to `AF_UNSPEC`, so that we
+/// can test for `AF_UNSPEC` to test whether it was stored to.
+pub(crate) unsafe fn initialize_family_to_unspec(storage: *mut c::sockaddr_storage) {
+    (*storage.cast::<sockaddr_header>()).ss_family = c::AF_UNSPEC as _;
+}
+
 pub(crate) unsafe fn read_sockaddr(
     storage: *const c::sockaddr_storage,
     len: usize,

--- a/src/imp/libc/net/read_sockaddr.rs
+++ b/src/imp/libc/net/read_sockaddr.rs
@@ -16,26 +16,29 @@ use core::mem::size_of;
 #[repr(C)]
 struct sockaddr_header {
     #[cfg(any(
-        target_os = "netbsd",
-        target_os = "macos",
-        target_os = "ios",
+        target_os = "dragonfly",
         target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
         target_os = "openbsd"
     ))]
     sa_len: u8,
     #[cfg(any(
-        target_os = "netbsd",
-        target_os = "macos",
-        target_os = "ios",
+        target_os = "dragonfly",
         target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
         target_os = "openbsd"
     ))]
     ss_family: u8,
     #[cfg(not(any(
-        target_os = "netbsd",
-        target_os = "macos",
-        target_os = "ios",
+        target_os = "dragonfly",
         target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
         target_os = "openbsd"
     )))]
     ss_family: u16,
@@ -56,17 +59,17 @@ unsafe fn read_ss_family(storage: *const c::sockaddr_storage) -> u16 {
         sa_len: 0_u8,
         #[cfg(any(
             target_os = "dragonfly",
-            target_os = "ios",
             target_os = "freebsd",
+            target_os = "ios",
             target_os = "macos",
             target_os = "netbsd",
-            target_os = "openbsd"
+            target_os = "openbsd",
         ))]
         sa_family: 0_u8,
         #[cfg(not(any(
             target_os = "dragonfly",
-            target_os = "ios",
             target_os = "freebsd",
+            target_os = "ios",
             target_os = "macos",
             target_os = "netbsd",
             target_os = "openbsd"

--- a/src/imp/linux_raw/net/mod.rs
+++ b/src/imp/linux_raw/net/mod.rs
@@ -6,7 +6,9 @@ mod write_sockaddr;
 
 pub(crate) mod ext;
 pub(crate) mod syscalls;
-pub(crate) use read_sockaddr::{maybe_read_sockaddr_os, read_sockaddr, read_sockaddr_os};
+pub(crate) use read_sockaddr::{
+    initialize_family_to_unspec, maybe_read_sockaddr_os, read_sockaddr, read_sockaddr_os,
+};
 pub(crate) use write_sockaddr::{encode_sockaddr_v4, encode_sockaddr_v6, write_sockaddr};
 
 pub use addr::{SocketAddrStorage, SocketAddrUnix};

--- a/src/imp/linux_raw/net/mod.rs
+++ b/src/imp/linux_raw/net/mod.rs
@@ -6,7 +6,7 @@ mod write_sockaddr;
 
 pub(crate) mod ext;
 pub(crate) mod syscalls;
-pub(crate) use read_sockaddr::{read_sockaddr, read_sockaddr_os};
+pub(crate) use read_sockaddr::{maybe_read_sockaddr_os, read_sockaddr, read_sockaddr_os};
 pub(crate) use write_sockaddr::{encode_sockaddr_v4, encode_sockaddr_v6, write_sockaddr};
 
 pub use addr::{SocketAddrStorage, SocketAddrUnix};

--- a/src/imp/linux_raw/net/read_sockaddr.rs
+++ b/src/imp/linux_raw/net/read_sockaddr.rs
@@ -38,6 +38,13 @@ unsafe fn read_ss_family(storage: *const sockaddr) -> u16 {
     (*storage.cast::<sockaddr_header>()).ss_family
 }
 
+/// Set the `ss_family` field of a socket address to `AF_UNSPEC`, so that we
+/// can test for `AF_UNSPEC` to test whether it was stored to.
+#[inline]
+pub(crate) unsafe fn initialize_family_to_unspec(storage: *mut sockaddr) {
+    (*storage.cast::<sockaddr_header>()).ss_family = linux_raw_sys::general::AF_UNSPEC as _;
+}
+
 /// Read a socket address encoded in a platform-specific format.
 ///
 /// # Safety

--- a/src/imp/linux_raw/net/read_sockaddr.rs
+++ b/src/imp/linux_raw/net/read_sockaddr.rs
@@ -104,6 +104,22 @@ pub(crate) unsafe fn read_sockaddr(
 /// # Safety
 ///
 /// `storage` must point to a valid socket address returned from the OS.
+pub(crate) unsafe fn maybe_read_sockaddr_os(
+    storage: *const sockaddr,
+    len: usize,
+) -> Option<SocketAddrAny> {
+    if len == 0 {
+        None
+    } else {
+        Some(read_sockaddr_os(storage, len))
+    }
+}
+
+/// Read a socket address returned from the OS.
+///
+/// # Safety
+///
+/// `storage` must point to a valid socket address returned from the OS.
 pub(crate) unsafe fn read_sockaddr_os(storage: *const sockaddr, len: usize) -> SocketAddrAny {
     let z = linux_raw_sys::general::sockaddr_un {
         sun_family: 0_u16,

--- a/src/io/dup.rs
+++ b/src/io/dup.rs
@@ -28,8 +28,7 @@ pub use imp::io::DupFlags;
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 pub fn dup<Fd: AsFd>(fd: &Fd) -> io::Result<OwnedFd> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::dup(fd)
+    imp::io::syscalls::dup(fd.as_fd())
 }
 
 /// `dup2(fd, new)`—Creates a new `OwnedFd` instance that shares the
@@ -50,8 +49,7 @@ pub fn dup<Fd: AsFd>(fd: &Fd) -> io::Result<OwnedFd> {
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 pub fn dup2<Fd: AsFd>(fd: &Fd, new: &OwnedFd) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::dup2(fd, new)
+    imp::io::syscalls::dup2(fd.as_fd(), new)
 }
 
 /// `dup3(fd, new, flags)`—Creates a new `OwnedFd` instance that shares the
@@ -71,6 +69,5 @@ pub fn dup2<Fd: AsFd>(fd: &Fd, new: &OwnedFd) -> io::Result<()> {
 #[inline]
 #[doc(alias = "dup3")]
 pub fn dup2_with<Fd: AsFd>(fd: &Fd, new: &OwnedFd, flags: DupFlags) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::dup2_with(fd, new, flags)
+    imp::io::syscalls::dup2_with(fd.as_fd(), new, flags)
 }

--- a/src/io/ioctl.rs
+++ b/src/io/ioctl.rs
@@ -25,8 +25,7 @@ use imp::fd::AsFd;
 #[doc(alias = "tcgetattr")]
 #[doc(alias = "TCGETS")]
 pub fn ioctl_tcgets<Fd: AsFd>(fd: &Fd) -> io::Result<Termios> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::ioctl_tcgets(fd)
+    imp::io::syscalls::ioctl_tcgets(fd.as_fd())
 }
 
 /// `ioctl(fd, FIOCLEX)`—Set the close-on-exec flag.
@@ -37,8 +36,7 @@ pub fn ioctl_tcgets<Fd: AsFd>(fd: &Fd) -> io::Result<Termios> {
 #[doc(alias = "FIOCLEX")]
 #[doc(alias = "FD_CLOEXEC")]
 pub fn ioctl_fioclex<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::ioctl_fioclex(fd)
+    imp::io::syscalls::ioctl_fioclex(fd.as_fd())
 }
 
 /// `ioctl(fd, TIOCGWINSZ)`—Get the current terminal window size.
@@ -51,16 +49,14 @@ pub fn ioctl_fioclex<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
 #[inline]
 #[doc(alias = "TIOCGWINSZ")]
 pub fn ioctl_tiocgwinsz<Fd: AsFd>(fd: &Fd) -> io::Result<Winsize> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::ioctl_tiocgwinsz(fd)
+    imp::io::syscalls::ioctl_tiocgwinsz(fd.as_fd())
 }
 
 /// `ioctl(fd, FIONBIO, &value)`—Enables or disables non-blocking mode.
 #[inline]
 #[doc(alias = "FIONBIO")]
 pub fn ioctl_fionbio<Fd: AsFd>(fd: &Fd, value: bool) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::ioctl_fionbio(fd, value)
+    imp::io::syscalls::ioctl_fionbio(fd.as_fd(), value)
 }
 
 /// `ioctl(fd, TIOCEXCL)`—Enables exclusive mode on a terminal.
@@ -76,8 +72,7 @@ pub fn ioctl_fionbio<Fd: AsFd>(fd: &Fd, value: bool) -> io::Result<()> {
 #[inline]
 #[doc(alias = "TIOCEXCL")]
 pub fn ioctl_tiocexcl<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::ioctl_tiocexcl(fd)
+    imp::io::syscalls::ioctl_tiocexcl(fd.as_fd())
 }
 
 /// `ioctl(fd, TIOCNXCL)`—Disables exclusive mode on a terminal.
@@ -93,8 +88,7 @@ pub fn ioctl_tiocexcl<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
 #[inline]
 #[doc(alias = "TIOCNXCL")]
 pub fn ioctl_tiocnxcl<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::ioctl_tiocnxcl(fd)
+    imp::io::syscalls::ioctl_tiocnxcl(fd.as_fd())
 }
 
 /// `ioctl(fd, FIONREAD)`—Returns the number of bytes ready to be read.
@@ -110,8 +104,7 @@ pub fn ioctl_tiocnxcl<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
 #[inline]
 #[doc(alias = "FIONREAD")]
 pub fn ioctl_fionread<Fd: AsFd>(fd: &Fd) -> io::Result<u64> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::ioctl_fionread(fd)
+    imp::io::syscalls::ioctl_fionread(fd.as_fd())
 }
 
 /// `ioctl(fd, BLKSSZGET)`—Returns the logical block size of a block device.
@@ -119,8 +112,7 @@ pub fn ioctl_fionread<Fd: AsFd>(fd: &Fd) -> io::Result<u64> {
 #[inline]
 #[doc(alias = "BLKSSZGET")]
 pub fn ioctl_blksszget<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::ioctl_blksszget(fd)
+    imp::io::syscalls::ioctl_blksszget(fd.as_fd())
 }
 
 /// `ioctl(fd, BLKPBSZGET)`—Returns the physical block size of a block device.
@@ -128,6 +120,5 @@ pub fn ioctl_blksszget<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
 #[inline]
 #[doc(alias = "BLKPBSZGET")]
 pub fn ioctl_blkpbszget<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::ioctl_blkpbszget(fd)
+    imp::io::syscalls::ioctl_blkpbszget(fd.as_fd())
 }

--- a/src/io/is_read_write.rs
+++ b/src/io/is_read_write.rs
@@ -12,6 +12,5 @@ use imp::fd::AsFd;
 /// [`is_file_read_write`]: crate::fs::is_file_read_write
 #[inline]
 pub fn is_read_write<Fd: AsFd>(fd: &Fd) -> io::Result<(bool, bool)> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::is_read_write(fd)
+    imp::io::syscalls::is_read_write(fd.as_fd())
 }

--- a/src/io/mmap.rs
+++ b/src/io/mmap.rs
@@ -41,8 +41,7 @@ pub unsafe fn mmap<Fd: AsFd>(
     fd: &Fd,
     offset: u64,
 ) -> io::Result<*mut c_void> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::mmap(ptr, len, prot, flags, fd, offset)
+    imp::io::syscalls::mmap(ptr, len, prot, flags, fd.as_fd(), offset)
 }
 
 /// `mmap(ptr, len, prot, MAP_ANONYMOUS | flags, -1, 0)`—Create an anonymous

--- a/src/io/procfs.rs
+++ b/src/io/procfs.rs
@@ -370,8 +370,7 @@ fn proc_self_fdinfo() -> io::Result<(BorrowedFd<'static>, &'static Stat)> {
 /// [Linux]: https://man7.org/linux/man-pages/man5/proc.5.html
 #[inline]
 pub fn proc_self_fdinfo_fd<Fd: AsFd>(fd: &Fd) -> io::Result<OwnedFd> {
-    let fd = fd.as_fd();
-    _proc_self_fdinfo(fd)
+    _proc_self_fdinfo(fd.as_fd())
 }
 
 fn _proc_self_fdinfo(fd: BorrowedFd<'_>) -> io::Result<OwnedFd> {

--- a/src/io/read_write.rs
+++ b/src/io/read_write.rs
@@ -18,8 +18,7 @@ pub use imp::io::ReadWriteFlags;
 /// [Linux]: https://man7.org/linux/man-pages/man2/read.2.html
 #[inline]
 pub fn read<Fd: AsFd>(fd: &Fd, buf: &mut [u8]) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::read(fd, buf)
+    imp::io::syscalls::read(fd.as_fd(), buf)
 }
 
 /// `write(fd, buf)`—Writes to a stream.
@@ -32,8 +31,7 @@ pub fn read<Fd: AsFd>(fd: &Fd, buf: &mut [u8]) -> io::Result<usize> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/write.2.html
 #[inline]
 pub fn write<Fd: AsFd>(fd: &Fd, buf: &[u8]) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::write(fd, buf)
+    imp::io::syscalls::write(fd.as_fd(), buf)
 }
 
 /// `pread(fd, buf, offset)`—Reads from a file at a given position.
@@ -46,8 +44,7 @@ pub fn write<Fd: AsFd>(fd: &Fd, buf: &[u8]) -> io::Result<usize> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/pread.2.html
 #[inline]
 pub fn pread<Fd: AsFd>(fd: &Fd, buf: &mut [u8], offset: u64) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::pread(fd, buf, offset)
+    imp::io::syscalls::pread(fd.as_fd(), buf, offset)
 }
 
 /// `pwrite(fd, bufs)`—Writes to a file at a given position.
@@ -60,8 +57,7 @@ pub fn pread<Fd: AsFd>(fd: &Fd, buf: &mut [u8], offset: u64) -> io::Result<usize
 /// [Linux]: https://man7.org/linux/man-pages/man2/pwrite.2.html
 #[inline]
 pub fn pwrite<Fd: AsFd>(fd: &Fd, buf: &[u8], offset: u64) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::pwrite(fd, buf, offset)
+    imp::io::syscalls::pwrite(fd.as_fd(), buf, offset)
 }
 
 /// `readv(fd, bufs)`—Reads from a stream into multiple buffers.
@@ -74,8 +70,7 @@ pub fn pwrite<Fd: AsFd>(fd: &Fd, buf: &[u8], offset: u64) -> io::Result<usize> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/readv.2.html
 #[inline]
 pub fn readv<Fd: AsFd>(fd: &Fd, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::readv(fd, bufs)
+    imp::io::syscalls::readv(fd.as_fd(), bufs)
 }
 
 /// `writev(fd, bufs)`—Writes to a stream from multiple buffers.
@@ -88,8 +83,7 @@ pub fn readv<Fd: AsFd>(fd: &Fd, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize
 /// [Linux]: https://man7.org/linux/man-pages/man2/writev.2.html
 #[inline]
 pub fn writev<Fd: AsFd>(fd: &Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::writev(fd, bufs)
+    imp::io::syscalls::writev(fd.as_fd(), bufs)
 }
 
 /// `preadv(fd, bufs, offset)`—Reads from a file at a given position into
@@ -102,8 +96,7 @@ pub fn writev<Fd: AsFd>(fd: &Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
 #[cfg(not(target_os = "redox"))]
 #[inline]
 pub fn preadv<Fd: AsFd>(fd: &Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::preadv(fd, bufs, offset)
+    imp::io::syscalls::preadv(fd.as_fd(), bufs, offset)
 }
 
 /// `pwritev(fd, bufs, offset)`—Writes to a file at a given position from
@@ -116,8 +109,7 @@ pub fn preadv<Fd: AsFd>(fd: &Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io
 #[cfg(not(target_os = "redox"))]
 #[inline]
 pub fn pwritev<Fd: AsFd>(fd: &Fd, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::pwritev(fd, bufs, offset)
+    imp::io::syscalls::pwritev(fd.as_fd(), bufs, offset)
 }
 
 /// `preadv2(fd, bufs, offset, flags)`—Reads data, with several options.
@@ -136,8 +128,7 @@ pub fn preadv2<Fd: AsFd>(
     offset: u64,
     flags: ReadWriteFlags,
 ) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::preadv2(fd, bufs, offset, flags)
+    imp::io::syscalls::preadv2(fd.as_fd(), bufs, offset, flags)
 }
 
 /// `pwritev2(fd, bufs, offset, flags)`—Writes data, with several options.
@@ -156,6 +147,5 @@ pub fn pwritev2<Fd: AsFd>(
     offset: u64,
     flags: ReadWriteFlags,
 ) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    imp::io::syscalls::pwritev2(fd, bufs, offset, flags)
+    imp::io::syscalls::pwritev2(fd.as_fd(), bufs, offset, flags)
 }

--- a/src/io/tty.rs
+++ b/src/io/tty.rs
@@ -26,8 +26,7 @@ use {
 /// [Linux]: https://man7.org/linux/man-pages/man3/isatty.3.html
 #[inline]
 pub fn isatty<Fd: AsFd>(fd: &Fd) -> bool {
-    let fd = fd.as_fd();
-    imp::io::syscalls::isatty(fd)
+    imp::io::syscalls::isatty(fd.as_fd())
 }
 
 /// `ttyname_r(fd)`
@@ -47,8 +46,7 @@ pub fn isatty<Fd: AsFd>(fd: &Fd) -> bool {
 #[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
 #[inline]
 pub fn ttyname<Fd: AsFd, B: Into<Vec<u8>>>(dirfd: &Fd, reuse: B) -> io::Result<ZString> {
-    let dirfd = dirfd.as_fd();
-    _ttyname(dirfd, reuse.into())
+    _ttyname(dirfd.as_fd(), reuse.into())
 }
 
 #[cfg(any(

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -25,7 +25,9 @@ pub mod sockopt;
 
 #[cfg(not(windows))]
 pub use send_recv::sendto_unix;
-pub use send_recv::{recv, recvfrom, send, sendto_v4, sendto_v6, RecvFlags, SendFlags};
+pub use send_recv::{
+    recv, recvfrom, send, sendto, sendto_any, sendto_v4, sendto_v6, RecvFlags, SendFlags,
+};
 pub use socket::{
     accept, accept_with, acceptfrom, acceptfrom_with, bind, bind_any, bind_v4, bind_v6, connect,
     connect_any, connect_v4, connect_v6, getpeername, getsockname, listen, shutdown, socket,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -27,9 +27,9 @@ pub mod sockopt;
 pub use send_recv::sendto_unix;
 pub use send_recv::{recv, recvfrom, send, sendto_v4, sendto_v6, RecvFlags, SendFlags};
 pub use socket::{
-    accept, accept_with, acceptfrom, acceptfrom_with, bind_v4, bind_v6, connect_v4, connect_v6,
-    getpeername, getsockname, listen, shutdown, socket, socket_with, AcceptFlags, AddressFamily,
-    Protocol, Shutdown, SocketFlags, SocketType,
+    accept, accept_with, acceptfrom, acceptfrom_with, bind_v4, bind_v6, connect, connect_any,
+    connect_v4, connect_v6, getpeername, getsockname, listen, shutdown, socket, socket_with,
+    AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType,
 };
 #[cfg(not(windows))]
 pub use socket::{bind_unix, connect_unix};

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -27,9 +27,9 @@ pub mod sockopt;
 pub use send_recv::sendto_unix;
 pub use send_recv::{recv, recvfrom, send, sendto_v4, sendto_v6, RecvFlags, SendFlags};
 pub use socket::{
-    accept, accept_with, acceptfrom, acceptfrom_with, bind_v4, bind_v6, connect, connect_any,
-    connect_v4, connect_v6, getpeername, getsockname, listen, shutdown, socket, socket_with,
-    AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType,
+    accept, accept_with, acceptfrom, acceptfrom_with, bind, bind_any, bind_v4, bind_v6, connect,
+    connect_any, connect_v4, connect_v6, getpeername, getsockname, listen, shutdown, socket,
+    socket_with, AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType,
 };
 #[cfg(not(windows))]
 pub use socket::{bind_unix, connect_unix};

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -51,4 +51,4 @@ pub use addr::{SocketAddr, SocketAddrV4, SocketAddrV6};
 #[cfg(not(feature = "std"))]
 pub use ip::{IpAddr, Ipv4Addr, Ipv6Addr, Ipv6MulticastScope};
 #[cfg(feature = "std")]
-pub use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
+pub use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};

--- a/src/net/send_recv.rs
+++ b/src/net/send_recv.rs
@@ -20,8 +20,7 @@ pub use imp::net::{RecvFlags, SendFlags};
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-recv
 #[inline]
 pub fn recv<Fd: AsFd>(fd: &Fd, buf: &mut [u8], flags: RecvFlags) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::recv(fd, buf, flags)
+    imp::net::syscalls::recv(fd.as_fd(), buf, flags)
 }
 
 /// `send(fd, buf, flags)`—Writes data to a socket.
@@ -36,8 +35,7 @@ pub fn recv<Fd: AsFd>(fd: &Fd, buf: &mut [u8], flags: RecvFlags) -> io::Result<u
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send
 #[inline]
 pub fn send<Fd: AsFd>(fd: &Fd, buf: &[u8], flags: SendFlags) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::send(fd, buf, flags)
+    imp::net::syscalls::send(fd.as_fd(), buf, flags)
 }
 
 /// `recvfrom(fd, buf, flags, addr, len)`—Reads data from a socket and
@@ -57,8 +55,7 @@ pub fn recvfrom<Fd: AsFd>(
     buf: &mut [u8],
     flags: RecvFlags,
 ) -> io::Result<(usize, Option<SocketAddrAny>)> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::recvfrom(fd, buf, flags)
+    imp::net::syscalls::recvfrom(fd.as_fd(), buf, flags)
 }
 
 /// `sendto(fd, buf, flags, addr)`—Writes data to a socket to a specific IP
@@ -76,8 +73,7 @@ pub fn sendto<Fd: AsFd>(
     flags: SendFlags,
     addr: &SocketAddr,
 ) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    _sendto(fd, buf, flags, addr)
+    _sendto(fd.as_fd(), buf, flags, addr)
 }
 
 fn _sendto(
@@ -107,8 +103,7 @@ pub fn sendto_any<Fd: AsFd>(
     flags: SendFlags,
     addr: &SocketAddrAny,
 ) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    _sendto_any(fd, buf, flags, addr)
+    _sendto_any(fd.as_fd(), buf, flags, addr)
 }
 
 fn _sendto_any(
@@ -144,8 +139,7 @@ pub fn sendto_v4<Fd: AsFd>(
     flags: SendFlags,
     addr: &SocketAddrV4,
 ) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sendto_v4(fd, buf, flags, addr)
+    imp::net::syscalls::sendto_v4(fd.as_fd(), buf, flags, addr)
 }
 
 /// `sendto(fd, buf, flags, addr, sizeof(struct sockaddr_in6))`—Writes data
@@ -167,8 +161,7 @@ pub fn sendto_v6<Fd: AsFd>(
     flags: SendFlags,
     addr: &SocketAddrV6,
 ) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sendto_v6(fd, buf, flags, addr)
+    imp::net::syscalls::sendto_v6(fd.as_fd(), buf, flags, addr)
 }
 
 /// `sendto(fd, buf, flags, addr, sizeof(struct sockaddr_un))`—Writes data to
@@ -191,8 +184,7 @@ pub fn sendto_unix<Fd: AsFd>(
     flags: SendFlags,
     addr: &SocketAddrUnix,
 ) -> io::Result<usize> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sendto_unix(fd, buf, flags, addr)
+    imp::net::syscalls::sendto_unix(fd.as_fd(), buf, flags, addr)
 }
 
 // TODO: `recvmsg`, `sendmsg`

--- a/src/net/send_recv.rs
+++ b/src/net/send_recv.rs
@@ -56,7 +56,7 @@ pub fn recvfrom<Fd: AsFd>(
     fd: &Fd,
     buf: &mut [u8],
     flags: RecvFlags,
-) -> io::Result<(usize, SocketAddrAny)> {
+) -> io::Result<(usize, Option<SocketAddrAny>)> {
     let fd = fd.as_fd();
     imp::net::syscalls::recvfrom(fd, buf, flags)
 }

--- a/src/net/send_recv.rs
+++ b/src/net/send_recv.rs
@@ -2,9 +2,9 @@
 
 #[cfg(not(windows))]
 use crate::net::SocketAddrUnix;
-use crate::net::{SocketAddrAny, SocketAddrV4, SocketAddrV6};
+use crate::net::{SocketAddr, SocketAddrAny, SocketAddrV4, SocketAddrV6};
 use crate::{imp, io};
-use imp::fd::AsFd;
+use imp::fd::{AsFd, BorrowedFd};
 
 pub use imp::net::{RecvFlags, SendFlags};
 
@@ -59,6 +59,70 @@ pub fn recvfrom<Fd: AsFd>(
 ) -> io::Result<(usize, SocketAddrAny)> {
     let fd = fd.as_fd();
     imp::net::syscalls::recvfrom(fd, buf, flags)
+}
+
+/// `sendto(fd, buf, flags, addr)`—Writes data to a socket to a specific IP
+/// address.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/sendto.2.html
+pub fn sendto<Fd: AsFd>(
+    fd: &Fd,
+    buf: &[u8],
+    flags: SendFlags,
+    addr: &SocketAddr,
+) -> io::Result<usize> {
+    let fd = fd.as_fd();
+    _sendto(fd, buf, flags, addr)
+}
+
+fn _sendto(
+    fd: BorrowedFd<'_>,
+    buf: &[u8],
+    flags: SendFlags,
+    addr: &SocketAddr,
+) -> io::Result<usize> {
+    match addr {
+        SocketAddr::V4(v4) => imp::net::syscalls::sendto_v4(fd, buf, flags, v4),
+        SocketAddr::V6(v6) => imp::net::syscalls::sendto_v6(fd, buf, flags, v6),
+    }
+}
+
+/// `sendto(fd, buf, flags, addr)`—Writes data to a socket to a specific
+/// address.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/sendto.2.html
+pub fn sendto_any<Fd: AsFd>(
+    fd: &Fd,
+    buf: &[u8],
+    flags: SendFlags,
+    addr: &SocketAddrAny,
+) -> io::Result<usize> {
+    let fd = fd.as_fd();
+    _sendto_any(fd, buf, flags, addr)
+}
+
+fn _sendto_any(
+    fd: BorrowedFd<'_>,
+    buf: &[u8],
+    flags: SendFlags,
+    addr: &SocketAddrAny,
+) -> io::Result<usize> {
+    match addr {
+        SocketAddrAny::V4(v4) => imp::net::syscalls::sendto_v4(fd, buf, flags, v4),
+        SocketAddrAny::V6(v6) => imp::net::syscalls::sendto_v6(fd, buf, flags, v6),
+        #[cfg(not(windows))]
+        SocketAddrAny::Unix(unix) => imp::net::syscalls::sendto_unix(fd, buf, flags, unix),
+    }
 }
 
 /// `sendto(fd, buf, flags, addr, sizeof(struct sockaddr_in))`—Writes data to

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -336,7 +336,7 @@ pub fn accept_with<Fd: AsFd>(sockfd: &Fd, flags: AcceptFlags) -> io::Result<Owne
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept
 #[inline]
 #[doc(alias = "accept4")]
-pub fn acceptfrom<Fd: AsFd>(sockfd: &Fd) -> io::Result<(OwnedFd, SocketAddrAny)> {
+pub fn acceptfrom<Fd: AsFd>(sockfd: &Fd) -> io::Result<(OwnedFd, Option<SocketAddrAny>)> {
     let sockfd = sockfd.as_fd();
     imp::net::syscalls::acceptfrom(sockfd)
 }
@@ -362,7 +362,7 @@ pub fn acceptfrom<Fd: AsFd>(sockfd: &Fd) -> io::Result<(OwnedFd, SocketAddrAny)>
 pub fn acceptfrom_with<Fd: AsFd>(
     sockfd: &Fd,
     flags: AcceptFlags,
-) -> io::Result<(OwnedFd, SocketAddrAny)> {
+) -> io::Result<(OwnedFd, Option<SocketAddrAny>)> {
     let sockfd = sockfd.as_fd();
     imp::net::syscalls::acceptfrom_with(sockfd, flags)
 }
@@ -411,7 +411,7 @@ pub fn getsockname<Fd: AsFd>(sockfd: &Fd) -> io::Result<SocketAddrAny> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/getpeername.2.html
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getpeername
 #[inline]
-pub fn getpeername<Fd: AsFd>(sockfd: &Fd) -> io::Result<SocketAddrAny> {
+pub fn getpeername<Fd: AsFd>(sockfd: &Fd) -> io::Result<Option<SocketAddrAny>> {
     let sockfd = sockfd.as_fd();
     imp::net::syscalls::getpeername(sockfd)
 }

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -70,8 +70,7 @@ pub fn socket_with(
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/bind.2.html
 pub fn bind<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddr) -> io::Result<()> {
-    let sockfd = sockfd.as_fd();
-    _bind(sockfd, addr)
+    _bind(sockfd.as_fd(), addr)
 }
 
 fn _bind(sockfd: BorrowedFd<'_>, addr: &SocketAddr) -> io::Result<()> {
@@ -91,8 +90,7 @@ fn _bind(sockfd: BorrowedFd<'_>, addr: &SocketAddr) -> io::Result<()> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/bind.2.html
 #[doc(alias = "bind")]
 pub fn bind_any<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrAny) -> io::Result<()> {
-    let sockfd = sockfd.as_fd();
-    _bind_any(sockfd, addr)
+    _bind_any(sockfd.as_fd(), addr)
 }
 
 fn _bind_any(sockfd: BorrowedFd<'_>, addr: &SocketAddrAny) -> io::Result<()> {
@@ -118,8 +116,7 @@ fn _bind_any(sockfd: BorrowedFd<'_>, addr: &SocketAddrAny) -> io::Result<()> {
 #[inline]
 #[doc(alias = "bind")]
 pub fn bind_v4<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV4) -> io::Result<()> {
-    let sockfd = sockfd.as_fd();
-    imp::net::syscalls::bind_v4(sockfd, addr)
+    imp::net::syscalls::bind_v4(sockfd.as_fd(), addr)
 }
 
 /// `bind(sockfd, addr, sizeof(struct sockaddr_in6))`—Binds a socket to an
@@ -136,8 +133,7 @@ pub fn bind_v4<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV4) -> io::Result<()> {
 #[inline]
 #[doc(alias = "bind")]
 pub fn bind_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> {
-    let sockfd = sockfd.as_fd();
-    imp::net::syscalls::bind_v6(sockfd, addr)
+    imp::net::syscalls::bind_v6(sockfd.as_fd(), addr)
 }
 
 /// `bind(sockfd, addr, sizeof(struct sockaddr_un))`—Binds a socket to a
@@ -155,8 +151,7 @@ pub fn bind_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> {
 #[doc(alias = "bind")]
 #[cfg(not(windows))]
 pub fn bind_unix<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrUnix) -> io::Result<()> {
-    let sockfd = sockfd.as_fd();
-    imp::net::syscalls::bind_unix(sockfd, addr)
+    imp::net::syscalls::bind_unix(sockfd.as_fd(), addr)
 }
 
 /// `connect(sockfd, addr)`—Initiates a connection to an IP address.
@@ -168,8 +163,7 @@ pub fn bind_unix<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrUnix) -> io::Result<()>
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/connect.2.html
 pub fn connect<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddr) -> io::Result<()> {
-    let sockfd = sockfd.as_fd();
-    _connect(sockfd, addr)
+    _connect(sockfd.as_fd(), addr)
 }
 
 fn _connect(sockfd: BorrowedFd<'_>, addr: &SocketAddr) -> io::Result<()> {
@@ -189,8 +183,7 @@ fn _connect(sockfd: BorrowedFd<'_>, addr: &SocketAddr) -> io::Result<()> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/connect.2.html
 #[doc(alias = "connect")]
 pub fn connect_any<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrAny) -> io::Result<()> {
-    let sockfd = sockfd.as_fd();
-    _connect_any(sockfd, addr)
+    _connect_any(sockfd.as_fd(), addr)
 }
 
 fn _connect_any(sockfd: BorrowedFd<'_>, addr: &SocketAddrAny) -> io::Result<()> {
@@ -216,8 +209,7 @@ fn _connect_any(sockfd: BorrowedFd<'_>, addr: &SocketAddrAny) -> io::Result<()> 
 #[inline]
 #[doc(alias = "connect")]
 pub fn connect_v4<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV4) -> io::Result<()> {
-    let sockfd = sockfd.as_fd();
-    imp::net::syscalls::connect_v4(sockfd, addr)
+    imp::net::syscalls::connect_v4(sockfd.as_fd(), addr)
 }
 
 /// `connect(sockfd, addr, sizeof(struct sockaddr_in6))`—Initiates a
@@ -234,8 +226,7 @@ pub fn connect_v4<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV4) -> io::Result<()> 
 #[inline]
 #[doc(alias = "connect")]
 pub fn connect_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> {
-    let sockfd = sockfd.as_fd();
-    imp::net::syscalls::connect_v6(sockfd, addr)
+    imp::net::syscalls::connect_v6(sockfd.as_fd(), addr)
 }
 
 /// `connect(sockfd, addr, sizeof(struct sockaddr_un))`—Initiates a
@@ -251,8 +242,7 @@ pub fn connect_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> 
 #[doc(alias = "connect")]
 #[cfg(not(windows))]
 pub fn connect_unix<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrUnix) -> io::Result<()> {
-    let sockfd = sockfd.as_fd();
-    imp::net::syscalls::connect_unix(sockfd, addr)
+    imp::net::syscalls::connect_unix(sockfd.as_fd(), addr)
 }
 
 /// `listen(fd, backlog)`—Enables listening for incoming connections.
@@ -267,8 +257,7 @@ pub fn connect_unix<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrUnix) -> io::Result<
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen
 #[inline]
 pub fn listen<Fd: AsFd>(sockfd: &Fd, backlog: i32) -> io::Result<()> {
-    let sockfd = sockfd.as_fd();
-    imp::net::syscalls::listen(sockfd, backlog)
+    imp::net::syscalls::listen(sockfd.as_fd(), backlog)
 }
 
 /// `accept(fd, NULL, NULL)`—Accepts an incoming connection.
@@ -290,8 +279,7 @@ pub fn listen<Fd: AsFd>(sockfd: &Fd, backlog: i32) -> io::Result<()> {
 #[inline]
 #[doc(alias = "accept4")]
 pub fn accept<Fd: AsFd>(sockfd: &Fd) -> io::Result<OwnedFd> {
-    let sockfd = sockfd.as_fd();
-    imp::net::syscalls::accept(sockfd)
+    imp::net::syscalls::accept(sockfd.as_fd())
 }
 
 /// `accept4(fd, NULL, NULL, flags)`—Accepts an incoming connection, with
@@ -317,8 +305,7 @@ pub fn accept<Fd: AsFd>(sockfd: &Fd) -> io::Result<OwnedFd> {
 #[inline]
 #[doc(alias = "accept4")]
 pub fn accept_with<Fd: AsFd>(sockfd: &Fd, flags: AcceptFlags) -> io::Result<OwnedFd> {
-    let sockfd = sockfd.as_fd();
-    imp::net::syscalls::accept_with(sockfd, flags)
+    imp::net::syscalls::accept_with(sockfd.as_fd(), flags)
 }
 
 /// `accept(fd, &addr, &len)`—Accepts an incoming connection and returns the
@@ -337,8 +324,7 @@ pub fn accept_with<Fd: AsFd>(sockfd: &Fd, flags: AcceptFlags) -> io::Result<Owne
 #[inline]
 #[doc(alias = "accept4")]
 pub fn acceptfrom<Fd: AsFd>(sockfd: &Fd) -> io::Result<(OwnedFd, Option<SocketAddrAny>)> {
-    let sockfd = sockfd.as_fd();
-    imp::net::syscalls::acceptfrom(sockfd)
+    imp::net::syscalls::acceptfrom(sockfd.as_fd())
 }
 
 /// `accept4(fd, &addr, &len, flags)`—Accepts an incoming connection and
@@ -363,8 +349,7 @@ pub fn acceptfrom_with<Fd: AsFd>(
     sockfd: &Fd,
     flags: AcceptFlags,
 ) -> io::Result<(OwnedFd, Option<SocketAddrAny>)> {
-    let sockfd = sockfd.as_fd();
-    imp::net::syscalls::acceptfrom_with(sockfd, flags)
+    imp::net::syscalls::acceptfrom_with(sockfd.as_fd(), flags)
 }
 
 /// `shutdown(fd, how)`—Closes the read and/or write sides of a stream.
@@ -379,8 +364,7 @@ pub fn acceptfrom_with<Fd: AsFd>(
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-shutdown
 #[inline]
 pub fn shutdown<Fd: AsFd>(sockfd: &Fd, how: Shutdown) -> io::Result<()> {
-    let sockfd = sockfd.as_fd();
-    imp::net::syscalls::shutdown(sockfd, how)
+    imp::net::syscalls::shutdown(sockfd.as_fd(), how)
 }
 
 /// `getsockname(fd, addr, len)`—Returns the address a socket is bound to.
@@ -395,8 +379,7 @@ pub fn shutdown<Fd: AsFd>(sockfd: &Fd, how: Shutdown) -> io::Result<()> {
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockname
 #[inline]
 pub fn getsockname<Fd: AsFd>(sockfd: &Fd) -> io::Result<SocketAddrAny> {
-    let sockfd = sockfd.as_fd();
-    imp::net::syscalls::getsockname(sockfd)
+    imp::net::syscalls::getsockname(sockfd.as_fd())
 }
 
 /// `getpeername(fd, addr, len)`—Returns the address a socket is connected
@@ -412,6 +395,5 @@ pub fn getsockname<Fd: AsFd>(sockfd: &Fd) -> io::Result<SocketAddrAny> {
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getpeername
 #[inline]
 pub fn getpeername<Fd: AsFd>(sockfd: &Fd) -> io::Result<Option<SocketAddrAny>> {
-    let sockfd = sockfd.as_fd();
-    imp::net::syscalls::getpeername(sockfd)
+    imp::net::syscalls::getpeername(sockfd.as_fd())
 }

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -32,8 +32,7 @@ pub use imp::net::Timeout;
 #[inline]
 #[doc(alias = "SO_TYPE")]
 pub fn get_socket_type<Fd: AsFd>(fd: &Fd) -> io::Result<SocketType> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::get_socket_type(fd)
+    imp::net::syscalls::sockopt::get_socket_type(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, value)`
@@ -55,8 +54,7 @@ pub fn get_socket_type<Fd: AsFd>(fd: &Fd) -> io::Result<SocketType> {
 #[inline]
 #[doc(alias = "SO_REUSEADDR")]
 pub fn set_socket_reuseaddr<Fd: AsFd>(fd: &Fd, value: bool) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::set_socket_reuseaddr(fd, value)
+    imp::net::syscalls::sockopt::set_socket_reuseaddr(fd.as_fd(), value)
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_BROADCAST, broadcast)`
@@ -78,8 +76,7 @@ pub fn set_socket_reuseaddr<Fd: AsFd>(fd: &Fd, value: bool) -> io::Result<()> {
 #[inline]
 #[doc(alias = "SO_BROADCAST")]
 pub fn set_socket_broadcast<Fd: AsFd>(fd: &Fd, broadcast: bool) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::set_socket_broadcast(fd, broadcast)
+    imp::net::syscalls::sockopt::set_socket_broadcast(fd.as_fd(), broadcast)
 }
 
 /// `getsockopt(fd, SOL_SOCKET, SO_BROADCAST)`
@@ -101,8 +98,7 @@ pub fn set_socket_broadcast<Fd: AsFd>(fd: &Fd, broadcast: bool) -> io::Result<()
 #[inline]
 #[doc(alias = "SO_BROADCAST")]
 pub fn get_socket_broadcast<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::get_socket_broadcast(fd)
+    imp::net::syscalls::sockopt::get_socket_broadcast(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_LINGER, linger)`
@@ -124,8 +120,7 @@ pub fn get_socket_broadcast<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
 #[inline]
 #[doc(alias = "SO_LINGER")]
 pub fn set_socket_linger<Fd: AsFd>(fd: &Fd, linger: Option<Duration>) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::set_socket_linger(fd, linger)
+    imp::net::syscalls::sockopt::set_socket_linger(fd.as_fd(), linger)
 }
 
 /// `getsockopt(fd, SOL_SOCKET, SO_LINGER)`
@@ -147,8 +142,7 @@ pub fn set_socket_linger<Fd: AsFd>(fd: &Fd, linger: Option<Duration>) -> io::Res
 #[inline]
 #[doc(alias = "SO_LINGER")]
 pub fn get_socket_linger<Fd: AsFd>(fd: &Fd) -> io::Result<Option<Duration>> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::get_socket_linger(fd)
+    imp::net::syscalls::sockopt::get_socket_linger(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_PASSCRED, passcred)`
@@ -163,8 +157,7 @@ pub fn get_socket_linger<Fd: AsFd>(fd: &Fd) -> io::Result<Option<Duration>> {
 #[inline]
 #[doc(alias = "SO_PASSCRED")]
 pub fn set_socket_passcred<Fd: AsFd>(fd: &Fd, passcred: bool) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::set_socket_passcred(fd, passcred)
+    imp::net::syscalls::sockopt::set_socket_passcred(fd.as_fd(), passcred)
 }
 
 /// `getsockopt(fd, SOL_SOCKET, SO_PASSCRED)`
@@ -179,8 +172,7 @@ pub fn set_socket_passcred<Fd: AsFd>(fd: &Fd, passcred: bool) -> io::Result<()> 
 #[inline]
 #[doc(alias = "SO_PASSCRED")]
 pub fn get_socket_passcred<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::get_socket_passcred(fd)
+    imp::net::syscalls::sockopt::get_socket_passcred(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_SOCKET, id, timeout)`—Set the sending
@@ -208,8 +200,7 @@ pub fn set_socket_timeout<Fd: AsFd>(
     id: Timeout,
     timeout: Option<Duration>,
 ) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::set_socket_timeout(fd, id, timeout)
+    imp::net::syscalls::sockopt::set_socket_timeout(fd.as_fd(), id, timeout)
 }
 
 /// `getsockopt(fd, SOL_SOCKET, id)`—Get the sending or receiving timeout.
@@ -232,8 +223,7 @@ pub fn set_socket_timeout<Fd: AsFd>(
 #[doc(alias = "SO_RCVTIMEO")]
 #[doc(alias = "SO_SNDTIMEO")]
 pub fn get_socket_timeout<Fd: AsFd>(fd: &Fd, id: Timeout) -> io::Result<Option<Duration>> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::get_socket_timeout(fd, id)
+    imp::net::syscalls::sockopt::get_socket_timeout(fd.as_fd(), id)
 }
 
 /// `setsockopt(fd, IPPROTO_IP, IP_TTL, ttl)`
@@ -254,8 +244,7 @@ pub fn get_socket_timeout<Fd: AsFd>(fd: &Fd, id: Timeout) -> io::Result<Option<D
 #[inline]
 #[doc(alias = "IP_TTL")]
 pub fn set_ip_ttl<Fd: AsFd>(fd: &Fd, ttl: u32) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::set_ip_ttl(fd, ttl)
+    imp::net::syscalls::sockopt::set_ip_ttl(fd.as_fd(), ttl)
 }
 
 /// `getsockopt(fd, IPPROTO_IP, IP_TTL)`
@@ -277,8 +266,7 @@ pub fn set_ip_ttl<Fd: AsFd>(fd: &Fd, ttl: u32) -> io::Result<()> {
 #[inline]
 #[doc(alias = "IP_TTL")]
 pub fn get_ip_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::get_ip_ttl(fd)
+    imp::net::syscalls::sockopt::get_ip_ttl(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, only_v6)`
@@ -300,8 +288,7 @@ pub fn get_ip_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
 #[inline]
 #[doc(alias = "IPV6_V6ONLY")]
 pub fn set_ipv6_v6only<Fd: AsFd>(fd: &Fd, only_v6: bool) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::set_ipv6_v6only(fd, only_v6)
+    imp::net::syscalls::sockopt::set_ipv6_v6only(fd.as_fd(), only_v6)
 }
 
 /// `getsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY)`
@@ -323,8 +310,7 @@ pub fn set_ipv6_v6only<Fd: AsFd>(fd: &Fd, only_v6: bool) -> io::Result<()> {
 #[inline]
 #[doc(alias = "IPV6_V6ONLY")]
 pub fn get_ipv6_v6only<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::get_ipv6_v6only(fd)
+    imp::net::syscalls::sockopt::get_ipv6_v6only(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_IP, IP_MULTICAST_LOOP, multicast_loop)`
@@ -346,8 +332,7 @@ pub fn get_ipv6_v6only<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
 #[inline]
 #[doc(alias = "IP_MULTICAST_LOOP")]
 pub fn set_ip_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::set_ip_multicast_loop(fd, multicast_loop)
+    imp::net::syscalls::sockopt::set_ip_multicast_loop(fd.as_fd(), multicast_loop)
 }
 
 /// `getsockopt(fd, IPPROTO_IP, IP_MULTICAST_LOOP)`
@@ -369,8 +354,7 @@ pub fn set_ip_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::Res
 #[inline]
 #[doc(alias = "IP_MULTICAST_LOOP")]
 pub fn get_ip_multicast_loop<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::get_ip_multicast_loop(fd)
+    imp::net::syscalls::sockopt::get_ip_multicast_loop(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_IP, IP_MULTICAST_TTL, multicast_ttl)`
@@ -392,8 +376,7 @@ pub fn get_ip_multicast_loop<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
 #[inline]
 #[doc(alias = "IP_MULTICAST_TTL")]
 pub fn set_ip_multicast_ttl<Fd: AsFd>(fd: &Fd, multicast_ttl: u32) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::set_ip_multicast_ttl(fd, multicast_ttl)
+    imp::net::syscalls::sockopt::set_ip_multicast_ttl(fd.as_fd(), multicast_ttl)
 }
 
 /// `getsockopt(fd, IPPROTO_IP, IP_MULTICAST_TTL)`
@@ -415,8 +398,7 @@ pub fn set_ip_multicast_ttl<Fd: AsFd>(fd: &Fd, multicast_ttl: u32) -> io::Result
 #[inline]
 #[doc(alias = "IP_MULTICAST_TTL")]
 pub fn get_ip_multicast_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::get_ip_multicast_ttl(fd)
+    imp::net::syscalls::sockopt::get_ip_multicast_ttl(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, multicast_loop)`
@@ -438,8 +420,7 @@ pub fn get_ip_multicast_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
 #[inline]
 #[doc(alias = "IPV6_MULTICAST_LOOP")]
 pub fn set_ipv6_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::set_ipv6_multicast_loop(fd, multicast_loop)
+    imp::net::syscalls::sockopt::set_ipv6_multicast_loop(fd.as_fd(), multicast_loop)
 }
 
 /// `getsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP)`
@@ -461,8 +442,7 @@ pub fn set_ipv6_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::R
 #[inline]
 #[doc(alias = "IPV6_MULTICAST_LOOP")]
 pub fn get_ipv6_multicast_loop<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::get_ipv6_multicast_loop(fd)
+    imp::net::syscalls::sockopt::get_ipv6_multicast_loop(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, multiaddr, interface)`
@@ -488,8 +468,7 @@ pub fn set_ip_add_membership<Fd: AsFd>(
     multiaddr: &Ipv4Addr,
     interface: &Ipv4Addr,
 ) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::set_ip_add_membership(fd, multiaddr, interface)
+    imp::net::syscalls::sockopt::set_ip_add_membership(fd.as_fd(), multiaddr, interface)
 }
 
 /// `setsockopt(fd, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, multiaddr, interface)`
@@ -518,8 +497,7 @@ pub fn set_ipv6_add_membership<Fd: AsFd>(
     multiaddr: &Ipv6Addr,
     interface: u32,
 ) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::set_ipv6_add_membership(fd, multiaddr, interface)
+    imp::net::syscalls::sockopt::set_ipv6_add_membership(fd.as_fd(), multiaddr, interface)
 }
 
 /// `setsockopt(fd, IPPROTO_IP, IP_DROP_MEMBERSHIP, multiaddr, interface)`
@@ -545,8 +523,7 @@ pub fn set_ip_drop_membership<Fd: AsFd>(
     multiaddr: &Ipv4Addr,
     interface: &Ipv4Addr,
 ) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::set_ip_drop_membership(fd, multiaddr, interface)
+    imp::net::syscalls::sockopt::set_ip_drop_membership(fd.as_fd(), multiaddr, interface)
 }
 
 /// `setsockopt(fd, IPPROTO_IPV6, IPV6_DROP_MEMBERSHIP, multiaddr, interface)`
@@ -575,8 +552,7 @@ pub fn set_ipv6_drop_membership<Fd: AsFd>(
     multiaddr: &Ipv6Addr,
     interface: u32,
 ) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::set_ipv6_drop_membership(fd, multiaddr, interface)
+    imp::net::syscalls::sockopt::set_ipv6_drop_membership(fd.as_fd(), multiaddr, interface)
 }
 
 /// `setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, nodelay)`
@@ -598,8 +574,7 @@ pub fn set_ipv6_drop_membership<Fd: AsFd>(
 #[inline]
 #[doc(alias = "TCP_NODELAY")]
 pub fn set_tcp_nodelay<Fd: AsFd>(fd: &Fd, nodelay: bool) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::set_tcp_nodelay(fd, nodelay)
+    imp::net::syscalls::sockopt::set_tcp_nodelay(fd.as_fd(), nodelay)
 }
 
 /// `getsockopt(fd, IPPROTO_TCP, TCP_NODELAY)`
@@ -621,6 +596,5 @@ pub fn set_tcp_nodelay<Fd: AsFd>(fd: &Fd, nodelay: bool) -> io::Result<()> {
 #[inline]
 #[doc(alias = "TCP_NODELAY")]
 pub fn get_tcp_nodelay<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
-    let fd = fd.as_fd();
-    imp::net::syscalls::sockopt::get_tcp_nodelay(fd)
+    imp::net::syscalls::sockopt::get_tcp_nodelay(fd.as_fd())
 }

--- a/src/process/chdir.rs
+++ b/src/process/chdir.rs
@@ -29,8 +29,7 @@ pub fn chdir<P: path::Arg>(path: P) -> io::Result<()> {
 #[cfg(not(target_os = "fuchsia"))]
 #[inline]
 pub fn fchdir<Fd: AsFd>(fd: Fd) -> io::Result<()> {
-    let fd = fd.as_fd();
-    imp::process::syscalls::fchdir(fd)
+    imp::process::syscalls::fchdir(fd.as_fd())
 }
 
 /// `getcwd()`

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -244,8 +244,7 @@ pub unsafe fn execveat<Fd: AsFd>(
     envp: *const *const u8,
     flags: AtFlags,
 ) -> io::Error {
-    let dirfd = dirfd.as_fd();
-    imp::syscalls::execveat(dirfd, path, argv, envp, flags)
+    imp::syscalls::execveat(dirfd.as_fd(), path, argv, envp, flags)
 }
 
 /// `execve(path.as_z_str(), argv, envp)`—Execute a new command using the

--- a/tests/net/connect_bind_send.rs
+++ b/tests/net/connect_bind_send.rs
@@ -1,0 +1,487 @@
+use rustix::net::{
+    AddressFamily, Ipv6Addr, Protocol, RecvFlags, SendFlags, SocketAddrAny, SocketAddrV4,
+    SocketAddrV6, SocketType,
+};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+// Test `connect_any`.
+#[test]
+fn net_v4_connect_any() -> std::io::Result<()> {
+    let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    let addr = SocketAddr::new(localhost, 0);
+    let listener =
+        rustix::net::socket(AddressFamily::INET, SocketType::STREAM, Protocol::default())?;
+    rustix::net::bind(&listener, &addr).expect("bind");
+    rustix::net::listen(&listener, 1).expect("listen");
+
+    let local_addr = rustix::net::getsockname(&listener)?;
+    let sender = rustix::net::socket(AddressFamily::INET, SocketType::STREAM, Protocol::default())?;
+    rustix::net::connect_any(&sender, &local_addr).expect("connect");
+    let request = b"Hello, World!!!";
+    let n = rustix::net::send(&sender, request, SendFlags::empty()).expect("send");
+    drop(sender);
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    let accepted = rustix::net::accept(&listener).expect("accept");
+    let mut response = [0u8; 128];
+    let n = rustix::net::recv(&accepted, &mut response, RecvFlags::empty()).expect("recv");
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    assert_eq!(request, &response[..n]);
+
+    Ok(())
+}
+
+// Similar, but with V6.
+#[test]
+fn net_v6_connect_any() -> std::io::Result<()> {
+    let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
+    let addr = SocketAddr::new(localhost, 0);
+    let listener = rustix::net::socket(
+        AddressFamily::INET6,
+        SocketType::STREAM,
+        Protocol::default(),
+    )?;
+    rustix::net::bind(&listener, &addr).expect("bind");
+    rustix::net::listen(&listener, 1).expect("listen");
+
+    let local_addr = rustix::net::getsockname(&listener)?;
+    let sender = rustix::net::socket(
+        AddressFamily::INET6,
+        SocketType::STREAM,
+        Protocol::default(),
+    )?;
+    rustix::net::connect_any(&sender, &local_addr).expect("connect");
+    let request = b"Hello, World!!!";
+    let n = rustix::net::send(&sender, request, SendFlags::empty()).expect("send");
+    drop(sender);
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    let accepted = rustix::net::accept(&listener).expect("accept");
+    let mut response = [0u8; 128];
+    let n = rustix::net::recv(&accepted, &mut response, RecvFlags::empty()).expect("recv");
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    assert_eq!(request, &response[..n]);
+
+    Ok(())
+}
+
+// Test `connect` with a `SocketAddr`.
+#[test]
+fn net_v4_connect() -> std::io::Result<()> {
+    let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    let addr = SocketAddr::new(localhost, 0);
+    let listener =
+        rustix::net::socket(AddressFamily::INET, SocketType::STREAM, Protocol::default())?;
+    rustix::net::bind(&listener, &addr).expect("bind");
+    rustix::net::listen(&listener, 1).expect("listen");
+
+    let local_addr = rustix::net::getsockname(&listener)?;
+    let local_addr = match local_addr {
+        SocketAddrAny::V4(v4) => SocketAddr::V4(v4),
+        other => panic!("unexpected socket address {:?}", other),
+    };
+    let sender = rustix::net::socket(AddressFamily::INET, SocketType::STREAM, Protocol::default())?;
+    rustix::net::connect(&sender, &local_addr).expect("connect");
+    let request = b"Hello, World!!!";
+    let n = rustix::net::send(&sender, request, SendFlags::empty()).expect("send");
+    drop(sender);
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    let accepted = rustix::net::accept(&listener).expect("accept");
+    let mut response = [0u8; 128];
+    let n = rustix::net::recv(&accepted, &mut response, RecvFlags::empty()).expect("recv");
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    assert_eq!(request, &response[..n]);
+
+    Ok(())
+}
+
+// Similar, but use V6.
+#[test]
+fn net_v6_connect() -> std::io::Result<()> {
+    let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
+    let addr = SocketAddr::new(localhost, 0);
+    let listener = rustix::net::socket(
+        AddressFamily::INET6,
+        SocketType::STREAM,
+        Protocol::default(),
+    )?;
+    rustix::net::bind(&listener, &addr).expect("bind");
+    rustix::net::listen(&listener, 1).expect("listen");
+
+    let local_addr = rustix::net::getsockname(&listener)?;
+    let local_addr = match local_addr {
+        SocketAddrAny::V6(v6) => SocketAddr::V6(v6),
+        other => panic!("unexpected socket address {:?}", other),
+    };
+    let sender = rustix::net::socket(
+        AddressFamily::INET6,
+        SocketType::STREAM,
+        Protocol::default(),
+    )?;
+    rustix::net::connect(&sender, &local_addr).expect("connect");
+    let request = b"Hello, World!!!";
+    let n = rustix::net::send(&sender, request, SendFlags::empty()).expect("send");
+    drop(sender);
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    let accepted = rustix::net::accept(&listener).expect("accept");
+    let mut response = [0u8; 128];
+    let n = rustix::net::recv(&accepted, &mut response, RecvFlags::empty()).expect("recv");
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    assert_eq!(request, &response[..n]);
+
+    Ok(())
+}
+
+// Test `bind_any`.
+#[test]
+fn net_v4_bind_any() -> std::io::Result<()> {
+    let localhost = Ipv4Addr::LOCALHOST;
+    let addr = SocketAddrAny::V4(SocketAddrV4::new(localhost, 0));
+    let listener =
+        rustix::net::socket(AddressFamily::INET, SocketType::STREAM, Protocol::default())?;
+    rustix::net::bind_any(&listener, &addr).expect("bind");
+    rustix::net::listen(&listener, 1).expect("listen");
+
+    let local_addr = rustix::net::getsockname(&listener)?;
+    let sender = rustix::net::socket(AddressFamily::INET, SocketType::STREAM, Protocol::default())?;
+    rustix::net::connect_any(&sender, &local_addr).expect("connect");
+    let request = b"Hello, World!!!";
+    let n = rustix::net::send(&sender, request, SendFlags::empty()).expect("send");
+    drop(sender);
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    let accepted = rustix::net::accept(&listener).expect("accept");
+    let mut response = [0u8; 128];
+    let n = rustix::net::recv(&accepted, &mut response, RecvFlags::empty()).expect("recv");
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    assert_eq!(request, &response[..n]);
+
+    Ok(())
+}
+
+// Similar, but use V6.
+#[test]
+fn net_v6_bind_any() -> std::io::Result<()> {
+    let localhost = Ipv6Addr::LOCALHOST;
+    let addr = SocketAddrAny::V6(SocketAddrV6::new(localhost, 0, 0, 0));
+    let listener = rustix::net::socket(
+        AddressFamily::INET6,
+        SocketType::STREAM,
+        Protocol::default(),
+    )?;
+    rustix::net::bind_any(&listener, &addr).expect("bind");
+    rustix::net::listen(&listener, 1).expect("listen");
+
+    let local_addr = rustix::net::getsockname(&listener)?;
+    let sender = rustix::net::socket(
+        AddressFamily::INET6,
+        SocketType::STREAM,
+        Protocol::default(),
+    )?;
+    rustix::net::connect_any(&sender, &local_addr).expect("connect");
+    let request = b"Hello, World!!!";
+    let n = rustix::net::send(&sender, request, SendFlags::empty()).expect("send");
+    drop(sender);
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    let accepted = rustix::net::accept(&listener).expect("accept");
+    let mut response = [0u8; 128];
+    let n = rustix::net::recv(&accepted, &mut response, RecvFlags::empty()).expect("recv");
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    assert_eq!(request, &response[..n]);
+
+    Ok(())
+}
+
+// Test `sendto`.
+#[test]
+fn net_v4_sendto() -> std::io::Result<()> {
+    let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    let addr = SocketAddr::new(localhost, 0);
+    let listener =
+        rustix::net::socket(AddressFamily::INET, SocketType::STREAM, Protocol::default())?;
+    rustix::net::bind(&listener, &addr).expect("bind");
+    rustix::net::listen(&listener, 1).expect("listen");
+
+    let local_addr = rustix::net::getsockname(&listener)?;
+    let sender = rustix::net::socket(AddressFamily::INET, SocketType::STREAM, Protocol::default())?;
+    rustix::net::connect_any(&sender, &local_addr).expect("connect");
+    let request = b"Hello, World!!!";
+    let local_addr = match local_addr {
+        SocketAddrAny::V4(v4) => SocketAddr::V4(v4),
+        other => panic!("unexpected socket address {:?}", other),
+    };
+    let n = rustix::net::sendto(&sender, request, SendFlags::empty(), &local_addr).expect("send");
+    drop(sender);
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    let accepted = rustix::net::accept(&listener).expect("accept");
+    let mut response = [0u8; 128];
+    let (n, from) =
+        rustix::net::recvfrom(&accepted, &mut response, RecvFlags::empty()).expect("recv");
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    assert_eq!(request, &response[..n]);
+    assert!(from.is_none());
+
+    Ok(())
+}
+
+// Similar, but with V6.
+#[test]
+fn net_v6_sendto() -> std::io::Result<()> {
+    let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
+    let addr = SocketAddr::new(localhost, 0);
+    let listener = rustix::net::socket(
+        AddressFamily::INET6,
+        SocketType::STREAM,
+        Protocol::default(),
+    )?;
+    rustix::net::bind(&listener, &addr).expect("bind");
+    rustix::net::listen(&listener, 1).expect("listen");
+
+    let local_addr = rustix::net::getsockname(&listener)?;
+    let sender = rustix::net::socket(
+        AddressFamily::INET6,
+        SocketType::STREAM,
+        Protocol::default(),
+    )?;
+    rustix::net::connect_any(&sender, &local_addr).expect("connect");
+    let request = b"Hello, World!!!";
+    let local_addr = match local_addr {
+        SocketAddrAny::V6(v6) => SocketAddr::V6(v6),
+        other => panic!("unexpected socket address {:?}", other),
+    };
+    let n = rustix::net::sendto(&sender, request, SendFlags::empty(), &local_addr).expect("send");
+    drop(sender);
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    let accepted = rustix::net::accept(&listener).expect("accept");
+    let mut response = [0u8; 128];
+    let (n, from) =
+        rustix::net::recvfrom(&accepted, &mut response, RecvFlags::empty()).expect("recv");
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    assert_eq!(request, &response[..n]);
+    assert!(from.is_none());
+
+    Ok(())
+}
+
+// Test `sendto_any`.
+#[test]
+fn net_v4_sendto_any() -> std::io::Result<()> {
+    let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    let addr = SocketAddr::new(localhost, 0);
+    let listener =
+        rustix::net::socket(AddressFamily::INET, SocketType::STREAM, Protocol::default())?;
+    rustix::net::bind(&listener, &addr).expect("bind");
+    rustix::net::listen(&listener, 1).expect("listen");
+
+    let local_addr = rustix::net::getsockname(&listener)?;
+    let sender = rustix::net::socket(AddressFamily::INET, SocketType::STREAM, Protocol::default())?;
+    rustix::net::connect_any(&sender, &local_addr).expect("connect");
+    let request = b"Hello, World!!!";
+    let n =
+        rustix::net::sendto_any(&sender, request, SendFlags::empty(), &local_addr).expect("send");
+    drop(sender);
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    let accepted = rustix::net::accept(&listener).expect("accept");
+    let mut response = [0u8; 128];
+    let (n, from) =
+        rustix::net::recvfrom(&accepted, &mut response, RecvFlags::empty()).expect("recv");
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    assert_eq!(request, &response[..n]);
+    assert!(from.is_none());
+
+    Ok(())
+}
+
+// Test `sendto_any`.
+#[test]
+fn net_v6_sendto_any() -> std::io::Result<()> {
+    let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
+    let addr = SocketAddr::new(localhost, 0);
+    let listener = rustix::net::socket(
+        AddressFamily::INET6,
+        SocketType::STREAM,
+        Protocol::default(),
+    )?;
+    rustix::net::bind(&listener, &addr).expect("bind");
+    rustix::net::listen(&listener, 1).expect("listen");
+
+    let local_addr = rustix::net::getsockname(&listener)?;
+    let sender = rustix::net::socket(
+        AddressFamily::INET6,
+        SocketType::STREAM,
+        Protocol::default(),
+    )?;
+    rustix::net::connect_any(&sender, &local_addr).expect("connect");
+    let request = b"Hello, World!!!";
+    let n =
+        rustix::net::sendto_any(&sender, request, SendFlags::empty(), &local_addr).expect("send");
+    drop(sender);
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    let accepted = rustix::net::accept(&listener).expect("accept");
+    let mut response = [0u8; 128];
+    let (n, from) =
+        rustix::net::recvfrom(&accepted, &mut response, RecvFlags::empty()).expect("recv");
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    assert_eq!(request, &response[..n]);
+    assert!(from.is_none());
+
+    Ok(())
+}
+
+// Test `acceptfrom`.
+#[test]
+fn net_v4_acceptfrom() -> std::io::Result<()> {
+    let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    let addr = SocketAddr::new(localhost, 0);
+    let listener =
+        rustix::net::socket(AddressFamily::INET, SocketType::STREAM, Protocol::default())?;
+    rustix::net::bind(&listener, &addr).expect("bind");
+    rustix::net::listen(&listener, 1).expect("listen");
+
+    let local_addr = rustix::net::getsockname(&listener)?;
+    let sender = rustix::net::socket(AddressFamily::INET, SocketType::STREAM, Protocol::default())?;
+    rustix::net::connect_any(&sender, &local_addr).expect("connect");
+    let request = b"Hello, World!!!";
+    let n = rustix::net::send(&sender, request, SendFlags::empty()).expect("send");
+    drop(sender);
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    let (accepted, from) = rustix::net::acceptfrom(&listener).expect("accept");
+
+    assert_ne!(from.clone().unwrap(), local_addr);
+
+    let from = match from.unwrap() {
+        SocketAddrAny::V4(v4) => v4,
+        other => panic!("unexpected socket address {:?}", other),
+    };
+    let local_addr = match local_addr {
+        SocketAddrAny::V4(v4) => v4,
+        other => panic!("unexpected socket address {:?}", other),
+    };
+
+    assert_eq!(from.clone().ip(), local_addr.ip());
+    assert_ne!(from.clone().port(), local_addr.port());
+
+    let mut response = [0u8; 128];
+    let n = rustix::net::recv(&accepted, &mut response, RecvFlags::empty()).expect("recv");
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    assert_eq!(request, &response[..n]);
+
+    Ok(())
+}
+
+// Similar, but with V6.
+#[test]
+fn net_v6_acceptfrom() -> std::io::Result<()> {
+    let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
+    let addr = SocketAddr::new(localhost, 0);
+    let listener = rustix::net::socket(
+        AddressFamily::INET6,
+        SocketType::STREAM,
+        Protocol::default(),
+    )?;
+    rustix::net::bind(&listener, &addr).expect("bind");
+    rustix::net::listen(&listener, 1).expect("listen");
+
+    let local_addr = rustix::net::getsockname(&listener)?;
+    let sender = rustix::net::socket(
+        AddressFamily::INET6,
+        SocketType::STREAM,
+        Protocol::default(),
+    )?;
+    rustix::net::connect_any(&sender, &local_addr).expect("connect");
+    let request = b"Hello, World!!!";
+    let n = rustix::net::send(&sender, request, SendFlags::empty()).expect("send");
+    drop(sender);
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    let (accepted, from) = rustix::net::acceptfrom(&listener).expect("accept");
+
+    assert_ne!(from.clone().unwrap(), local_addr);
+
+    let from = match from.unwrap() {
+        SocketAddrAny::V6(v6) => v6,
+        other => panic!("unexpected socket address {:?}", other),
+    };
+    let local_addr = match local_addr {
+        SocketAddrAny::V6(v6) => v6,
+        other => panic!("unexpected socket address {:?}", other),
+    };
+
+    assert_eq!(from.clone().ip(), local_addr.ip());
+    assert_ne!(from.clone().port(), local_addr.port());
+
+    let mut response = [0u8; 128];
+    let n = rustix::net::recv(&accepted, &mut response, RecvFlags::empty()).expect("recv");
+
+    // Not strictly required, but it makes the test simpler.
+    assert_eq!(n, request.len());
+
+    assert_eq!(request, &response[..n]);
+
+    Ok(())
+}

--- a/tests/net/connect_bind_send.rs
+++ b/tests/net/connect_bind_send.rs
@@ -7,9 +7,6 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 // Test `connect_any`.
 #[test]
 fn net_v4_connect_any() -> std::io::Result<()> {
-    #[cfg(windows)]
-    rustix::net::wsa_startup();
-
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener =
@@ -36,18 +33,12 @@ fn net_v4_connect_any() -> std::io::Result<()> {
 
     assert_eq!(request, &response[..n]);
 
-    #[cfg(windows)]
-    rustix::net::wsa_cleanup();
-
     Ok(())
 }
 
 // Similar, but with V6.
 #[test]
 fn net_v6_connect_any() -> std::io::Result<()> {
-    #[cfg(windows)]
-    rustix::net::wsa_startup();
-
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(
@@ -81,18 +72,12 @@ fn net_v6_connect_any() -> std::io::Result<()> {
 
     assert_eq!(request, &response[..n]);
 
-    #[cfg(windows)]
-    rustix::net::wsa_cleanup();
-
     Ok(())
 }
 
 // Test `connect` with a `SocketAddr`.
 #[test]
 fn net_v4_connect() -> std::io::Result<()> {
-    #[cfg(windows)]
-    rustix::net::wsa_startup();
-
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener =
@@ -123,18 +108,12 @@ fn net_v4_connect() -> std::io::Result<()> {
 
     assert_eq!(request, &response[..n]);
 
-    #[cfg(windows)]
-    rustix::net::wsa_cleanup();
-
     Ok(())
 }
 
 // Similar, but use V6.
 #[test]
 fn net_v6_connect() -> std::io::Result<()> {
-    #[cfg(windows)]
-    rustix::net::wsa_startup();
-
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(
@@ -172,18 +151,12 @@ fn net_v6_connect() -> std::io::Result<()> {
 
     assert_eq!(request, &response[..n]);
 
-    #[cfg(windows)]
-    rustix::net::wsa_cleanup();
-
     Ok(())
 }
 
 // Test `bind_any`.
 #[test]
 fn net_v4_bind_any() -> std::io::Result<()> {
-    #[cfg(windows)]
-    rustix::net::wsa_startup();
-
     let localhost = Ipv4Addr::LOCALHOST;
     let addr = SocketAddrAny::V4(SocketAddrV4::new(localhost, 0));
     let listener =
@@ -210,18 +183,12 @@ fn net_v4_bind_any() -> std::io::Result<()> {
 
     assert_eq!(request, &response[..n]);
 
-    #[cfg(windows)]
-    rustix::net::wsa_cleanup();
-
     Ok(())
 }
 
 // Similar, but use V6.
 #[test]
 fn net_v6_bind_any() -> std::io::Result<()> {
-    #[cfg(windows)]
-    rustix::net::wsa_startup();
-
     let localhost = Ipv6Addr::LOCALHOST;
     let addr = SocketAddrAny::V6(SocketAddrV6::new(localhost, 0, 0, 0));
     let listener = rustix::net::socket(
@@ -255,18 +222,12 @@ fn net_v6_bind_any() -> std::io::Result<()> {
 
     assert_eq!(request, &response[..n]);
 
-    #[cfg(windows)]
-    rustix::net::wsa_cleanup();
-
     Ok(())
 }
 
 // Test `sendto`.
 #[test]
 fn net_v4_sendto() -> std::io::Result<()> {
-    #[cfg(windows)]
-    rustix::net::wsa_startup();
-
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener =
@@ -299,18 +260,12 @@ fn net_v4_sendto() -> std::io::Result<()> {
     assert_eq!(request, &response[..n]);
     assert!(from.is_none());
 
-    #[cfg(windows)]
-    rustix::net::wsa_cleanup();
-
     Ok(())
 }
 
 // Similar, but with V6.
 #[test]
 fn net_v6_sendto() -> std::io::Result<()> {
-    #[cfg(windows)]
-    rustix::net::wsa_startup();
-
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(
@@ -350,18 +305,12 @@ fn net_v6_sendto() -> std::io::Result<()> {
     assert_eq!(request, &response[..n]);
     assert!(from.is_none());
 
-    #[cfg(windows)]
-    rustix::net::wsa_cleanup();
-
     Ok(())
 }
 
 // Test `sendto_any`.
 #[test]
 fn net_v4_sendto_any() -> std::io::Result<()> {
-    #[cfg(windows)]
-    rustix::net::wsa_startup();
-
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener =
@@ -390,9 +339,6 @@ fn net_v4_sendto_any() -> std::io::Result<()> {
 
     assert_eq!(request, &response[..n]);
     assert!(from.is_none());
-
-    #[cfg(windows)]
-    rustix::net::wsa_cleanup();
 
     Ok(())
 }
@@ -400,9 +346,6 @@ fn net_v4_sendto_any() -> std::io::Result<()> {
 // Test `sendto_any`.
 #[test]
 fn net_v6_sendto_any() -> std::io::Result<()> {
-    #[cfg(windows)]
-    rustix::net::wsa_startup();
-
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(
@@ -439,18 +382,12 @@ fn net_v6_sendto_any() -> std::io::Result<()> {
     assert_eq!(request, &response[..n]);
     assert!(from.is_none());
 
-    #[cfg(windows)]
-    rustix::net::wsa_cleanup();
-
     Ok(())
 }
 
 // Test `acceptfrom`.
 #[test]
 fn net_v4_acceptfrom() -> std::io::Result<()> {
-    #[cfg(windows)]
-    rustix::net::wsa_startup();
-
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener =
@@ -492,18 +429,12 @@ fn net_v4_acceptfrom() -> std::io::Result<()> {
 
     assert_eq!(request, &response[..n]);
 
-    #[cfg(windows)]
-    rustix::net::wsa_cleanup();
-
     Ok(())
 }
 
 // Similar, but with V6.
 #[test]
 fn net_v6_acceptfrom() -> std::io::Result<()> {
-    #[cfg(windows)]
-    rustix::net::wsa_startup();
-
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(
@@ -551,9 +482,6 @@ fn net_v6_acceptfrom() -> std::io::Result<()> {
     assert_eq!(n, request.len());
 
     assert_eq!(request, &response[..n]);
-
-    #[cfg(windows)]
-    rustix::net::wsa_cleanup();
 
     Ok(())
 }

--- a/tests/net/connect_bind_send.rs
+++ b/tests/net/connect_bind_send.rs
@@ -7,6 +7,9 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 // Test `connect_any`.
 #[test]
 fn net_v4_connect_any() -> std::io::Result<()> {
+    #[cfg(windows)]
+    rustix::net::wsa_startup();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener =
@@ -33,12 +36,18 @@ fn net_v4_connect_any() -> std::io::Result<()> {
 
     assert_eq!(request, &response[..n]);
 
+    #[cfg(windows)]
+    rustix::net::wsa_cleanup();
+
     Ok(())
 }
 
 // Similar, but with V6.
 #[test]
 fn net_v6_connect_any() -> std::io::Result<()> {
+    #[cfg(windows)]
+    rustix::net::wsa_startup();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(
@@ -72,12 +81,18 @@ fn net_v6_connect_any() -> std::io::Result<()> {
 
     assert_eq!(request, &response[..n]);
 
+    #[cfg(windows)]
+    rustix::net::wsa_cleanup();
+
     Ok(())
 }
 
 // Test `connect` with a `SocketAddr`.
 #[test]
 fn net_v4_connect() -> std::io::Result<()> {
+    #[cfg(windows)]
+    rustix::net::wsa_startup();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener =
@@ -108,12 +123,18 @@ fn net_v4_connect() -> std::io::Result<()> {
 
     assert_eq!(request, &response[..n]);
 
+    #[cfg(windows)]
+    rustix::net::wsa_cleanup();
+
     Ok(())
 }
 
 // Similar, but use V6.
 #[test]
 fn net_v6_connect() -> std::io::Result<()> {
+    #[cfg(windows)]
+    rustix::net::wsa_startup();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(
@@ -151,12 +172,18 @@ fn net_v6_connect() -> std::io::Result<()> {
 
     assert_eq!(request, &response[..n]);
 
+    #[cfg(windows)]
+    rustix::net::wsa_cleanup();
+
     Ok(())
 }
 
 // Test `bind_any`.
 #[test]
 fn net_v4_bind_any() -> std::io::Result<()> {
+    #[cfg(windows)]
+    rustix::net::wsa_startup();
+
     let localhost = Ipv4Addr::LOCALHOST;
     let addr = SocketAddrAny::V4(SocketAddrV4::new(localhost, 0));
     let listener =
@@ -183,12 +210,18 @@ fn net_v4_bind_any() -> std::io::Result<()> {
 
     assert_eq!(request, &response[..n]);
 
+    #[cfg(windows)]
+    rustix::net::wsa_cleanup();
+
     Ok(())
 }
 
 // Similar, but use V6.
 #[test]
 fn net_v6_bind_any() -> std::io::Result<()> {
+    #[cfg(windows)]
+    rustix::net::wsa_startup();
+
     let localhost = Ipv6Addr::LOCALHOST;
     let addr = SocketAddrAny::V6(SocketAddrV6::new(localhost, 0, 0, 0));
     let listener = rustix::net::socket(
@@ -222,12 +255,18 @@ fn net_v6_bind_any() -> std::io::Result<()> {
 
     assert_eq!(request, &response[..n]);
 
+    #[cfg(windows)]
+    rustix::net::wsa_cleanup();
+
     Ok(())
 }
 
 // Test `sendto`.
 #[test]
 fn net_v4_sendto() -> std::io::Result<()> {
+    #[cfg(windows)]
+    rustix::net::wsa_startup();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener =
@@ -260,12 +299,18 @@ fn net_v4_sendto() -> std::io::Result<()> {
     assert_eq!(request, &response[..n]);
     assert!(from.is_none());
 
+    #[cfg(windows)]
+    rustix::net::wsa_cleanup();
+
     Ok(())
 }
 
 // Similar, but with V6.
 #[test]
 fn net_v6_sendto() -> std::io::Result<()> {
+    #[cfg(windows)]
+    rustix::net::wsa_startup();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(
@@ -305,12 +350,18 @@ fn net_v6_sendto() -> std::io::Result<()> {
     assert_eq!(request, &response[..n]);
     assert!(from.is_none());
 
+    #[cfg(windows)]
+    rustix::net::wsa_cleanup();
+
     Ok(())
 }
 
 // Test `sendto_any`.
 #[test]
 fn net_v4_sendto_any() -> std::io::Result<()> {
+    #[cfg(windows)]
+    rustix::net::wsa_startup();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener =
@@ -339,6 +390,9 @@ fn net_v4_sendto_any() -> std::io::Result<()> {
 
     assert_eq!(request, &response[..n]);
     assert!(from.is_none());
+
+    #[cfg(windows)]
+    rustix::net::wsa_cleanup();
 
     Ok(())
 }
@@ -346,6 +400,9 @@ fn net_v4_sendto_any() -> std::io::Result<()> {
 // Test `sendto_any`.
 #[test]
 fn net_v6_sendto_any() -> std::io::Result<()> {
+    #[cfg(windows)]
+    rustix::net::wsa_startup();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(
@@ -382,12 +439,18 @@ fn net_v6_sendto_any() -> std::io::Result<()> {
     assert_eq!(request, &response[..n]);
     assert!(from.is_none());
 
+    #[cfg(windows)]
+    rustix::net::wsa_cleanup();
+
     Ok(())
 }
 
 // Test `acceptfrom`.
 #[test]
 fn net_v4_acceptfrom() -> std::io::Result<()> {
+    #[cfg(windows)]
+    rustix::net::wsa_startup();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener =
@@ -429,12 +492,18 @@ fn net_v4_acceptfrom() -> std::io::Result<()> {
 
     assert_eq!(request, &response[..n]);
 
+    #[cfg(windows)]
+    rustix::net::wsa_cleanup();
+
     Ok(())
 }
 
 // Similar, but with V6.
 #[test]
 fn net_v6_acceptfrom() -> std::io::Result<()> {
+    #[cfg(windows)]
+    rustix::net::wsa_startup();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(
@@ -482,6 +551,9 @@ fn net_v6_acceptfrom() -> std::io::Result<()> {
     assert_eq!(n, request.len());
 
     assert_eq!(request, &response[..n]);
+
+    #[cfg(windows)]
+    rustix::net::wsa_cleanup();
 
     Ok(())
 }

--- a/tests/net/main.rs
+++ b/tests/net/main.rs
@@ -11,3 +11,19 @@ mod poll;
 mod unix;
 mod v4;
 mod v6;
+
+/// Windows requires us to call a setup function before using any of the
+/// socket APIs.
+#[cfg(windows)]
+#[ctor::ctor]
+fn windows_startup() {
+    let _ = rustix::net::wsa_startup().unwrap();
+}
+
+/// Windows requires us to call a cleanup function after using any of the
+/// socket APIs.
+#[cfg(windows)]
+#[ctor::dtor]
+fn windows_shutdown() {
+    rustix::net::wsa_cleanup().unwrap();
+}

--- a/tests/net/main.rs
+++ b/tests/net/main.rs
@@ -5,6 +5,7 @@
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 
 mod addr;
+mod connect_bind_send;
 mod poll;
 #[cfg(not(windows))]
 mod unix;

--- a/tests/net/poll.rs
+++ b/tests/net/poll.rs
@@ -95,9 +95,6 @@ fn client(ready: Arc<(Mutex<u16>, Condvar)>) {
 
 #[test]
 fn test_poll() {
-    #[cfg(windows)]
-    rustix::net::wsa_startup().unwrap();
-
     let ready = Arc::new((Mutex::new(0_u16), Condvar::new()));
     let ready_clone = Arc::clone(&ready);
 
@@ -115,7 +112,4 @@ fn test_poll() {
         .unwrap();
     client.join().unwrap();
     server.join().unwrap();
-
-    #[cfg(windows)]
-    rustix::net::wsa_cleanup().unwrap();
 }

--- a/tests/net/v4.rs
+++ b/tests/net/v4.rs
@@ -65,9 +65,6 @@ fn client(ready: Arc<(Mutex<u16>, Condvar)>) {
 
 #[test]
 fn test_v4() {
-    #[cfg(windows)]
-    rustix::net::wsa_startup().unwrap();
-
     let ready = Arc::new((Mutex::new(0_u16), Condvar::new()));
     let ready_clone = Arc::clone(&ready);
 
@@ -85,7 +82,4 @@ fn test_v4() {
         .unwrap();
     client.join().unwrap();
     server.join().unwrap();
-
-    #[cfg(windows)]
-    rustix::net::wsa_cleanup().unwrap();
 }

--- a/tests/net/v6.rs
+++ b/tests/net/v6.rs
@@ -74,9 +74,6 @@ fn client(ready: Arc<(Mutex<u16>, Condvar)>) {
 
 #[test]
 fn test_v6() {
-    #[cfg(windows)]
-    rustix::net::wsa_startup().unwrap();
-
     let ready = Arc::new((Mutex::new(0_u16), Condvar::new()));
     let ready_clone = Arc::clone(&ready);
 
@@ -94,7 +91,4 @@ fn test_v6() {
         .unwrap();
     client.join().unwrap();
     server.join().unwrap();
-
-    #[cfg(windows)]
-    rustix::net::wsa_cleanup().unwrap();
 }


### PR DESCRIPTION
Add `sendto`, `connect`, and `bind` versions that operate on `SocketAddr`. These are needed by the port of std to rustix. And, add a testcase exercising these functions.
