### PR TITLE
Enable memfd support on FreeBSD.

### DIFF
--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -44,7 +44,7 @@ mod getpath;
     target_os = "wasi"
 )))]
 mod makedev;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 mod memfd_create;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod openat2;
@@ -165,7 +165,7 @@ pub use getpath::getpath;
     target_os = "wasi"
 )))]
 pub use makedev::{major, makedev, minor};
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 pub use memfd_create::{memfd_create, MemfdFlags};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use openat2::openat2;

--- a/src/imp/libc/fs/mod.rs
+++ b/src/imp/libc/fs/mod.rs
@@ -50,6 +50,8 @@ pub use types::Advice;
 pub use types::FallocateFlags;
 #[cfg(not(target_os = "wasi"))]
 pub use types::FlockOperation;
+#[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
+pub use types::MemfdFlags;
 #[cfg(any(
     target_os = "android",
     target_os = "freebsd",
@@ -70,6 +72,6 @@ pub use types::{Access, Dev, FdFlags, FileType, Mode, OFlags, RawMode, Stat};
 #[cfg(not(target_os = "redox"))]
 pub use types::{AtFlags, UTIME_NOW, UTIME_OMIT};
 #[cfg(any(target_os = "android", target_os = "linux"))]
-pub use types::{FsWord, MemfdFlags, RenameFlags, ResolveFlags, NFS_SUPER_MAGIC, PROC_SUPER_MAGIC};
+pub use types::{FsWord, RenameFlags, ResolveFlags, NFS_SUPER_MAGIC, PROC_SUPER_MAGIC};
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 pub use types::{Statx, StatxFlags};

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -748,9 +748,7 @@ pub(crate) fn memfd_create(path: &ZStr, flags: MemfdFlags) -> io::Result<OwnedFd
         ) via SYS_memfd_create -> c::c_int
     }
 
-    unsafe {
-        ret_owned_fd(memfd_create(c_str(path), flags.bits()))
-    }
+    unsafe { ret_owned_fd(memfd_create(c_str(path), flags.bits())) }
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -746,7 +746,7 @@ pub(crate) fn memfd_create(path: &ZStr, flags: MemfdFlags) -> io::Result<OwnedFd
             ) via SYS_memfd_create -> c::c_int
         }
 
-        ret(memfd_create(c_str(path), flags.bits()))
+        ret_owned_fd(memfd_create(c_str(path), flags.bits()))
     }
 }
 

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -737,7 +737,7 @@ pub(crate) fn memfd_create(path: &ZStr, flags: MemfdFlags) -> io::Result<OwnedFd
         fn memfd_create(
             name: *const c::c_char,
             flags: c::c_uint
-        ) via SYS_memfd_create -> c::c_int
+        ) -> c::c_int
     }
 
     #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -68,7 +68,7 @@ use crate::fs::Advice;
 use crate::fs::FallocateFlags;
 #[cfg(not(target_os = "wasi"))]
 use crate::fs::FlockOperation;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 use crate::fs::MemfdFlags;
 #[cfg(any(
     target_os = "android",
@@ -730,9 +730,24 @@ pub(crate) fn ftruncate(fd: BorrowedFd<'_>, length: u64) -> io::Result<()> {
     unsafe { ret(libc_ftruncate(borrowed_fd(fd), length)) }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 pub(crate) fn memfd_create(path: &ZStr, flags: MemfdFlags) -> io::Result<OwnedFd> {
-    unsafe { syscall_ret_owned_fd(c::syscall(c::SYS_memfd_create, c_str(path), flags.bits())) }
+    #[cfg(target_os = "freebsd")]
+    unsafe {
+        ret_owned_fd(libc::memfd_create(c_str(path), flags.bits()))
+    }
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    unsafe {
+        weak_or_syscall! {
+            fn memfd_create(
+                name: *const c::c_char,
+                flags: c::c_uint
+            ) via SYS_memfd_create -> c::c_int
+        }
+
+        ret(memfd_create(c_str(path), flags.bits()))
+    }
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/imp/libc/fs/types.rs
+++ b/src/imp/libc/fs/types.rs
@@ -495,7 +495,7 @@ pub enum Advice {
     DontNeed = c::POSIX_FADV_DONTNEED as c::c_uint,
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 bitflags! {
     /// `MFD_*` constants for use with [`memfd_create`].
     ///
@@ -511,28 +511,40 @@ bitflags! {
         const HUGETLB = c::MFD_HUGETLB;
 
         /// `MFD_HUGE_64KB`
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_64KB = c::MFD_HUGE_64KB;
         /// `MFD_HUGE_512JB`
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_512KB = c::MFD_HUGE_512KB;
         /// `MFD_HUGE_1MB`
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_1MB = c::MFD_HUGE_1MB;
         /// `MFD_HUGE_2MB`
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_2MB = c::MFD_HUGE_2MB;
         /// `MFD_HUGE_8MB`
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_8MB = c::MFD_HUGE_8MB;
         /// `MFD_HUGE_16MB`
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_16MB = c::MFD_HUGE_16MB;
         /// `MFD_HUGE_32MB`
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_32MB = c::MFD_HUGE_32MB;
         /// `MFD_HUGE_256MB`
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_256MB = c::MFD_HUGE_256MB;
         /// `MFD_HUGE_512MB`
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_512MB = c::MFD_HUGE_512MB;
         /// `MFD_HUGE_1GB`
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_1GB = c::MFD_HUGE_1GB;
         /// `MFD_HUGE_2GB`
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_2GB = c::MFD_HUGE_2GB;
         /// `MFD_HUGE_16GB`
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_16GB = c::MFD_HUGE_16GB;
     }
 }

--- a/src/imp/libc/process/syscalls.rs
+++ b/src/imp/libc/process/syscalls.rs
@@ -51,6 +51,10 @@ pub(crate) fn getcwd(buf: &mut [u8]) -> io::Result<()> {
     unsafe { ret_discarded_char_ptr(c::getcwd(buf.as_mut_ptr().cast(), buf.len())) }
 }
 
+// GLIBC does not have a wrapper for `membarrier`; [the documentation]
+// says to use `syscall`.
+//
+// [the documentation]: https://man7.org/linux/man-pages/man2/membarrier.2.html#NOTES
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub(crate) fn membarrier_query() -> MembarrierQuery {
     const MEMBARRIER_CMD_QUERY: u32 = 0;

--- a/tests/io/main.rs
+++ b/tests/io/main.rs
@@ -32,5 +32,5 @@ mod prot;
 #[cfg(not(target_os = "redox"))] // redox doesn't have cwd/openat
 #[cfg(not(target_os = "wasi"))] // wasi support for S_IRUSR etc. submitted to libc in #2264
 mod read_write;
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "android"))]
 mod seals;


### PR DESCRIPTION
FreeBSD supports the memfd_create API; enable support for it.

Also, on Linux, use the new `syscall_or_weak` instead of just using
libc::syscall, so that we use the libc wrapper when available.