### PR TITLE
Remove windows-2016 from CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,7 +180,7 @@ jobs:
       QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
-        build: [ubuntu, ubuntu-18.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux, ubuntu-stable, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, mipsel-linux-stable, mips64el-linux-stable, powerpc64le-linux-stable, arm-linux-stable, macos, macos-11, windows, windows-2016, windows-2022]
+        build: [ubuntu, ubuntu-18.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux, ubuntu-stable, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, mipsel-linux-stable, mips64el-linux-stable, powerpc64le-linux-stable, arm-linux-stable, macos, macos-11, windows, windows-2022]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -320,9 +320,6 @@ jobs:
             rust: nightly
           - build: windows-2022
             os: windows-2022
-            rust: nightly
-          - build: windows-2016
-            os: windows-2016
             rust: nightly
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
windows-2016 is now [deprecated] on Github Actions.

[deprecated]: https://github.com/actions/virtual-environments/issues/5238