### PR TITLE
Use `weak!`/`syscall! to support symbols missing from older glibc.

### DIFF
--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -363,7 +363,7 @@ pub(crate) fn fclonefileat(
             dst_dirfd: BorrowedFd<'_>,
             dst: *const c::c_char,
             flags: c::c_int
-        ) -> c::c_int
+        ) via SYS_fclonefileat -> c::c_int
     }
 
     unsafe { ret(fclonefileat(srcfd, dst_dirfd, c_str(dst), flags.bits())) }

--- a/src/imp/libc/offset.rs
+++ b/src/imp/libc/offset.rs
@@ -80,7 +80,7 @@ pub(super) use c::{
 
 // `prlimit64` wasn't supported in glibc until 2.13.
 #[cfg(target_os = "linux")]
-syscall! {
+weak_or_syscall! {
     fn prlimit64(
         pid: c::pid_t,
         resource: c::__rlimit_resource_t,
@@ -89,7 +89,7 @@ syscall! {
     ) via SYS_prlimit64 -> c::c_int
 }
 #[cfg(target_os = "android")]
-syscall! {
+weak_or_syscall! {
     fn prlimit64(
         pid: c::pid_t,
         resource: c::c_int,

--- a/src/imp/libc/process/auxv.rs
+++ b/src/imp/libc/process/auxv.rs
@@ -5,6 +5,13 @@ use super::super::c;
 ))]
 use crate::ffi::ZStr;
 
+// `getauxval` wasn't supported in glibc until 2.16.
+#[cfg(any(
+    all(target_os = "android", target_pointer_width = "64"),
+    target_os = "linux"
+))]
+weak!(fn getauxval(libc::c_ulong) -> libc::c_ulong);
+
 #[inline]
 pub(crate) fn page_size() -> usize {
     unsafe { c::sysconf(c::_SC_PAGESIZE) as usize }
@@ -16,10 +23,14 @@ pub(crate) fn page_size() -> usize {
 ))]
 #[inline]
 pub(crate) fn linux_hwcap() -> (usize, usize) {
-    unsafe {
-        let hwcap = c::getauxval(c::AT_HWCAP) as usize;
-        let hwcap2 = c::getauxval(c::AT_HWCAP2) as usize;
-        (hwcap, hwcap2)
+    if let Some(libc_getauxval) = getauxval.get() {
+        unsafe {
+            let hwcap = libc_getauxval(c::AT_HWCAP) as usize;
+            let hwcap2 = libc_getauxval(c::AT_HWCAP2) as usize;
+            (hwcap, hwcap2)
+        }
+    } else {
+        (0, 0)
     }
 }
 
@@ -29,5 +40,9 @@ pub(crate) fn linux_hwcap() -> (usize, usize) {
 ))]
 #[inline]
 pub(crate) fn linux_execfn() -> &'static ZStr {
-    unsafe { ZStr::from_ptr(c::getauxval(c::AT_EXECFN) as *const _) }
+    if let Some(libc_getauxval) = getauxval.get() {
+        unsafe { ZStr::from_ptr(libc_getauxval(c::AT_EXECFN) as *const _) }
+    } else {
+        zstr!("")
+    }
 }

--- a/src/imp/libc/rand/syscalls.rs
+++ b/src/imp/libc/rand/syscalls.rs
@@ -8,7 +8,7 @@ use {super::super::c, super::super::conv::ret_ssize_t, crate::io, crate::rand::G
 #[cfg(target_os = "linux")]
 pub(crate) fn getrandom(buf: &mut [u8], flags: GetRandomFlags) -> io::Result<usize> {
     // `getrandom` wasn't supported in glibc until 2.25.
-    syscall! {
+    weak_or_syscall! {
         fn getrandom(buf: *mut c::c_void, buflen: c::size_t, flags: c::c_uint) via SYS_getrandom -> c::ssize_t
     }
 

--- a/src/imp/libc/thread/syscalls.rs
+++ b/src/imp/libc/thread/syscalls.rs
@@ -82,8 +82,15 @@ pub(crate) fn nanosleep(request: &Timespec) -> NanosleepRelativeResult {
 #[inline]
 #[must_use]
 pub(crate) fn gettid() -> Pid {
+    // `gettid` wasn't supported in glibc until 2.30, and musl until 1.2.2,
+    // so use `syscall`.
+    // <https://sourceware.org/bugzilla/show_bug.cgi?id=6399#c62>
+    syscall! {
+        fn gettid() via SYS_gettid -> c::pid_t
+    }
+
     unsafe {
-        let tid: i32 = c::gettid();
+        let tid = gettid();
         debug_assert_ne!(tid, 0);
         Pid::from_raw_nonzero(RawNonZeroPid::new_unchecked(tid))
     }

--- a/src/imp/libc/thread/syscalls.rs
+++ b/src/imp/libc/thread/syscalls.rs
@@ -85,7 +85,7 @@ pub(crate) fn gettid() -> Pid {
     // `gettid` wasn't supported in glibc until 2.30, and musl until 1.2.2,
     // so use `syscall`.
     // <https://sourceware.org/bugzilla/show_bug.cgi?id=6399#c62>
-    syscall! {
+    weak_or_syscall! {
         fn gettid() via SYS_gettid -> c::pid_t
     }
 

--- a/src/process/auxv.rs
+++ b/src/process/auxv.rs
@@ -26,7 +26,7 @@ pub fn page_size() -> usize {
 /// data.
 ///
 /// Return the Linux `AT_HWCAP` and `AT_HWCAP2` values passed to the
-/// current process.
+/// current process. Returns 0 for each value if it is not available.
 ///
 /// # References
 ///  - [Linux]
@@ -50,7 +50,7 @@ pub fn linux_hwcap() -> (usize, usize) {
 /// `getauxval(AT_EXECFN)`—Returns the Linux "execfn" string.
 ///
 /// Return the string that Linux has recorded as the filesystem path to the
-/// executable.
+/// executable. Returns an empty string if the string is not available.
 ///
 /// # References
 ///  - [Linux]

--- a/src/thread/id.rs
+++ b/src/thread/id.rs
@@ -3,6 +3,9 @@ use crate::process::Pid;
 
 /// `gettid()`—Returns the thread ID.
 ///
+/// This returns the OS thread ID, which is not necessarily the same as the
+/// `rust::thread::Thread::id` or the pthread ID.
+///
 /// # References
 ///  - [Linux]
 ///


### PR DESCRIPTION
`gettid`, `getrandom`, `getauxval`, and `prlimit64` are not supported in
the oldest versions of glibc supported by Rust. Use the `weak!` and
`syscall!` macros to call these, to avoid linker errors.