### PR TITLE
Implement the Linux timerfd APIs.

### DIFF
--- a/src/imp/libc/time/mod.rs
+++ b/src/imp/libc/time/mod.rs
@@ -5,4 +5,6 @@ pub(crate) mod syscalls;
 
 #[cfg(not(target_os = "wasi"))]
 pub use types::{ClockId, DynamicClockId};
+#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+pub use types::{Itimerspec, TimerfdClockId, TimerfdFlags, TimerfdTimerFlags};
 pub use types::{Nsecs, Secs, Timespec};

--- a/src/imp/libc/time/types.rs
+++ b/src/imp/libc/time/types.rs
@@ -169,7 +169,7 @@ pub enum TimerfdClockId {
     ///
     /// This is a clock that tells the amount of time elapsed since the
     /// Unix epoch, 1970-01-01T00:00:00Z. The clock is externally settable, so
-    /// it is not monotonica. Successive reads may see decreasing times, so it
+    /// it is not monotonic. Successive reads may see decreasing times, so it
     /// isn't reliable for measuring durations.
     Realtime = c::CLOCK_REALTIME,
 

--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -19,7 +19,7 @@ use super::io::error::{
     try_decode_void, try_decode_void_star,
 };
 use super::reg::{raw_arg, ArgNumber, ArgReg, RetReg, R0};
-use super::time::ClockId;
+use super::time::{ClockId, TimerfdClockId};
 use crate::ffi::ZStr;
 use crate::io::{self, OwnedFd};
 use crate::process::{Pid, Resource, Signal};
@@ -234,6 +234,11 @@ pub(super) fn loff_t_from_u64<'a, Num: ArgNumber>(i: u64) -> ArgReg<'a, Num> {
 
 #[inline]
 pub(super) fn clockid_t<'a, Num: ArgNumber>(i: ClockId) -> ArgReg<'a, Num> {
+    pass_usize(i as __kernel_clockid_t as usize)
+}
+
+#[inline]
+pub(super) fn timerfd_clockid_t<'a, Num: ArgNumber>(i: TimerfdClockId) -> ArgReg<'a, Num> {
     pass_usize(i as __kernel_clockid_t as usize)
 }
 

--- a/src/imp/linux_raw/time/mod.rs
+++ b/src/imp/linux_raw/time/mod.rs
@@ -2,4 +2,7 @@ mod types;
 
 pub(crate) mod syscalls;
 
-pub use types::{ClockId, DynamicClockId, Nsecs, Secs, Timespec};
+pub use types::{
+    ClockId, DynamicClockId, Itimerspec, Nsecs, Secs, TimerfdClockId, TimerfdFlags,
+    TimerfdTimerFlags, Timespec,
+};

--- a/src/imp/linux_raw/time/syscalls.rs
+++ b/src/imp/linux_raw/time/syscalls.rs
@@ -6,16 +6,27 @@
 
 #![allow(unsafe_code)]
 
-use super::super::arch::choose::syscall2;
-use super::super::conv::{clockid_t, out};
+use super::super::arch::choose::{syscall2, syscall4};
+use super::super::conv::{
+    borrowed_fd, by_ref, c_uint, clockid_t, out, ret, ret_owned_fd, timerfd_clockid_t,
+};
 use super::super::reg::nr;
-use crate::time::ClockId;
+use crate::fd::BorrowedFd;
+use crate::io::{self, OwnedFd};
+use crate::time::{ClockId, Itimerspec, TimerfdClockId, TimerfdFlags, TimerfdTimerFlags};
 use core::mem::MaybeUninit;
-use linux_raw_sys::general::{__NR_clock_getres, __kernel_timespec};
+use linux_raw_sys::general::{
+    __NR_clock_getres, __NR_timerfd_create, __NR_timerfd_gettime, __NR_timerfd_settime,
+    __kernel_timespec,
+};
 #[cfg(target_pointer_width = "32")]
 use {
-    super::super::conv::ret, crate::io, linux_raw_sys::general::__NR_clock_getres_time64,
+    core::convert::TryInto,
+    core::ptr,
+    linux_raw_sys::general::__NR_clock_getres_time64,
+    linux_raw_sys::general::itimerspec as __kernel_old_itimerspec,
     linux_raw_sys::general::timespec as __kernel_old_timespec,
+    linux_raw_sys::general::{__NR_timerfd_gettime64, __NR_timerfd_settime64},
 };
 
 // `clock_gettime` has special optimizations via the vDSO.
@@ -60,15 +71,194 @@ unsafe fn clock_getres_old(
     result: &mut MaybeUninit<__kernel_timespec>,
 ) -> io::Result<()> {
     let mut old_result = MaybeUninit::<__kernel_old_timespec>::uninit();
-    let res = ret(syscall2(
+    ret(syscall2(
         nr(__NR_clock_getres),
         clockid_t(which_clock),
         out(&mut old_result),
-    ));
+    ))?;
     let old_result = old_result.assume_init();
-    *result.as_mut_ptr() = __kernel_timespec {
-        tv_sec: old_result.tv_sec.into(),
-        tv_nsec: old_result.tv_nsec.into(),
+    // TODO: With Rust 1.55, we can use MaybeUninit::write here.
+    ptr::write(
+        result.as_mut_ptr(),
+        __kernel_timespec {
+            tv_sec: old_result.tv_sec.into(),
+            tv_nsec: old_result.tv_nsec.into(),
+        },
+    );
+    Ok(())
+}
+
+#[inline]
+pub(crate) fn timerfd_create(clockid: TimerfdClockId, flags: TimerfdFlags) -> io::Result<OwnedFd> {
+    unsafe {
+        ret_owned_fd(syscall2(
+            nr(__NR_timerfd_create),
+            timerfd_clockid_t(clockid),
+            c_uint(flags.bits()),
+        ))
+    }
+}
+
+#[inline]
+pub(crate) fn timerfd_settime(
+    fd: BorrowedFd<'_>,
+    flags: TimerfdTimerFlags,
+    new_value: &Itimerspec,
+) -> io::Result<Itimerspec> {
+    let mut result = MaybeUninit::<Itimerspec>::uninit();
+
+    #[cfg(target_pointer_width = "64")]
+    unsafe {
+        ret(syscall4(
+            nr(__NR_timerfd_settime),
+            borrowed_fd(fd),
+            c_uint(flags.bits()),
+            by_ref(new_value),
+            out(&mut result),
+        ))
+        .map(|()| result.assume_init())
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    unsafe {
+        ret(syscall4(
+            nr(__NR_timerfd_settime64),
+            borrowed_fd(fd),
+            c_uint(flags.bits()),
+            by_ref(new_value),
+            out(&mut result),
+        ))
+        .or_else(|err| {
+            // See the comments in `rustix_clock_gettime_via_syscall` about
+            // emulation.
+            if err == io::Error::NOSYS {
+                timerfd_settime_old(fd, flags, new_value, &mut result)
+            } else {
+                Err(err)
+            }
+        })
+        .map(|()| result.assume_init())
+    }
+}
+
+#[cfg(target_pointer_width = "32")]
+unsafe fn timerfd_settime_old(
+    fd: BorrowedFd<'_>,
+    flags: TimerfdTimerFlags,
+    new_value: &Itimerspec,
+    result: &mut MaybeUninit<Itimerspec>,
+) -> io::Result<()> {
+    let mut old_result = MaybeUninit::<__kernel_old_itimerspec>::uninit();
+    let old_new_value = __kernel_old_itimerspec {
+        it_interval: __kernel_old_timespec {
+            tv_sec: new_value
+                .it_interval
+                .tv_sec
+                .try_into()
+                .map_err(|_| io::Error::INVAL)?,
+            tv_nsec: new_value
+                .it_interval
+                .tv_nsec
+                .try_into()
+                .map_err(|_| io::Error::INVAL)?,
+        },
+        it_value: __kernel_old_timespec {
+            tv_sec: new_value
+                .it_value
+                .tv_sec
+                .try_into()
+                .map_err(|_| io::Error::INVAL)?,
+            tv_nsec: new_value
+                .it_value
+                .tv_nsec
+                .try_into()
+                .map_err(|_| io::Error::INVAL)?,
+        },
     };
-    res
+    ret(syscall4(
+        nr(__NR_timerfd_settime),
+        borrowed_fd(fd),
+        c_uint(flags.bits()),
+        by_ref(&old_new_value),
+        out(&mut old_result),
+    ))?;
+    let old_result = old_result.assume_init();
+    // TODO: With Rust 1.55, we can use MaybeUninit::write here.
+    ptr::write(
+        result.as_mut_ptr(),
+        Itimerspec {
+            it_interval: __kernel_timespec {
+                tv_sec: old_result.it_interval.tv_sec.into(),
+                tv_nsec: old_result.it_interval.tv_nsec.into(),
+            },
+            it_value: __kernel_timespec {
+                tv_sec: old_result.it_value.tv_sec.into(),
+                tv_nsec: old_result.it_value.tv_nsec.into(),
+            },
+        },
+    );
+    Ok(())
+}
+
+#[inline]
+pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
+    let mut result = MaybeUninit::<Itimerspec>::uninit();
+
+    #[cfg(target_pointer_width = "64")]
+    unsafe {
+        ret(syscall2(
+            nr(__NR_timerfd_gettime),
+            borrowed_fd(fd),
+            out(&mut result),
+        ))
+        .map(|()| result.assume_init())
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    unsafe {
+        ret(syscall2(
+            nr(__NR_timerfd_gettime64),
+            borrowed_fd(fd),
+            out(&mut result),
+        ))
+        .or_else(|err| {
+            // See the comments in `rustix_clock_gettime_via_syscall` about
+            // emulation.
+            if err == io::Error::NOSYS {
+                timerfd_gettime_old(fd, &mut result)
+            } else {
+                Err(err)
+            }
+        })
+        .map(|()| result.assume_init())
+    }
+}
+
+#[cfg(target_pointer_width = "32")]
+unsafe fn timerfd_gettime_old(
+    fd: BorrowedFd<'_>,
+    result: &mut MaybeUninit<Itimerspec>,
+) -> io::Result<()> {
+    let mut old_result = MaybeUninit::<__kernel_old_itimerspec>::uninit();
+    ret(syscall2(
+        nr(__NR_timerfd_gettime),
+        borrowed_fd(fd),
+        out(&mut old_result),
+    ))?;
+    let old_result = old_result.assume_init();
+    // TODO: With Rust 1.55, we can use MaybeUninit::write here.
+    ptr::write(
+        result.as_mut_ptr(),
+        Itimerspec {
+            it_interval: __kernel_timespec {
+                tv_sec: old_result.it_interval.tv_sec.into(),
+                tv_nsec: old_result.it_interval.tv_nsec.into(),
+            },
+            it_value: __kernel_timespec {
+                tv_sec: old_result.it_value.tv_sec.into(),
+                tv_nsec: old_result.it_value.tv_nsec.into(),
+            },
+        },
+    );
+    Ok(())
 }

--- a/src/imp/linux_raw/time/types.rs
+++ b/src/imp/linux_raw/time/types.rs
@@ -1,4 +1,6 @@
+use super::super::c;
 use crate::fd::BorrowedFd;
+use bitflags::bitflags;
 
 /// `struct timespec`
 pub type Timespec = linux_raw_sys::general::__kernel_timespec;
@@ -9,9 +11,13 @@ pub type Secs = linux_raw_sys::general::__kernel_time64_t;
 /// A type for the `tv_nsec` field of [`Timespec`].
 pub type Nsecs = i64;
 
+/// `struct itimerspec` for use with [`timerfd_gettime`] and [`timerfd_settime`].
+#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+pub type Itimerspec = linux_raw_sys::general::__kernel_itimerspec;
+
 /// `CLOCK_*` constants for use with [`clock_gettime`].
 ///
-/// These constants are always supported at runtime so `clock_gettime` never
+/// These constants are always supported at runtime, so `clock_gettime` never
 /// has to fail with `INVAL` due to an unsupported clock. See
 /// [`DynamicClockId`] for a greater set of clocks, with the caveat that not
 /// all of them are always support
@@ -70,4 +76,72 @@ pub enum DynamicClockId<'a> {
 
     /// `CLOCK_BOOTTIME_ALARM`, available on Linux >= 2.6.39
     BoottimeAlarm,
+}
+
+bitflags! {
+    /// `TFD_*` flags for use with [`timerfd_create`].
+    pub struct TimerfdFlags: c::c_uint {
+        /// `TFD_NONBLOCK`
+        const NONBLOCK = linux_raw_sys::general::TFD_NONBLOCK;
+
+        /// `TFD_CLOEXEC`
+        const CLOEXEC = linux_raw_sys::general::TFD_CLOEXEC;
+    }
+}
+
+bitflags! {
+    /// `TFD_TIMER_*` flags for use with [`timerfd_settime`].
+    pub struct TimerfdTimerFlags: c::c_uint {
+        /// `TFD_TIMER_ABSTIME`
+        const ABSTIME = linux_raw_sys::general::TFD_TIMER_ABSTIME;
+
+        /// `TFD_TIMER_CANCEL_ON_SET`
+        const CANCEL_ON_SET = linux_raw_sys::general::TFD_TIMER_CANCEL_ON_SET;
+    }
+}
+
+/// `CLOCK_*` constants for use with [`timerfd_create`].
+///
+/// [`timerfd_create`]: crate::time::timerfd_create
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[repr(u32)]
+#[non_exhaustive]
+pub enum TimerfdClockId {
+    /// `CLOCK_REALTIME`—A clock that tells the "real" time.
+    ///
+    /// This is a clock that tells the amount of time elapsed since the
+    /// Unix epoch, 1970-01-01T00:00:00Z. The clock is externally settable, so
+    /// it is not monotonica. Successive reads may see decreasing times, so it
+    /// isn't reliable for measuring durations.
+    Realtime = linux_raw_sys::general::CLOCK_REALTIME,
+
+    /// `CLOCK_MONOTONIC`—A clock that tells an abstract time.
+    ///
+    /// Unlike `Realtime`, this clock is not based on a fixed known epoch, so
+    /// individual times aren't meaningful. However, since it isn't settable,
+    /// it is reliable for measuring durations.
+    ///
+    /// This clock does not advance while the system is suspended; see
+    /// `Boottime` for a clock that does.
+    Monotonic = linux_raw_sys::general::CLOCK_MONOTONIC,
+
+    /// `CLOCK_BOOTTIME`—Like `Monotonic`, but advances while suspended.
+    ///
+    /// This clock is similar to `Monotonic`, but does advance while the system
+    /// is suspended.
+    Boottime = linux_raw_sys::general::CLOCK_BOOTTIME,
+
+    /// `CLOCK_REALTIME_ALARM`—Like `Realtime`, but wakes a suspended system.
+    ///
+    /// This clock is like `Realtime`, but can wake up a suspended system.
+    ///
+    /// Use of this clock requires the `CAP_WAKE_ALARM` Linux capability.
+    RealtimeAlarm = linux_raw_sys::general::CLOCK_REALTIME_ALARM,
+
+    /// `CLOCK_BOOTTIME_ALARM`—Like `Boottime`, but wakes a suspended system.
+    ///
+    /// This clock is like `Boottime`, but can wake up a suspended system.
+    ///
+    /// Use of this clock requires the `CAP_WAKE_ALARM` Linux capability.
+    BoottimeAlarm = linux_raw_sys::general::CLOCK_BOOTTIME_ALARM,
 }

--- a/src/imp/linux_raw/time/types.rs
+++ b/src/imp/linux_raw/time/types.rs
@@ -111,7 +111,7 @@ pub enum TimerfdClockId {
     ///
     /// This is a clock that tells the amount of time elapsed since the
     /// Unix epoch, 1970-01-01T00:00:00Z. The clock is externally settable, so
-    /// it is not monotonica. Successive reads may see decreasing times, so it
+    /// it is not monotonic. Successive reads may see decreasing times, so it
     /// isn't reliable for measuring durations.
     Realtime = linux_raw_sys::general::CLOCK_REALTIME,
 

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -3,6 +3,8 @@
 use crate::imp;
 
 mod clock;
+#[cfg(any(target_os = "android", target_os = "linux"))]
+mod timerfd;
 
 // TODO: Convert WASI'S clock APIs to use handles rather than ambient clock
 // identifiers, update `wasi-libc`, and then add support in `rustix`.
@@ -10,5 +12,9 @@ mod clock;
 pub use clock::clock_getres;
 #[cfg(not(target_os = "wasi"))]
 pub use clock::{clock_gettime, clock_gettime_dynamic, ClockId, DynamicClockId};
-
 pub use imp::time::{Nsecs, Secs, Timespec};
+#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+pub use timerfd::{
+    timerfd_create, timerfd_gettime, timerfd_settime, Itimerspec, TimerfdClockId, TimerfdFlags,
+    TimerfdTimerFlags,
+};

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -3,7 +3,7 @@
 use crate::imp;
 
 mod clock;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
 mod timerfd;
 
 // TODO: Convert WASI'S clock APIs to use handles rather than ambient clock

--- a/src/time/timerfd.rs
+++ b/src/time/timerfd.rs
@@ -1,6 +1,6 @@
 use crate::imp;
 use crate::io::{self, OwnedFd};
-use io_lifetimes::AsFd;
+use crate::fd::AsFd;
 
 pub use imp::time::{Itimerspec, TimerfdClockId, TimerfdFlags, TimerfdTimerFlags};
 

--- a/src/time/timerfd.rs
+++ b/src/time/timerfd.rs
@@ -1,0 +1,42 @@
+use crate::imp;
+use crate::io::{self, OwnedFd};
+use io_lifetimes::AsFd;
+
+pub use imp::time::{Itimerspec, TimerfdClockId, TimerfdFlags, TimerfdTimerFlags};
+
+/// `timerfd_create(clockid, flags)`—Create a timer.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/timerfd_create.2.html
+#[inline]
+pub fn timerfd_create(clockid: TimerfdClockId, flags: TimerfdFlags) -> io::Result<OwnedFd> {
+    imp::time::syscalls::timerfd_create(clockid, flags)
+}
+
+/// `timerfd_settime(clockid, flags, new_value)`—Set the time on a timer.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/timerfd_settime.2.html
+#[inline]
+pub fn timerfd_settime<Fd: AsFd>(
+    fd: &Fd,
+    flags: TimerfdTimerFlags,
+    new_value: &Itimerspec,
+) -> io::Result<Itimerspec> {
+    imp::time::syscalls::timerfd_settime(fd.as_fd(), flags, new_value)
+}
+
+/// `timerfd_gettime(clockid, flags)`—Query a timer.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/timerfd_gettime.2.html
+#[inline]
+pub fn timerfd_gettime<Fd: AsFd>(fd: &Fd) -> io::Result<Itimerspec> {
+    imp::time::syscalls::timerfd_gettime(fd.as_fd())
+}

--- a/src/time/timerfd.rs
+++ b/src/time/timerfd.rs
@@ -1,6 +1,6 @@
+use crate::fd::AsFd;
 use crate::imp;
 use crate::io::{self, OwnedFd};
-use crate::fd::AsFd;
 
 pub use imp::time::{Itimerspec, TimerfdClockId, TimerfdFlags, TimerfdTimerFlags};
 

--- a/tests/time/main.rs
+++ b/tests/time/main.rs
@@ -7,5 +7,7 @@
 mod dynamic_clocks;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 mod monotonic;
+#[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
+mod timerfd;
 mod timespec;
 mod y2038;

--- a/tests/time/timerfd.rs
+++ b/tests/time/timerfd.rs
@@ -1,0 +1,30 @@
+use rustix::time::{
+    timerfd_create, timerfd_gettime, timerfd_settime, Itimerspec, TimerfdClockId, TimerfdFlags,
+    TimerfdTimerFlags, Timespec,
+};
+
+#[test]
+fn test_timerfd() {
+    let fd = timerfd_create(TimerfdClockId::Monotonic, TimerfdFlags::CLOEXEC).unwrap();
+
+    let set = Itimerspec {
+        it_interval: Timespec {
+            tv_sec: 3,
+            tv_nsec: 4,
+        },
+        it_value: Timespec {
+            tv_sec: 5,
+            tv_nsec: 6,
+        },
+    };
+    let _old: Itimerspec = timerfd_settime(&fd, TimerfdTimerFlags::ABSTIME, &set).unwrap();
+
+    let new = timerfd_gettime(&fd).unwrap();
+
+    assert_eq!(set.it_interval.tv_sec, new.it_interval.tv_sec);
+    assert_eq!(set.it_interval.tv_nsec, new.it_interval.tv_nsec);
+    assert!(new.it_value.tv_sec <= set.it_value.tv_sec);
+    assert!(
+        set.it_value.tv_nsec <= new.it_value.tv_nsec || set.it_value.tv_sec < new.it_value.tv_sec
+    );
+}


### PR DESCRIPTION
`timerfd_create`, `timerfd_gettime`, and `timerfd_settime`, and
associated enums and flags.