### PR TITLE
Don't pass `BorrowedFd` by reference.

### DIFF
--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -30,7 +30,7 @@ mod suite {
 
         c.bench_function("simple statat", |b| {
             b.iter(|| {
-                statat(&cwd(), "/", AtFlags::empty()).unwrap();
+                statat(cwd(), "/", AtFlags::empty()).unwrap();
             })
         });
     }
@@ -78,7 +78,7 @@ mod suite {
 
         c.bench_function("simple statat cstr", |b| {
             b.iter(|| {
-                statat(&cwd(), rustix::zstr!("/"), AtFlags::empty()).unwrap();
+                statat(cwd(), rustix::zstr!("/"), AtFlags::empty()).unwrap();
             })
         });
     }

--- a/src/io/procfs.rs
+++ b/src/io/procfs.rs
@@ -231,7 +231,7 @@ fn proc() -> io::Result<(BorrowedFd<'static>, &'static Stat)> {
     // has no side effects.
     PROC.get_or_try_init(|| {
         // Open "/proc".
-        let proc = proc_opendirat(&cwd(), zstr!("/proc"))?;
+        let proc = proc_opendirat(cwd(), zstr!("/proc"))?;
         let proc_stat = check_proc_entry(
             Kind::Proc,
             proc.as_fd(),

--- a/src/zstr.rs
+++ b/src/zstr.rs
@@ -14,7 +14,7 @@
 /// use rustix::fs::{cwd, statat, AtFlags};
 /// use rustix::zstr;
 ///
-/// let metadata = statat(&cwd(), zstr!("test.txt"), AtFlags::empty())?;
+/// let metadata = statat(cwd(), zstr!("test.txt"), AtFlags::empty())?;
 /// # Ok(())
 /// # }
 /// ```

--- a/tests/fs/flock.rs
+++ b/tests/fs/flock.rs
@@ -3,29 +3,29 @@
 fn test_flock() {
     use rustix::fs::{cwd, flock, openat, FlockOperation, Mode, OFlags};
 
-    let f = openat(&cwd(), "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
+    let f = openat(cwd(), "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
     flock(&f, FlockOperation::LockExclusive).unwrap();
     flock(&f, FlockOperation::Unlock).unwrap();
-    let g = openat(&cwd(), "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
+    let g = openat(cwd(), "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
     flock(&g, FlockOperation::LockExclusive).unwrap();
     flock(&g, FlockOperation::Unlock).unwrap();
     drop(f);
     drop(g);
 
-    let f = openat(&cwd(), "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
+    let f = openat(cwd(), "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
     flock(&f, FlockOperation::LockShared).unwrap();
-    let g = openat(&cwd(), "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
+    let g = openat(cwd(), "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
     flock(&g, FlockOperation::LockShared).unwrap();
     flock(&f, FlockOperation::Unlock).unwrap();
     flock(&g, FlockOperation::Unlock).unwrap();
     drop(f);
     drop(g);
 
-    let f = openat(&cwd(), "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
+    let f = openat(cwd(), "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
     flock(&f, FlockOperation::LockShared).unwrap();
     flock(&f, FlockOperation::LockExclusive).unwrap();
     flock(&f, FlockOperation::Unlock).unwrap();
-    let g = openat(&cwd(), "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
+    let g = openat(cwd(), "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
     flock(&g, FlockOperation::LockShared).unwrap();
     flock(&g, FlockOperation::LockExclusive).unwrap();
     flock(&g, FlockOperation::Unlock).unwrap();

--- a/tests/fs/futimens.rs
+++ b/tests/fs/futimens.rs
@@ -5,7 +5,7 @@ fn test_futimens() {
     use rustix::time::Timespec;
 
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
 
     let foo = openat(
         &dir,

--- a/tests/fs/invalid_offset.rs
+++ b/tests/fs/invalid_offset.rs
@@ -13,7 +13,7 @@ use rustix::io::SeekFrom;
 fn invalid_offset_seek() {
     use rustix::fs::{cwd, openat, seek, Mode, OFlags};
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
     let file = openat(
         &dir,
         "foo",
@@ -40,7 +40,7 @@ fn invalid_offset_seek() {
 fn invalid_offset_fallocate() {
     use rustix::fs::{cwd, fallocate, openat, FallocateFlags, Mode, OFlags};
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
     let file = openat(
         &dir,
         "foo",
@@ -65,7 +65,7 @@ fn invalid_offset_fallocate() {
 fn invalid_offset_fadvise() {
     use rustix::fs::{cwd, fadvise, openat, Advice, Mode, OFlags};
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
     let file = openat(
         &dir,
         "foo",
@@ -97,7 +97,7 @@ fn invalid_offset_pread() {
     use rustix::fs::{cwd, openat, Mode, OFlags};
     use rustix::io::pread;
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
     let file = openat(
         &dir,
         "foo",
@@ -117,7 +117,7 @@ fn invalid_offset_pwrite() {
     use rustix::fs::{cwd, openat, Mode, OFlags};
     use rustix::io::pwrite;
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
     let file = openat(
         &dir,
         "foo",
@@ -137,7 +137,7 @@ fn invalid_offset_copy_file_range() {
     use rustix::fs::{copy_file_range, cwd, openat, Mode, OFlags};
     use rustix::io::write;
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
     let foo = openat(
         &dir,
         "foo",

--- a/tests/fs/long_paths.rs
+++ b/tests/fs/long_paths.rs
@@ -4,7 +4,7 @@ fn test_long_paths() {
     use rustix::fs::{cwd, mkdirat, openat, Mode, OFlags};
 
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
 
     #[cfg(libc)]
     const PATH_MAX: usize = libc::PATH_MAX as usize;

--- a/tests/fs/mkdirat.rs
+++ b/tests/fs/mkdirat.rs
@@ -4,7 +4,7 @@ fn test_mkdirat() {
     use rustix::fs::{cwd, mkdirat, openat, statat, unlinkat, AtFlags, FileType, Mode, OFlags};
 
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
 
     mkdirat(&dir, "foo", Mode::RWXU).unwrap();
     let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();
@@ -19,7 +19,7 @@ fn test_mkdirat_with_o_path() {
 
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(
-        &cwd(),
+        cwd(),
         tmp.path(),
         OFlags::RDONLY | OFlags::PATH,
         Mode::empty(),

--- a/tests/fs/mknodat.rs
+++ b/tests/fs/mknodat.rs
@@ -9,7 +9,7 @@ fn test_mknodat() {
     use rustix::fs::{cwd, mknodat, openat, statat, unlinkat, AtFlags, FileType, Mode, OFlags};
 
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
 
     // Create a regular file. Not supported on FreeBSD or OpenBSD.
     #[cfg(not(any(target_os = "freebsd", target_os = "openbsd")))]

--- a/tests/fs/openat2.rs
+++ b/tests/fs/openat2.rs
@@ -25,7 +25,7 @@ fn openat2_more<Fd: AsFd, P: path::Arg>(
 #[test]
 fn test_openat2() {
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
 
     // Detect whether `openat2` is available.
     match openat2(

--- a/tests/io/mmap.rs
+++ b/tests/io/mmap.rs
@@ -9,7 +9,7 @@ fn test_mmap() {
     use std::slice;
 
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
 
     let file = openat(
         &dir,

--- a/tests/io/read_write.rs
+++ b/tests/io/read_write.rs
@@ -6,7 +6,7 @@ fn test_readwrite_pv() {
     use rustix::io::{preadv, pwritev};
 
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
     let foo = openat(
         &dir,
         "foo",
@@ -43,7 +43,7 @@ fn test_readwrite_p() {
     use rustix::io::{pread, pwrite};
 
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
     let foo = openat(
         &dir,
         "foo",
@@ -67,7 +67,7 @@ fn test_readwrite_v() {
     use rustix::io::{readv, writev, SeekFrom};
 
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
     let foo = openat(
         &dir,
         "foo",
@@ -93,7 +93,7 @@ fn test_readwrite() {
     use std::io::SeekFrom;
 
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
     let foo = openat(
         &dir,
         "foo",

--- a/tests/net/unix.rs
+++ b/tests/net/unix.rs
@@ -64,7 +64,7 @@ fn server(ready: Arc<(Mutex<bool>, Condvar)>, path: &Path) {
         write(&data_socket, DecInt::new(sum).as_bytes()).unwrap();
     }
 
-    unlinkat(&cwd(), path, AtFlags::empty()).unwrap();
+    unlinkat(cwd(), path, AtFlags::empty()).unwrap();
 }
 
 fn client(ready: Arc<(Mutex<bool>, Condvar)>, path: &Path, runs: &[(&[&str], i32)]) {

--- a/tests/process/working_directory.rs
+++ b/tests/process/working_directory.rs
@@ -15,7 +15,7 @@ fn test_changing_working_directory() {
     let tmpdir = tmpdir();
 
     let orig_cwd = rustix::process::getcwd(Vec::new()).expect("get the cwd");
-    let orig_fd_cwd = rustix::fs::openat(&rustix::fs::cwd(), ".", OFlags::RDONLY, Mode::empty())
+    let orig_fd_cwd = rustix::fs::openat(rustix::fs::cwd(), ".", OFlags::RDONLY, Mode::empty())
         .expect("get a fd for the current directory");
 
     rustix::process::chdir(tmpdir.path()).expect("changing dir to the tmp");


### PR DESCRIPTION
Functions that take `<Fd: AsFd>` parameters can take `BorrowedFd`
arguments by value; it's not necessary to pass `BorrowedFd` values
by reference anymore.