### PR TITLE
Fix a y2038 bug in `statat` on 32-bit platforms.

### DIFF
--- a/src/imp/linux_raw/fs/syscalls.rs
+++ b/src/imp/linux_raw/fs/syscalls.rs
@@ -66,9 +66,9 @@ use linux_raw_sys::general::{
 };
 #[cfg(target_pointer_width = "32")]
 use {
-    core::sync::atomic::{AtomicBool, Ordering::Relaxed},
     super::super::arch::choose::syscall6_readonly,
     super::super::conv::{hi, lo, slice_just_addr},
+    core::sync::atomic::{AtomicBool, Ordering::Relaxed},
     linux_raw_sys::general::__NR_utimensat_time64,
     linux_raw_sys::general::{
         __NR__llseek, __NR_fcntl64, __NR_fstat64, __NR_fstatat64, __NR_fstatfs64, __NR_ftruncate64,

--- a/src/imp/linux_raw/fs/types.rs
+++ b/src/imp/linux_raw/fs/types.rs
@@ -509,9 +509,33 @@ pub enum FlockOperation {
 
 /// `struct stat` for use with [`statat`] and [`fstat`].
 ///
+/// [`statat`]: crate::fs::statat
 /// [`fstat`]: crate::fs::fstat
+// On 32-bit, Linux's `struct stat64` has a 32-bit `st_mtime` and friends, so
+// we use our own struct, populated from `statx` where possible, to avoid the
+// y2038 bug.
 #[cfg(target_pointer_width = "32")]
-pub type Stat = linux_raw_sys::general::stat64;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]
+pub struct Stat {
+    pub st_dev: u64,
+    pub st_mode: u32,
+    pub st_nlink: u32,
+    pub st_uid: u32,
+    pub st_gid: u32,
+    pub st_rdev: u64,
+    pub st_size: i64,
+    pub st_blksize: u32,
+    pub st_blocks: u64,
+    pub st_atime: u64,
+    pub st_atime_nsec: u32,
+    pub st_mtime: u64,
+    pub st_mtime_nsec: u32,
+    pub st_ctime: u64,
+    pub st_ctime_nsec: u32,
+    pub st_ino: u64,
+}
 
 /// `struct stat` for use with [`statat`] and [`fstat`].
 ///


### PR DESCRIPTION
Linux's `stat64` on 32-bit platforms has 32-bit `time_t` fields for the
timestamps. To fix this, use a custom stat structure for linux_raw on
32-bit platforms, and populate it using `statx` when available.