### PR TITLE
Fix `dup2` and `dup2_with` inconsistencies.

### DIFF
--- a/src/imp/libc/io/syscalls.rs
+++ b/src/imp/libc/io/syscalls.rs
@@ -486,6 +486,7 @@ pub(crate) fn dup2_with(fd: BorrowedFd<'_>, new: &OwnedFd, _flags: DupFlags) -> 
     // Android 5.0 has `dup3`, but libc doesn't have bindings. Emulate it
     // using `dup2`, including the difference of failing with `EINVAL`
     // when the file descriptors are equal.
+    use std::os::unix::io::AsRawFd;
     if fd.as_raw_fd() == new.as_raw_fd() {
         return Err(io::Error::INVAL);
     }

--- a/src/imp/libc/io/syscalls.rs
+++ b/src/imp/libc/io/syscalls.rs
@@ -483,7 +483,12 @@ pub(crate) fn dup2_with(fd: BorrowedFd<'_>, new: &OwnedFd, flags: DupFlags) -> i
     target_os = "redox"
 ))]
 pub(crate) fn dup2_with(fd: BorrowedFd<'_>, new: &OwnedFd, _flags: DupFlags) -> io::Result<()> {
-    // Android 5.0 has `dup3`, but libc doesn't have bindings
+    // Android 5.0 has `dup3`, but libc doesn't have bindings. Emulate it
+    // using `dup2`, including the difference of failing with `EINVAL`
+    // when the file descriptors are equal.
+    if fd.as_raw_fd() == new.as_raw_fd() {
+        return Err(io::Error::INVAL);
+    }
     dup2(fd, new)
 }
 

--- a/src/imp/linux_raw/io/syscalls.rs
+++ b/src/imp/linux_raw/io/syscalls.rs
@@ -557,7 +557,7 @@ pub(crate) fn dup2(fd: BorrowedFd<'_>, new: &OwnedFd) -> io::Result<()> {
         // `dup3` fails if the old and new file descriptors have the same
         // value, so emulate the `dup2` behvior.
         if fd.as_raw_fd() == new.as_raw_fd() {
-            return Ok(())
+            return Ok(());
         }
         dup2_with(fd, new, DupFlags::empty())
     }

--- a/src/imp/linux_raw/io/syscalls.rs
+++ b/src/imp/linux_raw/io/syscalls.rs
@@ -556,6 +556,7 @@ pub(crate) fn dup2(fd: BorrowedFd<'_>, new: &OwnedFd) -> io::Result<()> {
     {
         // `dup3` fails if the old and new file descriptors have the same
         // value, so emulate the `dup2` behvior.
+        use std::os::unix::io::AsRawFd;
         if fd.as_raw_fd() == new.as_raw_fd() {
             return Ok(());
         }

--- a/src/imp/linux_raw/io/syscalls.rs
+++ b/src/imp/linux_raw/io/syscalls.rs
@@ -554,6 +554,11 @@ pub(crate) fn dup(fd: BorrowedFd<'_>) -> io::Result<OwnedFd> {
 pub(crate) fn dup2(fd: BorrowedFd<'_>, new: &OwnedFd) -> io::Result<()> {
     #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     {
+        // `dup3` fails if the old and new file descriptors have the same
+        // value, so emulate the `dup2` behvior.
+        if fd.as_raw_fd() == new.as_raw_fd() {
+            return Ok(())
+        }
         dup2_with(fd, new, DupFlags::empty())
     }
 

--- a/src/io/dup.rs
+++ b/src/io/dup.rs
@@ -56,7 +56,9 @@ pub fn dup2<Fd: AsFd>(fd: Fd, new: &OwnedFd) -> io::Result<()> {
 /// same underlying [file description] as the existing `OwnedFd` instance,
 /// closing `new` and reusing its file descriptor, with flags.
 ///
-/// `dup2_with` is the same as [`dup2`] but adds an additional flags operand.
+/// `dup2_with` is the same as [`dup2`] but adds an additional flags operand,
+/// and fails in the case that `fd` and `new` have the same file descriptor
+/// value.
 ///
 /// # References
 ///  - [POSIX]

--- a/tests/io/dup2_with.rs
+++ b/tests/io/dup2_with.rs
@@ -1,0 +1,21 @@
+use rustix::io::DupFlags;
+
+/// `dup2` uses POSIX `dup2` which silently does nothing if the file
+/// descriptors are equal.
+#[test]
+fn test_dup2() {
+    let (a, b) = rustix::io::pipe().unwrap();
+    rustix::io::dup2(&a, &a).unwrap();
+    rustix::io::dup2(&b, &b).unwrap();
+}
+
+/// `dup2_with` uses Linux `dup3` which fails with `INVAL` if the
+/// file descriptors are equal.
+#[test]
+fn test_dup2_with() {
+    let (a, b) = rustix::io::pipe().unwrap();
+    assert_eq!(rustix::io::dup2_with(&a, &a, DupFlags::empty()), Err(rustix::io::Error::INVAL));
+    assert_eq!(rustix::io::dup2_with(&b, &b, DupFlags::empty()), Err(rustix::io::Error::INVAL));
+    assert_eq!(rustix::io::dup2_with(&a, &a, DupFlags::CLOEXEC), Err(rustix::io::Error::INVAL));
+    assert_eq!(rustix::io::dup2_with(&b, &b, DupFlags::CLOEXEC), Err(rustix::io::Error::INVAL));
+}

--- a/tests/io/dup2_with.rs
+++ b/tests/io/dup2_with.rs
@@ -22,12 +22,20 @@ fn test_dup2_with() {
         rustix::io::dup2_with(&b, &b, DupFlags::empty()),
         Err(rustix::io::Error::INVAL)
     );
-    assert_eq!(
-        rustix::io::dup2_with(&a, &a, DupFlags::CLOEXEC),
-        Err(rustix::io::Error::INVAL)
-    );
-    assert_eq!(
-        rustix::io::dup2_with(&b, &b, DupFlags::CLOEXEC),
-        Err(rustix::io::Error::INVAL)
-    );
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "redox"
+    )))] // Android 5.0 has dup3, but libc doesn't have bindings
+    {
+        assert_eq!(
+            rustix::io::dup2_with(&a, &a, DupFlags::CLOEXEC),
+            Err(rustix::io::Error::INVAL)
+        );
+        assert_eq!(
+            rustix::io::dup2_with(&b, &b, DupFlags::CLOEXEC),
+            Err(rustix::io::Error::INVAL)
+        );
+    }
 }

--- a/tests/io/dup2_with.rs
+++ b/tests/io/dup2_with.rs
@@ -14,8 +14,20 @@ fn test_dup2() {
 #[test]
 fn test_dup2_with() {
     let (a, b) = rustix::io::pipe().unwrap();
-    assert_eq!(rustix::io::dup2_with(&a, &a, DupFlags::empty()), Err(rustix::io::Error::INVAL));
-    assert_eq!(rustix::io::dup2_with(&b, &b, DupFlags::empty()), Err(rustix::io::Error::INVAL));
-    assert_eq!(rustix::io::dup2_with(&a, &a, DupFlags::CLOEXEC), Err(rustix::io::Error::INVAL));
-    assert_eq!(rustix::io::dup2_with(&b, &b, DupFlags::CLOEXEC), Err(rustix::io::Error::INVAL));
+    assert_eq!(
+        rustix::io::dup2_with(&a, &a, DupFlags::empty()),
+        Err(rustix::io::Error::INVAL)
+    );
+    assert_eq!(
+        rustix::io::dup2_with(&b, &b, DupFlags::empty()),
+        Err(rustix::io::Error::INVAL)
+    );
+    assert_eq!(
+        rustix::io::dup2_with(&a, &a, DupFlags::CLOEXEC),
+        Err(rustix::io::Error::INVAL)
+    );
+    assert_eq!(
+        rustix::io::dup2_with(&b, &b, DupFlags::CLOEXEC),
+        Err(rustix::io::Error::INVAL)
+    );
 }

--- a/tests/io/main.rs
+++ b/tests/io/main.rs
@@ -6,6 +6,8 @@
 #[cfg(not(feature = "rustc-dep-of-std"))]
 #[cfg(not(windows))]
 mod dup2_to_replace_stdio;
+#[cfg(not(windows))]
+mod dup2_with;
 #[cfg(not(feature = "rustc-dep-of-std"))] // TODO
 #[cfg(not(windows))]
 mod epoll;


### PR DESCRIPTION
When emulating `dup2` using `dup3`, emulate the POSIX `dup2` behavior of
doing nothing if the file descriptors are equal.

When emulating `dup2_with` using `dup2`, emulate the Linux `dup3` behavior
of failing if the file descriptors are equal.

We may eventually want to make broader changes to the API; I've filed #244
to track this.