### PR TITLE
Cleanup clippy and other lints

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -11,10 +11,8 @@ fn main() -> std::io::Result<()> {
     // need the ability to compute substrings at arbitrary byte offsets.
     let mut bytes = message.as_bytes();
 
-    // # Safety
-    //
-    // See [here] for the safety conditions for calling `stdout`. In this
-    // example, the code is inside `main` itself so we know how `stdout`
+    // Safety: See [here] for the safety conditions for calling `stdout`. In
+    // this example, the code is inside `main` itself so we know how `stdout`
     // is being used and we know that it's not dropped.
     //
     // [here]: https://docs.rs/rustix/*/rustix/io/fn.stdout.html#safety

--- a/src/fs/cwd.rs
+++ b/src/fs/cwd.rs
@@ -1,3 +1,12 @@
+//! The `cwd` function, representing the current working directory.
+//!
+//! # Safety
+//!
+//! This file uses `AT_FDCWD`, which is a raw file descriptor, but which is
+//! always valid.
+
+#![allow(unsafe_code)]
+
 use crate::imp;
 use imp::fd::{BorrowedFd, RawFd};
 
@@ -17,12 +26,7 @@ use imp::fd::{BorrowedFd, RawFd};
 pub fn cwd() -> BorrowedFd<'static> {
     let at_fdcwd = imp::io::AT_FDCWD as RawFd;
 
-    // # Safety
-    //
-    // `AT_FDCWD` is a reserved value that is never dynamically allocated, so
-    // it'll remain valid for the duration of `'static`.
-    #[allow(unsafe_code)]
-    unsafe {
-        BorrowedFd::<'static>::borrow_raw(at_fdcwd)
-    }
+    // Safety: `AT_FDCWD` is a reserved value that is never dynamically
+    // allocated, so it'll remain valid for the duration of `'static`.
+    unsafe { BorrowedFd::<'static>::borrow_raw(at_fdcwd) }
 }

--- a/src/imp/libc/io/poll_fd.rs
+++ b/src/imp/libc/io/poll_fd.rs
@@ -119,10 +119,8 @@ impl<'fd> PollFd<'fd> {
 impl<'fd> AsFd for PollFd<'fd> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
-        // Safety:
-        //
-        // Our constructors and `set_fd` require `pollfd.fd` to be valid
-        // for the `fd lifetime.
+        // Safety: Our constructors and `set_fd` require `pollfd.fd` to be
+        // valid for the `fd lifetime.
         unsafe { BorrowedFd::borrow_raw(self.pollfd.fd) }
     }
 }
@@ -131,10 +129,8 @@ impl<'fd> AsFd for PollFd<'fd> {
 impl<'fd> io_lifetimes::AsSocket for PollFd<'fd> {
     #[inline]
     fn as_socket(&self) -> BorrowedFd<'_> {
-        // Safety:
-        //
-        // Our constructors and `set_fd` require `pollfd.fd` to be valid
-        // for the `fd lifetime.
+        // Safety: Our constructors and `set_fd` require `pollfd.fd` to be
+        // valid for the `fd lifetime.
         unsafe { BorrowedFd::borrow_raw(self.pollfd.fd as RawFd) }
     }
 }

--- a/src/imp/libc/mod.rs
+++ b/src/imp/libc/mod.rs
@@ -4,6 +4,10 @@
 //! Windows, this uses the Winsock2 API in `winapi`, which can be adapted
 //! to have a very `libc`-like interface.
 
+// Every FFI call requires an unsafe block, and there are a lot of FFI
+// calls. For now, set this to allow for the libc backend.
+#![allow(clippy::undocumented_unsafe_blocks)]
+
 #[cfg(not(any(windows, target_os = "wasi")))]
 #[macro_use]
 mod weak;

--- a/src/imp/libc/net/types.rs
+++ b/src/imp/libc/net/types.rs
@@ -591,6 +591,7 @@ bitflags! {
 ///
 /// [`set_socket_timeout`]: crate::net::sockopt::set_socket_timeout.
 /// [`get_socket_timeout`]: crate::net::sockopt::get_socket_timeout.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(i32)]
 pub enum Timeout {
     /// `SO_RCVTIMEO`—Timeout for receiving.

--- a/src/imp/libc/net/write_sockaddr.rs
+++ b/src/imp/libc/net/write_sockaddr.rs
@@ -1,6 +1,5 @@
 //! The BSD sockets API requires us to read the `ss_family` field before
 //! we can interpret the rest of a `sockaddr` produced by the kernel.
-#![allow(unsafe_code)]
 
 use super::super::c;
 use super::ext::{in6_addr_new, in_addr_new, sockaddr_in6_new};

--- a/src/imp/libc/rand/syscalls.rs
+++ b/src/imp/libc/rand/syscalls.rs
@@ -1,7 +1,5 @@
 //! libc syscalls supporting `rustix::rand`.
 
-#![allow(unsafe_code)]
-
 #[cfg(target_os = "linux")]
 use {super::super::c, super::super::conv::ret_ssize_t, crate::io, crate::rand::GetRandomFlags};
 

--- a/src/imp/libc/termios/types.rs
+++ b/src/imp/libc/termios/types.rs
@@ -3,6 +3,7 @@ use super::super::c;
 /// `TCSA*` values for use with [`tcsetattr`].
 ///
 /// [`tcsetattr`]: crate::termios::tcsetattr
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(i32)]
 pub enum OptionalActions {
     /// `TCSANOW`—Make the change immediately.
@@ -19,6 +20,7 @@ pub enum OptionalActions {
 /// `TC*` values for use with [`tcflush`].
 ///
 /// [`tcflush`]: crate::termios::tcflush
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(i32)]
 pub enum QueueSelector {
     /// `TCIFLUSH`—Flush data received but not read.
@@ -34,6 +36,7 @@ pub enum QueueSelector {
 /// `TC*` values for use with [`tcflow`].
 ///
 /// [`tcflow`]: crate::termios::tcflow
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(i32)]
 pub enum Action {
     /// `TCOOFF`—Suspend output.

--- a/src/imp/linux_raw/fs/syscalls.rs
+++ b/src/imp/linux_raw/fs/syscalls.rs
@@ -6,6 +6,7 @@
 
 #![allow(unsafe_code)]
 #![allow(dead_code)]
+#![allow(clippy::undocumented_unsafe_blocks)]
 
 #[cfg(target_arch = "mips")]
 use super::super::arch::choose::syscall7_readonly;

--- a/src/imp/linux_raw/io/syscalls.rs
+++ b/src/imp/linux_raw/io/syscalls.rs
@@ -5,6 +5,7 @@
 //! See the `rustix::imp::syscalls` module documentation for details.
 
 #![allow(unsafe_code)]
+#![allow(clippy::undocumented_unsafe_blocks)]
 
 #[cfg(not(any(
     target_arch = "aarch64",

--- a/src/imp/linux_raw/mod.rs
+++ b/src/imp/linux_raw/mod.rs
@@ -4,11 +4,11 @@
 
 mod arch;
 mod conv;
+mod elf;
 mod reg;
 mod vdso;
 mod vdso_wrappers;
 
-pub(crate) mod elf;
 pub(crate) mod fs;
 pub(crate) mod io;
 #[cfg(feature = "io_uring")]

--- a/src/imp/linux_raw/net/ext.rs
+++ b/src/imp/linux_raw/net/ext.rs
@@ -16,6 +16,7 @@ pub(crate) const fn in_addr_new(s_addr: u32) -> c::in_addr {
 #[cfg(not(feature = "std"))]
 #[inline]
 pub(crate) const fn in6_addr_s6_addr(addr: c::in6_addr) -> [u8; 16] {
+    // Safety: `in6_addr` is `repr(C)` and contains plain integer data.
     unsafe { addr.in6_u.u6_addr8 }
 }
 
@@ -24,6 +25,7 @@ pub(crate) const fn in6_addr_s6_addr(addr: c::in6_addr) -> [u8; 16] {
 #[cfg(not(not(feature = "std")))]
 #[inline]
 pub(crate) fn in6_addr_s6_addr(addr: c::in6_addr) -> [u8; 16] {
+    // Safety: `in6_addr` is `repr(C)` and contains plain integer data.
     unsafe { core::mem::transmute(addr) }
 }
 

--- a/src/imp/linux_raw/net/syscalls.rs
+++ b/src/imp/linux_raw/net/syscalls.rs
@@ -5,6 +5,7 @@
 //! See the `rustix::imp::syscalls` module documentation for details.
 
 #![allow(unsafe_code)]
+#![allow(clippy::undocumented_unsafe_blocks)]
 
 use super::super::arch::choose::syscall2_readonly;
 use super::super::c;

--- a/src/imp/linux_raw/net/types.rs
+++ b/src/imp/linux_raw/net/types.rs
@@ -271,6 +271,7 @@ bitflags! {
 ///
 /// [`set_socket_timeout`]: crate::net::sockopt::set_socket_timeout.
 /// [`get_socket_timeout`]: crate::net::sockopt::get_socket_timeout.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(u32)]
 pub enum Timeout {
     /// `SO_RCVTIMEO`—Timeout for receiving.

--- a/src/imp/linux_raw/process/syscalls.rs
+++ b/src/imp/linux_raw/process/syscalls.rs
@@ -5,6 +5,7 @@
 //! See the `rustix::imp::syscalls` module documentation for details.
 
 #![allow(unsafe_code)]
+#![allow(clippy::undocumented_unsafe_blocks)]
 
 use super::super::arch::choose::{
     syscall0_readonly, syscall1, syscall1_noreturn, syscall1_readonly, syscall2, syscall2_readonly,

--- a/src/imp/linux_raw/rand/mod.rs
+++ b/src/imp/linux_raw/rand/mod.rs
@@ -1,5 +1,3 @@
-#![allow(unsafe_code)]
-
 mod types;
 
 pub(crate) mod syscalls;

--- a/src/imp/linux_raw/rand/syscalls.rs
+++ b/src/imp/linux_raw/rand/syscalls.rs
@@ -5,6 +5,7 @@
 //! See the `rustix::imp::syscalls` module documentation for details.
 
 #![allow(unsafe_code)]
+#![allow(clippy::undocumented_unsafe_blocks)]
 
 use super::super::arch::choose::syscall3;
 use super::super::conv::{c_uint, ret_usize, slice_mut};

--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -11,7 +11,9 @@
 //! <linux/syscalls.h>, but we often need more information than it provides,
 //! such as which pointers are array slices, out parameters, or in-out
 //! parameters, which integers are owned or borrowed file descriptors, etc.
+
 #![allow(unsafe_code)]
+#![allow(clippy::undocumented_unsafe_blocks)]
 
 use super::arch::choose::{
     syscall1_noreturn, syscall1_readonly, syscall2_readonly, syscall3_readonly, syscall5_readonly,

--- a/src/imp/linux_raw/termios/types.rs
+++ b/src/imp/linux_raw/termios/types.rs
@@ -3,6 +3,7 @@ use super::super::c;
 /// `TCSA*` values for use with [`tcsetattr`].
 ///
 /// [`tcsetattr`]: crate::termios::tcsetattr
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(u32)]
 pub enum OptionalActions {
     /// `TCSANOW`—Make the change immediately.
@@ -19,6 +20,7 @@ pub enum OptionalActions {
 /// `TC*` values for use with [`tcflush`].
 ///
 /// [`tcflush`]: crate::termios::tcflush
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(u32)]
 pub enum QueueSelector {
     /// `TCIFLUSH`—Flush data received but not read.
@@ -34,6 +36,7 @@ pub enum QueueSelector {
 /// `TC*` values for use with [`tcflow`].
 ///
 /// [`tcflow`]: crate::termios::tcflow
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(u32)]
 pub enum Action {
     /// `TCOOFF`—Suspend output.

--- a/src/imp/linux_raw/thread/syscalls.rs
+++ b/src/imp/linux_raw/thread/syscalls.rs
@@ -5,6 +5,7 @@
 //! See the `rustix::imp::syscalls` module documentation for details.
 
 #![allow(unsafe_code)]
+#![allow(clippy::undocumented_unsafe_blocks)]
 
 use super::super::arch::choose::{
     syscall0_readonly, syscall2, syscall4, syscall4_readonly, syscall6,

--- a/src/imp/linux_raw/thread/tls.rs
+++ b/src/imp/linux_raw/thread/tls.rs
@@ -14,8 +14,11 @@ pub(crate) fn startup_tls_info() -> StartupTlsInfo {
     let mut tls_phdr = null();
     let mut stack_size = 0;
 
+    let phdrs = exe_phdrs_slice();
+
+    // Safety: We assume the phdr array pointer and length the kernel provided
+    // to the process describe a valid phdr array.
     unsafe {
-        let phdrs = exe_phdrs_slice();
         for phdr in phdrs {
             match (*phdr).p_type {
                 PT_PHDR => {

--- a/src/imp/linux_raw/time/syscalls.rs
+++ b/src/imp/linux_raw/time/syscalls.rs
@@ -5,6 +5,7 @@
 //! See the `rustix::imp::syscalls` module documentation for details.
 
 #![allow(unsafe_code)]
+#![allow(clippy::undocumented_unsafe_blocks)]
 
 use super::super::arch::choose::{syscall2, syscall4};
 use super::super::conv::{

--- a/src/imp/linux_raw/vdso_wrappers.rs
+++ b/src/imp/linux_raw/vdso_wrappers.rs
@@ -32,6 +32,9 @@ use {
 
 #[inline]
 pub(crate) fn clock_gettime(which_clock: ClockId) -> __kernel_timespec {
+    // Safety: `CLOCK_GETTIME` contains either null or the address of a
+    // function with an ABI like libc `clock_gettime`, and calling it has
+    // the side effect ot writing to the result buffer, and no others.
     unsafe {
         let mut result = MaybeUninit::<__kernel_timespec>::uninit();
         let callee = match transmute(CLOCK_GETTIME.load(Relaxed)) {
@@ -66,6 +69,9 @@ pub(crate) fn clock_gettime_dynamic(which_clock: DynamicClockId<'_>) -> io::Resu
         }
     };
 
+    // Safety: `CLOCK_GETTIME` contains either null or the address of a
+    // function with an ABI like libc `clock_gettime`, and calling it has
+    // the side effect ot writing to the result buffer, and no others.
     unsafe {
         const EINVAL: c::c_int = -(c::EINVAL as c::c_int);
         let mut timespec = MaybeUninit::<Timespec>::uninit();

--- a/src/io/msync.rs
+++ b/src/io/msync.rs
@@ -2,8 +2,8 @@
 //!
 //! # Safety
 //!
-//! `msync` operates on a raw pointer. Some forms of `msync` may
-//! mutate the memory or have other side effects.
+//! `msync` operates on a raw pointer. Some forms of `msync` may mutate the
+//! memory or have other side effects.
 #![allow(unsafe_code)]
 
 use crate::{imp, io};

--- a/src/io/owned_fd.rs
+++ b/src/io/owned_fd.rs
@@ -162,11 +162,12 @@ impl io_lifetimes::AsSocket for OwnedFd {
 impl From<OwnedFd> for crate::imp::fd::OwnedFd {
     #[inline]
     fn from(owned_fd: OwnedFd) -> Self {
+        let raw_fd = owned_fd.inner.as_fd().as_raw_fd();
+        forget(owned_fd);
+
         // Safety: We use `as_fd().as_raw_fd()` to extract the raw file
         // descriptor from `self.inner`, and then `forget` `self` so
         // that they remain valid until the new `OwnedFd` acquires them.
-        let raw_fd = owned_fd.inner.as_fd().as_raw_fd();
-        forget(owned_fd);
         unsafe { crate::imp::fd::OwnedFd::from_raw_fd(raw_fd) }
     }
 }
@@ -175,11 +176,12 @@ impl From<OwnedFd> for crate::imp::fd::OwnedFd {
 impl IntoFd for OwnedFd {
     #[inline]
     fn into_fd(self) -> crate::imp::fd::OwnedFd {
+        let raw_fd = self.inner.as_fd().as_raw_fd();
+        forget(self);
+
         // Safety: We use `as_fd().as_raw_fd()` to extract the raw file
         // descriptor from `self.inner`, and then `forget` `self` so
         // that they remain valid until the new `OwnedFd` acquires them.
-        let raw_fd = self.inner.as_fd().as_raw_fd();
-        forget(self);
         unsafe { crate::imp::fd::OwnedFd::from_raw_fd(raw_fd) }
     }
 }
@@ -218,11 +220,12 @@ impl From<crate::imp::fd::OwnedFd> for OwnedFd {
 impl From<OwnedFd> for crate::imp::fd::OwnedFd {
     #[inline]
     fn from(fd: OwnedFd) -> Self {
+        let raw_fd = fd.inner.as_fd().as_raw_fd();
+        forget(fd);
+
         // Safety: We use `as_fd().as_raw_fd()` to extract the raw file
         // descriptor from `self.inner`, and then `forget` `self` so
         // that they remain valid until the new `OwnedFd` acquires them.
-        let raw_fd = fd.inner.as_fd().as_raw_fd();
-        forget(fd);
         unsafe { Self::from_raw_fd(raw_fd) }
     }
 }

--- a/src/io/owned_fd.rs
+++ b/src/io/owned_fd.rs
@@ -223,7 +223,7 @@ impl From<OwnedFd> for crate::imp::fd::OwnedFd {
         // that they remain valid until the new `OwnedFd` acquires them.
         let raw_fd = fd.inner.as_fd().as_raw_fd();
         forget(fd);
-        unsafe { crate::imp::fd::OwnedFd::from_raw_fd(raw_fd) }
+        unsafe { Self::from_raw_fd(raw_fd) }
     }
 }
 

--- a/src/path/dec_int.rs
+++ b/src/path/dec_int.rs
@@ -72,10 +72,8 @@ impl DecInt {
     /// Return the raw byte buffer as a `&str`.
     #[inline]
     pub fn as_str(&self) -> &str {
-        // # Safety
-        //
-        // `DecInt` always holds a formatted decimal number, so it's always
-        // valid UTF-8.
+        // Safety: `DecInt` always holds a formatted decimal number, so it's
+        // always valid UTF-8.
         unsafe { core::str::from_utf8_unchecked(self.as_bytes()) }
     }
 
@@ -84,6 +82,7 @@ impl DecInt {
     pub fn as_z_str(&self) -> &ZStr {
         let bytes_with_nul = &self.buf[..=self.len];
         debug_assert!(ZStr::from_bytes_with_nul(bytes_with_nul).is_ok());
+
         // Safety: `self.buf` holds a single decimal ASCII representation and
         // at least one extra NUL byte.
         unsafe { ZStr::from_bytes_with_nul_unchecked(bytes_with_nul) }

--- a/src/process/auxv.rs
+++ b/src/process/auxv.rs
@@ -1,3 +1,7 @@
+//! APIs which are associated with the auxv array on Linux.
+//!
+//! # Safety
+//!
 //! On mustang, the `init` function is unsafe because it operates on raw
 //! pointers.
 #![cfg_attr(target_vendor = "mustang", allow(unsafe_code))]

--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -104,7 +104,10 @@ impl Gid {
 
 impl Pid {
     /// A `Pid` corresponding to the init process (pid 1).
-    pub const INIT: Self = Self(unsafe { RawNonZeroPid::new_unchecked(1) });
+    pub const INIT: Self = Self(
+        // Safety: The init process' pid is always valid.
+        unsafe { RawNonZeroPid::new_unchecked(1) },
+    );
 
     /// Converts a `RawPid` into a `Pid`.
     ///
@@ -134,12 +137,11 @@ impl Pid {
     #[cfg(feature = "std")]
     #[inline]
     pub fn from_child(child: &std::process::Child) -> Self {
-        // Safety
-        //
-        // We know the returned ID is valid because it came directly from
-        // an OS API.
         let id = child.id();
         debug_assert_ne!(id, 0);
+
+        // Safety: We know the returned ID is valid because it came directly
+        // from an OS API.
         unsafe { Self::from_raw_nonzero(RawNonZeroPid::new_unchecked(id as _)) }
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -17,7 +17,6 @@
 //! This module is intended to be used for implementing a runtime library
 //! such as libc. Use of these features for any other purpose is likely
 //! to create serious problems.
-
 #![allow(unsafe_code)]
 
 #[cfg(linux_raw)]

--- a/src/thread/futex.rs
+++ b/src/thread/futex.rs
@@ -4,7 +4,6 @@
 //!
 //! Futex is a very low-level mechanism for implementing concurrency
 //! primitives.
-
 #![allow(unsafe_code)]
 
 use crate::time::Timespec;

--- a/src/zstr.rs
+++ b/src/zstr.rs
@@ -35,17 +35,17 @@ macro_rules! zstr {
             "zstr argument contains embedded NUL bytes",
         );
 
-        // Now that we know the string doesn't have embedded NULs, we can call
-        // `from_bytes_with_nul_unchecked`, which as of this writing is defined
-        // as `#[inline]` and completely optimizes away.
-        //
-        // # Safety
-        //
-        // We have manually checked that the string does not contain embedded
-        // NULs above, and we append or own NUL terminator here.
         #[allow(unsafe_code)]
-        unsafe {
-            $crate::ffi::ZStr::from_bytes_with_nul_unchecked(concat!($str, "\0").as_bytes())
+        {
+            // Now that we know the string doesn't have embedded NULs, we can call
+            // `from_bytes_with_nul_unchecked`, which as of this writing is defined
+            // as `#[inline]` and completely optimizes away.
+            //
+            // Safety: We have manually checked that the string does not contain
+            // embedded NULs above, and we append or own NUL terminator here.
+            unsafe {
+                $crate::ffi::ZStr::from_bytes_with_nul_unchecked(concat!($str, "\0").as_bytes())
+            }
         }
     }};
 }

--- a/src/zstr.rs
+++ b/src/zstr.rs
@@ -35,7 +35,7 @@ macro_rules! zstr {
             "zstr argument contains embedded NUL bytes",
         );
 
-        #[allow(unsafe_code)]
+        #[allow(unsafe_code, unused_unsafe)]
         {
             // Now that we know the string doesn't have embedded NULs, we can call
             // `from_bytes_with_nul_unchecked`, which as of this writing is defined


### PR DESCRIPTION
Of particular note, this cleans up the Safety comments on unsafe blocks, so that all unsafe blocks (excluding the backend code) now have safety comments in the format that clippy recognizes.