### PR TITLE
Implement `Debug` for `Dir`.

### DIFF
--- a/src/imp/libc/fs/dir.rs
+++ b/src/imp/libc/fs/dir.rs
@@ -33,6 +33,7 @@ use c::readdir as libc_readdir;
     target_os = "linux"
 ))]
 use c::{dirent64 as libc_dirent, readdir64 as libc_readdir};
+use core::fmt;
 use core::mem::zeroed;
 use core::ptr::NonNull;
 use errno::{errno, set_errno, Errno};
@@ -245,6 +246,14 @@ impl Iterator for Dir {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         Self::read(self)
+    }
+}
+
+impl fmt::Debug for Dir {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Dir")
+            .field("fd", unsafe { &c::dirfd(self.0.as_ptr()) })
+            .finish()
     }
 }
 

--- a/src/imp/linux_raw/fs/dir.rs
+++ b/src/imp/linux_raw/fs/dir.rs
@@ -7,6 +7,7 @@ use crate::ffi::{ZStr, ZString};
 use crate::io::{self, OwnedFd};
 use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
+use core::fmt;
 use core::mem::size_of;
 use linux_raw_sys::general::linux_dirent64;
 
@@ -172,6 +173,12 @@ impl Iterator for Dir {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         Self::read(self)
+    }
+}
+
+impl fmt::Debug for Dir {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Dir").field("fd", &self.fd).finish()
     }
 }
 


### PR DESCRIPTION
`Dir` doesn't have much to say here, but it is convenient for it to
implement `Debug` when it's used as a member instead of structs which
use the `Debug` derive.