### PR TITLE
Support `preadv64` and `pwritev64` on Android versions which lack them.

### DIFF
--- a/src/imp/libc/offset.rs
+++ b/src/imp/libc/offset.rs
@@ -186,10 +186,96 @@ pub(super) use c::posix_fadvise64 as libc_posix_fadvise;
 ))))]
 pub(super) use c::{pread as libc_pread, pwrite as libc_pwrite};
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "emscripten"))]
-pub(super) use c::{
-    pread64 as libc_pread, preadv64 as libc_preadv, pwrite64 as libc_pwrite,
-    pwritev64 as libc_pwritev,
-};
+pub(super) use c::{pread64 as libc_pread, pwrite64 as libc_pwrite};
+#[cfg(any(target_os = "linux", target_os = "emscripten"))]
+pub(super) use c::{preadv64 as libc_preadv, pwritev64 as libc_pwritev};
+#[cfg(target_os = "android")]
+mod readwrite_pv64 {
+    use super::c;
+
+    // 64-bit offsets on 32-bit platforms are passed in endianness-specific
+    // lo/hi pairs. See src/imp/linux_raw/conv.rs for details.
+    #[cfg(all(target_endian = "little", target_pointer_width = "32"))]
+    fn lo(x: u64) -> usize {
+        (x >> 32) as usize
+    }
+    #[cfg(all(target_endian = "little", target_pointer_width = "32"))]
+    fn hi(x: u64) -> usize {
+        (x & 0xffff_ffff) as usize
+    }
+    #[cfg(all(target_endian = "big", target_pointer_width = "32"))]
+    fn lo(x: u64) -> usize {
+        (x & 0xffff_ffff) as usize
+    }
+    #[cfg(all(target_endian = "big", target_pointer_width = "32"))]
+    fn hi(x: u64) -> usize {
+        (x >> 32) as usize
+    }
+
+    pub(in super::super) unsafe fn preadv64(
+        fd: c::c_int,
+        iov: *const c::iovec,
+        iovcnt: c::c_int,
+        offset: c::off64_t,
+    ) -> c::ssize_t {
+        // Older Android libc lacks `preadv64`, so use the `weak!` mechanism
+        // to test for it, and call back to `libc::syscall`. We don't use
+        // `weak_or_syscall` here because we need to pass the 64-bit offset
+        // speciallly.
+        weak! {
+            fn preadv64(c::c_int, *const c::iovec, c::c_int, c::off64_t) -> c::ssize_t
+        }
+        if let Some(fun) = preadv64.get() {
+            fun(fd, iov, iovcnt, offset)
+        } else {
+            #[cfg(target_pointer_width = "32")]
+            {
+                libc::syscall(
+                    libc::SYS_preadv,
+                    fd,
+                    iov,
+                    iovcnt,
+                    hi(offset as u64),
+                    lo(offset as u64),
+                ) as c::ssize_t
+            }
+            #[cfg(target_pointer_width = "64")]
+            {
+                libc::syscall(libc::SYS_preadv, fd, iov, iovcnt, offset) as c::ssize_t
+            }
+        }
+    }
+    pub(in super::super) unsafe fn pwritev64(
+        fd: c::c_int,
+        iov: *const c::iovec,
+        iovcnt: c::c_int,
+        offset: c::off64_t,
+    ) -> c::ssize_t {
+        // See the comments in `preadv64`.
+        weak! {
+            fn pwritev64(c::c_int, *const c::iovec, c::c_int, c::off64_t) -> c::ssize_t
+        }
+        if let Some(fun) = pwritev64.get() {
+            fun(fd, iov, iovcnt, offset)
+        } else {
+            #[cfg(target_pointer_width = "32")]
+            {
+                libc::syscall(
+                    libc::SYS_pwritev,
+                    fd,
+                    iov,
+                    iovcnt,
+                    hi(offset as u64),
+                    lo(offset as u64),
+                ) as c::ssize_t
+            }
+            #[cfg(target_pointer_width = "64")]
+            {
+                libc::syscall(libc::SYS_pwritev, fd, iov, iovcnt, offset) as c::ssize_t
+            }
+        }
+    }
+}
 #[cfg(not(any(
     windows,
     target_os = "android",
@@ -200,6 +286,8 @@ pub(super) use c::{
     target_os = "redox",
 )))]
 pub(super) use c::{preadv as libc_preadv, pwritev as libc_pwritev};
+#[cfg(target_os = "android")]
+pub(super) use readwrite_pv64::{preadv64 as libc_preadv, pwritev64 as libc_pwritev};
 // macOS added preadv and pwritev in version 11.0
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 mod readwrite_pv {


### PR DESCRIPTION
Use `weak!` to test for `preadv64` and `pwrite64` on Android, and fall
back to calling them via `libc::syscall` when they aren't present.

`libc::syscall` is a little tricky here because on 32-bit platforms, the
64-bit offsets are passed as two halves.

Fixes #256.