### PR TITLE
Fix a race condition in the timerfd test.

### DIFF
--- a/tests/time/timerfd.rs
+++ b/tests/time/timerfd.rs
@@ -28,7 +28,7 @@ fn test_timerfd() {
 
     assert_eq!(set.it_interval.tv_sec, new.it_interval.tv_sec);
     assert_eq!(set.it_interval.tv_nsec, new.it_interval.tv_nsec);
-    assert!(new.it_value.tv_sec <= set.it_value.tv_sec);
+    assert!(new.it_value.tv_sec >= set.it_value.tv_sec);
     assert!(
         set.it_value.tv_nsec <= new.it_value.tv_nsec || set.it_value.tv_sec < new.it_value.tv_sec
     );

--- a/tests/time/timerfd.rs
+++ b/tests/time/timerfd.rs
@@ -9,8 +9,8 @@ fn test_timerfd() {
 
     let set = Itimerspec {
         it_interval: Timespec {
-            tv_sec: 3,
-            tv_nsec: 4,
+            tv_sec: 0,
+            tv_nsec: 0,
         },
         it_value: Timespec {
             tv_sec: 1,
@@ -26,10 +26,50 @@ fn test_timerfd() {
 
     let new = timerfd_gettime(&fd).unwrap();
 
+    // The timer counts down.
     assert_eq!(set.it_interval.tv_sec, new.it_interval.tv_sec);
     assert_eq!(set.it_interval.tv_nsec, new.it_interval.tv_nsec);
-    assert!(new.it_value.tv_sec >= set.it_value.tv_sec);
+    assert!(new.it_value.tv_sec <= set.it_value.tv_sec);
     assert!(
-        set.it_value.tv_nsec <= new.it_value.tv_nsec || set.it_value.tv_sec < new.it_value.tv_sec
+        new.it_value.tv_nsec < set.it_value.tv_nsec || new.it_value.tv_sec < set.it_value.tv_sec
     );
+}
+
+// Similar, but set an interval for a repeated timer. Don't check that the
+// times are monotonic because that would race with the timer repeating.
+#[test]
+fn test_timerfd_with_interval() {
+    let fd = timerfd_create(TimerfdClockId::Monotonic, TimerfdFlags::CLOEXEC).unwrap();
+
+    let set = Itimerspec {
+        it_interval: Timespec {
+            tv_sec: 0,
+            tv_nsec: 6,
+        },
+        it_value: Timespec {
+            tv_sec: 1,
+            tv_nsec: 7,
+        },
+    };
+    let _old: Itimerspec = timerfd_settime(&fd, TimerfdTimerFlags::ABSTIME, &set).unwrap();
+
+    // Wait for the timer to expire.
+    let mut buf = [0u8; 8usize];
+    assert_eq!(rustix::io::read(&fd, &mut buf), Ok(8));
+    assert!(u64::from_ne_bytes(buf) >= 1);
+
+    let new = timerfd_gettime(&fd).unwrap();
+
+    assert_eq!(set.it_interval.tv_sec, new.it_interval.tv_sec);
+    assert_eq!(set.it_interval.tv_nsec, new.it_interval.tv_nsec);
+
+    // Wait for the timer to expire again.
+    let mut buf = [0u8; 8usize];
+    assert_eq!(rustix::io::read(&fd, &mut buf), Ok(8));
+    assert!(u64::from_ne_bytes(buf) >= 1);
+
+    let new = timerfd_gettime(&fd).unwrap();
+
+    assert_eq!(set.it_interval.tv_sec, new.it_interval.tv_sec);
+    assert_eq!(set.it_interval.tv_nsec, new.it_interval.tv_nsec);
 }

--- a/tests/time/timerfd.rs
+++ b/tests/time/timerfd.rs
@@ -13,11 +13,16 @@ fn test_timerfd() {
             tv_nsec: 4,
         },
         it_value: Timespec {
-            tv_sec: 5,
-            tv_nsec: 6,
+            tv_sec: 1,
+            tv_nsec: 2,
         },
     };
     let _old: Itimerspec = timerfd_settime(&fd, TimerfdTimerFlags::ABSTIME, &set).unwrap();
+
+    // Wait for the timer to expire.
+    let mut buf = [0u8; 8usize];
+    assert_eq!(rustix::io::read(&fd, &mut buf), Ok(8));
+    assert!(u64::from_ne_bytes(buf) >= 1);
 
     let new = timerfd_gettime(&fd).unwrap();
 


### PR DESCRIPTION
Add a `read` from the created timerfd so that the test waits until the
timer has expired.

Also, for convenience, decrease the time for the timerfd to expire.