### PR TITLE
Preserve provenance in the auxv parsing code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@
 `rustix` provides efficient memory-safe and [I/O-safe] wrappers to POSIX-like,
 Unix-like, Linux, and Winsock2 syscall-like APIs, with configurable backends.
 It uses Rust references, slices, and return values instead of raw pointers, and
-[`io-lifetimes`] instead of raw file descriptors, providing memory safety and
-[I/O safety]. It uses `Result`s for reporting errors, [`bitflags`] instead of
-bare integer flags, an [`Arg`] trait with optimizations to efficiently accept
-any Rust string type, and several other efficient conveniences.
+[`io-lifetimes`] instead of raw file descriptors, providing memory safety,
+[I/O safety], and [provenance]. It uses `Result`s for reporting errors,
+[`bitflags`] instead of bare integer flags, an [`Arg`] trait with optimizations
+to efficiently accept any Rust string type, and several other efficient
+conveniences.
 
 `rustix` is low-level and, and while the `net` API supports Winsock2 on
 Windows, the rest of the APIs do not support Windows; for higher-level and more
@@ -37,8 +38,8 @@ portable APIs built on this functionality, see the [`system-interface`],
       cancellation, and employing some specialized optimizations, most functions
       compile down to very efficient code. On nightly Rust, they can often be
       fully inlined into user code.
-    - Most functions in `linux_raw` preserve memory and I/O safety all the way
-      down to the syscalls.
+    - Most functions in `linux_raw` preserve memory, I/O safety, and pointer
+      provenance all the way down to the syscalls.
     - `linux_raw` uses a 64-bit `time_t` type on all platforms, avoiding the
       [y2038 bug].
 
@@ -118,6 +119,7 @@ version of this crate.
 [`Arg`]: https://docs.rs/rustix/latest/rustix/path/trait.Arg.html
 [I/O-safe]: https://github.com/rust-lang/rfcs/blob/master/text/3128-io-safety.md
 [I/O safety]: https://github.com/rust-lang/rfcs/blob/master/text/3128-io-safety.md
+[provenance]: https://github.com/rust-lang/rust/issues/95228
 [y2038 bug]: https://en.wikipedia.org/wiki/Year_2038_problem
 [`OwnedFd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/struct.OwnedFd.html
 [`AsFd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/trait.AsFd.html

--- a/src/imp/linux_raw/vdso.rs
+++ b/src/imp/linux_raw/vdso.rs
@@ -66,7 +66,10 @@ const fn make_pointer<T>(value: usize) -> Option<*const T> {
 /// # Safety
 ///
 /// `base` must be a valid pointer to an ELF image in memory.
-unsafe fn init_from_sysinfo_ehdr(base: usize) -> Option<Vdso> {
+unsafe fn init_from_sysinfo_ehdr(base: *const Elf_Ehdr) -> Option<Vdso> {
+    // The vDSO parsing code does not yet preserve provenance.
+    let base = base as usize;
+
     // Check that `base` is a valid pointer to the kernel-provided vDSO.
     let hdr = check_vdso_base(base)?;
 

--- a/src/imp/linux_raw/vdso.rs
+++ b/src/imp/linux_raw/vdso.rs
@@ -17,7 +17,7 @@ use super::elf::*;
 use crate::ffi::ZStr;
 use crate::io::{self, madvise, Advice};
 use core::mem::{align_of, size_of};
-use core::ptr::null;
+use core::ptr::{null, null_mut};
 
 pub(super) struct Vdso {
     // Load information
@@ -356,7 +356,7 @@ impl Vdso {
     }
 
     /// Look up a symbol in the vDSO.
-    pub(super) fn sym(&self, version: &ZStr, name: &ZStr) -> *const c::c_void {
+    pub(super) fn sym(&self, version: &ZStr, name: &ZStr) -> *mut c::c_void {
         let ver_hash = elf_hash(version);
         let name_hash = elf_hash(name);
 
@@ -385,11 +385,11 @@ impl Vdso {
 
                 let sum = self.load_offset.checked_add(sym.st_value).unwrap();
                 assert!(sum >= self.load_addr && sum <= self.load_end);
-                return sum as *const c::c_void;
+                return sum as *mut c::c_void;
             }
         }
 
-        null()
+        null_mut()
     }
 }
 

--- a/tests/process/weak.rs
+++ b/tests/process/weak.rs
@@ -26,9 +26,14 @@
 #![allow(dead_code, unused_macros)]
 #![allow(clippy::doc_markdown)]
 
-use core::sync::atomic::{self, AtomicUsize, Ordering};
+use core::ffi::c_void;
+use core::ptr::null_mut;
+use core::sync::atomic::{self, AtomicPtr, Ordering};
 use core::{marker, mem};
 use rustix::ffi::ZStr;
+
+const NULL: *mut c_void = null_mut();
+const INVALID: *mut c_void = 1 as *mut c_void;
 
 macro_rules! weak {
     (fn $name:ident($($t:ty),*) -> $ret:ty) => (
@@ -40,7 +45,7 @@ macro_rules! weak {
 
 pub(crate) struct Weak<F> {
     name: &'static str,
-    addr: AtomicUsize,
+    addr: AtomicPtr<c_void>,
     _marker: marker::PhantomData<F>,
 }
 
@@ -48,7 +53,7 @@ impl<F> Weak<F> {
     pub(crate) const fn new(name: &'static str) -> Self {
         Self {
             name,
-            addr: AtomicUsize::new(1),
+            addr: AtomicPtr::new(INVALID),
             _marker: marker::PhantomData,
         }
     }
@@ -59,10 +64,10 @@ impl<F> Weak<F> {
             // Relaxed is fine here because we fence before reading through the
             // pointer (see the comment below).
             match self.addr.load(Ordering::Relaxed) {
-                1 => self.initialize(),
-                0 => None,
+                INVALID => self.initialize(),
+                NULL => None,
                 addr => {
-                    let func = mem::transmute_copy::<usize, F>(&addr);
+                    let func = mem::transmute_copy::<*mut c_void, F>(&addr);
                     // The caller is presumably going to read through this value
                     // (by calling the function we've dlsymed). This means we'd
                     // need to have loaded it with at least C11's consume
@@ -95,18 +100,18 @@ impl<F> Weak<F> {
         self.addr.store(val, Ordering::Release);
 
         match val {
-            0 => None,
-            addr => Some(mem::transmute_copy::<usize, F>(&addr)),
+            NULL => None,
+            addr => Some(mem::transmute_copy::<*mut c_void, F>(&addr)),
         }
     }
 }
 
-unsafe fn fetch(name: &str) -> usize {
+unsafe fn fetch(name: &str) -> *mut c_void {
     let name = match ZStr::from_bytes_with_nul(name.as_bytes()) {
         Ok(c_str) => c_str,
-        Err(..) => return 0,
+        Err(..) => return null_mut(),
     };
-    libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr().cast()) as usize
+    libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr().cast())
 }
 
 #[cfg(not(any(target_os = "android", target_os = "linux")))]


### PR DESCRIPTION
Some of the values in Linux's auxv array are pointers, so use pointer
types to avoid casting them to `usize`, to preserve their provenance.