### PR TITLE
Test `isatty` with `libc::isatty` and `ioctl_tiocgwinsz` instead of ` is-terminal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ libc = { version = "0.2.114", features = ["extra_traits"] }
 winapi = { version = "0.3.9", features = ["ws2ipdef", "ws2tcpip"] }
 
 [dev-dependencies]
-is-terminal = "0.1.0"
 tempfile = "3.2.0"
 libc = "0.2.114"
 serial_test = "0.5"


### PR DESCRIPTION
is-terminal is implemented in terms of rustix, so the code was
previously just testing rustix against itself, and creating an awkward
circluar dependency besides.

Test against `libc::isatty` and `ioctl_tiocgwinsz` instead.