### PR TITLE
Enable io_uring documentation on docs.rs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ name = "mod"
 harness = false
 
 [package.metadata.docs.rs]
-features = ["procfs"]
+features = ["all-apis"]
 rustdoc-args = ["--cfg", "doc_cfg"]
 targets = [
     "x86_64-unknown-linux-gnu",


### PR DESCRIPTION
Enable the all-apis feature in the docs.rs build, to enable
documentation for the io_uring feature.