### PR TITLE
Miscellaneous fixes.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,7 @@ jobs:
         mipsel-unknown-linux-gnu
         mips64el-unknown-linux-gnuabi64
         armv5te-unknown-linux-gnueabi
+        s390x-unknown-linux-gnu
     - name: Install cross-compilation tools
       run: |
         set -ex
@@ -180,7 +181,7 @@ jobs:
       QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
-        build: [ubuntu, ubuntu-18.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux, ubuntu-stable, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, mipsel-linux-stable, mips64el-linux-stable, powerpc64le-linux-stable, arm-linux-stable, macos, macos-11, windows, windows-2022]
+        build: [ubuntu, ubuntu-18.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, mipsel-linux-stable, mips64el-linux-stable, powerpc64le-linux-stable, arm-linux-stable, macos, macos-11, windows, windows-2022]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -238,6 +239,15 @@ jobs:
             qemu: qemu-riscv64
             qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
+          - build: s390x-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: s390x-unknown-linux-gnu
+            gcc_package: gcc-s390x-linux-gnu
+            gcc: s390x-linux-gnu-gcc
+            qemu: qemu-s390x
+            qemu_args: -L /usr/s390x-linux-gnu
+            qemu_target: s390x-linux-user
           - build: arm-linux
             os: ubuntu-latest
             rust: nightly
@@ -275,6 +285,15 @@ jobs:
             qemu: qemu-riscv64
             qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
+          - build: s390x-linux-stable
+            os: ubuntu-latest
+            rust: stable
+            target: s390x-unknown-linux-gnu
+            gcc_package: gcc-s390x-linux-gnu
+            gcc: s390x-linux-gnu-gcc
+            qemu: qemu-s390x
+            qemu_args: -L /usr/s390x-linux-gnu
+            qemu_target: s390x-linux-user
           - build: powerpc64le-linux-stable
             os: ubuntu-latest
             rust: stable

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -35,6 +35,7 @@ pub use imp::fs::FsWord;
 
 /// Timestamps used by [`utimensat`] and [`futimens`].
 ///
+/// [`utimensat`]: crate::fs::utimensat
 /// [`futimens`]: crate::fs::futimens
 //
 // This is `repr(C)` and specifically laid out to match the representation

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -131,7 +131,7 @@ fn openat_via_syscall(
         ret_owned_fd(libc::syscall(
             libc::SYS_openat,
             dirfd as c::c_long,
-            path as c::c_long,
+            path,
             oflags as c::c_long,
             mode as c::c_long,
         ) as c::c_int)

--- a/src/imp/libc/fs/types.rs
+++ b/src/imp/libc/fs/types.rs
@@ -934,6 +934,7 @@ pub type FsWord = u32;
 ))]
 pub type FsWord = u64;
 
+/// `__fsword_t`
 // s390x uses `u32` for `statfs` entries, even though `__fsword_t` is `u64`.
 #[cfg(all(target_os = "linux", target_arch = "s390x"))]
 pub type FsWord = u32;

--- a/src/imp/libc/fs/types.rs
+++ b/src/imp/libc/fs/types.rs
@@ -559,8 +559,8 @@ bitflags! {
     /// `F_SEAL_*` constants for use with [`fcntl_add_seals`] and
     /// [`fcntl_get_seals`].
     ///
-    /// [`fcntl_add_seals`]: rustix::fs::fcntl_add_seals
-    /// [`fcntl_get_seals`]: rustix::fs::fcntl_get_seals
+    /// [`fcntl_add_seals`]: crate::fs::fcntl_add_seals
+    /// [`fcntl_get_seals`]: crate::fs::fcntl_get_seals
     pub struct SealFlags: i32 {
        /// `F_SEAL_SEAL`.
        const SEAL = c::F_SEAL_SEAL;

--- a/src/imp/libc/io/poll_fd.rs
+++ b/src/imp/libc/io/poll_fd.rs
@@ -11,7 +11,7 @@ use std::fmt;
 bitflags! {
     /// `POLL*` flags for use with [`poll`].
     ///
-    /// [`poll`]: rustix::io::poll
+    /// [`poll`]: crate::io::poll
     pub struct PollFlags: c::c_short {
         /// `POLLIN`
         const IN = c::POLLIN;
@@ -49,7 +49,7 @@ bitflags! {
 
 /// `struct pollfd`—File descriptor and flags for use with [`poll`].
 ///
-/// [`poll`]: rustix::io::poll
+/// [`poll`]: crate::io::poll
 #[doc(alias = "pollfd")]
 #[derive(Clone)]
 #[cfg_attr(not(windows), derive(Debug))]

--- a/src/imp/libc/process/auxv.rs
+++ b/src/imp/libc/process/auxv.rs
@@ -10,7 +10,7 @@ use crate::ffi::ZStr;
     all(target_os = "android", target_pointer_width = "64"),
     target_os = "linux"
 ))]
-weak!(fn getauxval(c::c_ulong) -> c::c_ulong);
+weak!(fn getauxval(c::c_ulong) -> *mut c::c_void);
 
 #[inline]
 pub(crate) fn page_size() -> usize {
@@ -47,7 +47,7 @@ pub(crate) fn linux_hwcap() -> (usize, usize) {
 #[inline]
 pub(crate) fn linux_execfn() -> &'static ZStr {
     if let Some(libc_getauxval) = getauxval.get() {
-        unsafe { ZStr::from_ptr(libc_getauxval(c::AT_EXECFN) as *const _) }
+        unsafe { ZStr::from_ptr(libc_getauxval(c::AT_EXECFN).cast()) }
     } else {
         zstr!("")
     }

--- a/src/imp/linux_raw/fs/types.rs
+++ b/src/imp/linux_raw/fs/types.rs
@@ -400,8 +400,8 @@ bitflags! {
     /// `F_SEAL_*` constants for use with [`fcntl_add_seals`] and
     /// [`fcntl_get_seals`].
     ///
-    /// [`fcntl_add_seals`]: rustix::fs::fcntl_add_seals
-    /// [`fcntl_get_seals`]: rustix::fs::fcntl_get_seals
+    /// [`fcntl_add_seals`]: crate::fs::fcntl_add_seals
+    /// [`fcntl_get_seals`]: crate::fs::fcntl_get_seals
     pub struct SealFlags: u32 {
        /// `F_SEAL_SEAL`.
        const SEAL = linux_raw_sys::general::F_SEAL_SEAL;

--- a/src/imp/linux_raw/io/poll_fd.rs
+++ b/src/imp/linux_raw/io/poll_fd.rs
@@ -4,7 +4,7 @@ use bitflags::bitflags;
 bitflags! {
     /// `POLL*` flags for use with [`poll`].
     ///
-    /// [`poll`]: rustix::io::poll
+    /// [`poll`]: crate::io::poll
     pub struct PollFlags: u16 {
         /// `POLLIN`
         const IN = linux_raw_sys::general::POLLIN as u16;
@@ -33,7 +33,7 @@ bitflags! {
 
 /// `struct pollfd`—File descriptor and flags for use with [`poll`].
 ///
-/// [`poll`]: rustix::io::poll
+/// [`poll`]: crate::io::poll
 #[doc(alias = "pollfd")]
 #[repr(C)]
 #[derive(Debug, Clone)]

--- a/src/imp/linux_raw/time/types.rs
+++ b/src/imp/linux_raw/time/types.rs
@@ -13,6 +13,9 @@ pub type Nsecs = i64;
 
 /// `struct itimerspec` for use with [`timerfd_gettime`] and
 /// [`timerfd_settime`].
+///
+/// [`timerfd_gettime`]: crate::time::timerfd_gettime
+/// [`timerfd_settime`]: crate::time::timerfd_settime
 #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
 pub type Itimerspec = linux_raw_sys::general::__kernel_itimerspec;
 

--- a/src/io/owned_fd.rs
+++ b/src/io/owned_fd.rs
@@ -158,7 +158,7 @@ impl io_lifetimes::AsSocket for OwnedFd {
     }
 }
 
-#[cfg(io_lifetimes_use_std)]
+#[cfg(any(io_lifetimes_use_std, not(feature = "std")))]
 impl From<OwnedFd> for crate::imp::fd::OwnedFd {
     #[inline]
     fn from(owned_fd: OwnedFd) -> Self {

--- a/src/io/procfs.rs
+++ b/src/io/procfs.rs
@@ -291,6 +291,7 @@ fn proc_self() -> io::Result<(BorrowedFd<'static>, &'static Stat)> {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man5/proc.5.html
+#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
 pub fn proc_self_fd() -> io::Result<BorrowedFd<'static>> {
     static PROC_SELF_FD: StaticFd = StaticFd::new();
 
@@ -369,6 +370,7 @@ fn proc_self_fdinfo() -> io::Result<(BorrowedFd<'static>, &'static Stat)> {
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man5/proc.5.html
 #[inline]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
 pub fn proc_self_fdinfo_fd<Fd: AsFd>(fd: Fd) -> io::Result<OwnedFd> {
     _proc_self_fdinfo(fd.as_fd())
 }
@@ -391,6 +393,7 @@ fn _proc_self_fdinfo(fd: BorrowedFd<'_>) -> io::Result<OwnedFd> {
 /// [Linux]: https://man7.org/linux/man-pages/man5/proc.5.html
 /// [Linux pagemap]: https://www.kernel.org/doc/Documentation/vm/pagemap.txt
 #[inline]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
 pub fn proc_self_pagemap() -> io::Result<OwnedFd> {
     proc_self_file(zstr!("pagemap"))
 }
@@ -405,6 +408,7 @@ pub fn proc_self_pagemap() -> io::Result<OwnedFd> {
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man5/proc.5.html
 #[inline]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
 pub fn proc_self_maps() -> io::Result<OwnedFd> {
     proc_self_file(zstr!("maps"))
 }

--- a/tests/process/priority.rs
+++ b/tests/process/priority.rs
@@ -13,8 +13,14 @@ fn test_priorities() {
         assert_eq!(get_prio, old);
     }
 
+    // Lower the priority by one.
     let new = nice(1).unwrap();
-    assert_eq!(old + 1, new);
+
+    // If the test wasn't running with the lowest priority initially, test that
+    // we were able to lower the priority.
+    if old < 19 {
+        assert_eq!(old + 1, new);
+    }
 
     let get = nice(0).unwrap();
     assert_eq!(new, get);


### PR DESCRIPTION
This patch contains three fixes:
 - Fix a missing documentation comment on s390x.
 - Remove an unnecessary ptr2int cast which would break strict-provenance.
 - Adjust test_priorities to work even if run with the lowest priority.