### PR TITLE
More fixes for older glibc versions.

### DIFF
--- a/src/imp/libc/conv.rs
+++ b/src/imp/libc/conv.rs
@@ -65,7 +65,7 @@ pub(super) fn nonnegative_ret(raw: c::c_int) -> io::Result<()> {
 
 #[inline]
 pub(super) unsafe fn ret_infallible(raw: c::c_int) {
-    debug_assert_eq!(raw, 0);
+    debug_assert_eq!(raw, 0, "unexpected error: {:?}", io::Error::last_os_error());
 }
 
 #[inline]

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -219,8 +219,19 @@ pub(crate) fn renameat2(
     new_path: &ZStr,
     flags: RenameFlags,
 ) -> io::Result<()> {
+    // `getrandom` wasn't supported in glibc until 2.28.
+    weak_or_syscall! {
+        fn renameat2(
+            olddirfd: c::c_int,
+            oldpath: *const c::c_char,
+            newdirfd: c::c_int,
+            newpath: *const c::c_char,
+            flags: c::c_uint
+        ) via SYS_renameat2 -> c::c_int
+    }
+
     unsafe {
-        ret(c::renameat2(
+        ret(renameat2(
             borrowed_fd(old_dirfd),
             c_str(old_path),
             borrowed_fd(new_dirfd),

--- a/src/imp/libc/process/syscalls.rs
+++ b/src/imp/libc/process/syscalls.rs
@@ -293,13 +293,13 @@ pub(crate) fn prlimit(pid: Option<Pid>, limit: Resource, new: Rlimit) -> io::Res
     let lim = rlimit_to_libc(new)?;
     let mut result = MaybeUninit::<libc_rlimit>::uninit();
     unsafe {
-        ret_infallible(libc_prlimit(
+        ret(libc_prlimit(
             Pid::as_raw(pid),
             limit as _,
             &lim,
             result.as_mut_ptr(),
-        ));
-        Ok(rlimit_from_libc(result.assume_init()))
+        ))
+        .map(|()| rlimit_from_libc(result.assume_init()))
     }
 }
 


### PR DESCRIPTION
 - Use `weak_or_syscall!` for `renameat2`, which is supported as of glibc 2.28.

 - Handle errors from `prlimit64`, which may now fail with `ENOSYS`.

 - Add a more helpful debug message for `ret_infallible`'s assert.