### PR TITLE
Use `unix` instead of `not(windows)` for Unix-domain socket code.

### DIFF
--- a/src/imp/libc/net/addr.rs
+++ b/src/imp/libc/net/addr.rs
@@ -1,23 +1,23 @@
 //! IPv4, IPv6, and Socket addresses.
 
 use super::super::c;
-#[cfg(not(windows))]
+#[cfg(unix)]
 use super::offsetof_sun_path;
-#[cfg(not(windows))]
+#[cfg(unix)]
 use crate::ffi::ZStr;
-#[cfg(not(windows))]
+#[cfg(unix)]
 use crate::io;
-#[cfg(not(windows))]
+#[cfg(unix)]
 use crate::path;
 #[cfg(not(windows))]
 use core::convert::TryInto;
-#[cfg(not(windows))]
+#[cfg(unix)]
 use core::fmt;
-#[cfg(not(windows))]
+#[cfg(unix)]
 use core::mem::transmute;
 
 /// `struct sockaddr_un`
-#[cfg(not(windows))]
+#[cfg(unix)]
 #[derive(Clone)]
 #[doc(alias = "sockaddr_un")]
 pub struct SocketAddrUnix {
@@ -33,7 +33,7 @@ pub struct SocketAddrUnix {
     len: libc::socklen_t,
 }
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 impl SocketAddrUnix {
     /// Construct a new Unix-domain address from a filesystem path.
     #[inline]
@@ -200,7 +200,7 @@ impl SocketAddrUnix {
     }
 }
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 impl PartialEq for SocketAddrUnix {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
@@ -210,10 +210,10 @@ impl PartialEq for SocketAddrUnix {
     }
 }
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 impl Eq for SocketAddrUnix {}
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 impl PartialOrd for SocketAddrUnix {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
@@ -223,7 +223,7 @@ impl PartialOrd for SocketAddrUnix {
     }
 }
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 impl Ord for SocketAddrUnix {
     #[inline]
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
@@ -233,7 +233,7 @@ impl Ord for SocketAddrUnix {
     }
 }
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 impl core::hash::Hash for SocketAddrUnix {
     #[inline]
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
@@ -242,7 +242,7 @@ impl core::hash::Hash for SocketAddrUnix {
     }
 }
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 impl fmt::Debug for SocketAddrUnix {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(path) = self.path() {

--- a/src/imp/libc/net/mod.rs
+++ b/src/imp/libc/net/mod.rs
@@ -10,7 +10,7 @@ mod write_sockaddr;
 pub(crate) mod ext;
 pub(crate) mod syscalls;
 pub use addr::SocketAddrStorage;
-#[cfg(not(windows))]
+#[cfg(unix)]
 pub use addr::SocketAddrUnix;
 pub(crate) use read_sockaddr::{
     initialize_family_to_unspec, maybe_read_sockaddr_os, read_sockaddr, read_sockaddr_os,
@@ -20,7 +20,7 @@ pub use types::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, Soc
 pub(crate) use write_sockaddr::{encode_sockaddr_v4, encode_sockaddr_v6, write_sockaddr};
 
 /// Return the offset of the `sun_path` field of `sockaddr_un`.
-#[cfg(not(windows))]
+#[cfg(unix)]
 #[inline]
 pub(crate) fn offsetof_sun_path() -> usize {
     let z = c::sockaddr_un {

--- a/src/imp/libc/net/read_sockaddr.rs
+++ b/src/imp/libc/net/read_sockaddr.rs
@@ -1,6 +1,6 @@
 use super::super::c;
 use super::ext::{in6_addr_s6_addr, in_addr_s_addr, sockaddr_in6_sin6_scope_id};
-#[cfg(not(windows))]
+#[cfg(unix)]
 use super::SocketAddrUnix;
 #[cfg(not(windows))]
 use crate::as_ptr;
@@ -91,7 +91,7 @@ pub(crate) unsafe fn read_sockaddr(
     storage: *const c::sockaddr_storage,
     len: usize,
 ) -> io::Result<SocketAddrAny> {
-    #[cfg(not(windows))]
+    #[cfg(unix)]
     let offsetof_sun_path = super::offsetof_sun_path();
 
     if len < size_of::<c::sa_family_t>() {
@@ -128,7 +128,7 @@ pub(crate) unsafe fn read_sockaddr(
                 sin6_scope_id,
             )))
         }
-        #[cfg(not(windows))]
+        #[cfg(unix)]
         c::AF_UNIX => {
             if len < offsetof_sun_path {
                 return Err(io::Error::INVAL);
@@ -200,7 +200,7 @@ unsafe fn inner_read_sockaddr_os(
     storage: *const c::sockaddr_storage,
     len: usize,
 ) -> SocketAddrAny {
-    #[cfg(not(windows))]
+    #[cfg(unix)]
     let z = c::sockaddr_un {
         #[cfg(any(
             target_os = "dragonfly",
@@ -248,7 +248,7 @@ unsafe fn inner_read_sockaddr_os(
         )))]
         sun_path: [0; 108],
     };
-    #[cfg(not(windows))]
+    #[cfg(unix)]
     let offsetof_sun_path = (as_ptr(&z.sun_path) as usize) - (as_ptr(&z) as usize);
 
     assert!(len >= size_of::<c::sa_family_t>());
@@ -271,7 +271,7 @@ unsafe fn inner_read_sockaddr_os(
                 sockaddr_in6_sin6_scope_id(decode),
             ))
         }
-        #[cfg(not(windows))]
+        #[cfg(unix)]
         c::AF_UNIX => {
             assert!(len >= offsetof_sun_path);
             if len == offsetof_sun_path {

--- a/src/imp/libc/net/syscalls.rs
+++ b/src/imp/libc/net/syscalls.rs
@@ -3,7 +3,7 @@
 use super::super::c;
 use super::super::conv::{borrowed_fd, ret, ret_owned_fd, ret_send_recv, send_recv_len};
 use super::ext::{in6_addr_new, in_addr_new};
-#[cfg(not(windows))]
+#[cfg(unix)]
 use super::SocketAddrUnix;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 use super::{

--- a/src/imp/libc/net/write_sockaddr.rs
+++ b/src/imp/libc/net/write_sockaddr.rs
@@ -5,7 +5,7 @@
 use super::super::c;
 use super::ext::{in6_addr_new, in_addr_new, sockaddr_in6_new};
 use super::SocketAddrStorage;
-#[cfg(not(windows))]
+#[cfg(unix)]
 use super::SocketAddrUnix;
 use crate::net::{SocketAddrAny, SocketAddrV4, SocketAddrV6};
 use core::mem::size_of;
@@ -17,7 +17,7 @@ pub(crate) unsafe fn write_sockaddr(
     match addr {
         SocketAddrAny::V4(v4) => write_sockaddr_v4(v4, storage),
         SocketAddrAny::V6(v6) => write_sockaddr_v6(v6, storage),
-        #[cfg(not(windows))]
+        #[cfg(unix)]
         SocketAddrAny::Unix(unix) => write_sockaddr_unix(unix, storage),
     }
 }
@@ -90,7 +90,7 @@ unsafe fn write_sockaddr_v6(v6: &SocketAddrV6, storage: *mut SocketAddrStorage) 
     size_of::<c::sockaddr_in6>()
 }
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 unsafe fn write_sockaddr_unix(unix: &SocketAddrUnix, storage: *mut SocketAddrStorage) -> usize {
     core::ptr::write(storage.cast(), unix.unix);
     unix.len()

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -23,7 +23,7 @@ mod wsa;
 
 pub mod sockopt;
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 pub use send_recv::sendto_unix;
 pub use send_recv::{
     recv, recvfrom, send, sendto, sendto_any, sendto_v4, sendto_v6, RecvFlags, SendFlags,
@@ -33,7 +33,7 @@ pub use socket::{
     connect_any, connect_v4, connect_v6, getpeername, getsockname, listen, shutdown, socket,
     socket_with, AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType,
 };
-#[cfg(not(windows))]
+#[cfg(unix)]
 pub use socket::{bind_unix, connect_unix};
 pub use socket_addr_any::SocketAddrAny;
 #[cfg(not(any(windows, target_os = "wasi")))]
@@ -42,7 +42,7 @@ pub use socketpair::socketpair;
 pub use wsa::{wsa_cleanup, wsa_startup};
 
 pub use imp::net::SocketAddrStorage;
-#[cfg(not(windows))]
+#[cfg(unix)]
 pub use imp::net::SocketAddrUnix;
 
 // Declare the `Ip` and `Socket` address types.

--- a/src/net/send_recv.rs
+++ b/src/net/send_recv.rs
@@ -1,6 +1,6 @@
 //! `recv` and `send`, and variants
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 use crate::net::SocketAddrUnix;
 use crate::net::{SocketAddr, SocketAddrAny, SocketAddrV4, SocketAddrV6};
 use crate::{imp, io};
@@ -115,7 +115,7 @@ fn _sendto_any(
     match addr {
         SocketAddrAny::V4(v4) => imp::net::syscalls::sendto_v4(fd, buf, flags, v4),
         SocketAddrAny::V6(v6) => imp::net::syscalls::sendto_v6(fd, buf, flags, v6),
-        #[cfg(not(windows))]
+        #[cfg(unix)]
         SocketAddrAny::Unix(unix) => imp::net::syscalls::sendto_unix(fd, buf, flags, unix),
     }
 }
@@ -177,7 +177,7 @@ pub fn sendto_v6<Fd: AsFd>(
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto
 #[inline]
 #[doc(alias = "sendto")]
-#[cfg(not(windows))]
+#[cfg(unix)]
 pub fn sendto_unix<Fd: AsFd>(
     fd: &Fd,
     buf: &[u8],

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -1,6 +1,6 @@
 use crate::imp;
 use crate::io::{self, OwnedFd};
-#[cfg(not(windows))]
+#[cfg(unix)]
 use crate::net::SocketAddrUnix;
 use crate::net::{SocketAddr, SocketAddrAny, SocketAddrV4, SocketAddrV6};
 use imp::fd::{AsFd, BorrowedFd};
@@ -97,7 +97,7 @@ fn _bind_any(sockfd: BorrowedFd<'_>, addr: &SocketAddrAny) -> io::Result<()> {
     match addr {
         SocketAddrAny::V4(v4) => imp::net::syscalls::bind_v4(sockfd, v4),
         SocketAddrAny::V6(v6) => imp::net::syscalls::bind_v6(sockfd, v6),
-        #[cfg(not(windows))]
+        #[cfg(unix)]
         SocketAddrAny::Unix(unix) => imp::net::syscalls::bind_unix(sockfd, unix),
     }
 }
@@ -149,7 +149,7 @@ pub fn bind_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> {
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-bind
 #[inline]
 #[doc(alias = "bind")]
-#[cfg(not(windows))]
+#[cfg(unix)]
 pub fn bind_unix<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrUnix) -> io::Result<()> {
     imp::net::syscalls::bind_unix(sockfd.as_fd(), addr)
 }
@@ -190,7 +190,7 @@ fn _connect_any(sockfd: BorrowedFd<'_>, addr: &SocketAddrAny) -> io::Result<()> 
     match addr {
         SocketAddrAny::V4(v4) => imp::net::syscalls::connect_v4(sockfd, v4),
         SocketAddrAny::V6(v6) => imp::net::syscalls::connect_v6(sockfd, v6),
-        #[cfg(not(windows))]
+        #[cfg(unix)]
         SocketAddrAny::Unix(unix) => imp::net::syscalls::connect_unix(sockfd, unix),
     }
 }
@@ -240,7 +240,7 @@ pub fn connect_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> 
 /// [Linux]: https://man7.org/linux/man-pages/man2/connect.2.html
 #[inline]
 #[doc(alias = "connect")]
-#[cfg(not(windows))]
+#[cfg(unix)]
 pub fn connect_unix<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrUnix) -> io::Result<()> {
     imp::net::syscalls::connect_unix(sockfd.as_fd(), addr)
 }

--- a/src/net/socket_addr_any.rs
+++ b/src/net/socket_addr_any.rs
@@ -9,7 +9,7 @@
 //! OS-specific socket address representations in memory.
 #![allow(unsafe_code)]
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 use crate::net::SocketAddrUnix;
 use crate::net::{AddressFamily, SocketAddrStorage, SocketAddrV4, SocketAddrV6};
 use crate::{imp, io};
@@ -26,7 +26,7 @@ pub enum SocketAddrAny {
     /// `struct sockaddr_in6`
     V6(SocketAddrV6),
     /// `struct sockaddr_un`
-    #[cfg(not(windows))]
+    #[cfg(unix)]
     Unix(SocketAddrUnix),
 }
 
@@ -37,7 +37,7 @@ impl SocketAddrAny {
         match self {
             SocketAddrAny::V4(_) => AddressFamily::INET,
             SocketAddrAny::V6(_) => AddressFamily::INET6,
-            #[cfg(not(windows))]
+            #[cfg(unix)]
             SocketAddrAny::Unix(_) => AddressFamily::UNIX,
         }
     }
@@ -72,7 +72,7 @@ impl fmt::Debug for SocketAddrAny {
         match self {
             SocketAddrAny::V4(v4) => v4.fmt(fmt),
             SocketAddrAny::V6(v6) => v6.fmt(fmt),
-            #[cfg(not(windows))]
+            #[cfg(unix)]
             SocketAddrAny::Unix(unix) => unix.fmt(fmt),
         }
     }

--- a/tests/net/addr.rs
+++ b/tests/net/addr.rs
@@ -1,6 +1,6 @@
 #[test]
 fn encode_decode() {
-    #[cfg(not(windows))]
+    #[cfg(unix)]
     use rustix::net::SocketAddrUnix;
     use rustix::net::{
         Ipv4Addr, Ipv6Addr, SocketAddrAny, SocketAddrStorage, SocketAddrV4, SocketAddrV6,

--- a/tests/net/main.rs
+++ b/tests/net/main.rs
@@ -7,7 +7,7 @@
 mod addr;
 mod connect_bind_send;
 mod poll;
-#[cfg(not(windows))]
+#[cfg(unix)]
 mod unix;
 mod v4;
 mod v6;


### PR DESCRIPTION
This is just a minor cleanup; Unix-domain sockets are Unix-specific, so
use `cfg(unix)` for them.