### PR TITLE
Make `backend-libc` and `backend-linux-raw` features

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,6 @@ jobs:
         sudo apt-get install -y gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-riscv64-linux-gnu gcc-arm-linux-gnueabi musl-tools
     - run: cargo check --workspace --release -vv
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-musl
-    - run: cargo check --workspace --release -vv --target=i686-linux-android
     - run: cargo check --workspace --release -vv --target=i686-unknown-linux-gnu
     - run: cargo check --workspace --release -vv --target=i686-unknown-linux-musl
     - run: cargo check --workspace --release -vv --target=riscv64gc-unknown-linux-gnu
@@ -82,6 +81,7 @@ jobs:
     - run: cargo check --workspace --release -vv --target=powerpc64le-unknown-linux-gnu
     # List backends that require libc here
     - run: cargo check --workspace --release --features backend-libc -vv --target=x86_64-linux-android
+    - run: cargo check --workspace --release --features backend-libc -vv --target=i686-linux-android
     - run: cargo check --workspace --release --features backend-libc -vv --target=x86_64-unknown-linux-gnux32
     - run: cargo check --workspace --release --features backend-libc -vv --target=x86_64-unknown-freebsd
     - run: cargo check --workspace --release --features backend-libc -vv --target=x86_64-unknown-netbsd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -399,14 +399,7 @@ jobs:
             qemu_target: arm-linux-user
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.
-      RUSTFLAGS: --cfg rustix_use_libc -D warnings
-      RUSTDOCFLAGS: --cfg rustix_use_libc
-      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_libc
-      CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_libc
-      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_libc
-      CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_libc
-      CARGO_TARGET_RISCV64_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_libc
-      CARGO_TARGET_ARM_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_libc
+      RUSTFLAGS: -D warnings
       QEMU_BUILD_VERSION: 6.1.0
     steps:
     - uses: actions/checkout@v2
@@ -468,7 +461,7 @@ jobs:
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     - run: |
-        cargo test --verbose --features=all-impls,procfs --release --workspace -- --nocapture
+        cargo test --verbose --features=backend-libc,all-impls,procfs --release --workspace -- --nocapture
       env:
         RUST_BACKTRACE: 1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,6 @@ jobs:
         sudo apt-get install -y gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-riscv64-linux-gnu gcc-arm-linux-gnueabi musl-tools
     - run: cargo check --workspace --release -vv
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-musl
-    - run: cargo check --workspace --release -vv --target=x86_64-linux-android
     - run: cargo check --workspace --release -vv --target=i686-linux-android
     - run: cargo check --workspace --release -vv --target=i686-unknown-linux-gnu
     - run: cargo check --workspace --release -vv --target=i686-unknown-linux-musl
@@ -82,6 +81,7 @@ jobs:
     - run: cargo check --workspace --release -vv --target=aarch64-unknown-linux-musl
     - run: cargo check --workspace --release -vv --target=powerpc64le-unknown-linux-gnu
     # List backends that require libc here
+    - run: cargo check --workspace --release --features backend-libc -vv --target=x86_64-linux-android
     - run: cargo check --workspace --release --features backend-libc -vv --target=x86_64-unknown-linux-gnux32
     - run: cargo check --workspace --release --features backend-libc -vv --target=x86_64-unknown-freebsd
     - run: cargo check --workspace --release --features backend-libc -vv --target=x86_64-unknown-netbsd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - run: cargo check --workspace --release --no-default-features --features itoa -vv
+    - run: cargo check --workspace --release --no-default-features --features backend-linux-raw,itoa -vv
 
   check_nightly:
     name: Check on Rust nightly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,22 +73,23 @@ jobs:
         sudo apt-get install -y gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-riscv64-linux-gnu gcc-arm-linux-gnueabi musl-tools
     - run: cargo check --workspace --release -vv
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-musl
-    - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-gnux32
     - run: cargo check --workspace --release -vv --target=x86_64-linux-android
     - run: cargo check --workspace --release -vv --target=i686-linux-android
-    - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin
-    - run: cargo check --workspace --release -vv --target=x86_64-unknown-freebsd
-    - run: cargo check --workspace --release -vv --target=x86_64-unknown-netbsd
-    - run: cargo check --workspace --release -vv --target=x86_64-fuchsia
-    - run: cargo check --workspace --release -vv --target=x86_64-unknown-illumos
     - run: cargo check --workspace --release -vv --target=i686-unknown-linux-gnu
     - run: cargo check --workspace --release -vv --target=i686-unknown-linux-musl
-    - run: cargo check --workspace --release -vv --target=wasm32-unknown-emscripten
     - run: cargo check --workspace --release -vv --target=riscv64gc-unknown-linux-gnu
     - run: cargo check --workspace --release -vv --target=aarch64-unknown-linux-gnu
     - run: cargo check --workspace --release -vv --target=aarch64-unknown-linux-musl
     - run: cargo check --workspace --release -vv --target=powerpc64le-unknown-linux-gnu
-    - run: cargo check --workspace --release -vv --target=armv5te-unknown-linux-gnueabi
+    # List backends that require libc here
+    - run: cargo check --workspace --release --features backend-libc -vv --target=x86_64-unknown-linux-gnux32
+    - run: cargo check --workspace --release --features backend-libc -vv --target=x86_64-unknown-freebsd
+    - run: cargo check --workspace --release --features backend-libc -vv --target=x86_64-unknown-netbsd
+    - run: cargo check --workspace --release --features backend-libc -vv --target=x86_64-unknown-illumos
+    - run: cargo check --workspace --release --features backend-libc -vv --target=wasm32-unknown-emscripten
+    - run: cargo check --workspace --release --features backend-libc -vv --target=x86_64-apple-darwin
+    - run: cargo check --workspace --release --features backend-libc -vv --target=x86_64-fuchsia
+    - run: cargo check --workspace --release --features backend-libc -vv --target=armv5te-unknown-linux-gnueabi
 
   check_no_default_features:
     name: Check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,8 +139,8 @@ jobs:
         rustup target add
         x86_64-unknown-redox
         wasm32-wasi
-    - run: cargo check --workspace --release -vv --target=x86_64-unknown-redox
-    - run: cargo check --workspace --release -vv --target=wasm32-wasi
+    - run: cargo check --workspace --release --no-default-features --features=backend-libc,std -vv --target=x86_64-unknown-redox
+    - run: cargo check --workspace --release --no-default=features --features=backend-libc,std -vv --target=wasm32-wasi
 
   check_tier3:
     name: Check selected Tier 3 platforms

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,7 +164,7 @@ jobs:
         # See the comments in the libc crate
         RUSTFLAGS: -A improper_ctypes_definitions
     - run: rustup component add rust-src
-    - run: cargo check -Z build-std=core,alloc,std --no-default=features --features=backend-libc,std --target x86_64-unknown-openbsd --all-targets
+    - run: cargo check -Z build-std=core,alloc,std --no-default-features --features=backend-libc,std --target x86_64-unknown-openbsd --all-targets
 
   test:
     name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -337,7 +337,14 @@ jobs:
 
     - run: |
         # Run the tests, and check the prebuilt release libraries.
-        cargo test --verbose --features=all-impls,procfs,cc --release --workspace -- --nocapture
+        features=all-impls,procfs,cc
+        # Use libc on macos/windows
+        case "${{ matrix.os }}" in
+          *windows*|*macos*) args="--no-default-features --features=backend-libc,$features";;
+          *) args="--features=$features"
+        esac
+
+        cargo test --verbose $args --release --workspace -- --nocapture
       env:
         RUST_BACKTRACE: 1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,7 +164,7 @@ jobs:
         # See the comments in the libc crate
         RUSTFLAGS: -A improper_ctypes_definitions
     - run: rustup component add rust-src
-    - run: cargo check -Z build-std=core,alloc,std --target x86_64-unknown-openbsd --all-targets
+    - run: cargo check -Z build-std=core,alloc,std --no-default=features --features=backend-libc,std --target x86_64-unknown-openbsd --all-targets
 
   test:
     name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,7 +140,7 @@ jobs:
         x86_64-unknown-redox
         wasm32-wasi
     - run: cargo check --workspace --release --no-default-features --features=backend-libc,std -vv --target=x86_64-unknown-redox
-    - run: cargo check --workspace --release --no-default=features --features=backend-libc,std -vv --target=wasm32-wasi
+    - run: cargo check --workspace --release --no-default-features --features=backend-libc,std -vv --target=wasm32-wasi
 
   check_tier3:
     name: Check selected Tier 3 platforms

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,15 @@ linux-raw-sys = { version = "0.0.40", default-features = false, features = ["gen
 # For the libc backend on Unix platforms, use the libc crate, and errno for
 # setting `errno`.  Don't try to enable these directly; instead, enable
 # via `use-libc` feature.
+[target.'cfg(target_os = "linux")'.dependencies]
+# Keep these in sync with the non-Linux case below
 errno = { version = "0.2.8", default-features = false, optional = true }
 libc = { version = "0.2.114", features = ["extra_traits"], optional = true }
+
+# libc/errno are hard required on non-Linux
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+errno = { version = "0.2.8", default-features = false }
+libc = { version = "0.2.114", features = ["extra_traits"] }
 
 # For the libc backend on Windows, use the Winsock2 API in winapi.
 [target.'cfg(windows)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,14 +32,13 @@ compiler_builtins = { version = '0.1.49', optional = true }
 once_cell = { version = "1.5.2", optional = true }
 
 # For the linux_raw backend, linux-raw-sys provides Linux ABI details.
-[target.'cfg(all(not(rustix_use_libc), any(target_os = "linux"), any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64")))'.dependencies]
-linux-raw-sys = { version = "0.0.40", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
+linux-raw-sys = { version = "0.0.40", default-features = false, features = ["general", "errno", "ioctl", "no_std"], optional = true }
 
 # For the libc backend on Unix platforms, use the libc crate, and errno for
-# setting `errno`.
-[target.'cfg(any(rustix_use_libc, not(all(any(target_os = "linux"), any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64")))))'.dependencies]
-errno = { version = "0.2.8", default-features = false }
-libc = { version = "0.2.114", features = ["extra_traits"] }
+# setting `errno`.  Don't try to enable these directly; instead, enable
+# via `use-libc` feature.
+errno = { version = "0.2.8", default-features = false, optional = true }
+libc = { version = "0.2.114", features = ["extra_traits"], optional = true }
 
 # For the libc backend on Windows, use the Winsock2 API in winapi.
 [target.'cfg(windows)'.dependencies]
@@ -58,16 +57,26 @@ criterion = "0.3"
 ctor = "0.1.21"
 
 [features]
-default = ["std"]
-std = ["io-lifetimes", "linux-raw-sys/std"]
-rustc-dep-of-std = [
+default = ["std", "backend-linux-raw"]
+std = ["io-lifetimes"]
+rustc-dep-of-std-core = [
     "core",
     "alloc",
     "compiler_builtins",
-    "linux-raw-sys/rustc-dep-of-std",
     "bitflags/rustc-dep-of-std",
+]
+rustc-dep-of-std-libc = [
     "libc/rustc-dep-of-std",
 ]
+rustc-dep-of-std-libc-linux-raw-sys = [
+    "linux-raw-sys/rustc-dep-of-std",
+]
+# Enable this to perform system calls via libc.
+backend-libc = ["errno", "libc"]
+# Enable this to perform system calls directly.
+# Note that if both `backend-linux-raw` and `backend-libc` are set,
+# then `backend-libc` takes precedence.
+backend-linux-raw = ["linux-raw-sys"]
 
 # Enable this to enable `proc_self_fd` (on Linux) and `ttyname`.
 procfs = ["once_cell", "itoa"]

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Windows, the rest of the APIs do not support Windows; for higher-level and more
 portable APIs built on this functionality, see the [`system-interface`],
 [`cap-std`], and [`fs-set-times`] crates, for example.
 
-`rustix` currently has two backends available: `linux_raw` and `libc`.
+`rustix` currently has two backends available exposed via the feature flags
+`backend-linux-raw` and `backend-libc`.
 
-The `linux_raw` backend is enabled by default on Linux on x86-64, x86, aarch64,
+`backend-linux-raw` is enabled by default; it works on Linux on x86-64, x86, aarch64,
 riscv64gc, powerpc64le, and arm (v5 onwards), and uses raw Linux system calls
 and vDSO calls. It supports stable as well as nightly and 1.48 Rust.
  - By being implemented entirely in Rust, avoiding `libc`, `errno`, and pthread
@@ -42,10 +43,13 @@ and vDSO calls. It supports stable as well as nightly and 1.48 Rust.
  - `linux_raw` uses a 64-bit `time_t` type on all platforms, avoiding the
    [y2038 bug].
 
-The `libc` backend is enabled by default on all other platforms, and can be set
-explicitly for any target by setting `RUSTFLAGS` to `--cfg=rustix_use_libc`. It
+On other platforms, you must enable the `use-libc` feature.  This
 uses the [`libc`] crate which provides bindings to native `libc` libraries, and
 [`winapi`] for Winsock2, and is portable to many OS's.
+
+At the current time, building with both `backend-linux-raw` and `backend-libc`
+will use libc (but still try to compile `linux-raw-sys`)  It's recommended to use e.g.:
+`rustix = { version = "...", default-features = false, features = ["std", "backend-libc"] }`
 
 ## Similar crates
 

--- a/build.rs
+++ b/build.rs
@@ -47,7 +47,8 @@ fn main() {
     let rustix_linux_raw = var("CARGO_FEATURE_BACKEND_LINUX_RAW").is_ok();
 
     let backend = if !(rustix_libc || rustix_linux_raw) {
-        eprintln!("rustix: At least one of use-libc or use-linux-raw must be set");
+        // https://internals.rust-lang.org/t/clearer-display-of-build-script-errors-in-cargo/14222/5
+        eprintln!("error: At least one of use-libc or use-linux-raw must be set");
         std::process::exit(1)
     } else if rustix_libc {
         // If backend-libc is set (as it must be explicitly), then it takes precedence

--- a/build.rs
+++ b/build.rs
@@ -68,6 +68,8 @@ fn main() {
             use_feature("libc");
         }
         Backend::LinuxRaw => {
+            // In the future we could probably support `android` here too, but it looks like that
+            // needs at least a few fixes.
             let can_use_linux_raw =
                 os_name == "linux" && std::fs::metadata(&asm_name).is_ok() && can_do_raw_arch;
             if !can_use_linux_raw {


### PR DESCRIPTION


Closes: https://github.com/bytecodealliance/rustix/issues/215

Today, rustix supports `libc` and `linux-raw-sys` as backends.
The default is to use `linux-raw-sys` if available (i.e. we're
on Linux on a supported architecture).

There's some support for requiring libc via an environment variable,
but this operates outside the `cargo` native build system and hence
works less reliably for projects that want libc always.

Change things so that `backend-libc` and `backend-linux-raw` are explicit
cargo features; one of them must be set.  In this proposal, the default
remains `backend-linux-raw`.

More rationale:

I am a big fan of the rustix approach of I/O safety, and there's
a lot of very nice code in this crate.

However, I am less excited by replacing libc.  For the forseeable
future for at least most of my employer's group's usage, all
production usage of rustix will have libc linked in.

I don't want to discover that our application is broken because
some obscure system call on a less-common architecture in a corner
case is broken.

I also want to avoid the pre-compiled assembly code when vendoring.

This support for `backend-libc` helps address those concerns.

A side benefit: the `Cargo.toml` no longer needs
to replicate the architecture checking conditionals
from the build script.

---

