### PR TITLE
Define `SealFlags::FUTURE_WRITE` on Android too.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,13 +37,13 @@ once_cell = { version = "1.5.2", optional = true }
 [target.'cfg(all(not(rustix_use_libc), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))'.dependencies]
 linux-raw-sys = { version = "0.0.42", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 errno = { version = "0.2.8", default-features = false, optional = true }
-libc = { version = "0.2.116", features = ["extra_traits"], optional = true }
+libc = { version = "0.2.118", features = ["extra_traits"], optional = true }
 
 # On all other Unix-family platforms, we always use the libc backend, so enable
 # its dependencies unconditionally.
 [target.'cfg(any(rustix_use_libc, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
 errno = { version = "0.2.8", default-features = false }
-libc = { version = "0.2.116", features = ["extra_traits"] }
+libc = { version = "0.2.118", features = ["extra_traits"] }
 
 # For the libc backend on Windows, use the Winsock2 API in winapi.
 [target.'cfg(windows)'.dependencies]
@@ -53,7 +53,7 @@ winapi = { version = "0.3.9", features = ["handleapi"] }
 
 [dev-dependencies]
 tempfile = "3.2.0"
-libc = "0.2.116"
+libc = "0.2.118"
 errno = "0.2.8"
 serial_test = "0.6"
 

--- a/src/imp/libc/fs/types.rs
+++ b/src/imp/libc/fs/types.rs
@@ -559,7 +559,7 @@ bitflags! {
        /// `F_SEAL_WRITE`.
        const WRITE = c::F_SEAL_WRITE;
        /// `F_SEAL_FUTURE_WRITE` (since Linux 5.1)
-       #[cfg(target_os = "linux")]
+       #[cfg(any(target_os = "android", target_os = "linux"))]
        const FUTURE_WRITE = c::F_SEAL_FUTURE_WRITE;
     }
 }


### PR DESCRIPTION
This depends on libc 0.2.118, which recently added the definition
for Android.