### PR TITLE
Add some missing Linux 5.17 features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,18 +34,18 @@ once_cell = { version = "1.5.2", optional = true }
 # On Linux on selected architectures, we have two supported backends: linux_raw
 # and libc. The libc and errno dependencies are only enabled when the libc
 # backend is in use.
-[target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))'.dependencies]
+[target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), all(target_arch = "powerpc64", target_endian = "little"), target_arch = "riscv64", all(target_arch = "mips", target_endian = "little"), all(target_arch = "mips64", target_endian = "little"))))'.dependencies]
 linux-raw-sys = { version = "0.0.46", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 errno = { version = "0.2.8", default-features = false, optional = true }
 libc = { version = "0.2.118", features = ["extra_traits"], optional = true }
 
 # On all other Unix-family platforms, and under Miri, we always use the libc
 # backend, so enable its dependencies unconditionally.
-[target.'cfg(any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
+[target.'cfg(any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), all(target_arch = "powerpc64", target_endian = "little"), target_arch = "riscv64", all(target_arch = "mips", target_endian = "little"), all(target_arch = "mips64", target_endian = "little"))))))'.dependencies]
 errno = { version = "0.2.8", default-features = false }
 libc = { version = "0.2.118", features = ["extra_traits"] }
 
-[target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64"))))))'.dependencies]
+[target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), all(target_arch = "powerpc64", target_endian = "little"), target_arch = "riscv64", all(target_arch = "mips", target_endian = "little"), all(target_arch = "mips64", target_endian = "little")))))))'.dependencies]
 # Some syscalls do not have libc wrappers, such as in `io_uring`. For these,
 # we use the linux-raw-sys ABI and `libc::syscall`.
 linux-raw-sys = { version = "0.0.46", default-features = false, optional = true, features = ["general", "no_std"] }

--- a/src/imp/libc/fs/types.rs
+++ b/src/imp/libc/fs/types.rs
@@ -352,6 +352,9 @@ bitflags! {
 
         /// `RESOLVE_IN_ROOT`
         const IN_ROOT = 0x10;
+
+        /// `RESOLVE_CACHED` (since Linux 5.12)
+        const CACHED = 0x20;
     }
 }
 

--- a/src/imp/libc/mm/types.rs
+++ b/src/imp/libc/mm/types.rs
@@ -349,18 +349,36 @@ pub enum Advice {
     /// `MADV_UNMERGEABLE`
     #[cfg(any(target_os = "android", target_os = "linux"))]
     LinuxUnmergeable = c::MADV_UNMERGEABLE,
-    /// `MADV_HUGEPAGE`
+    /// `MADV_HUGEPAGE` (since Linux 2.6.38)
     #[cfg(any(target_os = "android", target_os = "linux"))]
     LinuxHugepage = c::MADV_HUGEPAGE,
-    /// `MADV_NOHUGEPAGE`
+    /// `MADV_NOHUGEPAGE` (since Linux 2.6.38)
     #[cfg(any(target_os = "android", target_os = "linux"))]
     LinuxNoHugepage = c::MADV_NOHUGEPAGE,
-    /// `MADV_DONTDUMP`
+    /// `MADV_DONTDUMP` (since Linux 3.4)
     #[cfg(any(target_os = "android", target_os = "linux"))]
     LinuxDontDump = c::MADV_DONTDUMP,
-    /// `MADV_DODUMP`
+    /// `MADV_DODUMP` (since Linux 3.4)
     #[cfg(any(target_os = "android", target_os = "linux"))]
     LinuxDoDump = c::MADV_DODUMP,
+    /// `MADV_WIPEONFORK` (since Linux 4.14)
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    LinuxWipeOnFork = linux_raw_sys::general::MADV_WIPEONFORK as i32,
+    /// `MADV_KEEPONFORK` (since Linux 4.14)
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    LinuxKeepOnFork = linux_raw_sys::general::MADV_KEEPONFORK as i32,
+    /// `MADV_COLD` (since Linux 5.4)
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    LinuxCold = linux_raw_sys::general::MADV_COLD as i32,
+    /// `MADV_PAGEOUT` (since Linux 5.4)
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    LinuxPageOut = linux_raw_sys::general::MADV_PAGEOUT as i32,
+    /// `MADV_POPULATE_READ` (since Linux 5.14)
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    LinuxPopulateRead = linux_raw_sys::general::MADV_POPULATE_READ as i32,
+    /// `MADV_POPULATE_WRITE` (since Linux 5.14)
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    LinuxPopulateWrite = linux_raw_sys::general::MADV_POPULATE_WRITE as i32,
 }
 
 #[cfg(target_os = "emscripten")]

--- a/src/imp/linux_raw/fs/types.rs
+++ b/src/imp/linux_raw/fs/types.rs
@@ -232,6 +232,9 @@ bitflags! {
 
         /// `RESOLVE_IN_ROOT`
         const IN_ROOT = linux_raw_sys::general::RESOLVE_IN_ROOT as u64;
+
+        /// `RESOLVE_CACHED` (since Linux 5.12)
+        const CACHED = linux_raw_sys::general::RESOLVE_CACHED as u64;
     }
 }
 

--- a/src/imp/linux_raw/mm/types.rs
+++ b/src/imp/linux_raw/mm/types.rs
@@ -190,6 +190,10 @@ pub enum Advice {
     LinuxCold = linux_raw_sys::general::MADV_COLD,
     /// `MADV_PAGEOUT` (since Linux 5.4)
     LinuxPageOut = linux_raw_sys::general::MADV_PAGEOUT,
+    /// `MADV_POPULATE_READ` (since Linux 5.14)
+    LinuxPopulateRead = linux_raw_sys::general::MADV_POPULATE_READ,
+    /// `MADV_POPULATE_WRITE` (since Linux 5.14)
+    LinuxPopulateWrite = linux_raw_sys::general::MADV_POPULATE_WRITE,
 }
 
 impl Advice {


### PR DESCRIPTION
linux-raw-sys is now supporting linux 5.17, so add several new flags
to `madvise` and `openat2`.