### PR TITLE
Rename `dup2_with` to `dup3`.

### DIFF
--- a/src/imp/libc/io/syscalls.rs
+++ b/src/imp/libc/io/syscalls.rs
@@ -465,7 +465,7 @@ pub(crate) fn dup2(fd: BorrowedFd<'_>, new: &OwnedFd) -> io::Result<()> {
     target_os = "redox",
     target_os = "wasi"
 )))]
-pub(crate) fn dup2_with(fd: BorrowedFd<'_>, new: &OwnedFd, flags: DupFlags) -> io::Result<()> {
+pub(crate) fn dup3(fd: BorrowedFd<'_>, new: &OwnedFd, flags: DupFlags) -> io::Result<()> {
     unsafe {
         ret_discarded_fd(c::dup3(
             borrowed_fd(fd),
@@ -482,7 +482,7 @@ pub(crate) fn dup2_with(fd: BorrowedFd<'_>, new: &OwnedFd, flags: DupFlags) -> i
     target_os = "ios",
     target_os = "redox"
 ))]
-pub(crate) fn dup2_with(fd: BorrowedFd<'_>, new: &OwnedFd, _flags: DupFlags) -> io::Result<()> {
+pub(crate) fn dup3(fd: BorrowedFd<'_>, new: &OwnedFd, _flags: DupFlags) -> io::Result<()> {
     // Android 5.0 has `dup3`, but libc doesn't have bindings. Emulate it
     // using `dup2`, including the difference of failing with `EINVAL`
     // when the file descriptors are equal.

--- a/src/imp/linux_raw/io/syscalls.rs
+++ b/src/imp/linux_raw/io/syscalls.rs
@@ -561,7 +561,7 @@ pub(crate) fn dup2(fd: BorrowedFd<'_>, new: &OwnedFd) -> io::Result<()> {
         if fd.as_raw_fd() == new.as_raw_fd() {
             return Ok(());
         }
-        dup2_with(fd, new, DupFlags::empty())
+        dup3(fd, new, DupFlags::empty())
     }
 
     #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
@@ -575,7 +575,7 @@ pub(crate) fn dup2(fd: BorrowedFd<'_>, new: &OwnedFd) -> io::Result<()> {
 }
 
 #[inline]
-pub(crate) fn dup2_with(fd: BorrowedFd<'_>, new: &OwnedFd, flags: DupFlags) -> io::Result<()> {
+pub(crate) fn dup3(fd: BorrowedFd<'_>, new: &OwnedFd, flags: DupFlags) -> io::Result<()> {
     unsafe {
         ret_discarded_fd(syscall3_readonly(
             nr(__NR_dup3),

--- a/src/io/dup.rs
+++ b/src/io/dup.rs
@@ -36,7 +36,7 @@ pub fn dup<Fd: AsFd>(fd: Fd) -> io::Result<OwnedFd> {
 /// closing `new` and reusing its file descriptor.
 ///
 /// Note that this function does not set the `O_CLOEXEC` flag. To do a `dup2`
-/// that does set `O_CLOEXEC`, use [`dup2_with`] with [`DupFlags::CLOEXEC`] on
+/// that does set `O_CLOEXEC`, use [`dup3`] with [`DupFlags::CLOEXEC`] on
 /// platforms which support it.
 ///
 /// # References
@@ -56,9 +56,10 @@ pub fn dup2<Fd: AsFd>(fd: Fd, new: &OwnedFd) -> io::Result<()> {
 /// same underlying [file description] as the existing `OwnedFd` instance,
 /// closing `new` and reusing its file descriptor, with flags.
 ///
-/// `dup2_with` is the same as [`dup2`] but adds an additional flags operand,
-/// and fails in the case that `fd` and `new` have the same file descriptor
-/// value.
+/// `dup3` is the same as [`dup2`] but adds an additional flags operand,
+/// and it fails in the case that `fd` and `new` have the same file descriptor
+/// value. This additional difference is the reason this function isn't named
+/// `dup2_with`.
 ///
 /// # References
 ///  - [POSIX]
@@ -69,7 +70,6 @@ pub fn dup2<Fd: AsFd>(fd: Fd, new: &OwnedFd) -> io::Result<()> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/dup2.2.html
 #[cfg(not(target_os = "wasi"))]
 #[inline]
-#[doc(alias = "dup3")]
-pub fn dup2_with<Fd: AsFd>(fd: Fd, new: &OwnedFd, flags: DupFlags) -> io::Result<()> {
-    imp::io::syscalls::dup2_with(fd.as_fd(), new, flags)
+pub fn dup3<Fd: AsFd>(fd: Fd, new: &OwnedFd, flags: DupFlags) -> io::Result<()> {
+    imp::io::syscalls::dup3(fd.as_fd(), new, flags)
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -42,7 +42,7 @@ mod userfaultfd;
 
 pub use close::close;
 #[cfg(not(any(windows, target_os = "wasi")))]
-pub use dup::{dup, dup2, dup2_with, DupFlags};
+pub use dup::{dup, dup2, dup3, DupFlags};
 pub use error::{with_retrying, Error, Result};
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 pub use eventfd::{eventfd, EventfdFlags};

--- a/tests/io/dup3.rs
+++ b/tests/io/dup3.rs
@@ -9,17 +9,17 @@ fn test_dup2() {
     rustix::io::dup2(&b, &b).unwrap();
 }
 
-/// `dup2_with` uses Linux `dup3` which fails with `INVAL` if the
+/// `dup3` uses Linux `dup3` which fails with `INVAL` if the
 /// file descriptors are equal.
 #[test]
-fn test_dup2_with() {
+fn test_dup3() {
     let (a, b) = rustix::io::pipe().unwrap();
     assert_eq!(
-        rustix::io::dup2_with(&a, &a, DupFlags::empty()),
+        rustix::io::dup3(&a, &a, DupFlags::empty()),
         Err(rustix::io::Error::INVAL)
     );
     assert_eq!(
-        rustix::io::dup2_with(&b, &b, DupFlags::empty()),
+        rustix::io::dup3(&b, &b, DupFlags::empty()),
         Err(rustix::io::Error::INVAL)
     );
     #[cfg(not(any(
@@ -30,11 +30,11 @@ fn test_dup2_with() {
     )))] // Android 5.0 has dup3, but libc doesn't have bindings
     {
         assert_eq!(
-            rustix::io::dup2_with(&a, &a, DupFlags::CLOEXEC),
+            rustix::io::dup3(&a, &a, DupFlags::CLOEXEC),
             Err(rustix::io::Error::INVAL)
         );
         assert_eq!(
-            rustix::io::dup2_with(&b, &b, DupFlags::CLOEXEC),
+            rustix::io::dup3(&b, &b, DupFlags::CLOEXEC),
             Err(rustix::io::Error::INVAL)
         );
     }

--- a/tests/io/main.rs
+++ b/tests/io/main.rs
@@ -7,7 +7,7 @@
 #[cfg(not(windows))]
 mod dup2_to_replace_stdio;
 #[cfg(not(windows))]
-mod dup2_with;
+mod dup3;
 #[cfg(not(feature = "rustc-dep-of-std"))] // TODO
 #[cfg(not(windows))]
 mod epoll;


### PR DESCRIPTION
Fixes #244.