### PR TITLE
Use `c_uint` rather than `bool` in `getsockopt` calls.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -386,7 +386,7 @@ jobs:
         # Run the tests, and check the prebuilt release libraries.
         cargo test --verbose --features=all-impls,procfs,cc --release --workspace -- --nocapture
       env:
-        RUST_BACKTRACE: 1
+        RUST_BACKTRACE: full
 
     - run: |
         # Check the prebuilt debug libraries too.
@@ -529,7 +529,7 @@ jobs:
     - run: |
         cargo test --verbose --features=use-libc,all-impls,procfs --release --workspace -- --nocapture
       env:
-        RUST_BACKTRACE: 1
+        RUST_BACKTRACE: full
 
   test_rustix_use_experimental_asm:
     name: Test rustix_use_experimental_asm
@@ -635,4 +635,4 @@ jobs:
     - run: |
         cargo test --verbose --features=all-impls,procfs --release --workspace -- --nocapture
       env:
-        RUST_BACKTRACE: 1
+        RUST_BACKTRACE: full

--- a/src/imp/libc/net/syscalls.rs
+++ b/src/imp/libc/net/syscalls.rs
@@ -398,7 +398,7 @@ pub(crate) mod sockopt {
     const DURATION_ZERO: Duration = Duration::from_secs(0);
 
     #[inline]
-    fn getsockopt<T>(fd: BorrowedFd<'_>, level: i32, optname: i32) -> io::Result<T> {
+    fn getsockopt<T: Copy>(fd: BorrowedFd<'_>, level: i32, optname: i32) -> io::Result<T> {
         use super::*;
 
         let mut optlen = core::mem::size_of::<T>().try_into().unwrap();
@@ -426,7 +426,12 @@ pub(crate) mod sockopt {
     }
 
     #[inline]
-    fn setsockopt<T>(fd: BorrowedFd<'_>, level: i32, optname: i32, value: T) -> io::Result<()> {
+    fn setsockopt<T: Copy>(
+        fd: BorrowedFd<'_>,
+        level: i32,
+        optname: i32,
+        value: T,
+    ) -> io::Result<()> {
         use super::*;
 
         let optlen = core::mem::size_of::<T>().try_into().unwrap();

--- a/src/imp/libc/net/syscalls.rs
+++ b/src/imp/libc/net/syscalls.rs
@@ -402,10 +402,7 @@ pub(crate) mod sockopt {
         use super::*;
 
         let mut optlen = core::mem::size_of::<T>().try_into().unwrap();
-        debug_assert!(
-            optlen >= 4,
-            "Socket APIs don't ever use `bool` directly"
-        );
+        debug_assert!(optlen >= 4, "Socket APIs don't ever use `bool` directly");
 
         unsafe {
             let mut value = MaybeUninit::<T>::uninit();
@@ -430,10 +427,7 @@ pub(crate) mod sockopt {
         use super::*;
 
         let optlen = core::mem::size_of::<T>().try_into().unwrap();
-        debug_assert!(
-            optlen >= 4,
-            "Socket APIs don't ever use `bool` directly"
-        );
+        debug_assert!(optlen >= 4, "Socket APIs don't ever use `bool` directly");
 
         unsafe {
             ret(c::setsockopt(

--- a/src/imp/libc/net/syscalls.rs
+++ b/src/imp/libc/net/syscalls.rs
@@ -402,7 +402,10 @@ pub(crate) mod sockopt {
         use super::*;
 
         let mut optlen = core::mem::size_of::<T>().try_into().unwrap();
-        debug_assert!(optlen >= 4, "Socket APIs don't ever use `bool` directly");
+        debug_assert!(
+            optlen as usize >= core::mem::size_of::<c::c_int>(),
+            "Socket APIs don't ever use `bool` directly"
+        );
 
         unsafe {
             let mut value = MaybeUninit::<T>::uninit();
@@ -427,7 +430,10 @@ pub(crate) mod sockopt {
         use super::*;
 
         let optlen = core::mem::size_of::<T>().try_into().unwrap();
-        debug_assert!(optlen >= 4, "Socket APIs don't ever use `bool` directly");
+        debug_assert!(
+            optlen as usize >= core::mem::size_of::<c::c_int>(),
+            "Socket APIs don't ever use `bool` directly"
+        );
 
         unsafe {
             ret(c::setsockopt(

--- a/src/imp/linux_raw/net/syscalls.rs
+++ b/src/imp/linux_raw/net/syscalls.rs
@@ -838,10 +838,7 @@ pub(crate) mod sockopt {
         use super::*;
 
         let mut optlen = core::mem::size_of::<T>();
-        debug_assert!(
-            optlen >= 4,
-            "Socket APIs don't ever use `bool` directly"
-        );
+        debug_assert!(optlen >= 4, "Socket APIs don't ever use `bool` directly");
 
         #[cfg(not(target_arch = "x86"))]
         unsafe {
@@ -890,10 +887,7 @@ pub(crate) mod sockopt {
         use super::*;
 
         let optlen = core::mem::size_of::<T>().try_into().unwrap();
-        debug_assert!(
-            optlen >= 4,
-            "Socket APIs don't ever use `bool` directly"
-        );
+        debug_assert!(optlen >= 4, "Socket APIs don't ever use `bool` directly");
 
         #[cfg(not(target_arch = "x86"))]
         unsafe {

--- a/src/imp/linux_raw/net/syscalls.rs
+++ b/src/imp/linux_raw/net/syscalls.rs
@@ -836,10 +836,16 @@ pub(crate) mod sockopt {
     #[inline]
     fn getsockopt<T>(fd: BorrowedFd<'_>, level: u32, optname: u32) -> io::Result<T> {
         use super::*;
+
+        let mut optlen = core::mem::size_of::<T>();
+        debug_assert!(
+            optlen >= 4,
+            "Socket APIs don't ever use `bool` directly"
+        );
+
         #[cfg(not(target_arch = "x86"))]
         unsafe {
             let mut value = MaybeUninit::<T>::uninit();
-            let mut optlen = core::mem::size_of::<T>();
             ret(syscall5(
                 nr(__NR_getsockopt),
                 borrowed_fd(fd),
@@ -859,7 +865,6 @@ pub(crate) mod sockopt {
         #[cfg(target_arch = "x86")]
         unsafe {
             let mut value = MaybeUninit::<T>::uninit();
-            let mut optlen = core::mem::size_of::<T>();
             ret(syscall2(
                 nr(__NR_socketcall),
                 x86_sys(SYS_GETSOCKOPT),
@@ -883,9 +888,15 @@ pub(crate) mod sockopt {
     #[inline]
     fn setsockopt<T>(fd: BorrowedFd<'_>, level: u32, optname: u32, value: T) -> io::Result<()> {
         use super::*;
+
+        let optlen = core::mem::size_of::<T>().try_into().unwrap();
+        debug_assert!(
+            optlen >= 4,
+            "Socket APIs don't ever use `bool` directly"
+        );
+
         #[cfg(not(target_arch = "x86"))]
         unsafe {
-            let optlen = core::mem::size_of::<T>().try_into().unwrap();
             ret(syscall5_readonly(
                 nr(__NR_setsockopt),
                 borrowed_fd(fd),
@@ -897,7 +908,6 @@ pub(crate) mod sockopt {
         }
         #[cfg(target_arch = "x86")]
         unsafe {
-            let optlen = core::mem::size_of::<T>().try_into().unwrap();
             ret(syscall2_readonly(
                 nr(__NR_socketcall),
                 x86_sys(SYS_SETSOCKOPT),
@@ -939,7 +949,7 @@ pub(crate) mod sockopt {
 
     #[inline]
     pub(crate) fn get_socket_broadcast(fd: BorrowedFd<'_>) -> io::Result<bool> {
-        getsockopt(fd, c::SOL_SOCKET as _, c::SO_BROADCAST)
+        getsockopt(fd, c::SOL_SOCKET as _, c::SO_BROADCAST).map(to_bool)
     }
 
     #[inline]
@@ -982,7 +992,7 @@ pub(crate) mod sockopt {
 
     #[inline]
     pub(crate) fn get_socket_passcred(fd: BorrowedFd<'_>) -> io::Result<bool> {
-        getsockopt(fd, c::SOL_SOCKET as _, c::SO_PASSCRED)
+        getsockopt(fd, c::SOL_SOCKET as _, c::SO_PASSCRED).map(to_bool)
     }
 
     #[inline]
@@ -1139,7 +1149,7 @@ pub(crate) mod sockopt {
 
     #[inline]
     pub(crate) fn get_ipv6_v6only(fd: BorrowedFd<'_>) -> io::Result<bool> {
-        getsockopt(fd, c::IPPROTO_IPV6 as _, c::IPV6_V6ONLY)
+        getsockopt(fd, c::IPPROTO_IPV6 as _, c::IPV6_V6ONLY).map(to_bool)
     }
 
     #[inline]
@@ -1157,7 +1167,7 @@ pub(crate) mod sockopt {
 
     #[inline]
     pub(crate) fn get_ip_multicast_loop(fd: BorrowedFd<'_>) -> io::Result<bool> {
-        getsockopt(fd, c::IPPROTO_IP as _, c::IP_MULTICAST_LOOP)
+        getsockopt(fd, c::IPPROTO_IP as _, c::IP_MULTICAST_LOOP).map(to_bool)
     }
 
     #[inline]
@@ -1185,7 +1195,7 @@ pub(crate) mod sockopt {
 
     #[inline]
     pub(crate) fn get_ipv6_multicast_loop(fd: BorrowedFd<'_>) -> io::Result<bool> {
-        getsockopt(fd, c::IPPROTO_IPV6 as _, c::IPV6_MULTICAST_LOOP)
+        getsockopt(fd, c::IPPROTO_IPV6 as _, c::IPV6_MULTICAST_LOOP).map(to_bool)
     }
 
     #[inline]
@@ -1235,7 +1245,7 @@ pub(crate) mod sockopt {
 
     #[inline]
     pub(crate) fn get_tcp_nodelay(fd: BorrowedFd<'_>) -> io::Result<bool> {
-        getsockopt(fd, c::IPPROTO_TCP as _, c::TCP_NODELAY)
+        getsockopt(fd, c::IPPROTO_TCP as _, c::TCP_NODELAY).map(to_bool)
     }
 
     #[inline]
@@ -1278,5 +1288,10 @@ pub(crate) mod sockopt {
     #[inline]
     fn from_bool(value: bool) -> c::c_uint {
         value as c::c_uint
+    }
+
+    #[inline]
+    fn to_bool(value: c::c_uint) -> bool {
+        value != 0
     }
 }

--- a/src/imp/linux_raw/net/syscalls.rs
+++ b/src/imp/linux_raw/net/syscalls.rs
@@ -838,7 +838,10 @@ pub(crate) mod sockopt {
         use super::*;
 
         let mut optlen = core::mem::size_of::<T>();
-        debug_assert!(optlen >= 4, "Socket APIs don't ever use `bool` directly");
+        debug_assert!(
+            optlen as usize >= core::mem::size_of::<c::c_int>(),
+            "Socket APIs don't ever use `bool` directly"
+        );
 
         #[cfg(not(target_arch = "x86"))]
         unsafe {
@@ -887,7 +890,10 @@ pub(crate) mod sockopt {
         use super::*;
 
         let optlen = core::mem::size_of::<T>().try_into().unwrap();
-        debug_assert!(optlen >= 4, "Socket APIs don't ever use `bool` directly");
+        debug_assert!(
+            optlen as usize >= core::mem::size_of::<c::c_int>(),
+            "Socket APIs don't ever use `bool` directly"
+        );
 
         #[cfg(not(target_arch = "x86"))]
         unsafe {

--- a/src/imp/linux_raw/net/syscalls.rs
+++ b/src/imp/linux_raw/net/syscalls.rs
@@ -834,7 +834,7 @@ pub(crate) mod sockopt {
     const DURATION_ZERO: Duration = Duration::from_secs(0);
 
     #[inline]
-    fn getsockopt<T>(fd: BorrowedFd<'_>, level: u32, optname: u32) -> io::Result<T> {
+    fn getsockopt<T: Copy>(fd: BorrowedFd<'_>, level: u32, optname: u32) -> io::Result<T> {
         use super::*;
 
         let mut optlen = core::mem::size_of::<T>();
@@ -886,7 +886,12 @@ pub(crate) mod sockopt {
     }
 
     #[inline]
-    fn setsockopt<T>(fd: BorrowedFd<'_>, level: u32, optname: u32, value: T) -> io::Result<()> {
+    fn setsockopt<T: Copy>(
+        fd: BorrowedFd<'_>,
+        level: u32,
+        optname: u32,
+        value: T,
+    ) -> io::Result<()> {
         use super::*;
 
         let optlen = core::mem::size_of::<T>().try_into().unwrap();

--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -154,16 +154,5 @@ fn test_sockopts() {
     rustix::net::sockopt::set_tcp_nodelay(&s, true).unwrap();
 
     // Check that the nodelay flag is set.
-    if cfg!(not(any(
-        target_os = "dragonfly",
-        target_os = "ios",
-        target_os = "freebsd",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd"
-    ))) {
-        assert_eq!(rustix::net::sockopt::get_tcp_nodelay(&s).unwrap(), true);
-    } else {
-        assert_eq!(rustix::net::sockopt::get_tcp_nodelay(&s).unwrap(), false);
-    }
+    assert_eq!(rustix::net::sockopt::get_tcp_nodelay(&s).unwrap(), true);
 }


### PR DESCRIPTION
`getsockopt` and `setsockopt` represent boolean values as integers, not as
`bool` types. The code already handled this for `setsockopt`, but not
for `getsockopt`. Handle it for `getsockopt`, and add assertions to catch
accidental uses of `bool.
