### PR TITLE
Update to io-lifetime 0.6.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ cc = { version = "1.0.68", optional = true }
 [dependencies]
 bitflags = "1.2.1"
 itoa = { version = "1.0.1", default-features = false, optional = true }
-io-lifetimes = { version = "0.5.2", default-features = false, optional = true }
+io-lifetimes = { version = "0.6.0", default-features = false, optional = true }
 
 # Special dependencies used in rustc-dep-of-std mode.
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }

--- a/src/fs/cwd.rs
+++ b/src/fs/cwd.rs
@@ -23,6 +23,6 @@ pub fn cwd() -> BorrowedFd<'static> {
     // it'll remain valid for the duration of `'static`.
     #[allow(unsafe_code)]
     unsafe {
-        BorrowedFd::<'static>::borrow_raw_fd(at_fdcwd)
+        BorrowedFd::<'static>::borrow_raw(at_fdcwd)
     }
 }

--- a/src/imp/libc/fs/dir.rs
+++ b/src/imp/libc/fs/dir.rs
@@ -230,7 +230,7 @@ unsafe impl Send for Dir {}
 impl AsFd for Dir {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
-        unsafe { BorrowedFd::borrow_raw_fd(c::dirfd(self.0.as_ptr()) as RawFd) }
+        unsafe { BorrowedFd::borrow_raw(c::dirfd(self.0.as_ptr()) as RawFd) }
     }
 }
 

--- a/src/imp/libc/io/epoll.rs
+++ b/src/imp/libc/io/epoll.rs
@@ -194,7 +194,7 @@ impl<'a> Context for Borrowing<'a> {
 
     #[inline]
     unsafe fn decode<'call>(&self, raw: u64) -> Ref<'call, Self::Target> {
-        Ref::new(BorrowedFd::<'a>::borrow_raw_fd(raw as RawFd))
+        Ref::new(BorrowedFd::<'a>::borrow_raw(raw as RawFd))
     }
 
     #[inline]
@@ -236,9 +236,9 @@ impl<'context, T: AsFd + IntoFd + FromFd> Context for Owning<'context, T> {
         // Safety: `epoll` will assign ownership of the file descriptor to the
         // kernel epoll object. We use `IntoFd`+`IntoRawFd` to consume the
         // `Data` and extract the raw file descriptor and then "borrow" it
-        // with `borrow_raw_fd` knowing that the borrow won't outlive the
+        // with `borrow_raw` knowing that the borrow won't outlive the
         // kernel epoll object.
-        unsafe { Ref::new(BorrowedFd::<'context>::borrow_raw_fd(raw_fd)) }
+        unsafe { Ref::new(BorrowedFd::<'context>::borrow_raw(raw_fd)) }
     }
 
     #[inline]
@@ -248,7 +248,7 @@ impl<'context, T: AsFd + IntoFd + FromFd> Context for Owning<'context, T> {
 
     #[inline]
     unsafe fn decode<'call>(&self, raw: u64) -> Ref<'call, Self::Target> {
-        Ref::new(BorrowedFd::<'context>::borrow_raw_fd(raw as RawFd))
+        Ref::new(BorrowedFd::<'context>::borrow_raw(raw as RawFd))
     }
 
     #[inline]

--- a/src/imp/libc/io/poll_fd.rs
+++ b/src/imp/libc/io/poll_fd.rs
@@ -123,7 +123,7 @@ impl<'fd> AsFd for PollFd<'fd> {
         //
         // Our constructors and `set_fd` require `pollfd.fd` to be valid
         // for the `fd lifetime.
-        unsafe { BorrowedFd::borrow_raw_fd(self.pollfd.fd) }
+        unsafe { BorrowedFd::borrow_raw(self.pollfd.fd) }
     }
 }
 
@@ -135,6 +135,6 @@ impl<'fd> io_lifetimes::AsSocket for PollFd<'fd> {
         //
         // Our constructors and `set_fd` require `pollfd.fd` to be valid
         // for the `fd lifetime.
-        unsafe { BorrowedFd::borrow_raw_socket(self.pollfd.fd as RawFd) }
+        unsafe { BorrowedFd::borrow_raw(self.pollfd.fd as RawFd) }
     }
 }

--- a/src/imp/linux_raw/io/epoll.rs
+++ b/src/imp/linux_raw/io/epoll.rs
@@ -194,7 +194,7 @@ impl<'a> Context for Borrowing<'a> {
 
     #[inline]
     unsafe fn decode<'call>(&self, raw: u64) -> Ref<'call, Self::Target> {
-        Ref::new(BorrowedFd::<'a>::borrow_raw_fd(raw as RawFd))
+        Ref::new(BorrowedFd::<'a>::borrow_raw(raw as RawFd))
     }
 
     #[inline]
@@ -236,9 +236,9 @@ impl<'context, T: AsFd + IntoFd + FromFd> Context for Owning<'context, T> {
         // Safety: `epoll` will assign ownership of the file descriptor to the
         // kernel epoll object. We use `IntoFd`+`IntoRawFd` to consume the
         // `Data` and extract the raw file descriptor and then "borrow" it
-        // with `borrow_raw_fd` knowing that the borrow won't outlive the
+        // with `borrow_raw` knowing that the borrow won't outlive the
         // kernel epoll object.
-        unsafe { Ref::new(BorrowedFd::<'context>::borrow_raw_fd(raw_fd)) }
+        unsafe { Ref::new(BorrowedFd::<'context>::borrow_raw(raw_fd)) }
     }
 
     #[inline]
@@ -248,7 +248,7 @@ impl<'context, T: AsFd + IntoFd + FromFd> Context for Owning<'context, T> {
 
     #[inline]
     unsafe fn decode<'call>(&self, raw: u64) -> Ref<'call, Self::Target> {
-        Ref::new(BorrowedFd::<'context>::borrow_raw_fd(raw as RawFd))
+        Ref::new(BorrowedFd::<'context>::borrow_raw(raw as RawFd))
     }
 
     #[inline]

--- a/src/io/fd/owned.rs
+++ b/src/io/fd/owned.rs
@@ -64,7 +64,7 @@ impl BorrowedFd<'_> {
     /// the returned `BorrowedFd`, and it must not have the value `-1`.
     #[inline]
     #[cfg_attr(staged_api, unstable(feature = "io_safety", issue = "87074"))]
-    pub unsafe fn borrow_raw_fd(fd: RawFd) -> Self {
+    pub unsafe fn borrow_raw(fd: RawFd) -> Self {
         assert_ne!(fd, u32::MAX as RawFd);
         // SAFETY: we just asserted that the value is in the valid range and isn't `-1` (the only value bigger than `0xFF_FF_FF_FE` unsigned)
         #[allow(unused_unsafe)]
@@ -211,6 +211,6 @@ impl AsFd for OwnedFd {
         // Safety: `OwnedFd` and `BorrowedFd` have the same validity
         // invariants, and the `BorrowedFd` is bounded by the lifetime
         // of `&self`.
-        unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
+        unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
     }
 }

--- a/src/io/stdio.rs
+++ b/src/io/stdio.rs
@@ -38,7 +38,7 @@ use imp::fd::{BorrowedFd, FromRawFd, RawFd};
 /// [Linux]: https://man7.org/linux/man-pages/man3/stdin.3.html
 #[inline]
 pub unsafe fn stdin() -> BorrowedFd<'static> {
-    BorrowedFd::borrow_raw_fd(imp::io::STDIN_FILENO as RawFd)
+    BorrowedFd::borrow_raw(imp::io::STDIN_FILENO as RawFd)
 }
 
 /// `STDIN_FILENO`—Standard input, owned.
@@ -99,7 +99,7 @@ pub unsafe fn take_stdin() -> OwnedFd {
 /// [Linux]: https://man7.org/linux/man-pages/man3/stdout.3.html
 #[inline]
 pub unsafe fn stdout() -> BorrowedFd<'static> {
-    BorrowedFd::borrow_raw_fd(imp::io::STDOUT_FILENO as RawFd)
+    BorrowedFd::borrow_raw(imp::io::STDOUT_FILENO as RawFd)
 }
 
 /// `STDOUT_FILENO`—Standard output, owned.
@@ -159,7 +159,7 @@ pub unsafe fn take_stdout() -> OwnedFd {
 /// [Linux]: https://man7.org/linux/man-pages/man3/stderr.3.html
 #[inline]
 pub unsafe fn stderr() -> BorrowedFd<'static> {
-    BorrowedFd::borrow_raw_fd(imp::io::STDERR_FILENO as RawFd)
+    BorrowedFd::borrow_raw(imp::io::STDERR_FILENO as RawFd)
 }
 
 /// `STDERR_FILENO`—Standard error, owned.


### PR DESCRIPTION
`BorrowedFd::borrow_raw_fd` is renamed to `BorrowedFd::borrow_raw`.