### PR TITLE
Simplify the "procfs" feature.

### DIFF
--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -5,7 +5,8 @@
 
 #[cfg(not(windows))]
 use rustix::fd::AsFd;
-#[cfg(any(all(linux_raw, feature = "procfs"), all(not(windows), libc)))]
+#[cfg(feature = "procfs")]
+#[cfg(not(windows))]
 use rustix::io::ttyname;
 #[cfg(not(windows))]
 use rustix::io::{self, isatty, stderr, stdin, stdout};
@@ -30,7 +31,7 @@ fn main() -> io::Result<()> {
 fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     let fd = fd.as_fd();
     if isatty(fd) {
-        #[cfg(any(all(linux_raw, feature = "procfs"), libc))]
+        #[cfg(feature = "procfs")]
         println!(" - ttyname: {}", ttyname(fd, Vec::new())?.to_string_lossy());
         println!(" - attrs: {:?}", rustix::io::ioctl_tcgets(fd)?);
         println!(" - winsize: {:?}", rustix::io::ioctl_tiocgwinsz(fd)?);

--- a/src/imp/libc/io/syscalls.rs
+++ b/src/imp/libc/io/syscalls.rs
@@ -15,6 +15,7 @@ use super::super::offset::{libc_preadv, libc_pwritev};
 use super::super::offset::{libc_preadv2, libc_pwritev2};
 use crate::fd::{AsFd, BorrowedFd, RawFd};
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(feature = "procfs")]
 use crate::ffi::ZStr;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 use crate::io::Advice;
@@ -489,8 +490,8 @@ pub(crate) fn dup3(fd: BorrowedFd<'_>, new: &OwnedFd, _flags: DupFlags) -> io::R
     dup2(fd, new)
 }
 
-#[cfg(feature = "procfs")]
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(feature = "procfs")]
 pub(crate) fn ttyname(dirfd: BorrowedFd<'_>, buf: &mut [u8]) -> io::Result<usize> {
     unsafe {
         ret(c::ttyname_r(

--- a/src/imp/libc/io/syscalls.rs
+++ b/src/imp/libc/io/syscalls.rs
@@ -489,6 +489,7 @@ pub(crate) fn dup3(fd: BorrowedFd<'_>, new: &OwnedFd, _flags: DupFlags) -> io::R
     dup2(fd, new)
 }
 
+#[cfg(feature = "procfs")]
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 pub(crate) fn ttyname(dirfd: BorrowedFd<'_>, buf: &mut [u8]) -> io::Result<usize> {
     unsafe {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -92,10 +92,8 @@ pub use read_write::{preadv2, pwritev2, ReadWriteFlags};
 pub use stdio::{stderr, stdin, stdout, take_stderr, take_stdin, take_stdout};
 #[cfg(not(windows))]
 pub use tty::isatty;
-#[cfg(any(
-    all(linux_raw, feature = "procfs"),
-    all(libc, not(any(windows, target_os = "fuchsia", target_os = "wasi")))
-))]
+#[cfg(not(any(windows, target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(feature = "procfs")]
 pub use tty::ttyname;
 #[cfg(not(windows))]
 #[cfg(not(target_os = "wasi"))]

--- a/src/io/tty.rs
+++ b/src/io/tty.rs
@@ -1,17 +1,12 @@
 //! Functions which operate on file descriptors which might be terminals.
 
 use crate::imp;
-#[cfg(any(
-    all(linux_raw, feature = "procfs"),
-    all(libc, not(any(target_os = "fuchsia", target_os = "wasi")))
-))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(feature = "procfs")]
 use crate::io;
 use imp::fd::AsFd;
-#[cfg(any(
-    all(linux_raw, feature = "procfs"),
-    all(libc, not(any(target_os = "fuchsia", target_os = "wasi")))
-))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(feature = "procfs")]
 use {
     crate::ffi::ZString, crate::path::SMALL_PATH_BUFFER_SIZE, alloc::vec::Vec, imp::fd::BorrowedFd,
 };
@@ -46,20 +41,16 @@ pub fn isatty<Fd: AsFd>(fd: Fd) -> bool {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/ttyname.html
 /// [Linux]: https://man7.org/linux/man-pages/man3/ttyname.3.html
-#[cfg(any(
-    all(linux_raw, feature = "procfs"),
-    all(libc, not(any(target_os = "fuchsia", target_os = "wasi")))
-))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(feature = "procfs")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
 #[inline]
 pub fn ttyname<Fd: AsFd, B: Into<Vec<u8>>>(dirfd: Fd, reuse: B) -> io::Result<ZString> {
     _ttyname(dirfd.as_fd(), reuse.into())
 }
 
-#[cfg(any(
-    all(linux_raw, feature = "procfs"),
-    all(libc, not(any(target_os = "fuchsia", target_os = "wasi")))
-))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(feature = "procfs")]
 fn _ttyname(dirfd: BorrowedFd<'_>, mut buffer: Vec<u8>) -> io::Result<ZString> {
     // This code would benefit from having a better way to read into
     // uninitialized memory, but that requires `unsafe`.


### PR DESCRIPTION
Make `ttyname` conditional on the "procfs" feature, regardless of which
backend is enabled. This makes it easier to switch backends without
having to worry about which APIs are in use.