### PR TITLE
Fix unsoundness in `rustix::fs::Dir`.

### DIFF
--- a/src/imp/libc/fs/dir.rs
+++ b/src/imp/libc/fs/dir.rs
@@ -15,7 +15,7 @@ use crate::fs::{fcntl_getfl, fstat, openat, Mode, OFlags, Stat};
 )))] // not implemented in libc for netbsd yet
 use crate::fs::{fstatfs, StatFs};
 use crate::io;
-#[cfg(not(target_os = "fuchsia"))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 use crate::process::fchdir;
 #[cfg(target_os = "wasi")]
 use alloc::borrow::ToOwned;
@@ -140,7 +140,7 @@ impl Dir {
     }
 
     /// `fchdir(self)`
-    #[cfg(not(target_os = "fuchsia"))]
+    #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
     #[inline]
     pub fn chdir(&self) -> io::Result<()> {
         fchdir(unsafe { BorrowedFd::borrow_raw(c::dirfd(self.0.as_ptr())) })

--- a/src/imp/libc/fs/dir.rs
+++ b/src/imp/libc/fs/dir.rs
@@ -15,6 +15,7 @@ use crate::fs::{fcntl_getfl, fstat, openat, Mode, OFlags, Stat};
 )))] // not implemented in libc for netbsd yet
 use crate::fs::{fstatfs, StatFs};
 use crate::io;
+#[cfg(not(target_os = "fuchsia"))]
 use crate::process::fchdir;
 #[cfg(target_os = "wasi")]
 use alloc::borrow::ToOwned;
@@ -139,6 +140,7 @@ impl Dir {
     }
 
     /// `fchdir(self)`
+    #[cfg(not(target_os = "fuchsia"))]
     #[inline]
     pub fn chdir(&self) -> io::Result<()> {
         fchdir(unsafe { BorrowedFd::borrow_raw(c::dirfd(self.0.as_ptr())) })

--- a/src/imp/libc/fs/dir.rs
+++ b/src/imp/libc/fs/dir.rs
@@ -6,14 +6,14 @@ use crate::fd::{AsFd, BorrowedFd};
 use crate::ffi::ZStr;
 #[cfg(target_os = "wasi")]
 use crate::ffi::ZString;
+use crate::fs::{fcntl_getfl, fstat, openat, Mode, OFlags, Stat};
 #[cfg(not(any(
     target_os = "illumos",
     target_os = "netbsd",
     target_os = "redox",
     target_os = "wasi"
 )))] // not implemented in libc for netbsd yet
-use crate::fs::fstatfs;
-use crate::fs::{fcntl_getfl, fstat, openat, Mode, OFlags, Stat, StatFs};
+use crate::fs::{fstatfs, StatFs};
 use crate::io;
 use crate::process::fchdir;
 #[cfg(target_os = "wasi")]

--- a/src/imp/libc/fs/dir.rs
+++ b/src/imp/libc/fs/dir.rs
@@ -6,7 +6,14 @@ use crate::fd::{AsFd, BorrowedFd};
 use crate::ffi::ZStr;
 #[cfg(target_os = "wasi")]
 use crate::ffi::ZString;
-use crate::fs::{fcntl_getfl, fstat, fstatfs, openat, Mode, OFlags, Stat, StatFs};
+#[cfg(not(any(
+    target_os = "illumos",
+    target_os = "netbsd",
+    target_os = "redox",
+    target_os = "wasi"
+)))] // not implemented in libc for netbsd yet
+use crate::fs::fstatfs;
+use crate::fs::{fcntl_getfl, fstat, openat, Mode, OFlags, Stat, StatFs};
 use crate::io;
 use crate::process::fchdir;
 #[cfg(target_os = "wasi")]
@@ -120,6 +127,12 @@ impl Dir {
     }
 
     /// `fstatfs(self)`
+    #[cfg(not(any(
+        target_os = "illumos",
+        target_os = "netbsd",
+        target_os = "redox",
+        target_os = "wasi"
+    )))] // not implemented in libc for netbsd yet
     #[inline]
     pub fn statfs(&self) -> io::Result<StatFs> {
         fstatfs(unsafe { BorrowedFd::borrow_raw(c::dirfd(self.0.as_ptr())) })

--- a/tests/fs/dir.rs
+++ b/tests/fs/dir.rs
@@ -1,0 +1,37 @@
+#[test]
+fn test_dir() {
+    let t = rustix::fs::openat(
+        rustix::fs::cwd(),
+        rustix::zstr!("."),
+        rustix::fs::OFlags::RDONLY | rustix::fs::OFlags::CLOEXEC,
+        rustix::fs::Mode::empty(),
+    )
+    .unwrap();
+
+    let dir = rustix::fs::Dir::read_from(&t).unwrap();
+
+    let _file = rustix::fs::openat(
+        &t,
+        rustix::zstr!("Cargo.toml"),
+        rustix::fs::OFlags::RDONLY | rustix::fs::OFlags::CLOEXEC,
+        rustix::fs::Mode::empty(),
+    )
+    .unwrap();
+
+    let mut saw_dot = false;
+    let mut saw_dotdot = false;
+    let mut saw_cargo_toml = false;
+    for entry in dir {
+        let entry = entry.unwrap();
+        if entry.file_name() == rustix::zstr!(".") {
+            saw_dot = true;
+        } else if entry.file_name() == rustix::zstr!("..") {
+            saw_dotdot = true;
+        } else if entry.file_name() == rustix::zstr!("Cargo.toml") {
+            saw_cargo_toml = true;
+        }
+    }
+    assert!(saw_dot);
+    assert!(saw_dotdot);
+    assert!(saw_cargo_toml);
+}

--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 
+mod dir;
 mod fcntl;
 mod file;
 #[cfg(not(target_os = "wasi"))]

--- a/tests/fs/readdir.rs
+++ b/tests/fs/readdir.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 fn dir_entries() {
     let tmpdir = tempfile::tempdir().expect("construct tempdir");
     let dirfd = std::fs::File::open(tmpdir.path()).expect("open tempdir as file");
-    let mut dir = Dir::from(dirfd).expect("construct Dir from dirfd");
+    let mut dir = Dir::read_from(dirfd).expect("construct Dir from dirfd");
 
     let entries = read_entries(&mut dir);
     assert_eq!(entries.len(), 0, "no files in directory");
@@ -64,5 +64,5 @@ fn dir_from_openat() {
         rustix::fs::Mode::empty(),
     )
     .expect("open cwd as file");
-    let _dir = Dir::from(dirfd).expect("construct Dir from dirfd");
+    let _dir = Dir::read_from(dirfd).expect("construct Dir from dirfd");
 }


### PR DESCRIPTION
In the libc backend, the `AsFd` implementation used `libc::dirfd`.
However, `libc::dirfd` is documented to have Undefined Behavior if the
file descriptor is used for anything other than a very small set of
functions. Rustix considers many functions outside that set to be ok
to wrap in a safe interface, so this made it possible for users to
evoke Undefined Behavior without using `unsafe`.

To fix this, remove the `AsFd` implementation from `Dir`.

Similarly, the libc backend used `libc::fdopendir` to acquire a
`libc::DIR` from a passed-in file descriptor, and `libc::fdopendir`
is documented to have Undefined Behavior if that file desctiptor's
file description is modified in any way, including via functions that
rustix exposes as safe functions.

To fix this, change `Dir::from(fd: OwnedFd)` to
`Dir::read_from<Fd: AsFd>(fd: Fd)`, and have it open an independent
file descriptor with `openat(fd, ".", ...)`.