### PR TITLE
Use the new `impl AsFd for &T` support in io-lifetimes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ cc = { version = "1.0.68", optional = true }
 [dependencies]
 bitflags = "1.2.1"
 itoa = { version = "1.0.1", default-features = false, optional = true }
-io-lifetimes = { version = "0.5.1", default-features = false, optional = true }
+io-lifetimes = { version = "0.5.2", default-features = false, optional = true }
 
 # Special dependencies used in rustc-dep-of-std mode.
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ libc = { version = "0.2.114", features = ["extra_traits"] }
 winapi = { version = "0.3.9", features = ["ws2ipdef", "ws2tcpip"] }
 
 [dev-dependencies]
-is-terminal = "0.1.0"
 tempfile = "3.2.0"
 libc = "0.2.114"
 serial_test = "0.5"

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -25,7 +25,8 @@ fn main() -> io::Result<()> {
 }
 
 #[cfg(not(windows))]
-fn show<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
+fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
+    let fd = fd.as_fd();
     if isatty(fd) {
         #[cfg(any(all(linux_raw, feature = "procfs"), libc))]
         println!(" - ttyname: {}", ttyname(fd, Vec::new())?.to_string_lossy());

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -40,7 +40,7 @@ use imp::fs::{Dev, FileType};
 /// [Linux]: https://man7.org/linux/man-pages/man2/open.2.html
 #[inline]
 pub fn openat<P: path::Arg, Fd: AsFd>(
-    dirfd: &Fd,
+    dirfd: Fd,
     path: P,
     oflags: OFlags,
     create_mode: Mode,
@@ -60,7 +60,7 @@ pub fn openat<P: path::Arg, Fd: AsFd>(
 /// [Linux]: https://man7.org/linux/man-pages/man2/readlinkat.2.html
 #[inline]
 pub fn readlinkat<P: path::Arg, Fd: AsFd, B: Into<Vec<u8>>>(
-    dirfd: &Fd,
+    dirfd: Fd,
     path: P,
     reuse: B,
 ) -> io::Result<ZString> {
@@ -97,7 +97,7 @@ fn _readlinkat(dirfd: BorrowedFd<'_>, path: &ZStr, mut buffer: Vec<u8>) -> io::R
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/mkdirat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/mkdirat.2.html
 #[inline]
-pub fn mkdirat<P: path::Arg, Fd: AsFd>(dirfd: &Fd, path: P, mode: Mode) -> io::Result<()> {
+pub fn mkdirat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, mode: Mode) -> io::Result<()> {
     path.into_with_z_str(|path| imp::fs::syscalls::mkdirat(dirfd.as_fd(), path, mode))
 }
 
@@ -112,9 +112,9 @@ pub fn mkdirat<P: path::Arg, Fd: AsFd>(dirfd: &Fd, path: P, mode: Mode) -> io::R
 /// [Linux]: https://man7.org/linux/man-pages/man2/linkat.2.html
 #[inline]
 pub fn linkat<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(
-    old_dirfd: &PFd,
+    old_dirfd: PFd,
     old_path: P,
-    new_dirfd: &QFd,
+    new_dirfd: QFd,
     new_path: Q,
     flags: AtFlags,
 ) -> io::Result<()> {
@@ -144,7 +144,7 @@ pub fn linkat<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/unlinkat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/unlinkat.2.html
 #[inline]
-pub fn unlinkat<P: path::Arg, Fd: AsFd>(dirfd: &Fd, path: P, flags: AtFlags) -> io::Result<()> {
+pub fn unlinkat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, flags: AtFlags) -> io::Result<()> {
     path.into_with_z_str(|path| imp::fs::syscalls::unlinkat(dirfd.as_fd(), path, flags))
 }
 
@@ -159,9 +159,9 @@ pub fn unlinkat<P: path::Arg, Fd: AsFd>(dirfd: &Fd, path: P, flags: AtFlags) -> 
 /// [Linux]: https://man7.org/linux/man-pages/man2/renameat.2.html
 #[inline]
 pub fn renameat<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(
-    old_dirfd: &PFd,
+    old_dirfd: PFd,
     old_path: P,
-    new_dirfd: &QFd,
+    new_dirfd: QFd,
     new_path: Q,
 ) -> io::Result<()> {
     old_path.into_with_z_str(|old_path| {
@@ -182,9 +182,9 @@ pub fn renameat<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(
 #[inline]
 #[doc(alias = "renameat2")]
 pub fn renameat_with<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(
-    old_dirfd: &PFd,
+    old_dirfd: PFd,
     old_path: P,
-    new_dirfd: &QFd,
+    new_dirfd: QFd,
     new_path: Q,
     flags: RenameFlags,
 ) -> io::Result<()> {
@@ -212,7 +212,7 @@ pub fn renameat_with<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(
 #[inline]
 pub fn symlinkat<P: path::Arg, Q: path::Arg, Fd: AsFd>(
     old_path: P,
-    new_dirfd: &Fd,
+    new_dirfd: Fd,
     new_path: Q,
 ) -> io::Result<()> {
     old_path.into_with_z_str(|old_path| {
@@ -237,7 +237,7 @@ pub fn symlinkat<P: path::Arg, Q: path::Arg, Fd: AsFd>(
 /// [`FileType::from_raw_mode`]: crate::fs::FileType::from_raw_mode
 #[inline]
 #[doc(alias = "fstatat")]
-pub fn statat<P: path::Arg, Fd: AsFd>(dirfd: &Fd, path: P, flags: AtFlags) -> io::Result<Stat> {
+pub fn statat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, flags: AtFlags) -> io::Result<Stat> {
     path.into_with_z_str(|path| imp::fs::syscalls::statat(dirfd.as_fd(), path, flags))
 }
 
@@ -254,7 +254,7 @@ pub fn statat<P: path::Arg, Fd: AsFd>(dirfd: &Fd, path: P, flags: AtFlags) -> io
 #[inline]
 #[doc(alias = "faccessat")]
 pub fn accessat<P: path::Arg, Fd: AsFd>(
-    dirfd: &Fd,
+    dirfd: Fd,
     path: P,
     access: Access,
     flags: AtFlags,
@@ -272,7 +272,7 @@ pub fn accessat<P: path::Arg, Fd: AsFd>(
 /// [Linux]: https://man7.org/linux/man-pages/man2/utimensat.2.html
 #[inline]
 pub fn utimensat<P: path::Arg, Fd: AsFd>(
-    dirfd: &Fd,
+    dirfd: Fd,
     path: P,
     times: &Timestamps,
     flags: AtFlags,
@@ -297,7 +297,7 @@ pub fn utimensat<P: path::Arg, Fd: AsFd>(
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 #[doc(alias = "fchmodat")]
-pub fn chmodat<P: path::Arg, Fd: AsFd>(dirfd: &Fd, path: P, mode: Mode) -> io::Result<()> {
+pub fn chmodat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, mode: Mode) -> io::Result<()> {
     path.into_with_z_str(|path| imp::fs::syscalls::chmodat(dirfd.as_fd(), path, mode))
 }
 
@@ -331,7 +331,7 @@ pub fn fclonefileat<Fd: AsFd, DstFd: AsFd, P: path::Arg>(
 #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 #[inline]
 pub fn mknodat<P: path::Arg, Fd: AsFd>(
-    dirfd: &Fd,
+    dirfd: Fd,
     path: P,
     file_type: FileType,
     mode: Mode,
@@ -354,7 +354,7 @@ pub fn mknodat<P: path::Arg, Fd: AsFd>(
 #[cfg(not(any(target_os = "wasi")))]
 #[inline]
 pub fn chownat<P: path::Arg, Fd: AsFd>(
-    dirfd: &Fd,
+    dirfd: Fd,
     path: P,
     owner: Uid,
     group: Gid,

--- a/src/fs/fadvise.rs
+++ b/src/fs/fadvise.rs
@@ -14,6 +14,6 @@ pub use imp::fs::Advice;
 /// [Linux]: https://man7.org/linux/man-pages/man2/posix_fadvise.2.html
 #[inline]
 #[doc(alias = "posix_fadvise")]
-pub fn fadvise<Fd: AsFd>(fd: &Fd, offset: u64, len: u64, advice: Advice) -> io::Result<()> {
+pub fn fadvise<Fd: AsFd>(fd: Fd, offset: u64, len: u64, advice: Advice) -> io::Result<()> {
     imp::fs::syscalls::fadvise(fd.as_fd(), offset, len, advice)
 }

--- a/src/fs/fcntl.rs
+++ b/src/fs/fcntl.rs
@@ -18,7 +18,7 @@ use imp::fs::{FdFlags, OFlags};
 /// [Linux]: https://man7.org/linux/man-pages/man2/fcntl.2.html
 #[inline]
 #[doc(alias = "F_GETFD")]
-pub fn fcntl_getfd<Fd: AsFd>(fd: &Fd) -> io::Result<FdFlags> {
+pub fn fcntl_getfd<Fd: AsFd>(fd: Fd) -> io::Result<FdFlags> {
     imp::fs::syscalls::fcntl_getfd(fd.as_fd())
 }
 
@@ -32,7 +32,7 @@ pub fn fcntl_getfd<Fd: AsFd>(fd: &Fd) -> io::Result<FdFlags> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/fcntl.2.html
 #[inline]
 #[doc(alias = "F_SETFD")]
-pub fn fcntl_setfd<Fd: AsFd>(fd: &Fd, flags: FdFlags) -> io::Result<()> {
+pub fn fcntl_setfd<Fd: AsFd>(fd: Fd, flags: FdFlags) -> io::Result<()> {
     imp::fs::syscalls::fcntl_setfd(fd.as_fd(), flags)
 }
 
@@ -46,7 +46,7 @@ pub fn fcntl_setfd<Fd: AsFd>(fd: &Fd, flags: FdFlags) -> io::Result<()> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/fcntl.2.html
 #[inline]
 #[doc(alias = "F_GETFL")]
-pub fn fcntl_getfl<Fd: AsFd>(fd: &Fd) -> io::Result<OFlags> {
+pub fn fcntl_getfl<Fd: AsFd>(fd: Fd) -> io::Result<OFlags> {
     imp::fs::syscalls::fcntl_getfl(fd.as_fd())
 }
 
@@ -60,7 +60,7 @@ pub fn fcntl_getfl<Fd: AsFd>(fd: &Fd) -> io::Result<OFlags> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/fcntl.2.html
 #[inline]
 #[doc(alias = "F_SETFL")]
-pub fn fcntl_setfl<Fd: AsFd>(fd: &Fd, flags: OFlags) -> io::Result<()> {
+pub fn fcntl_setfl<Fd: AsFd>(fd: Fd, flags: OFlags) -> io::Result<()> {
     imp::fs::syscalls::fcntl_setfl(fd.as_fd(), flags)
 }
 
@@ -78,7 +78,7 @@ pub fn fcntl_setfl<Fd: AsFd>(fd: &Fd, flags: OFlags) -> io::Result<()> {
 ))]
 #[inline]
 #[doc(alias = "F_GET_SEALS")]
-pub fn fcntl_get_seals<Fd: AsFd>(fd: &Fd) -> io::Result<SealFlags> {
+pub fn fcntl_get_seals<Fd: AsFd>(fd: Fd) -> io::Result<SealFlags> {
     imp::fs::syscalls::fcntl_get_seals(fd.as_fd())
 }
 
@@ -104,7 +104,7 @@ pub use imp::fs::SealFlags;
 ))]
 #[inline]
 #[doc(alias = "F_ADD_SEALS")]
-pub fn fcntl_add_seals<Fd: AsFd>(fd: &Fd, seals: SealFlags) -> io::Result<()> {
+pub fn fcntl_add_seals<Fd: AsFd>(fd: Fd, seals: SealFlags) -> io::Result<()> {
     imp::fs::syscalls::fcntl_add_seals(fd.as_fd(), seals)
 }
 
@@ -126,6 +126,6 @@ pub fn fcntl_add_seals<Fd: AsFd>(fd: &Fd, seals: SealFlags) -> io::Result<()> {
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 #[doc(alias = "F_DUPFD_CLOEXEC")]
-pub fn fcntl_dupfd_cloexec<Fd: AsFd>(fd: &Fd, min: RawFd) -> io::Result<OwnedFd> {
+pub fn fcntl_dupfd_cloexec<Fd: AsFd>(fd: Fd, min: RawFd) -> io::Result<OwnedFd> {
     imp::fs::syscalls::fcntl_dupfd_cloexec(fd.as_fd(), min)
 }

--- a/src/fs/fcntl_darwin.rs
+++ b/src/fs/fcntl_darwin.rs
@@ -8,7 +8,7 @@ use imp::fd::AsFd;
 ///
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html
 #[inline]
-pub fn fcntl_rdadvise<Fd: AsFd>(fd: &Fd, offset: u64, len: u64) -> io::Result<()> {
+pub fn fcntl_rdadvise<Fd: AsFd>(fd: Fd, offset: u64, len: u64) -> io::Result<()> {
     imp::fs::syscalls::fcntl_rdadvise(fd.as_fd(), offset, len)
 }
 
@@ -19,6 +19,6 @@ pub fn fcntl_rdadvise<Fd: AsFd>(fd: &Fd, offset: u64, len: u64) -> io::Result<()
 ///
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html
 #[inline]
-pub fn fcntl_fullfsync<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
+pub fn fcntl_fullfsync<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     imp::fs::syscalls::fcntl_fullfsync(fd.as_fd())
 }

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -35,7 +35,7 @@ use imp::fs::{FlockOperation, Mode};
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/lseek.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/lseek.2.html
 #[inline]
-pub fn seek<Fd: AsFd>(fd: &Fd, pos: SeekFrom) -> io::Result<u64> {
+pub fn seek<Fd: AsFd>(fd: Fd, pos: SeekFrom) -> io::Result<u64> {
     imp::fs::syscalls::seek(fd.as_fd(), pos)
 }
 
@@ -52,7 +52,7 @@ pub fn seek<Fd: AsFd>(fd: &Fd, pos: SeekFrom) -> io::Result<u64> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/lseek.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/lseek.2.html
 #[inline]
-pub fn tell<Fd: AsFd>(fd: &Fd) -> io::Result<u64> {
+pub fn tell<Fd: AsFd>(fd: Fd) -> io::Result<u64> {
     imp::fs::syscalls::tell(fd.as_fd())
 }
 
@@ -69,7 +69,7 @@ pub fn tell<Fd: AsFd>(fd: &Fd) -> io::Result<u64> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/fchmod.2.html
 #[cfg(not(target_os = "wasi"))]
 #[inline]
-pub fn fchmod<Fd: AsFd>(fd: &Fd, mode: Mode) -> io::Result<()> {
+pub fn fchmod<Fd: AsFd>(fd: Fd, mode: Mode) -> io::Result<()> {
     imp::fs::syscalls::fchmod(fd.as_fd(), mode)
 }
 
@@ -83,7 +83,7 @@ pub fn fchmod<Fd: AsFd>(fd: &Fd, mode: Mode) -> io::Result<()> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/fchown.2.html
 #[cfg(not(target_os = "wasi"))]
 #[inline]
-pub fn fchown<Fd: AsFd>(fd: &Fd, owner: Uid, group: Gid) -> io::Result<()> {
+pub fn fchown<Fd: AsFd>(fd: Fd, owner: Uid, group: Gid) -> io::Result<()> {
     imp::fs::syscalls::fchown(fd.as_fd(), owner, group)
 }
 
@@ -101,7 +101,7 @@ pub fn fchown<Fd: AsFd>(fd: &Fd, owner: Uid, group: Gid) -> io::Result<()> {
 /// [`Mode::from_raw_mode`]: crate::fs::Mode::from_raw_mode
 /// [`FileType::from_raw_mode`]: crate::fs::FileType::from_raw_mode
 #[inline]
-pub fn fstat<Fd: AsFd>(fd: &Fd) -> io::Result<Stat> {
+pub fn fstat<Fd: AsFd>(fd: Fd) -> io::Result<Stat> {
     imp::fs::syscalls::fstat(fd.as_fd())
 }
 
@@ -118,7 +118,7 @@ pub fn fstat<Fd: AsFd>(fd: &Fd) -> io::Result<Stat> {
     target_os = "wasi"
 )))] // not implemented in libc for netbsd yet
 #[inline]
-pub fn fstatfs<Fd: AsFd>(fd: &Fd) -> io::Result<StatFs> {
+pub fn fstatfs<Fd: AsFd>(fd: Fd) -> io::Result<StatFs> {
     imp::fs::syscalls::fstatfs(fd.as_fd())
 }
 
@@ -131,7 +131,7 @@ pub fn fstatfs<Fd: AsFd>(fd: &Fd) -> io::Result<StatFs> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/futimens.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/utimensat.2.html
 #[inline]
-pub fn futimens<Fd: AsFd>(fd: &Fd, times: &Timestamps) -> io::Result<()> {
+pub fn futimens<Fd: AsFd>(fd: Fd, times: &Timestamps) -> io::Result<()> {
     imp::fs::syscalls::futimens(fd.as_fd(), times)
 }
 
@@ -159,7 +159,7 @@ pub fn futimens<Fd: AsFd>(fd: &Fd, times: &Timestamps) -> io::Result<()> {
 )))] // not implemented in libc for netbsd yet
 #[inline]
 #[doc(alias = "posix_fallocate")]
-pub fn fallocate<Fd: AsFd>(fd: &Fd, mode: FallocateFlags, offset: u64, len: u64) -> io::Result<()> {
+pub fn fallocate<Fd: AsFd>(fd: Fd, mode: FallocateFlags, offset: u64, len: u64) -> io::Result<()> {
     imp::fs::syscalls::fallocate(fd.as_fd(), mode, offset, len)
 }
 
@@ -170,7 +170,7 @@ pub fn fallocate<Fd: AsFd>(fd: &Fd, mode: FallocateFlags, offset: u64, len: u64)
 /// example, it doesn't reflect whether sockets have been shut down; for
 /// general I/O handle support, use [`io::is_read_write`].
 #[inline]
-pub fn is_file_read_write<Fd: AsFd>(fd: &Fd) -> io::Result<(bool, bool)> {
+pub fn is_file_read_write<Fd: AsFd>(fd: Fd) -> io::Result<(bool, bool)> {
     _is_file_read_write(fd.as_fd())
 }
 
@@ -212,7 +212,7 @@ pub(crate) fn _is_file_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)
 /// [Linux]: https://man7.org/linux/man-pages/man2/fsync.2.html
 /// [`fcntl_fullfsync`]: https://docs.rs/rustix/*/x86_64-apple-darwin/rustix/fs/fn.fcntl_fullfsync.html
 #[inline]
-pub fn fsync<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
+pub fn fsync<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     imp::fs::syscalls::fsync(fd.as_fd())
 }
 
@@ -232,7 +232,7 @@ pub fn fsync<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
     target_os = "redox"
 )))]
 #[inline]
-pub fn fdatasync<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
+pub fn fdatasync<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     imp::fs::syscalls::fdatasync(fd.as_fd())
 }
 
@@ -245,7 +245,7 @@ pub fn fdatasync<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/ftruncate.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/ftruncate.2.html
 #[inline]
-pub fn ftruncate<Fd: AsFd>(fd: &Fd, length: u64) -> io::Result<()> {
+pub fn ftruncate<Fd: AsFd>(fd: Fd, length: u64) -> io::Result<()> {
     imp::fs::syscalls::ftruncate(fd.as_fd(), length)
 }
 
@@ -257,6 +257,6 @@ pub fn ftruncate<Fd: AsFd>(fd: &Fd, length: u64) -> io::Result<()> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/flock.2.html
 #[cfg(not(target_os = "wasi"))]
 #[inline]
-pub fn flock<Fd: AsFd>(fd: &Fd, operation: FlockOperation) -> io::Result<()> {
+pub fn flock<Fd: AsFd>(fd: Fd, operation: FlockOperation) -> io::Result<()> {
     imp::fs::syscalls::flock(fd.as_fd(), operation)
 }

--- a/src/fs/getpath.rs
+++ b/src/fs/getpath.rs
@@ -9,6 +9,6 @@ use imp::fd::AsFd;
 ///
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html
 #[inline]
-pub fn getpath<Fd: AsFd>(fd: &Fd) -> io::Result<ZString> {
+pub fn getpath<Fd: AsFd>(fd: Fd) -> io::Result<ZString> {
     imp::fs::syscalls::getpath(fd.as_fd())
 }

--- a/src/fs/openat2.rs
+++ b/src/fs/openat2.rs
@@ -11,7 +11,7 @@ use imp::fs::{Mode, OFlags, ResolveFlags};
 /// [Linux]: https://man7.org/linux/man-pages/man2/openat2.2.html
 #[inline]
 pub fn openat2<Fd: AsFd, P: path::Arg>(
-    dirfd: &Fd,
+    dirfd: Fd,
     path: P,
     oflags: OFlags,
     mode: Mode,

--- a/src/fs/sendfile.rs
+++ b/src/fs/sendfile.rs
@@ -10,8 +10,8 @@ use imp::fd::AsFd;
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 #[inline]
 pub fn sendfile<OutFd: AsFd, InFd: AsFd>(
-    out_fd: &OutFd,
-    in_fd: &InFd,
+    out_fd: OutFd,
+    in_fd: InFd,
     offset: Option<&mut u64>,
     count: usize,
 ) -> io::Result<usize> {

--- a/src/fs/statx.rs
+++ b/src/fs/statx.rs
@@ -18,7 +18,7 @@ pub use imp::fs::StatxFlags;
 /// [Linux]: https://man7.org/linux/man-pages/man2/statx.2.html
 #[inline]
 pub fn statx<P: path::Arg, Fd: AsFd>(
-    dirfd: &Fd,
+    dirfd: Fd,
     path: P,
     flags: AtFlags,
     mask: StatxFlags,

--- a/src/io/dup.rs
+++ b/src/io/dup.rs
@@ -27,7 +27,7 @@ pub use imp::io::DupFlags;
 /// [Linux]: https://man7.org/linux/man-pages/man2/dup.2.html
 #[cfg(not(target_os = "wasi"))]
 #[inline]
-pub fn dup<Fd: AsFd>(fd: &Fd) -> io::Result<OwnedFd> {
+pub fn dup<Fd: AsFd>(fd: Fd) -> io::Result<OwnedFd> {
     imp::io::syscalls::dup(fd.as_fd())
 }
 
@@ -48,7 +48,7 @@ pub fn dup<Fd: AsFd>(fd: &Fd) -> io::Result<OwnedFd> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/dup2.2.html
 #[cfg(not(target_os = "wasi"))]
 #[inline]
-pub fn dup2<Fd: AsFd>(fd: &Fd, new: &OwnedFd) -> io::Result<()> {
+pub fn dup2<Fd: AsFd>(fd: Fd, new: &OwnedFd) -> io::Result<()> {
     imp::io::syscalls::dup2(fd.as_fd(), new)
 }
 
@@ -68,6 +68,6 @@ pub fn dup2<Fd: AsFd>(fd: &Fd, new: &OwnedFd) -> io::Result<()> {
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 #[doc(alias = "dup3")]
-pub fn dup2_with<Fd: AsFd>(fd: &Fd, new: &OwnedFd, flags: DupFlags) -> io::Result<()> {
+pub fn dup2_with<Fd: AsFd>(fd: Fd, new: &OwnedFd, flags: DupFlags) -> io::Result<()> {
     imp::io::syscalls::dup2_with(fd.as_fd(), new, flags)
 }

--- a/src/io/fd/owned.rs
+++ b/src/io/fd/owned.rs
@@ -181,6 +181,22 @@ pub trait AsFd {
 }
 
 #[cfg_attr(staged_api, unstable(feature = "io_safety", issue = "87074"))]
+impl<T: AsFd> AsFd for &T {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        T::as_fd(self)
+    }
+}
+
+#[cfg_attr(staged_api, unstable(feature = "io_safety", issue = "87074"))]
+impl<T: AsFd> AsFd for &mut T {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        T::as_fd(self)
+    }
+}
+
+#[cfg_attr(staged_api, unstable(feature = "io_safety", issue = "87074"))]
 impl AsFd for BorrowedFd<'_> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {

--- a/src/io/ioctl.rs
+++ b/src/io/ioctl.rs
@@ -24,7 +24,7 @@ use imp::fd::AsFd;
 #[inline]
 #[doc(alias = "tcgetattr")]
 #[doc(alias = "TCGETS")]
-pub fn ioctl_tcgets<Fd: AsFd>(fd: &Fd) -> io::Result<Termios> {
+pub fn ioctl_tcgets<Fd: AsFd>(fd: Fd) -> io::Result<Termios> {
     imp::io::syscalls::ioctl_tcgets(fd.as_fd())
 }
 
@@ -35,7 +35,7 @@ pub fn ioctl_tcgets<Fd: AsFd>(fd: &Fd) -> io::Result<Termios> {
 #[inline]
 #[doc(alias = "FIOCLEX")]
 #[doc(alias = "FD_CLOEXEC")]
-pub fn ioctl_fioclex<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
+pub fn ioctl_fioclex<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     imp::io::syscalls::ioctl_fioclex(fd.as_fd())
 }
 
@@ -48,14 +48,14 @@ pub fn ioctl_fioclex<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
 #[cfg(not(any(windows, target_os = "wasi")))]
 #[inline]
 #[doc(alias = "TIOCGWINSZ")]
-pub fn ioctl_tiocgwinsz<Fd: AsFd>(fd: &Fd) -> io::Result<Winsize> {
+pub fn ioctl_tiocgwinsz<Fd: AsFd>(fd: Fd) -> io::Result<Winsize> {
     imp::io::syscalls::ioctl_tiocgwinsz(fd.as_fd())
 }
 
 /// `ioctl(fd, FIONBIO, &value)`—Enables or disables non-blocking mode.
 #[inline]
 #[doc(alias = "FIONBIO")]
-pub fn ioctl_fionbio<Fd: AsFd>(fd: &Fd, value: bool) -> io::Result<()> {
+pub fn ioctl_fionbio<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
     imp::io::syscalls::ioctl_fionbio(fd.as_fd(), value)
 }
 
@@ -71,7 +71,7 @@ pub fn ioctl_fionbio<Fd: AsFd>(fd: &Fd, value: bool) -> io::Result<()> {
 ))]
 #[inline]
 #[doc(alias = "TIOCEXCL")]
-pub fn ioctl_tiocexcl<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
+pub fn ioctl_tiocexcl<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     imp::io::syscalls::ioctl_tiocexcl(fd.as_fd())
 }
 
@@ -87,7 +87,7 @@ pub fn ioctl_tiocexcl<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
 ))]
 #[inline]
 #[doc(alias = "TIOCNXCL")]
-pub fn ioctl_tiocnxcl<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
+pub fn ioctl_tiocnxcl<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     imp::io::syscalls::ioctl_tiocnxcl(fd.as_fd())
 }
 
@@ -103,7 +103,7 @@ pub fn ioctl_tiocnxcl<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
 #[cfg(not(any(windows, target_os = "redox")))]
 #[inline]
 #[doc(alias = "FIONREAD")]
-pub fn ioctl_fionread<Fd: AsFd>(fd: &Fd) -> io::Result<u64> {
+pub fn ioctl_fionread<Fd: AsFd>(fd: Fd) -> io::Result<u64> {
     imp::io::syscalls::ioctl_fionread(fd.as_fd())
 }
 
@@ -111,7 +111,7 @@ pub fn ioctl_fionread<Fd: AsFd>(fd: &Fd) -> io::Result<u64> {
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 #[doc(alias = "BLKSSZGET")]
-pub fn ioctl_blksszget<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
+pub fn ioctl_blksszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
     imp::io::syscalls::ioctl_blksszget(fd.as_fd())
 }
 
@@ -119,6 +119,6 @@ pub fn ioctl_blksszget<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 #[doc(alias = "BLKPBSZGET")]
-pub fn ioctl_blkpbszget<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
+pub fn ioctl_blkpbszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
     imp::io::syscalls::ioctl_blkpbszget(fd.as_fd())
 }

--- a/src/io/is_read_write.rs
+++ b/src/io/is_read_write.rs
@@ -11,6 +11,6 @@ use imp::fd::AsFd;
 ///
 /// [`is_file_read_write`]: crate::fs::is_file_read_write
 #[inline]
-pub fn is_read_write<Fd: AsFd>(fd: &Fd) -> io::Result<(bool, bool)> {
+pub fn is_read_write<Fd: AsFd>(fd: Fd) -> io::Result<(bool, bool)> {
     imp::io::syscalls::is_read_write(fd.as_fd())
 }

--- a/src/io/mmap.rs
+++ b/src/io/mmap.rs
@@ -38,7 +38,7 @@ pub unsafe fn mmap<Fd: AsFd>(
     len: usize,
     prot: ProtFlags,
     flags: MapFlags,
-    fd: &Fd,
+    fd: Fd,
     offset: u64,
 ) -> io::Result<*mut c_void> {
     imp::io::syscalls::mmap(ptr, len, prot, flags, fd.as_fd(), offset)

--- a/src/io/procfs.rs
+++ b/src/io/procfs.rs
@@ -208,7 +208,7 @@ fn is_mountpoint(file: BorrowedFd<'_>) -> bool {
 }
 
 /// Open a directory in `/proc`, mapping all errors to `io::Error::NOTSUP`.
-fn proc_opendirat<P: crate::path::Arg, Fd: AsFd>(dirfd: &Fd, path: P) -> io::Result<OwnedFd> {
+fn proc_opendirat<P: crate::path::Arg, Fd: AsFd>(dirfd: Fd, path: P) -> io::Result<OwnedFd> {
     // We could add `PATH`|`NOATIME` here but Linux 2.6.32 doesn't support it.
     let oflags = OFlags::NOFOLLOW | OFlags::DIRECTORY | OFlags::CLOEXEC | OFlags::NOCTTY;
     openat(dirfd, path, oflags, Mode::empty()).map_err(|_err| io::Error::NOTSUP)
@@ -369,7 +369,7 @@ fn proc_self_fdinfo() -> io::Result<(BorrowedFd<'static>, &'static Stat)> {
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man5/proc.5.html
 #[inline]
-pub fn proc_self_fdinfo_fd<Fd: AsFd>(fd: &Fd) -> io::Result<OwnedFd> {
+pub fn proc_self_fdinfo_fd<Fd: AsFd>(fd: Fd) -> io::Result<OwnedFd> {
     _proc_self_fdinfo(fd.as_fd())
 }
 

--- a/src/io/read_write.rs
+++ b/src/io/read_write.rs
@@ -17,7 +17,7 @@ pub use imp::io::ReadWriteFlags;
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/read.2.html
 #[inline]
-pub fn read<Fd: AsFd>(fd: &Fd, buf: &mut [u8]) -> io::Result<usize> {
+pub fn read<Fd: AsFd>(fd: Fd, buf: &mut [u8]) -> io::Result<usize> {
     imp::io::syscalls::read(fd.as_fd(), buf)
 }
 
@@ -30,7 +30,7 @@ pub fn read<Fd: AsFd>(fd: &Fd, buf: &mut [u8]) -> io::Result<usize> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/write.2.html
 #[inline]
-pub fn write<Fd: AsFd>(fd: &Fd, buf: &[u8]) -> io::Result<usize> {
+pub fn write<Fd: AsFd>(fd: Fd, buf: &[u8]) -> io::Result<usize> {
     imp::io::syscalls::write(fd.as_fd(), buf)
 }
 
@@ -43,7 +43,7 @@ pub fn write<Fd: AsFd>(fd: &Fd, buf: &[u8]) -> io::Result<usize> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/pread.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/pread.2.html
 #[inline]
-pub fn pread<Fd: AsFd>(fd: &Fd, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+pub fn pread<Fd: AsFd>(fd: Fd, buf: &mut [u8], offset: u64) -> io::Result<usize> {
     imp::io::syscalls::pread(fd.as_fd(), buf, offset)
 }
 
@@ -56,7 +56,7 @@ pub fn pread<Fd: AsFd>(fd: &Fd, buf: &mut [u8], offset: u64) -> io::Result<usize
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/pwrite.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/pwrite.2.html
 #[inline]
-pub fn pwrite<Fd: AsFd>(fd: &Fd, buf: &[u8], offset: u64) -> io::Result<usize> {
+pub fn pwrite<Fd: AsFd>(fd: Fd, buf: &[u8], offset: u64) -> io::Result<usize> {
     imp::io::syscalls::pwrite(fd.as_fd(), buf, offset)
 }
 
@@ -69,7 +69,7 @@ pub fn pwrite<Fd: AsFd>(fd: &Fd, buf: &[u8], offset: u64) -> io::Result<usize> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/readv.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/readv.2.html
 #[inline]
-pub fn readv<Fd: AsFd>(fd: &Fd, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+pub fn readv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
     imp::io::syscalls::readv(fd.as_fd(), bufs)
 }
 
@@ -82,7 +82,7 @@ pub fn readv<Fd: AsFd>(fd: &Fd, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/writev.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/writev.2.html
 #[inline]
-pub fn writev<Fd: AsFd>(fd: &Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+pub fn writev<Fd: AsFd>(fd: Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
     imp::io::syscalls::writev(fd.as_fd(), bufs)
 }
 
@@ -95,7 +95,7 @@ pub fn writev<Fd: AsFd>(fd: &Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/preadv.2.html
 #[cfg(not(target_os = "redox"))]
 #[inline]
-pub fn preadv<Fd: AsFd>(fd: &Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
+pub fn preadv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
     imp::io::syscalls::preadv(fd.as_fd(), bufs, offset)
 }
 
@@ -108,7 +108,7 @@ pub fn preadv<Fd: AsFd>(fd: &Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io
 /// [Linux]: https://man7.org/linux/man-pages/man2/pwritev.2.html
 #[cfg(not(target_os = "redox"))]
 #[inline]
-pub fn pwritev<Fd: AsFd>(fd: &Fd, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
+pub fn pwritev<Fd: AsFd>(fd: Fd, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
     imp::io::syscalls::pwritev(fd.as_fd(), bufs, offset)
 }
 
@@ -123,7 +123,7 @@ pub fn pwritev<Fd: AsFd>(fd: &Fd, bufs: &[IoSlice<'_>], offset: u64) -> io::Resu
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 #[inline]
 pub fn preadv2<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     bufs: &mut [IoSliceMut<'_>],
     offset: u64,
     flags: ReadWriteFlags,
@@ -142,7 +142,7 @@ pub fn preadv2<Fd: AsFd>(
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 #[inline]
 pub fn pwritev2<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     bufs: &[IoSlice<'_>],
     offset: u64,
     flags: ReadWriteFlags,

--- a/src/io/tty.rs
+++ b/src/io/tty.rs
@@ -25,7 +25,7 @@ use {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/isatty.html
 /// [Linux]: https://man7.org/linux/man-pages/man3/isatty.3.html
 #[inline]
-pub fn isatty<Fd: AsFd>(fd: &Fd) -> bool {
+pub fn isatty<Fd: AsFd>(fd: Fd) -> bool {
     imp::io::syscalls::isatty(fd.as_fd())
 }
 
@@ -45,7 +45,7 @@ pub fn isatty<Fd: AsFd>(fd: &Fd) -> bool {
 ))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
 #[inline]
-pub fn ttyname<Fd: AsFd, B: Into<Vec<u8>>>(dirfd: &Fd, reuse: B) -> io::Result<ZString> {
+pub fn ttyname<Fd: AsFd, B: Into<Vec<u8>>>(dirfd: Fd, reuse: B) -> io::Result<ZString> {
     _ttyname(dirfd.as_fd(), reuse.into())
 }
 

--- a/src/net/send_recv.rs
+++ b/src/net/send_recv.rs
@@ -19,7 +19,7 @@ pub use imp::net::{RecvFlags, SendFlags};
 /// [Linux]: https://man7.org/linux/man-pages/man2/recv.2.html
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-recv
 #[inline]
-pub fn recv<Fd: AsFd>(fd: &Fd, buf: &mut [u8], flags: RecvFlags) -> io::Result<usize> {
+pub fn recv<Fd: AsFd>(fd: Fd, buf: &mut [u8], flags: RecvFlags) -> io::Result<usize> {
     imp::net::syscalls::recv(fd.as_fd(), buf, flags)
 }
 
@@ -34,7 +34,7 @@ pub fn recv<Fd: AsFd>(fd: &Fd, buf: &mut [u8], flags: RecvFlags) -> io::Result<u
 /// [Linux]: https://man7.org/linux/man-pages/man2/send.2.html
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send
 #[inline]
-pub fn send<Fd: AsFd>(fd: &Fd, buf: &[u8], flags: SendFlags) -> io::Result<usize> {
+pub fn send<Fd: AsFd>(fd: Fd, buf: &[u8], flags: SendFlags) -> io::Result<usize> {
     imp::net::syscalls::send(fd.as_fd(), buf, flags)
 }
 
@@ -51,7 +51,7 @@ pub fn send<Fd: AsFd>(fd: &Fd, buf: &[u8], flags: SendFlags) -> io::Result<usize
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-recvfrom
 #[inline]
 pub fn recvfrom<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     buf: &mut [u8],
     flags: RecvFlags,
 ) -> io::Result<(usize, Option<SocketAddrAny>)> {
@@ -68,7 +68,7 @@ pub fn recvfrom<Fd: AsFd>(
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/sendto.2.html
 pub fn sendto<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     buf: &[u8],
     flags: SendFlags,
     addr: &SocketAddr,
@@ -98,7 +98,7 @@ fn _sendto(
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/sendto.2.html
 pub fn sendto_any<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     buf: &[u8],
     flags: SendFlags,
     addr: &SocketAddrAny,
@@ -134,7 +134,7 @@ fn _sendto_any(
 #[inline]
 #[doc(alias = "sendto")]
 pub fn sendto_v4<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     buf: &[u8],
     flags: SendFlags,
     addr: &SocketAddrV4,
@@ -156,7 +156,7 @@ pub fn sendto_v4<Fd: AsFd>(
 #[inline]
 #[doc(alias = "sendto")]
 pub fn sendto_v6<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     buf: &[u8],
     flags: SendFlags,
     addr: &SocketAddrV6,
@@ -179,7 +179,7 @@ pub fn sendto_v6<Fd: AsFd>(
 #[doc(alias = "sendto")]
 #[cfg(unix)]
 pub fn sendto_unix<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     buf: &[u8],
     flags: SendFlags,
     addr: &SocketAddrUnix,

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -69,7 +69,7 @@ pub fn socket_with(
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/bind.2.html
-pub fn bind<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddr) -> io::Result<()> {
+pub fn bind<Fd: AsFd>(sockfd: Fd, addr: &SocketAddr) -> io::Result<()> {
     _bind(sockfd.as_fd(), addr)
 }
 
@@ -89,7 +89,7 @@ fn _bind(sockfd: BorrowedFd<'_>, addr: &SocketAddr) -> io::Result<()> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/bind.2.html
 #[doc(alias = "bind")]
-pub fn bind_any<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrAny) -> io::Result<()> {
+pub fn bind_any<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrAny) -> io::Result<()> {
     _bind_any(sockfd.as_fd(), addr)
 }
 
@@ -115,7 +115,7 @@ fn _bind_any(sockfd: BorrowedFd<'_>, addr: &SocketAddrAny) -> io::Result<()> {
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-bind
 #[inline]
 #[doc(alias = "bind")]
-pub fn bind_v4<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV4) -> io::Result<()> {
+pub fn bind_v4<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrV4) -> io::Result<()> {
     imp::net::syscalls::bind_v4(sockfd.as_fd(), addr)
 }
 
@@ -132,7 +132,7 @@ pub fn bind_v4<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV4) -> io::Result<()> {
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-bind
 #[inline]
 #[doc(alias = "bind")]
-pub fn bind_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> {
+pub fn bind_v6<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrV6) -> io::Result<()> {
     imp::net::syscalls::bind_v6(sockfd.as_fd(), addr)
 }
 
@@ -150,7 +150,7 @@ pub fn bind_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> {
 #[inline]
 #[doc(alias = "bind")]
 #[cfg(unix)]
-pub fn bind_unix<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrUnix) -> io::Result<()> {
+pub fn bind_unix<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrUnix) -> io::Result<()> {
     imp::net::syscalls::bind_unix(sockfd.as_fd(), addr)
 }
 
@@ -162,7 +162,7 @@ pub fn bind_unix<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrUnix) -> io::Result<()>
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/connect.2.html
-pub fn connect<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddr) -> io::Result<()> {
+pub fn connect<Fd: AsFd>(sockfd: Fd, addr: &SocketAddr) -> io::Result<()> {
     _connect(sockfd.as_fd(), addr)
 }
 
@@ -182,7 +182,7 @@ fn _connect(sockfd: BorrowedFd<'_>, addr: &SocketAddr) -> io::Result<()> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/connect.2.html
 #[doc(alias = "connect")]
-pub fn connect_any<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrAny) -> io::Result<()> {
+pub fn connect_any<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrAny) -> io::Result<()> {
     _connect_any(sockfd.as_fd(), addr)
 }
 
@@ -208,7 +208,7 @@ fn _connect_any(sockfd: BorrowedFd<'_>, addr: &SocketAddrAny) -> io::Result<()> 
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect
 #[inline]
 #[doc(alias = "connect")]
-pub fn connect_v4<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV4) -> io::Result<()> {
+pub fn connect_v4<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrV4) -> io::Result<()> {
     imp::net::syscalls::connect_v4(sockfd.as_fd(), addr)
 }
 
@@ -225,7 +225,7 @@ pub fn connect_v4<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV4) -> io::Result<()> 
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect
 #[inline]
 #[doc(alias = "connect")]
-pub fn connect_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> {
+pub fn connect_v6<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrV6) -> io::Result<()> {
     imp::net::syscalls::connect_v6(sockfd.as_fd(), addr)
 }
 
@@ -241,7 +241,7 @@ pub fn connect_v6<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrV6) -> io::Result<()> 
 #[inline]
 #[doc(alias = "connect")]
 #[cfg(unix)]
-pub fn connect_unix<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrUnix) -> io::Result<()> {
+pub fn connect_unix<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrUnix) -> io::Result<()> {
     imp::net::syscalls::connect_unix(sockfd.as_fd(), addr)
 }
 
@@ -256,7 +256,7 @@ pub fn connect_unix<Fd: AsFd>(sockfd: &Fd, addr: &SocketAddrUnix) -> io::Result<
 /// [Linux]: https://man7.org/linux/man-pages/man2/listen.2.html
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen
 #[inline]
-pub fn listen<Fd: AsFd>(sockfd: &Fd, backlog: i32) -> io::Result<()> {
+pub fn listen<Fd: AsFd>(sockfd: Fd, backlog: i32) -> io::Result<()> {
     imp::net::syscalls::listen(sockfd.as_fd(), backlog)
 }
 
@@ -278,7 +278,7 @@ pub fn listen<Fd: AsFd>(sockfd: &Fd, backlog: i32) -> io::Result<()> {
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept
 #[inline]
 #[doc(alias = "accept4")]
-pub fn accept<Fd: AsFd>(sockfd: &Fd) -> io::Result<OwnedFd> {
+pub fn accept<Fd: AsFd>(sockfd: Fd) -> io::Result<OwnedFd> {
     imp::net::syscalls::accept(sockfd.as_fd())
 }
 
@@ -304,7 +304,7 @@ pub fn accept<Fd: AsFd>(sockfd: &Fd) -> io::Result<OwnedFd> {
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept
 #[inline]
 #[doc(alias = "accept4")]
-pub fn accept_with<Fd: AsFd>(sockfd: &Fd, flags: AcceptFlags) -> io::Result<OwnedFd> {
+pub fn accept_with<Fd: AsFd>(sockfd: Fd, flags: AcceptFlags) -> io::Result<OwnedFd> {
     imp::net::syscalls::accept_with(sockfd.as_fd(), flags)
 }
 
@@ -323,7 +323,7 @@ pub fn accept_with<Fd: AsFd>(sockfd: &Fd, flags: AcceptFlags) -> io::Result<Owne
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept
 #[inline]
 #[doc(alias = "accept4")]
-pub fn acceptfrom<Fd: AsFd>(sockfd: &Fd) -> io::Result<(OwnedFd, Option<SocketAddrAny>)> {
+pub fn acceptfrom<Fd: AsFd>(sockfd: Fd) -> io::Result<(OwnedFd, Option<SocketAddrAny>)> {
     imp::net::syscalls::acceptfrom(sockfd.as_fd())
 }
 
@@ -346,7 +346,7 @@ pub fn acceptfrom<Fd: AsFd>(sockfd: &Fd) -> io::Result<(OwnedFd, Option<SocketAd
 #[inline]
 #[doc(alias = "accept4")]
 pub fn acceptfrom_with<Fd: AsFd>(
-    sockfd: &Fd,
+    sockfd: Fd,
     flags: AcceptFlags,
 ) -> io::Result<(OwnedFd, Option<SocketAddrAny>)> {
     imp::net::syscalls::acceptfrom_with(sockfd.as_fd(), flags)
@@ -363,7 +363,7 @@ pub fn acceptfrom_with<Fd: AsFd>(
 /// [Linux]: https://man7.org/linux/man-pages/man2/shutdown.2.html
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-shutdown
 #[inline]
-pub fn shutdown<Fd: AsFd>(sockfd: &Fd, how: Shutdown) -> io::Result<()> {
+pub fn shutdown<Fd: AsFd>(sockfd: Fd, how: Shutdown) -> io::Result<()> {
     imp::net::syscalls::shutdown(sockfd.as_fd(), how)
 }
 
@@ -378,7 +378,7 @@ pub fn shutdown<Fd: AsFd>(sockfd: &Fd, how: Shutdown) -> io::Result<()> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/getsockname.2.html
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockname
 #[inline]
-pub fn getsockname<Fd: AsFd>(sockfd: &Fd) -> io::Result<SocketAddrAny> {
+pub fn getsockname<Fd: AsFd>(sockfd: Fd) -> io::Result<SocketAddrAny> {
     imp::net::syscalls::getsockname(sockfd.as_fd())
 }
 
@@ -394,6 +394,6 @@ pub fn getsockname<Fd: AsFd>(sockfd: &Fd) -> io::Result<SocketAddrAny> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/getpeername.2.html
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getpeername
 #[inline]
-pub fn getpeername<Fd: AsFd>(sockfd: &Fd) -> io::Result<Option<SocketAddrAny>> {
+pub fn getpeername<Fd: AsFd>(sockfd: Fd) -> io::Result<Option<SocketAddrAny>> {
     imp::net::syscalls::getpeername(sockfd.as_fd())
 }

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -31,7 +31,7 @@ pub use imp::net::Timeout;
 /// [Winsock2 `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
 #[inline]
 #[doc(alias = "SO_TYPE")]
-pub fn get_socket_type<Fd: AsFd>(fd: &Fd) -> io::Result<SocketType> {
+pub fn get_socket_type<Fd: AsFd>(fd: Fd) -> io::Result<SocketType> {
     imp::net::syscalls::sockopt::get_socket_type(fd.as_fd())
 }
 
@@ -53,7 +53,7 @@ pub fn get_socket_type<Fd: AsFd>(fd: &Fd) -> io::Result<SocketType> {
 /// [Winsock2 `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
 #[inline]
 #[doc(alias = "SO_REUSEADDR")]
-pub fn set_socket_reuseaddr<Fd: AsFd>(fd: &Fd, value: bool) -> io::Result<()> {
+pub fn set_socket_reuseaddr<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
     imp::net::syscalls::sockopt::set_socket_reuseaddr(fd.as_fd(), value)
 }
 
@@ -75,7 +75,7 @@ pub fn set_socket_reuseaddr<Fd: AsFd>(fd: &Fd, value: bool) -> io::Result<()> {
 /// [Winsock2 `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
 #[inline]
 #[doc(alias = "SO_BROADCAST")]
-pub fn set_socket_broadcast<Fd: AsFd>(fd: &Fd, broadcast: bool) -> io::Result<()> {
+pub fn set_socket_broadcast<Fd: AsFd>(fd: Fd, broadcast: bool) -> io::Result<()> {
     imp::net::syscalls::sockopt::set_socket_broadcast(fd.as_fd(), broadcast)
 }
 
@@ -97,7 +97,7 @@ pub fn set_socket_broadcast<Fd: AsFd>(fd: &Fd, broadcast: bool) -> io::Result<()
 /// [Winsock2 `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
 #[inline]
 #[doc(alias = "SO_BROADCAST")]
-pub fn get_socket_broadcast<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
+pub fn get_socket_broadcast<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
     imp::net::syscalls::sockopt::get_socket_broadcast(fd.as_fd())
 }
 
@@ -119,7 +119,7 @@ pub fn get_socket_broadcast<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
 /// [Winsock2 `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
 #[inline]
 #[doc(alias = "SO_LINGER")]
-pub fn set_socket_linger<Fd: AsFd>(fd: &Fd, linger: Option<Duration>) -> io::Result<()> {
+pub fn set_socket_linger<Fd: AsFd>(fd: Fd, linger: Option<Duration>) -> io::Result<()> {
     imp::net::syscalls::sockopt::set_socket_linger(fd.as_fd(), linger)
 }
 
@@ -141,7 +141,7 @@ pub fn set_socket_linger<Fd: AsFd>(fd: &Fd, linger: Option<Duration>) -> io::Res
 /// [Winsock2 `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
 #[inline]
 #[doc(alias = "SO_LINGER")]
-pub fn get_socket_linger<Fd: AsFd>(fd: &Fd) -> io::Result<Option<Duration>> {
+pub fn get_socket_linger<Fd: AsFd>(fd: Fd) -> io::Result<Option<Duration>> {
     imp::net::syscalls::sockopt::get_socket_linger(fd.as_fd())
 }
 
@@ -156,7 +156,7 @@ pub fn get_socket_linger<Fd: AsFd>(fd: &Fd) -> io::Result<Option<Duration>> {
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 #[doc(alias = "SO_PASSCRED")]
-pub fn set_socket_passcred<Fd: AsFd>(fd: &Fd, passcred: bool) -> io::Result<()> {
+pub fn set_socket_passcred<Fd: AsFd>(fd: Fd, passcred: bool) -> io::Result<()> {
     imp::net::syscalls::sockopt::set_socket_passcred(fd.as_fd(), passcred)
 }
 
@@ -171,7 +171,7 @@ pub fn set_socket_passcred<Fd: AsFd>(fd: &Fd, passcred: bool) -> io::Result<()> 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 #[doc(alias = "SO_PASSCRED")]
-pub fn get_socket_passcred<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
+pub fn get_socket_passcred<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
     imp::net::syscalls::sockopt::get_socket_passcred(fd.as_fd())
 }
 
@@ -196,7 +196,7 @@ pub fn get_socket_passcred<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
 #[doc(alias = "SO_RCVTIMEO")]
 #[doc(alias = "SO_SNDTIMEO")]
 pub fn set_socket_timeout<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     id: Timeout,
     timeout: Option<Duration>,
 ) -> io::Result<()> {
@@ -222,7 +222,7 @@ pub fn set_socket_timeout<Fd: AsFd>(
 #[inline]
 #[doc(alias = "SO_RCVTIMEO")]
 #[doc(alias = "SO_SNDTIMEO")]
-pub fn get_socket_timeout<Fd: AsFd>(fd: &Fd, id: Timeout) -> io::Result<Option<Duration>> {
+pub fn get_socket_timeout<Fd: AsFd>(fd: Fd, id: Timeout) -> io::Result<Option<Duration>> {
     imp::net::syscalls::sockopt::get_socket_timeout(fd.as_fd(), id)
 }
 
@@ -243,7 +243,7 @@ pub fn get_socket_timeout<Fd: AsFd>(fd: &Fd, id: Timeout) -> io::Result<Option<D
 /// [Winsock2 `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 #[inline]
 #[doc(alias = "IP_TTL")]
-pub fn set_ip_ttl<Fd: AsFd>(fd: &Fd, ttl: u32) -> io::Result<()> {
+pub fn set_ip_ttl<Fd: AsFd>(fd: Fd, ttl: u32) -> io::Result<()> {
     imp::net::syscalls::sockopt::set_ip_ttl(fd.as_fd(), ttl)
 }
 
@@ -265,7 +265,7 @@ pub fn set_ip_ttl<Fd: AsFd>(fd: &Fd, ttl: u32) -> io::Result<()> {
 /// [Winsock2 `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 #[inline]
 #[doc(alias = "IP_TTL")]
-pub fn get_ip_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
+pub fn get_ip_ttl<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
     imp::net::syscalls::sockopt::get_ip_ttl(fd.as_fd())
 }
 
@@ -287,7 +287,7 @@ pub fn get_ip_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
 /// [Winsock2 `IPPROTO_IPV6` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
 #[inline]
 #[doc(alias = "IPV6_V6ONLY")]
-pub fn set_ipv6_v6only<Fd: AsFd>(fd: &Fd, only_v6: bool) -> io::Result<()> {
+pub fn set_ipv6_v6only<Fd: AsFd>(fd: Fd, only_v6: bool) -> io::Result<()> {
     imp::net::syscalls::sockopt::set_ipv6_v6only(fd.as_fd(), only_v6)
 }
 
@@ -309,7 +309,7 @@ pub fn set_ipv6_v6only<Fd: AsFd>(fd: &Fd, only_v6: bool) -> io::Result<()> {
 /// [Winsock2 `IPPROTO_IPV6` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
 #[inline]
 #[doc(alias = "IPV6_V6ONLY")]
-pub fn get_ipv6_v6only<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
+pub fn get_ipv6_v6only<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
     imp::net::syscalls::sockopt::get_ipv6_v6only(fd.as_fd())
 }
 
@@ -331,7 +331,7 @@ pub fn get_ipv6_v6only<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
 /// [Winsock2 `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 #[inline]
 #[doc(alias = "IP_MULTICAST_LOOP")]
-pub fn set_ip_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::Result<()> {
+pub fn set_ip_multicast_loop<Fd: AsFd>(fd: Fd, multicast_loop: bool) -> io::Result<()> {
     imp::net::syscalls::sockopt::set_ip_multicast_loop(fd.as_fd(), multicast_loop)
 }
 
@@ -353,7 +353,7 @@ pub fn set_ip_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::Res
 /// [Winsock2 `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 #[inline]
 #[doc(alias = "IP_MULTICAST_LOOP")]
-pub fn get_ip_multicast_loop<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
+pub fn get_ip_multicast_loop<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
     imp::net::syscalls::sockopt::get_ip_multicast_loop(fd.as_fd())
 }
 
@@ -375,7 +375,7 @@ pub fn get_ip_multicast_loop<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
 /// [Winsock2 `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 #[inline]
 #[doc(alias = "IP_MULTICAST_TTL")]
-pub fn set_ip_multicast_ttl<Fd: AsFd>(fd: &Fd, multicast_ttl: u32) -> io::Result<()> {
+pub fn set_ip_multicast_ttl<Fd: AsFd>(fd: Fd, multicast_ttl: u32) -> io::Result<()> {
     imp::net::syscalls::sockopt::set_ip_multicast_ttl(fd.as_fd(), multicast_ttl)
 }
 
@@ -397,7 +397,7 @@ pub fn set_ip_multicast_ttl<Fd: AsFd>(fd: &Fd, multicast_ttl: u32) -> io::Result
 /// [Winsock2 `IPPROTO_IP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 #[inline]
 #[doc(alias = "IP_MULTICAST_TTL")]
-pub fn get_ip_multicast_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
+pub fn get_ip_multicast_ttl<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
     imp::net::syscalls::sockopt::get_ip_multicast_ttl(fd.as_fd())
 }
 
@@ -419,7 +419,7 @@ pub fn get_ip_multicast_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
 /// [Winsock2 `IPPROTO_IPV6` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
 #[inline]
 #[doc(alias = "IPV6_MULTICAST_LOOP")]
-pub fn set_ipv6_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::Result<()> {
+pub fn set_ipv6_multicast_loop<Fd: AsFd>(fd: Fd, multicast_loop: bool) -> io::Result<()> {
     imp::net::syscalls::sockopt::set_ipv6_multicast_loop(fd.as_fd(), multicast_loop)
 }
 
@@ -441,7 +441,7 @@ pub fn set_ipv6_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::R
 /// [Winsock2 `IPPROTO_IPV6` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
 #[inline]
 #[doc(alias = "IPV6_MULTICAST_LOOP")]
-pub fn get_ipv6_multicast_loop<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
+pub fn get_ipv6_multicast_loop<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
     imp::net::syscalls::sockopt::get_ipv6_multicast_loop(fd.as_fd())
 }
 
@@ -464,7 +464,7 @@ pub fn get_ipv6_multicast_loop<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
 #[inline]
 #[doc(alias = "IP_ADD_MEMBERSHIP")]
 pub fn set_ip_add_membership<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     multiaddr: &Ipv4Addr,
     interface: &Ipv4Addr,
 ) -> io::Result<()> {
@@ -493,7 +493,7 @@ pub fn set_ip_add_membership<Fd: AsFd>(
 #[doc(alias = "IPV6_JOIN_GROUP")]
 #[doc(alias = "IPV6_ADD_MEMBERSHIP")]
 pub fn set_ipv6_add_membership<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     multiaddr: &Ipv6Addr,
     interface: u32,
 ) -> io::Result<()> {
@@ -519,7 +519,7 @@ pub fn set_ipv6_add_membership<Fd: AsFd>(
 #[inline]
 #[doc(alias = "IP_DROP_MEMBERSHIP")]
 pub fn set_ip_drop_membership<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     multiaddr: &Ipv4Addr,
     interface: &Ipv4Addr,
 ) -> io::Result<()> {
@@ -548,7 +548,7 @@ pub fn set_ip_drop_membership<Fd: AsFd>(
 #[doc(alias = "IPV6_LEAVE_GROUP")]
 #[doc(alias = "IPV6_DROP_MEMBERSHIP")]
 pub fn set_ipv6_drop_membership<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     multiaddr: &Ipv6Addr,
     interface: u32,
 ) -> io::Result<()> {
@@ -573,7 +573,7 @@ pub fn set_ipv6_drop_membership<Fd: AsFd>(
 /// [Winsock2 `IPPROTO_TCP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-tcp-socket-options
 #[inline]
 #[doc(alias = "TCP_NODELAY")]
-pub fn set_tcp_nodelay<Fd: AsFd>(fd: &Fd, nodelay: bool) -> io::Result<()> {
+pub fn set_tcp_nodelay<Fd: AsFd>(fd: Fd, nodelay: bool) -> io::Result<()> {
     imp::net::syscalls::sockopt::set_tcp_nodelay(fd.as_fd(), nodelay)
 }
 
@@ -595,6 +595,6 @@ pub fn set_tcp_nodelay<Fd: AsFd>(fd: &Fd, nodelay: bool) -> io::Result<()> {
 /// [Winsock2 `IPPROTO_TCP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-tcp-socket-options
 #[inline]
 #[doc(alias = "TCP_NODELAY")]
-pub fn get_tcp_nodelay<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
+pub fn get_tcp_nodelay<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
     imp::net::syscalls::sockopt::get_tcp_nodelay(fd.as_fd())
 }

--- a/src/path/dec_int.rs
+++ b/src/path/dec_int.rs
@@ -59,7 +59,7 @@ impl DecInt {
 
     /// Construct a new path component from a file descriptor.
     #[inline]
-    pub fn from_fd<Fd: AsFd>(fd: &Fd) -> Self {
+    pub fn from_fd<Fd: AsFd>(fd: Fd) -> Self {
         Self::new(fd.as_fd().as_raw_fd())
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -238,7 +238,7 @@ pub unsafe fn fork() -> io::Result<Option<Pid>> {
 #[inline]
 #[cfg(linux_raw)]
 pub unsafe fn execveat<Fd: AsFd>(
-    dirfd: &Fd,
+    dirfd: Fd,
     path: &ZStr,
     argv: *const *const u8,
     envp: *const *const u8,

--- a/tests/fs/openat2.rs
+++ b/tests/fs/openat2.rs
@@ -6,7 +6,7 @@ use std::os::unix::io::AsRawFd;
 
 // Like `openat2`, but keep retrying until it fails or succeeds.
 fn openat2_more<Fd: AsFd, P: path::Arg>(
-    dirfd: &Fd,
+    dirfd: Fd,
     path: P,
     oflags: OFlags,
     mode: Mode,
@@ -14,7 +14,7 @@ fn openat2_more<Fd: AsFd, P: path::Arg>(
 ) -> io::Result<OwnedFd> {
     let path = path.as_cow_z_str().unwrap().into_owned();
     loop {
-        match openat2(dirfd, &path, oflags, mode, resolve) {
+        match openat2(dirfd.as_fd(), &path, oflags, mode, resolve) {
             Ok(file) => return Ok(file),
             Err(io::Error::AGAIN) => continue,
             Err(err) => return Err(err),


### PR DESCRIPTION
With rust-lang/rust#93888 now in nightly, and sunfishcode/io-lifetimes#18 now
in io-lifetimes 0.5.2, we can now simplify the `AsFd` pattern from
`fn foo<Fd: AsFd>(fd: &Fd)` to `fn foo<Fd: AsFd>(fd: Fd)`, without the `&`.

This also follows the emerging convention in std, as seen in the new
[`fchown`] function.

This means that users can now pass `BorrowedFd` values directly to
functions that expect `AsFd` arguments, without having to write an
extra `&` when passing them.

[`fchown`]: https://doc.rust-lang.org/nightly/std/os/unix/fs/fn.fchown.html