### PR TITLE
Enable "handleapi" for Windows.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,6 +171,7 @@ jobs:
         RUSTFLAGS: -A improper_ctypes_definitions
     - run: rustup component add rust-src
     - run: cargo check -Z build-std=core,alloc,std --target x86_64-unknown-openbsd --all-targets
+    - run: cargo check -Z build-std=core,alloc,std --target x86_64-uwp-windows-msvc --all-targets
 
   test:
     name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ libc = { version = "0.2.116", features = ["extra_traits"] }
 # For the libc backend on Windows, use the Winsock2 API in winapi.
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["ws2ipdef", "ws2tcpip"] }
+[target.'cfg(all(windows, not(target_vendor = "uwp")))'.dependencies]
+winapi = { version = "0.3.9", features = ["handleapi"] }
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/imp/libc/net/syscalls.rs
+++ b/src/imp/libc/net/syscalls.rs
@@ -557,8 +557,6 @@ pub(crate) mod sockopt {
                     return Err(io::Error::INVAL);
                 }
 
-                let millis = timeout.as_millis();
-
                 // `as_millis` rounds down, so we use `as_nanos` and
                 // manually round up.
                 let mut timeout: DWORD = ((timeout.as_nanos() + 999999) / 1000000)

--- a/src/io/owned_fd.rs
+++ b/src/io/owned_fd.rs
@@ -135,9 +135,9 @@ impl OwnedFd {
     #[cfg(windows)]
     #[cfg(target_vendor = "uwp")]
     fn set_no_inherit(&self) -> std::io::Result<()> {
-        Err(io::Error::new_const(
+        Err(std::io::Error::new(
             std::io::ErrorKind::Unsupported,
-            &"Unavailable on UWP",
+            "Unavailable on UWP",
         ))
     }
 }

--- a/src/io/owned_fd.rs
+++ b/src/io/owned_fd.rs
@@ -64,8 +64,9 @@ impl OwnedFd {
     pub fn try_clone(&self) -> std::io::Result<Self> {
         use winapi::um::processthreadsapi::GetCurrentProcessId;
         use winapi::um::winsock2::{
-            WSADuplicateSocketW, WSAGetLastError, WSASocketW, INVALID_SOCKET, WSAEINVAL,
-            WSAEPROTOTYPE, WSAPROTOCOL_INFOW, WSA_FLAG_NO_HANDLE_INHERIT, WSA_FLAG_OVERLAPPED,
+            WSADuplicateSocketW, WSAGetLastError, WSASocketW, INVALID_SOCKET, SOCKET_ERROR,
+            WSAEINVAL, WSAEPROTOTYPE, WSAPROTOCOL_INFOW, WSA_FLAG_NO_HANDLE_INHERIT,
+            WSA_FLAG_OVERLAPPED,
         };
 
         let mut info = unsafe { std::mem::zeroed::<WSAPROTOCOL_INFOW>() };


### PR DESCRIPTION
Rustix was depending on winapi's "handleapi" feature being enabled, but it was only enabled by the dev-dependencies. This adds it as a regular dependency too.

And while here, this fixes a few issues in windows "uwp" builds, and adds a "uwp" tier-3 cross check. 