### PR TITLE
Use the libc backend when running under Miri.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,14 +34,14 @@ once_cell = { version = "1.5.2", optional = true }
 # On Linux on selected architectures, we have two supported backends: linux_raw
 # and libc. The libc and errno dependencies are only enabled when the libc
 # backend is in use.
-[target.'cfg(all(not(rustix_use_libc), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))'.dependencies]
+[target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))'.dependencies]
 linux-raw-sys = { version = "0.0.42", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 errno = { version = "0.2.8", default-features = false, optional = true }
 libc = { version = "0.2.118", features = ["extra_traits"], optional = true }
 
-# On all other Unix-family platforms, we always use the libc backend, so enable
-# its dependencies unconditionally.
-[target.'cfg(any(rustix_use_libc, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
+# On all other Unix-family platforms, and under Miri, we always use the libc
+# backend, so enable its dependencies unconditionally.
+[target.'cfg(any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
 errno = { version = "0.2.8", default-features = false }
 libc = { version = "0.2.118", features = ["extra_traits"] }
 

--- a/build.rs
+++ b/build.rs
@@ -52,6 +52,10 @@ fn main() {
     // and not something we want accidentally enabled via --all-features.
     let rustix_use_experimental_asm = var("CARGO_CFG_RUSTIX_USE_EXPERIMENTAL_ASM").is_ok();
 
+    // Miri doesn't support inline asm, and has builtin support for recognizing
+    // libc FFI calls, so if we're running under miri, use the libc backend.
+    let miri = var("CARGO_CFG_MIRI").is_ok();
+
     // If the libc backend is requested, or if we're not on a platform for
     // which we have linux-raw support, use the libc backend.
     //
@@ -63,6 +67,7 @@ fn main() {
         || os_name != "linux"
         || !asm_name_present
         || is_unsupported_abi
+        || miri
     {
         // Use the libc backend.
         use_feature("libc");


### PR DESCRIPTION
Miri doesn't support inline asm, and it has builtin support for
recognizing libc FFI calls, so if we're running under miri, use the
libc backend.

It may be interesting to teach miri about raw Linux syscalls at
some point, but until that happens, using the libc backend allows
users using rustix to use Miri.