### PR TITLE
Don't pass `BorrowedFd` by reference, in more places.

### DIFF
--- a/tests/fs/fcntl.rs
+++ b/tests/fs/fcntl.rs
@@ -5,7 +5,7 @@ fn test_fcntl_dupfd_cloexec() {
     use std::os::unix::io::AsRawFd;
 
     let file = rustix::fs::openat(
-        &rustix::fs::cwd(),
+        rustix::fs::cwd(),
         "Cargo.toml",
         rustix::fs::OFlags::RDONLY,
         rustix::fs::Mode::empty(),

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -2,7 +2,7 @@
 #[test]
 fn test_file() {
     rustix::fs::accessat(
-        &rustix::fs::cwd(),
+        rustix::fs::cwd(),
         "Cargo.toml",
         rustix::fs::Access::READ_OK,
         rustix::fs::AtFlags::empty(),
@@ -11,7 +11,7 @@ fn test_file() {
 
     assert_eq!(
         rustix::fs::openat(
-            &rustix::fs::cwd(),
+            rustix::fs::cwd(),
             "Cagro.motl",
             rustix::fs::OFlags::RDONLY,
             rustix::fs::Mode::empty(),
@@ -21,7 +21,7 @@ fn test_file() {
     );
 
     let file = rustix::fs::openat(
-        &rustix::fs::cwd(),
+        rustix::fs::cwd(),
         "Cargo.toml",
         rustix::fs::OFlags::RDONLY,
         rustix::fs::Mode::empty(),

--- a/tests/fs/openat.rs
+++ b/tests/fs/openat.rs
@@ -8,7 +8,7 @@ use std::io::Write;
 fn test_openat_tmpfile() {
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(
-        &cwd(),
+        cwd(),
         tmp.path(),
         OFlags::RDONLY | OFlags::CLOEXEC,
         Mode::empty(),

--- a/tests/fs/readdir.rs
+++ b/tests/fs/readdir.rs
@@ -58,7 +58,7 @@ fn read_entries(dir: &mut Dir) -> HashMap<String, DirEntry> {
 #[test]
 fn dir_from_openat() {
     let dirfd = rustix::fs::openat(
-        &rustix::fs::cwd(),
+        rustix::fs::cwd(),
         ".",
         rustix::fs::OFlags::RDONLY,
         rustix::fs::Mode::empty(),

--- a/tests/fs/renameat.rs
+++ b/tests/fs/renameat.rs
@@ -13,7 +13,7 @@ fn test_renameat() {
 
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(
-        &cwd(),
+        cwd(),
         tmp.path(),
         OFlags::RDONLY | OFlags::PATH,
         Mode::empty(),
@@ -34,7 +34,7 @@ fn test_renameat_with() {
 
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(
-        &cwd(),
+        cwd(),
         tmp.path(),
         OFlags::RDONLY | OFlags::PATH,
         Mode::empty(),

--- a/tests/fs/utimensat.rs
+++ b/tests/fs/utimensat.rs
@@ -6,7 +6,7 @@ fn test_utimensat() {
 
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(
-        &cwd(),
+        cwd(),
         tmp.path(),
         OFlags::RDONLY | OFlags::CLOEXEC,
         Mode::empty(),
@@ -50,7 +50,7 @@ fn test_utimensat_noent() {
 
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(
-        &cwd(),
+        cwd(),
         tmp.path(),
         OFlags::RDONLY | OFlags::CLOEXEC,
         Mode::empty(),
@@ -81,7 +81,7 @@ fn test_utimensat_notdir() {
 
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(
-        &cwd(),
+        cwd(),
         tmp.path(),
         OFlags::RDONLY | OFlags::CLOEXEC,
         Mode::empty(),

--- a/tests/io/from_into.rs
+++ b/tests/io/from_into.rs
@@ -8,7 +8,7 @@ fn test_owned() {
     use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd};
 
     let file = rustix::fs::openat(
-        &rustix::fs::cwd(),
+        rustix::fs::cwd(),
         "Cargo.toml",
         rustix::fs::OFlags::RDONLY,
         rustix::fs::Mode::empty(),


### PR DESCRIPTION
Following up on 2fb59ecd05209c54378eb1add6b3df19065900ff, fix more
places to avoid needlessly passing `BorrowedFd` by reference.