### PR TITLE
Add `#[inline]` attributes to small functions.

### DIFF
--- a/src/imp/linux_raw/io/syscalls.rs
+++ b/src/imp/linux_raw/io/syscalls.rs
@@ -122,6 +122,7 @@ pub(crate) fn pread(fd: BorrowedFd<'_>, buf: &mut [u8], pos: u64) -> io::Result<
     }
 }
 
+#[inline]
 pub(crate) fn readv(fd: BorrowedFd<'_>, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
     let (bufs_addr, bufs_len) = slice(&bufs[..cmp::min(bufs.len(), max_iov())]);
 
@@ -135,6 +136,7 @@ pub(crate) fn readv(fd: BorrowedFd<'_>, bufs: &mut [IoSliceMut<'_>]) -> io::Resu
     }
 }
 
+#[inline]
 pub(crate) fn preadv(
     fd: BorrowedFd<'_>,
     bufs: &mut [IoSliceMut<'_>],
@@ -165,6 +167,7 @@ pub(crate) fn preadv(
     }
 }
 
+#[inline]
 pub(crate) fn preadv2(
     fd: BorrowedFd<'_>,
     bufs: &mut [IoSliceMut<'_>],

--- a/src/imp/linux_raw/process/syscalls.rs
+++ b/src/imp/linux_raw/process/syscalls.rs
@@ -58,6 +58,7 @@ pub(crate) fn getcwd(buf: &mut [u8]) -> io::Result<usize> {
     unsafe { ret_usize(syscall2(nr(__NR_getcwd), buf_addr_mut, buf_len)) }
 }
 
+#[inline]
 pub(crate) fn membarrier_query() -> MembarrierQuery {
     unsafe {
         match ret_c_uint(syscall2(
@@ -79,6 +80,7 @@ pub(crate) fn membarrier_query() -> MembarrierQuery {
     }
 }
 
+#[inline]
 pub(crate) fn membarrier(cmd: MembarrierCommand) -> io::Result<()> {
     unsafe {
         ret(syscall2(
@@ -89,6 +91,7 @@ pub(crate) fn membarrier(cmd: MembarrierCommand) -> io::Result<()> {
     }
 }
 
+#[inline]
 pub(crate) fn membarrier_cpu(cmd: MembarrierCommand, cpu: Cpuid) -> io::Result<()> {
     unsafe {
         ret(syscall3(

--- a/src/path/arg.rs
+++ b/src/path/arg.rs
@@ -79,6 +79,7 @@ pub trait Arg {
 
     /// Returns a view of this string as a maybe-owned [`ZStr`].
     #[cfg(not(feature = "rustc-dep-of-std"))]
+    #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, ZStr>> {
         self.as_cow_z_str()
     }
@@ -86,6 +87,7 @@ pub trait Arg {
     /// Consumes `self` and returns a view of this string as a maybe-owned
     /// [`ZStr`].
     #[cfg(not(feature = "rustc-dep-of-std"))]
+    #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, ZStr>>
     where
         Self: 'b + Sized,
@@ -95,6 +97,7 @@ pub trait Arg {
 
     /// Runs a closure with `self` passed in as a `&ZStr`.
     #[cfg(not(feature = "rustc-dep-of-std"))]
+    #[inline]
     fn into_with_c_str<T, F>(self, f: F) -> io::Result<T>
     where
         Self: Sized,


### PR DESCRIPTION
These functions inline into a small number of instructions, so mark them
`#[inline]`.