### PR TITLE
Use `decode_void` for syscalls which are expected to always return 0.

### DIFF
--- a/src/imp/linux_raw/io/syscalls.rs
+++ b/src/imp/linux_raw/io/syscalls.rs
@@ -353,7 +353,8 @@ const fn max_iov() -> usize {
 
 #[inline]
 pub(crate) unsafe fn close(fd: RawFd) {
-    let _ = syscall1_readonly(nr(__NR_close), raw_fd(fd));
+    // See the docunentation for [`io::close`] for why errors are ignored.
+    syscall1_readonly(nr(__NR_close), raw_fd(fd)).decode_void();
 }
 
 #[inline]

--- a/src/imp/linux_raw/process/syscalls.rs
+++ b/src/imp/linux_raw/process/syscalls.rs
@@ -225,7 +225,9 @@ pub(crate) fn sched_setaffinity(pid: Option<Pid>, cpuset: &RawCpuSet) -> io::Res
 #[inline]
 pub(crate) fn sched_yield() {
     unsafe {
-        let _ = syscall0_readonly(nr(__NR_sched_yield));
+        // See the docunentation for [`crate::process::sched_yield`] for why
+        // errors are ignored.
+        syscall0_readonly(nr(__NR_sched_yield)).decode_void();
     }
 }
 

--- a/src/imp/linux_raw/reg.rs
+++ b/src/imp/linux_raw/reg.rs
@@ -101,19 +101,14 @@ pub(super) struct RetReg<Num: RetNumber> {
 
 impl<Num: RetNumber> RetReg<Num> {
     #[inline]
-    fn decode(self) -> usize {
+    pub(super) fn decode_usize(self) -> usize {
         debug_assert!(!(-4095..0).contains(&(self.bits as isize)));
         self.bits
     }
 
     #[inline]
-    pub(super) fn decode_usize(self) -> usize {
-        self.decode()
-    }
-
-    #[inline]
     pub(super) fn decode_raw_fd(self) -> RawFd {
-        let bits = self.decode();
+        let bits = self.decode_usize();
         let raw_fd = bits as RawFd;
 
         // Converting `raw` to `RawFd` should be lossless.
@@ -124,7 +119,7 @@ impl<Num: RetNumber> RetReg<Num> {
 
     #[inline]
     pub(super) fn decode_c_int(self) -> c::c_int {
-        let bits = self.decode();
+        let bits = self.decode_usize();
         let c_int_ = bits as c::c_int;
 
         // Converting `raw` to `c_int` should be lossless.
@@ -135,7 +130,7 @@ impl<Num: RetNumber> RetReg<Num> {
 
     #[inline]
     pub(super) fn decode_c_uint(self) -> c::c_uint {
-        let bits = self.decode();
+        let bits = self.decode_usize();
         let c_uint_ = bits as c::c_uint;
 
         // Converting `raw` to `c_uint` should be lossless.
@@ -146,18 +141,19 @@ impl<Num: RetNumber> RetReg<Num> {
 
     #[inline]
     pub(super) fn decode_void_star(self) -> *mut c::c_void {
-        self.decode() as *mut c::c_void
+        self.decode_usize() as *mut c::c_void
     }
 
     #[cfg(target_pointer_width = "64")]
     #[inline]
     pub(super) fn decode_u64(self) -> u64 {
-        self.decode() as u64
+        self.decode_usize() as u64
     }
 
     #[inline]
     pub(super) fn decode_void(self) {
-        let _ = self.decode();
+        let ignore = self.decode_usize();
+        debug_assert_eq!(ignore, 0);
     }
 
     #[inline]


### PR DESCRIPTION
This is a minor cleanup to use `decode_void` to "decode" the return
value of syscalls which effectively don't return a value.