### PR TITLE
Avoid using `std::mem::transmute` in several places.

### DIFF
--- a/src/imp/libc/fs/dir.rs
+++ b/src/imp/libc/fs/dir.rs
@@ -102,7 +102,7 @@ impl Dir {
                 check_dirent_layout(&*dirent_ptr);
 
                 let result = DirEntry {
-                    dirent: read_dirent(core::mem::transmute(&*dirent_ptr)),
+                    dirent: read_dirent(&*dirent_ptr.cast()),
 
                     #[cfg(target_os = "wasi")]
                     name: ZStr::from_ptr((*dirent_ptr).d_name.as_ptr().cast()).to_owned(),

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -106,8 +106,6 @@ use core::convert::TryInto;
     target_os = "macos"
 ))]
 use core::mem::size_of;
-#[cfg(target_os = "linux")]
-use core::mem::transmute;
 use core::mem::MaybeUninit;
 #[cfg(any(
     target_os = "android",
@@ -1006,7 +1004,7 @@ pub(crate) fn sendfile(
         let nsent = ret_ssize_t(c::sendfile64(
             borrowed_fd(out_fd),
             borrowed_fd(in_fd),
-            transmute(offset),
+            offset.map(crate::as_mut_ptr).unwrap_or(null_mut()).cast(),
             count,
         ))?;
         Ok(nsent as usize)

--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -25,8 +25,6 @@ use crate::io::{self, OwnedFd};
 use crate::process::{Pid, Resource, Signal};
 use crate::{as_mut_ptr, as_ptr};
 use core::mem::MaybeUninit;
-#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-use core::ptr::null;
 use core::ptr::null_mut;
 #[cfg(target_pointer_width = "64")]
 use linux_raw_sys::general::__kernel_loff_t;
@@ -202,7 +200,7 @@ pub(super) fn opt_ref<'a, T: Sized, Num: ArgNumber>(t: Option<&'a T>) -> ArgReg<
     // advantage of not requiring `unsafe`.
     match t {
         Some(t) => by_ref(t),
-        None => raw_arg(null()),
+        None => raw_arg(null_mut()),
     }
 }
 

--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -3,8 +3,8 @@
 //!
 //! # Safety
 //!
-//! Some of these functions are `unsafe` because they `transmute` `Option`
-//! types knowing their layouts, or construct owned file descriptors.
+//! Some of this code is `unsafe` in order to work with raw file descriptors,
+//! and some is `unsafe` to interpret the values in a `RetReg`.
 #![allow(unsafe_code)]
 
 use super::c;
@@ -24,7 +24,9 @@ use crate::ffi::ZStr;
 use crate::io::{self, OwnedFd};
 use crate::process::{Pid, Resource, Signal};
 use crate::{as_mut_ptr, as_ptr};
-use core::mem::{transmute, MaybeUninit};
+use core::mem::MaybeUninit;
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+use core::ptr::null;
 use core::ptr::null_mut;
 #[cfg(target_pointer_width = "64")]
 use linux_raw_sys::general::__kernel_loff_t;
@@ -181,31 +183,27 @@ pub(super) fn by_mut<'a, T: Sized, Num: ArgNumber>(t: &'a mut T) -> ArgReg<'a, N
 
 /// Convert an optional mutable reference into a `usize` for passing to a
 /// syscall.
-///
-/// # Safety
-///
-/// `Option<&mut T>` is represented as a nullable pointer to `T`, which is the
-/// same size as a `usize`, so we can directly transmute it and pass the result
-/// to syscalls expecting nullable pointers.
 #[inline]
-pub(super) unsafe fn opt_mut<'a, T: Sized, Num: ArgNumber>(
-    t: Option<&'a mut T>,
-) -> ArgReg<'a, Num> {
-    transmute(t)
+pub(super) fn opt_mut<'a, T: Sized, Num: ArgNumber>(t: Option<&'a mut T>) -> ArgReg<'a, Num> {
+    // This optimizes into the equivalent of `transmute(t)`, and has the
+    // advantage of not requiring `unsafe`.
+    match t {
+        Some(t) => by_mut(t),
+        None => raw_arg(null_mut()),
+    }
 }
 
 /// Convert an optional immutable reference into a `usize` for passing to a
 /// syscall.
-///
-/// # Safety
-///
-/// `Option<&T>` is represented as a nullable pointer to `T`, which is the
-/// same size as a `usize`, so we can directly transmute it and pass the result
-/// to syscalls expecting nullable pointers.
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 #[inline]
-pub(super) unsafe fn opt_ref<'a, T: Sized, Num: ArgNumber>(t: Option<&'a T>) -> ArgReg<'a, Num> {
-    transmute(t)
+pub(super) fn opt_ref<'a, T: Sized, Num: ArgNumber>(t: Option<&'a T>) -> ArgReg<'a, Num> {
+    // This optimizes into the equivalent of `transmute(t)`, and has the
+    // advantage of not requiring `unsafe`.
+    match t {
+        Some(t) => by_ref(t),
+        None => raw_arg(null()),
+    }
 }
 
 #[inline]


### PR DESCRIPTION
Avoid using `std::mem::transmute` when we can express the same thing in
other ways. This reduces the amount of `unsafe` code needed.