### PR TITLE
Fix compatibility with musl and with Rust 1.48

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,7 @@ jobs:
         sudo apt-get install -y gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-riscv64-linux-gnu gcc-arm-linux-gnueabi musl-tools
     - run: cargo check --workspace --release -vv
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-musl
+    - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-musl --features=use-libc
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-gnux32
     - run: cargo check --workspace --release -vv --target=x86_64-linux-android
     - run: cargo check --workspace --release -vv --target=i686-linux-android
@@ -85,10 +86,12 @@ jobs:
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-illumos
     - run: cargo check --workspace --release -vv --target=i686-unknown-linux-gnu
     - run: cargo check --workspace --release -vv --target=i686-unknown-linux-musl
+    - run: cargo check --workspace --release -vv --target=i686-unknown-linux-musl --features=use-libc
     - run: cargo check --workspace --release -vv --target=wasm32-unknown-emscripten
     - run: cargo check --workspace --release -vv --target=riscv64gc-unknown-linux-gnu
     - run: cargo check --workspace --release -vv --target=aarch64-unknown-linux-gnu
     - run: cargo check --workspace --release -vv --target=aarch64-unknown-linux-musl
+    - run: cargo check --workspace --release -vv --target=aarch64-unknown-linux-musl --features=use-libc
     - run: cargo check --workspace --release -vv --target=powerpc64le-unknown-linux-gnu
     - run: cargo check --workspace --release -vv --target=mipsel-unknown-linux-gnu
     - run: cargo check --workspace --release -vv --target=mips64el-unknown-linux-gnuabi64

--- a/src/imp/libc/offset.rs
+++ b/src/imp/libc/offset.rs
@@ -79,11 +79,20 @@ pub(super) use c::{
 };
 
 // `prlimit64` wasn't supported in glibc until 2.13.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 weak_or_syscall! {
     fn prlimit64(
         pid: c::pid_t,
         resource: c::__rlimit_resource_t,
+        new_limit: *const c::rlimit64,
+        old_limit: *mut c::rlimit64
+    ) via SYS_prlimit64 -> c::c_int
+}
+#[cfg(all(target_os = "linux", target_env = "musl"))]
+weak_or_syscall! {
+    fn prlimit64(
+        pid: c::pid_t,
+        resource: c::c_int,
         new_limit: *const c::rlimit64,
         old_limit: *mut c::rlimit64
     ) via SYS_prlimit64 -> c::c_int
@@ -97,10 +106,19 @@ weak_or_syscall! {
         old_limit: *mut c::rlimit64
     ) via SYS_prlimit64 -> c::c_int
 }
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 pub(super) unsafe fn libc_prlimit(
     pid: c::pid_t,
     resource: c::__rlimit_resource_t,
+    new_limit: *const c::rlimit64,
+    old_limit: *mut c::rlimit64,
+) -> c::c_int {
+    prlimit64(pid, resource, new_limit, old_limit)
+}
+#[cfg(all(target_os = "linux", target_env = "musl"))]
+pub(super) unsafe fn libc_prlimit(
+    pid: c::pid_t,
+    resource: c::c_int,
     new_limit: *const c::rlimit64,
     old_limit: *mut c::rlimit64,
 ) -> c::c_int {

--- a/test-crates/use-default/Cargo.toml
+++ b/test-crates/use-default/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "use-default"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/test-crates/use-libc/Cargo.toml
+++ b/test-crates/use-libc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "use-libc"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
This contains a musl-compatible declaration of `prlimit64`, and switches the test crates to the 2018 edition, so that the tests can be run with older Rust versions.
