### PR TITLE
Update the feature detection for inline asm to work on stable Rust.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -547,7 +547,7 @@ jobs:
             qemu_target: ppc64le-linux-user
           - build: mips64el-linux
             os: ubuntu-latest
-            rust: stable
+            rust: nightly
             target: mips64el-unknown-linux-gnuabi64
             gcc_package: gcc-mips64el-linux-gnuabi64
             gcc: mips64el-linux-gnuabi64-gcc
@@ -555,7 +555,7 @@ jobs:
             qemu_target: mips64el-linux-user
           - build: mipsel-linux
             os: ubuntu-latest
-            rust: stable
+            rust: nightly
             target: mipsel-unknown-linux-gnu
             gcc_package: gcc-mipsel-linux-gnu
             gcc: mipsel-linux-gnu-gcc

--- a/build.rs
+++ b/build.rs
@@ -75,10 +75,14 @@ fn main() {
         // and MIPS, Rust's inline asm is considered experimental, so only use
         // it if `--cfg=rustix_use_experimental_asm` is given.
         if can_compile("use std::arch::asm;")
+            && (arch != "x86" || has_feature("naked_functions"))
             && ((arch != "powerpc64" && arch != "mips" && arch != "mips64")
                 || rustix_use_experimental_asm)
         {
             use_feature("asm");
+            if arch == "x86" {
+                use_feature("naked_functions");
+            }
             if rustix_use_experimental_asm {
                 use_feature("asm_experimental_arch");
             }

--- a/build.rs
+++ b/build.rs
@@ -74,7 +74,7 @@ fn main() {
         // Use inline asm if we have it, or outline asm otherwise. On PowerPC
         // and MIPS, Rust's inline asm is considered experimental, so only use
         // it if `--cfg=rustix_use_experimental_asm` is given.
-        if has_feature("asm")
+        if can_compile("use std::arch::asm;")
             && ((arch != "powerpc64" && arch != "mips" && arch != "mips64")
                 || rustix_use_experimental_asm)
         {
@@ -147,6 +147,11 @@ fn use_feature(feature: &str) {
 
 /// Test whether the rustc at `var("RUSTC")` supports the given feature.
 fn has_feature(feature: &str) -> bool {
+    can_compile(&format!("#![allow(stable_features)]\n#![feature({})]", feature))
+}
+
+/// Test whether the rustc at `var("RUSTC")` can compile the given code.
+fn can_compile(code: &str) -> bool {
     use std::process::Stdio;
     let out_dir = var("OUT_DIR").unwrap();
     let rustc = var("RUSTC").unwrap();
@@ -164,8 +169,8 @@ fn has_feature(feature: &str) -> bool {
 
     writeln!(
         child.stdin.take().unwrap(),
-        "#![allow(stable_features)]\n#![feature({})]",
-        feature
+        "{}",
+        code
     )
     .unwrap();
 

--- a/build.rs
+++ b/build.rs
@@ -147,7 +147,10 @@ fn use_feature(feature: &str) {
 
 /// Test whether the rustc at `var("RUSTC")` supports the given feature.
 fn has_feature(feature: &str) -> bool {
-    can_compile(&format!("#![allow(stable_features)]\n#![feature({})]", feature))
+    can_compile(&format!(
+        "#![allow(stable_features)]\n#![feature({})]",
+        feature
+    ))
 }
 
 /// Test whether the rustc at `var("RUSTC")` can compile the given code.
@@ -167,12 +170,7 @@ fn can_compile(code: &str) -> bool {
         .spawn()
         .unwrap();
 
-    writeln!(
-        child.stdin.take().unwrap(),
-        "{}",
-        code
-    )
-    .unwrap();
+    writeln!(child.stdin.take().unwrap(), "{}", code).unwrap();
 
     child.wait().unwrap().success()
 }

--- a/src/imp/linux_raw/vdso_wrappers.rs
+++ b/src/imp/linux_raw/vdso_wrappers.rs
@@ -206,16 +206,12 @@ pub(super) mod x86_via_vdso {
 }
 
 type ClockGettimeType = unsafe extern "C" fn(c::c_int, *mut Timespec) -> c::c_int;
+
+/// The underlying syscall functions are only called from asm, using the
+/// special syscall calling convention to pass arguments and return values,
+/// which the signature here doesn't reflect.
 #[cfg(target_arch = "x86")]
-pub(super) type SyscallType = unsafe extern "C" fn(
-    SyscallNumber,
-    ArgReg<'_, A0>,
-    ArgReg<'_, A1>,
-    ArgReg<'_, A2>,
-    ArgReg<'_, A3>,
-    ArgReg<'_, A4>,
-    ArgReg<'_, A5>,
-) -> RetReg<R0>;
+pub(super) type SyscallType = unsafe extern "C" fn();
 
 fn init_clock_gettime() -> ClockGettimeType {
     init();

--- a/src/imp/linux_raw/vdso_wrappers.rs
+++ b/src/imp/linux_raw/vdso_wrappers.rs
@@ -303,31 +303,19 @@ unsafe fn _rustix_clock_gettime_via_syscall(
     ))
 }
 
+/// A symbol pointing to an `int 0x80` instruction. This "function" is only
+/// called from assembly, and only with the x86 syscall calling convention,
+/// so its signature here is not its true signature.
 #[cfg(all(asm, target_arch = "x86"))]
 #[naked]
-unsafe extern "C" fn rustix_int_0x80(
-    _nr: SyscallNumber<'_>,
-    _a0: ArgReg<'_, A0>,
-    _a1: ArgReg<'_, A1>,
-    _a2: ArgReg<'_, A2>,
-    _a3: ArgReg<'_, A3>,
-    _a4: ArgReg<'_, A4>,
-    _a5: ArgReg<'_, A5>,
-) -> RetReg<R0> {
+unsafe extern "C" fn rustix_int_0x80() {
     asm!("int $$0x80", "ret", options(noreturn))
 }
 
+/// The outline version of the `rustix_int_0x80` above.
 #[cfg(all(not(asm), target_arch = "x86"))]
 extern "C" {
-    fn rustix_int_0x80(
-        _nr: SyscallNumber<'_>,
-        _a0: ArgReg<'_, A0>,
-        _a1: ArgReg<'_, A1>,
-        _a2: ArgReg<'_, A2>,
-        _a3: ArgReg<'_, A3>,
-        _a4: ArgReg<'_, A4>,
-        _a5: ArgReg<'_, A5>,
-    ) -> RetReg<R0>;
+    fn rustix_int_0x80();
 }
 
 fn minimal_init() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@
 #![cfg_attr(rustc_attrs, feature(rustc_attrs))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![cfg_attr(all(target_os = "wasi", feature = "std"), feature(wasi_ext))]
-#![cfg_attr(all(linux_raw, asm, target_arch = "x86"), feature(naked_functions))]
+#![cfg_attr(all(linux_raw, target_arch = "x86"), feature(naked_functions))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(all(not(feature = "std"), specialization), allow(incomplete_features))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,6 @@
 #![deny(missing_docs)]
 #![allow(stable_features)]
 #![cfg_attr(linux_raw, deny(unsafe_code))]
-#![cfg_attr(asm, feature(asm))]
 #![cfg_attr(rustc_attrs, feature(rustc_attrs))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![cfg_attr(all(target_os = "wasi", feature = "std"), feature(wasi_ext))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,10 @@
 #![cfg_attr(rustc_attrs, feature(rustc_attrs))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![cfg_attr(all(target_os = "wasi", feature = "std"), feature(wasi_ext))]
-#![cfg_attr(all(linux_raw, target_arch = "x86"), feature(naked_functions))]
+#![cfg_attr(
+    all(linux_raw, naked_functions, target_arch = "x86"),
+    feature(naked_functions)
+)]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(all(not(feature = "std"), specialization), allow(incomplete_features))]


### PR DESCRIPTION
Inline asm is now stabilized in Rust 1.59, so we can now use it
without `#[feature(asm)], on stable and nightly. Update the detection
to detect the presence of `std::arch::asm`.