### PR TITLE
Fixes for --cfg=io_lifetimes_use_std mode

### DIFF
--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -1,6 +1,8 @@
 //! A command which prints out information about the standard input,
 //! output, and error streams provided to it.
 
+#![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
+
 #[cfg(not(windows))]
 use rustix::fd::AsFd;
 #[cfg(any(all(linux_raw, feature = "procfs"), all(not(windows), libc)))]

--- a/src/imp/libc/fs/dir.rs
+++ b/src/imp/libc/fs/dir.rs
@@ -53,8 +53,9 @@ impl Dir {
     /// Construct a `Dir`, assuming ownership of the file descriptor.
     #[cfg(any(io_lifetimes_use_std, not(feature = "std")))]
     #[inline]
-    pub fn from<F: Into<OwnedFd>>(fd: F) -> io::Result<Self> {
-        let fd = fd.into();
+    pub fn from<F: Into<crate::fd::OwnedFd>>(fd: F) -> io::Result<Self> {
+        let fd: crate::fd::OwnedFd = fd.into();
+        let fd: OwnedFd = fd.into();
         Self::_from(fd)
     }
 

--- a/src/imp/linux_raw/fs/dir.rs
+++ b/src/imp/linux_raw/fs/dir.rs
@@ -1,6 +1,6 @@
 use super::FileType;
 use crate::as_ptr;
-#[cfg(feature = "std")]
+#[cfg(not(any(io_lifetimes_use_std, not(feature = "std"))))]
 use crate::fd::IntoFd;
 use crate::fd::{AsFd, BorrowedFd};
 use crate::ffi::{ZStr, ZString};
@@ -30,8 +30,9 @@ impl Dir {
     /// Construct a `Dir`, assuming ownership of the file descriptor.
     #[cfg(any(io_lifetimes_use_std, not(feature = "std")))]
     #[inline]
-    pub fn from<F: Into<OwnedFd>>(fd: F) -> io::Result<Self> {
-        let fd = fd.into();
+    pub fn from<F: Into<crate::fd::OwnedFd>>(fd: F) -> io::Result<Self> {
+        let fd: crate::fd::OwnedFd = fd.into();
+        let fd: OwnedFd = fd.into();
         Self::_from(fd)
     }
 

--- a/tests/fs/readdir.rs
+++ b/tests/fs/readdir.rs
@@ -54,3 +54,15 @@ fn read_entries(dir: &mut Dir) -> HashMap<String, DirEntry> {
     }
     out
 }
+
+#[test]
+fn dir_from_openat() {
+    let dirfd = rustix::fs::openat(
+        &rustix::fs::cwd(),
+        ".",
+        rustix::fs::OFlags::RDONLY,
+        rustix::fs::Mode::empty(),
+    )
+    .expect("open cwd as file");
+    let _dir = Dir::from(dirfd).expect("construct Dir from dirfd");
+}


### PR DESCRIPTION
This contains a few fixes for building rustix in io_lifetimes_use_std
mode, which tells io-lifetimes to be a passthrough for the I/O safety
types and traits in nightly std rather than using its own.