### PR TITLE
Update the virtual-environment versions in the CI scripts.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,7 +181,7 @@ jobs:
       QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
-        build: [ubuntu, ubuntu-18.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, mipsel-linux-stable, mips64el-linux-stable, powerpc64le-linux-stable, arm-linux-stable, macos, macos-11, windows, windows-2022]
+        build: [ubuntu, ubuntu-18.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, mipsel-linux-stable, mips64el-linux-stable, powerpc64le-linux-stable, arm-linux-stable, macos-latest, macos-10.15, windows, windows-2019]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -328,17 +328,17 @@ jobs:
             qemu: qemu-arm
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
-          - build: macos
+          - build: macos-latest
             os: macos-latest
             rust: stable
-          - build: macos-11
-            os: macos-11
+          - build: macos-10.15
+            os: macos-10.15
             rust: stable
           - build: windows
             os: windows-latest
             rust: nightly
-          - build: windows-2022
-            os: windows-2022
+          - build: windows-2019
+            os: windows-2019
             rust: nightly
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -12,7 +12,7 @@ jobs:
       QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux, macos-11]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux, macos-latest]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -76,8 +76,8 @@ jobs:
             qemu: qemu-arm
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
-          - build: macos-11
-            os: macos-11
+          - build: macos-latest
+            os: macos-latest
             rust: nightly
     steps:
     - uses: actions/checkout@v2
@@ -172,7 +172,7 @@ jobs:
       QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux, macos-11]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux, macos-latest]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -236,8 +236,8 @@ jobs:
             qemu: qemu-arm
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
-          - build: macos-11
-            os: macos-11
+          - build: macos-latest
+            os: macos-latest
             rust: nightly
     steps:
     - uses: actions/checkout@v2
@@ -315,7 +315,7 @@ jobs:
       QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux, macos-11]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux, macos-latest]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -379,8 +379,8 @@ jobs:
             qemu: qemu-arm
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
-          - build: macos-11
-            os: macos-11
+          - build: macos-latest
+            os: macos-latest
             rust: nightly
     steps:
     - uses: actions/checkout@v2
@@ -630,7 +630,7 @@ jobs:
       QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux, macos-11]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux, macos-latest]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -694,8 +694,8 @@ jobs:
             qemu: qemu-arm
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
-          - build: macos-11
-            os: macos-11
+          - build: macos-latest
+            os: macos-latest
             rust: nightly
     steps:
     - uses: actions/checkout@v2
@@ -773,7 +773,7 @@ jobs:
       QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux, macos-11]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux, macos-latest]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -837,8 +837,8 @@ jobs:
             qemu: qemu-arm
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
-          - build: macos-11
-            os: macos-11
+          - build: macos-latest
+            os: macos-latest
             rust: nightly
     steps:
     - uses: actions/checkout@v2
@@ -915,13 +915,13 @@ jobs:
     strategy:
       matrix:
         # Qemu doesn't support running Wasmtime.
-        build: [ubuntu, macos-11]
+        build: [ubuntu, macos-latest]
         include:
           - build: ubuntu
             os: ubuntu-latest
             rust: nightly
-          - build: macos-11
-            os: macos-11
+          - build: macos-latest
+            os: macos-latest
             rust: nightly
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
windows-latest now refers to windows-2022, and macos-latest now refers
to macos-11. Update main.yml so that it doesn't test windows-2022
and macos-11 redundantly, and so that it does test macos-10.15 and
windows-2019.

In test-users.yml, use macos-latest instead of macos-11.