### PR TITLE
Fix vDSO parsing on powerpc64.

### DIFF
--- a/src/imp/linux_raw/elf.rs
+++ b/src/imp/linux_raw/elf.rs
@@ -46,6 +46,7 @@ pub(super) const DT_VERSYM: i32 = 0x6fff_fff0;
 pub(super) const DT_VERDEF: i32 = 0x6fff_fffc;
 pub(super) const STB_WEAK: u8 = 2;
 pub(super) const STB_GLOBAL: u8 = 1;
+pub(super) const STT_NOTYPE: u8 = 0;
 pub(super) const STT_FUNC: u8 = 2;
 pub(super) const STN_UNDEF: u32 = 0;
 pub(super) const VER_FLG_BASE: u16 = 0x1;

--- a/src/imp/linux_raw/vdso.rs
+++ b/src/imp/linux_raw/vdso.rs
@@ -366,7 +366,12 @@ impl Vdso {
                 let sym = &*self.symtab.add(chain as usize);
 
                 // Check for a defined global or weak function w/ right name.
-                if ELF_ST_TYPE(sym.st_info) != STT_FUNC
+                //
+                // The reference parser in Linux's parse_vdso.c requires
+                // symbols to have type `STT_FUNC`, but on powerpc64, the vDSO
+                // uses `STT_NOTYPE`, so allow that too.
+                if (ELF_ST_TYPE(sym.st_info) != STT_FUNC &&
+                        ELF_ST_TYPE(sym.st_info) != STT_NOTYPE)
                     || (ELF_ST_BIND(sym.st_info) != STB_GLOBAL
                         && ELF_ST_BIND(sym.st_info) != STB_WEAK)
                     || sym.st_shndx == SHN_UNDEF


### PR DESCRIPTION
On almost all architectures, including [32-bit powerpc], function symbols
in the vDSO have type `STT_FUNC`. And,
[Linux's own reference vDSO parsing code] expects such symbols to have
type `STT_FUNC`.

But on powerpc64, [they don't]. No `.type` declaration is used, so the
symbols default to `STT_NOTYPE`.

It's not clear why powerpc64 is different here, but it is, and it seems
to have been this way for a long time, so change rustix's vDSO parsing
code to recognize `STT_NOTYPE`, in addition to `STT_FUNC`.

[32-bit powerpc]: https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/arch/powerpc/include/asm/vdso.h#L43
[they don't]: https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/arch/powerpc/include/asm/vdso.h#L29
[Linux's own reference vDSO parsing code]: https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/tools/testing/selftests/vDSO/parse_vdso.c#L213