### PR TITLE
Fix y2038 bugs in the libc backend on glibc platforms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ portable APIs built on this functionality, see the [`system-interface`],
       fully inlined into user code.
     - Most functions in `linux_raw` preserve memory, I/O safety, and pointer
       provenance all the way down to the syscalls.
-    - `linux_raw` uses a 64-bit `time_t` type on all platforms, avoiding the
-      [y2038 bug].
 
  * libc, which uses the [`libc`] crate which provides bindings to native `libc`
    libraries on Unix-family platforms, and [`windows-sys`] for Winsock2 on
@@ -126,7 +124,6 @@ version of this crate.
 [I/O-safe]: https://github.com/rust-lang/rfcs/blob/master/text/3128-io-safety.md
 [I/O safety]: https://github.com/rust-lang/rfcs/blob/master/text/3128-io-safety.md
 [provenance]: https://github.com/rust-lang/rust/issues/95228
-[y2038 bug]: https://en.wikipedia.org/wiki/Year_2038_problem
 [`OwnedFd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/struct.OwnedFd.html
 [`AsFd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/trait.AsFd.html
 [`NOSYS`]: https://docs.rs/rustix/latest/rustix/io/struct.Error.html#associatedconstant.NOSYS

--- a/examples/process.rs
+++ b/examples/process.rs
@@ -11,7 +11,10 @@ fn main() -> io::Result<()> {
     println!("Parent Pid: {}", Pid::as_raw(getppid()));
     println!("Uid: {}", getuid().as_raw());
     println!("Gid: {}", getgid().as_raw());
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(any(
+        all(target_os = "android", target_pointer_width = "64"),
+        target_os = "linux"
+    ))]
     {
         let (a, b) = linux_hwcap();
         println!("Linux hwcap: {:#x}, {:#x}", a, b);

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -45,10 +45,10 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
             use rustix::termios::*;
             let term = tcgetattr(fd)?;
 
-            if let Some(speed) = display_speed(cfgetispeed(&term)) {
+            if let Some(speed) = speed_value(cfgetispeed(&term)) {
                 println!(" - ispeed: {}", speed);
             }
-            if let Some(speed) = display_speed(cfgetospeed(&term)) {
+            if let Some(speed) = speed_value(cfgetospeed(&term)) {
                 println!(" - ospeed: {}", speed);
             }
 
@@ -441,46 +441,6 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 
     println!();
     Ok(())
-}
-
-#[cfg(feature = "termios")]
-#[cfg(not(windows))]
-fn display_speed(speed: rustix::termios::Speed) -> Option<u32> {
-    use rustix::termios::*;
-    match speed {
-        B0 => Some(0),
-        B50 => Some(50),
-        B75 => Some(75),
-        B110 => Some(110),
-        B134 => Some(134),
-        B150 => Some(150),
-        B200 => Some(200),
-        B300 => Some(300),
-        B600 => Some(600),
-        B1200 => Some(1200),
-        B1800 => Some(1800),
-        B2400 => Some(2400),
-        B4800 => Some(4800),
-        B9600 => Some(9600),
-        B19200 => Some(19200),
-        B38400 => Some(38400),
-        B57600 => Some(57600),
-        B115200 => Some(115200),
-        B230400 => Some(230400),
-        B460800 => Some(460800),
-        B500000 => Some(500000),
-        B576000 => Some(576000),
-        B921600 => Some(921600),
-        B1000000 => Some(1000000),
-        B1152000 => Some(1152000),
-        B1500000 => Some(1500000),
-        B2000000 => Some(2000000),
-        B2500000 => Some(2500000),
-        B3000000 => Some(3000000),
-        B3500000 => Some(3500000),
-        B4000000 => Some(4000000),
-        _ => None,
-    }
 }
 
 #[cfg(feature = "termios")]

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -452,7 +452,8 @@ pub(crate) fn utimensat(
         }
     }
 
-    // Main version: libc is y2038 safe and has `utimensat`.
+    // Main version: libc is y2038 safe and has `utimensat`. Or, the platform
+    // is not y2038 safe and there's nothing practical we can do.
     #[cfg(not(any(
         target_os = "ios",
         target_os = "macos",
@@ -982,7 +983,8 @@ pub(crate) fn futimens(fd: BorrowedFd<'_>, times: &Timestamps) -> io::Result<()>
         }
     }
 
-    // Main version: libc is y2038 safe and has `futimens`.
+    // Main version: libc is y2038 safe and has `futimens`. Or, the platform
+    // is not y2038 safe and there's nothing practical we can do.
     #[cfg(not(any(
         target_os = "ios",
         target_os = "macos",

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -1110,8 +1110,7 @@ pub(crate) fn fallocate(
     offset: u64,
     len: u64,
 ) -> io::Result<()> {
-    // Silently cast; we'll get `EINVAL` if the value is negative.
-    let offset = offset as i64;
+    let offset: i64 = offset.try_into().map_err(|_e| io::Error::INVAL)?;
     let len = len as i64;
 
     assert!(mode.is_empty());

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -127,7 +127,7 @@ use core::mem::MaybeUninit;
 use core::ptr::null_mut;
 #[cfg(all(
     any(target_os = "android", target_os = "linux"),
-    target_pointer_width = "32"
+    any(target_pointer_width = "32", target_arch = "mips64")
 ))]
 use core::sync::atomic::{AtomicBool, Ordering::Relaxed};
 #[cfg(any(target_os = "ios", target_os = "macos"))]
@@ -345,10 +345,11 @@ pub(crate) fn symlinkat(
 
 #[cfg(not(target_os = "redox"))]
 pub(crate) fn statat(dirfd: BorrowedFd<'_>, path: &ZStr, flags: AtFlags) -> io::Result<Stat> {
-    // 32-bit Linux: `struct stat64` is not y2038 compatible; use `statx`.
+    // 32-bit and mips64 Linux: `struct stat64` is not y2038 compatible; use
+    // `statx`.
     #[cfg(all(
         any(target_os = "android", target_os = "linux"),
-        target_pointer_width = "32"
+        any(target_pointer_width = "32", target_arch = "mips64")
     ))]
     {
         if !NO_STATX.load(Relaxed) {
@@ -363,7 +364,7 @@ pub(crate) fn statat(dirfd: BorrowedFd<'_>, path: &ZStr, flags: AtFlags) -> io::
 
     #[cfg(not(all(
         any(target_os = "android", target_os = "linux"),
-        target_pointer_width = "32"
+        any(target_pointer_width = "32", target_arch = "mips64")
     )))]
     unsafe {
         let mut stat = MaybeUninit::<Stat>::uninit();
@@ -379,7 +380,7 @@ pub(crate) fn statat(dirfd: BorrowedFd<'_>, path: &ZStr, flags: AtFlags) -> io::
 
 #[cfg(all(
     any(target_os = "android", target_os = "linux"),
-    target_pointer_width = "32"
+    any(target_pointer_width = "32", target_arch = "mips64")
 ))]
 fn statat_old(dirfd: BorrowedFd<'_>, path: &ZStr, flags: AtFlags) -> io::Result<Stat> {
     unsafe {
@@ -905,15 +906,16 @@ pub(crate) fn flock(fd: BorrowedFd<'_>, operation: FlockOperation) -> io::Result
 /// `statx` was introduced in Linux 4.11.
 #[cfg(all(
     any(target_os = "android", target_os = "linux"),
-    target_pointer_width = "32"
+    any(target_pointer_width = "32", target_arch = "mips64")
 ))]
 static NO_STATX: AtomicBool = AtomicBool::new(false);
 
 pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
-    // 32-bit Linux: `struct stat64` is not y2038 compatible; use `statx`.
+    // 32-bit and mips64 Linux: `struct stat64` is not y2038 compatible; use
+    // `statx`.
     #[cfg(all(
         any(target_os = "android", target_os = "linux"),
-        target_pointer_width = "32"
+        any(target_pointer_width = "32", target_arch = "mips64")
     ))]
     {
         if !NO_STATX.load(Relaxed) {
@@ -926,10 +928,11 @@ pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
         fstat_old(fd)
     }
 
-    // 32-bit Linux: `struct stat64` is not y2038-safe.
+    // Main version: libc is y2038 safe. Or, the platform is not y2038 safe and
+    // there's nothing practical we can do.
     #[cfg(not(all(
         any(target_os = "android", target_os = "linux"),
-        target_pointer_width = "32"
+        any(target_pointer_width = "32", target_arch = "mips64")
     )))]
     unsafe {
         let mut stat = MaybeUninit::<Stat>::uninit();
@@ -940,7 +943,7 @@ pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
 
 #[cfg(all(
     any(target_os = "android", target_os = "linux"),
-    target_pointer_width = "32"
+    any(target_pointer_width = "32", target_arch = "mips64")
 ))]
 fn fstat_old(fd: BorrowedFd<'_>) -> io::Result<Stat> {
     unsafe {
@@ -1275,6 +1278,48 @@ fn statx_to_stat(x: crate::fs::Statx) -> io::Result<Stat> {
     })
 }
 
+/// Convert from a Linux `statx` value to rustix's `Stat`.
+///
+/// mips64' `struct stat64` in libc has private fields, and `stx_blocks`
+#[cfg(all(
+    any(target_os = "android", target_os = "linux"),
+    target_arch = "mips64"
+))]
+fn statx_to_stat(x: crate::fs::Statx) -> io::Result<Stat> {
+    let mut result: Stat = unsafe { core::mem::zeroed() };
+
+    result.st_dev = crate::fs::makedev(x.stx_dev_major, x.stx_dev_minor);
+    result.st_mode = x.stx_mode.into();
+    result.st_nlink = x.stx_nlink.into();
+    result.st_uid = x.stx_uid.into();
+    result.st_gid = x.stx_gid.into();
+    result.st_rdev = crate::fs::makedev(x.stx_rdev_major, x.stx_rdev_minor);
+    result.st_size = x.stx_size.try_into().map_err(|_| io::Error::OVERFLOW)?;
+    result.st_blksize = x.stx_blksize.into();
+    result.st_blocks = x.stx_blocks.try_into().map_err(|_e| io::Error::OVERFLOW)?;
+    result.st_atime = x
+        .stx_atime
+        .tv_sec
+        .try_into()
+        .map_err(|_| io::Error::OVERFLOW)?;
+    result.st_atime_nsec = x.stx_atime.tv_nsec as _;
+    result.st_mtime = x
+        .stx_mtime
+        .tv_sec
+        .try_into()
+        .map_err(|_| io::Error::OVERFLOW)?;
+    result.st_mtime_nsec = x.stx_mtime.tv_nsec as _;
+    result.st_ctime = x
+        .stx_ctime
+        .tv_sec
+        .try_into()
+        .map_err(|_| io::Error::OVERFLOW)?;
+    result.st_ctime_nsec = x.stx_ctime.tv_nsec as _;
+    result.st_ino = x.stx_ino.into();
+
+    Ok(result)
+}
+
 /// Convert from a Linux `stat64` value to rustix's `Stat`.
 #[cfg(all(
     any(target_os = "android", target_os = "linux"),
@@ -1308,6 +1353,46 @@ fn stat64_to_stat(s64: c::stat64) -> io::Result<Stat> {
             .map_err(|_| io::Error::OVERFLOW)?,
         st_ino: s64.st_ino.try_into().map_err(|_| io::Error::OVERFLOW)?,
     })
+}
+
+/// Convert from a Linux `stat64` value to rustix's `Stat`.
+///
+/// mips64' `struct stat64` in libc has private fields, and `st_blocks` has
+/// type `i64`.
+#[cfg(all(
+    any(target_os = "android", target_os = "linux"),
+    target_arch = "mips64"
+))]
+fn stat64_to_stat(s64: c::stat64) -> io::Result<Stat> {
+    let mut result: Stat = unsafe { core::mem::zeroed() };
+
+    result.st_dev = s64.st_dev.try_into().map_err(|_| io::Error::OVERFLOW)?;
+    result.st_mode = s64.st_mode.try_into().map_err(|_| io::Error::OVERFLOW)?;
+    result.st_nlink = s64.st_nlink.try_into().map_err(|_| io::Error::OVERFLOW)?;
+    result.st_uid = s64.st_uid.try_into().map_err(|_| io::Error::OVERFLOW)?;
+    result.st_gid = s64.st_gid.try_into().map_err(|_| io::Error::OVERFLOW)?;
+    result.st_rdev = s64.st_rdev.try_into().map_err(|_| io::Error::OVERFLOW)?;
+    result.st_size = s64.st_size.try_into().map_err(|_| io::Error::OVERFLOW)?;
+    result.st_blksize = s64.st_blksize.try_into().map_err(|_| io::Error::OVERFLOW)?;
+    result.st_blocks = s64.st_blocks.try_into().map_err(|_| io::Error::OVERFLOW)?;
+    result.st_atime = s64.st_atime.try_into().map_err(|_| io::Error::OVERFLOW)?;
+    result.st_atime_nsec = s64
+        .st_atime_nsec
+        .try_into()
+        .map_err(|_| io::Error::OVERFLOW)?;
+    result.st_mtime = s64.st_mtime.try_into().map_err(|_| io::Error::OVERFLOW)?;
+    result.st_mtime_nsec = s64
+        .st_mtime_nsec
+        .try_into()
+        .map_err(|_| io::Error::OVERFLOW)?;
+    result.st_ctime = s64.st_ctime.try_into().map_err(|_| io::Error::OVERFLOW)?;
+    result.st_ctime_nsec = s64
+        .st_ctime_nsec
+        .try_into()
+        .map_err(|_| io::Error::OVERFLOW)?;
+    result.st_ino = s64.st_ino.try_into().map_err(|_| io::Error::OVERFLOW)?;
+
+    Ok(result)
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/imp/libc/fs/types.rs
+++ b/src/imp/libc/fs/types.rs
@@ -808,12 +808,47 @@ pub type Stat = c::stat;
 /// [`statat`]: crate::fs::statat
 /// [`fstat`]: crate::fs::fstat
 #[cfg(any(
-    target_os = "android",
-    target_os = "linux",
+    all(
+        any(target_os = "android", target_os = "linux"),
+        target_pointer_width = "64"
+    ),
     target_os = "emscripten",
     target_os = "l4re"
 ))]
 pub type Stat = c::stat64;
+
+/// `struct stat` for use with [`statat`] and [`fstat`].
+///
+/// [`statat`]: crate::fs::statat
+/// [`fstat`]: crate::fs::fstat
+// On 32-bit, Linux's `struct stat64` has a 32-bit `st_mtime` and friends, so
+// we use our own struct, populated from `statx` where possible, to avoid the
+// y2038 bug.
+#[cfg(all(
+    any(target_os = "android", target_os = "linux"),
+    target_pointer_width = "32"
+))]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]
+pub struct Stat {
+    pub st_dev: u64,
+    pub st_mode: u32,
+    pub st_nlink: u32,
+    pub st_uid: u32,
+    pub st_gid: u32,
+    pub st_rdev: u64,
+    pub st_size: i64,
+    pub st_blksize: u32,
+    pub st_blocks: u64,
+    pub st_atime: u64,
+    pub st_atime_nsec: u32,
+    pub st_mtime: u64,
+    pub st_mtime_nsec: u32,
+    pub st_ctime: u64,
+    pub st_ctime_nsec: u32,
+    pub st_ino: u64,
+}
 
 /// `struct statfs` for use with [`fstatfs`].
 ///

--- a/src/imp/libc/time/types.rs
+++ b/src/imp/libc/time/types.rs
@@ -5,11 +5,39 @@ use crate::fd::BorrowedFd;
 use bitflags::bitflags;
 
 /// `struct timespec`
+#[cfg(not(all(
+    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
+    target_env = "gnu"
+)))]
 pub type Timespec = c::timespec;
 
+/// `struct timespec`
+#[allow(missing_docs)]
+#[derive(Debug, Clone)]
+#[cfg(all(
+    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
+    target_env = "gnu"
+))]
+#[repr(C)]
+pub struct Timespec {
+    pub tv_sec: Secs,
+    pub tv_nsec: Nsecs,
+}
+
 /// A type for the `tv_sec` field of [`Timespec`].
+#[cfg(not(all(
+    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
+    target_env = "gnu"
+)))]
 #[allow(deprecated)]
 pub type Secs = c::time_t;
+
+/// A type for the `tv_sec` field of [`Timespec`].
+#[cfg(all(
+    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
+    target_env = "gnu"
+))]
+pub type Secs = i64;
 
 /// A type for the `tv_nsec` field of [`Timespec`].
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
@@ -130,26 +158,42 @@ pub enum DynamicClockId<'a> {
 
 /// `struct itimerspec`
 #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
-pub type Itimerspec = libc::itimerspec;
+#[cfg(not(all(
+    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
+    target_env = "gnu"
+)))]
+pub type Itimerspec = c::itimerspec;
+
+#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(all(
+    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
+    target_env = "gnu"
+))]
+#[allow(missing_docs)]
+#[repr(C)]
+pub struct Itimerspec {
+    pub it_interval: Timespec,
+    pub it_value: Timespec,
+}
 
 #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
 bitflags! {
     /// `TFD_*` flags for use with [`timerfd_create`].
-    pub struct TimerfdFlags: libc::c_int {
+    pub struct TimerfdFlags: c::c_int {
         /// `TFD_NONBLOCK`
-        const NONBLOCK = libc::TFD_NONBLOCK;
+        const NONBLOCK = c::TFD_NONBLOCK;
 
         /// `TFD_CLOEXEC`
-        const CLOEXEC = libc::TFD_CLOEXEC;
+        const CLOEXEC = c::TFD_CLOEXEC;
     }
 }
 
 #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
 bitflags! {
     /// `TFD_TIMER_*` flags for use with [`timerfd_settime`].
-    pub struct TimerfdTimerFlags: libc::c_int {
+    pub struct TimerfdTimerFlags: c::c_int {
         /// `TFD_TIMER_ABSTIME`
-        const ABSTIME = libc::TFD_TIMER_ABSTIME;
+        const ABSTIME = c::TFD_TIMER_ABSTIME;
 
         /// `TFD_TIMER_CANCEL_ON_SET`
         #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/imp/linux_raw/fs/syscalls.rs
+++ b/src/imp/linux_raw/fs/syscalls.rs
@@ -511,7 +511,7 @@ pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
 #[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
 fn fstat_old(fd: BorrowedFd<'_>) -> io::Result<Stat> {
     unsafe {
-        let mut result = MaybeUninit::<linux_stat>::uninit();
+        let mut result = MaybeUninit::<linux_stat64>::uninit();
         ret(syscall2(
             nr(__NR_fstat64),
             borrowed_fd(fd),
@@ -557,7 +557,7 @@ pub(crate) fn stat(filename: &ZStr) -> io::Result<Stat> {
 #[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
 fn stat_old(filename: &ZStr) -> io::Result<Stat> {
     unsafe {
-        let mut result = MaybeUninit::<linux_stat>::uninit();
+        let mut result = MaybeUninit::<linux_stat64>::uninit();
         ret(syscall4(
             nr(__NR_fstatat64),
             c_int(AT_FDCWD),
@@ -600,7 +600,7 @@ pub(crate) fn statat(dirfd: BorrowedFd<'_>, filename: &ZStr, flags: AtFlags) -> 
 #[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
 fn statat_old(dirfd: BorrowedFd<'_>, filename: &ZStr, flags: AtFlags) -> io::Result<Stat> {
     unsafe {
-        let mut result = MaybeUninit::<linux_stat>::uninit();
+        let mut result = MaybeUninit::<linux_stat64>::uninit();
         ret(syscall4(
             nr(__NR_fstatat64),
             borrowed_fd(dirfd),
@@ -648,7 +648,7 @@ pub(crate) fn lstat(filename: &ZStr) -> io::Result<Stat> {
 #[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
 fn lstat_old(filename: &ZStr) -> io::Result<Stat> {
     unsafe {
-        let mut result = MaybeUninit::<linux_stat>::uninit();
+        let mut result = MaybeUninit::<linux_stat64>::uninit();
         ret(syscall4(
             nr(__NR_fstatat64),
             c_int(AT_FDCWD),

--- a/src/imp/linux_raw/fs/syscalls.rs
+++ b/src/imp/linux_raw/fs/syscalls.rs
@@ -28,6 +28,7 @@ use super::super::reg::nr;
 #[cfg(any(
     target_arch = "aarch64",
     target_arch = "riscv64",
+    target_arch = "mips64",
     target_pointer_width = "32"
 ))]
 use crate::fd::AsFd;
@@ -41,6 +42,8 @@ use crate::io::{self, OwnedFd, SeekFrom};
 use crate::process::{Gid, Uid};
 use core::convert::TryInto;
 use core::mem::MaybeUninit;
+#[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
+use core::sync::atomic::{AtomicBool, Ordering::Relaxed};
 #[cfg(target_arch = "arm")]
 use linux_raw_sys::general::__NR_arm_fadvise64_64 as __NR_fadvise64_64;
 #[cfg(target_arch = "mips")]
@@ -63,23 +66,28 @@ use linux_raw_sys::general::{
     F_DUPFD_CLOEXEC, F_GETFD, F_GETFL, F_GETLEASE, F_GETOWN, F_GETPIPE_SZ, F_GETSIG, F_GET_SEALS,
     F_SETFD, F_SETFL, F_SETPIPE_SZ,
 };
+#[cfg(all(target_pointer_width = "64", not(target_arch = "mips64")))]
+use linux_raw_sys::general::{__NR_fstat, __NR_newfstatat};
+#[cfg(target_arch = "mips64")]
+use linux_raw_sys::general::{
+    __NR_fstat as __NR_fstat64, __NR_newfstatat as __NR_fstatat64, stat as linux_stat64,
+};
 #[cfg(target_pointer_width = "32")]
 use {
     super::super::arch::choose::syscall6_readonly,
     super::super::conv::{hi, lo, slice_just_addr},
-    core::sync::atomic::{AtomicBool, Ordering::Relaxed},
     linux_raw_sys::general::__NR_utimensat_time64,
     linux_raw_sys::general::{
         __NR__llseek, __NR_fcntl64, __NR_fstat64, __NR_fstatat64, __NR_fstatfs64, __NR_ftruncate64,
-        __NR_sendfile64, __NR_statfs64, timespec as __kernel_old_timespec,
+        __NR_sendfile64, __NR_statfs64, stat64 as linux_stat64, timespec as __kernel_old_timespec,
     },
 };
 #[cfg(target_pointer_width = "64")]
 use {
     super::super::conv::{loff_t, loff_t_from_u64, ret_u64},
     linux_raw_sys::general::{
-        __NR_fadvise64, __NR_fcntl, __NR_fstat, __NR_fstatfs, __NR_ftruncate, __NR_lseek,
-        __NR_newfstatat, __NR_sendfile, __NR_statfs,
+        __NR_fadvise64, __NR_fcntl, __NR_fstatfs, __NR_ftruncate, __NR_lseek, __NR_sendfile,
+        __NR_statfs,
     },
 };
 
@@ -475,12 +483,12 @@ pub(crate) fn flock(fd: BorrowedFd<'_>, operation: FlockOperation) -> io::Result
 }
 
 /// `statx` was introduced in Linux 4.11.
-#[cfg(target_pointer_width = "32")]
+#[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
 static NO_STATX: AtomicBool = AtomicBool::new(false);
 
 #[inline]
 pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
     {
         if !NO_STATX.load(Relaxed) {
             match statx(fd, zstr!(""), AtFlags::EMPTY_PATH, StatxFlags::ALL) {
@@ -491,7 +499,8 @@ pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
         }
         fstat_old(fd)
     }
-    #[cfg(target_pointer_width = "64")]
+
+    #[cfg(all(target_pointer_width = "64", not(target_arch = "mips64")))]
     unsafe {
         let mut result = MaybeUninit::<Stat>::uninit();
         ret(syscall2(nr(__NR_fstat), borrowed_fd(fd), out(&mut result)))
@@ -499,22 +508,22 @@ pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
     }
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
 fn fstat_old(fd: BorrowedFd<'_>) -> io::Result<Stat> {
     unsafe {
-        let mut result = MaybeUninit::<linux_raw_sys::general::stat64>::uninit();
+        let mut result = MaybeUninit::<linux_stat>::uninit();
         ret(syscall2(
             nr(__NR_fstat64),
             borrowed_fd(fd),
             out(&mut result),
         ))
-        .and_then(|()| stat64_to_stat(result.assume_init()))
+        .and_then(|()| stat_to_stat(result.assume_init()))
     }
 }
 
 #[inline]
 pub(crate) fn stat(filename: &ZStr) -> io::Result<Stat> {
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
     {
         if !NO_STATX.load(Relaxed) {
             match statx(
@@ -530,7 +539,8 @@ pub(crate) fn stat(filename: &ZStr) -> io::Result<Stat> {
         }
         stat_old(filename)
     }
-    #[cfg(target_pointer_width = "64")]
+
+    #[cfg(all(target_pointer_width = "64", not(target_arch = "mips64")))]
     unsafe {
         let mut result = MaybeUninit::<Stat>::uninit();
         ret(syscall4(
@@ -544,10 +554,10 @@ pub(crate) fn stat(filename: &ZStr) -> io::Result<Stat> {
     }
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
 fn stat_old(filename: &ZStr) -> io::Result<Stat> {
     unsafe {
-        let mut result = MaybeUninit::<linux_raw_sys::general::stat64>::uninit();
+        let mut result = MaybeUninit::<linux_stat>::uninit();
         ret(syscall4(
             nr(__NR_fstatat64),
             c_int(AT_FDCWD),
@@ -555,13 +565,13 @@ fn stat_old(filename: &ZStr) -> io::Result<Stat> {
             out(&mut result),
             c_uint(0),
         ))
-        .and_then(|()| stat64_to_stat(result.assume_init()))
+        .and_then(|()| stat_to_stat(result.assume_init()))
     }
 }
 
 #[inline]
 pub(crate) fn statat(dirfd: BorrowedFd<'_>, filename: &ZStr, flags: AtFlags) -> io::Result<Stat> {
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
     {
         if !NO_STATX.load(Relaxed) {
             match statx(dirfd, filename, flags, StatxFlags::ALL) {
@@ -572,7 +582,8 @@ pub(crate) fn statat(dirfd: BorrowedFd<'_>, filename: &ZStr, flags: AtFlags) -> 
         }
         statat_old(dirfd, filename, flags)
     }
-    #[cfg(target_pointer_width = "64")]
+
+    #[cfg(all(target_pointer_width = "64", not(target_arch = "mips64")))]
     unsafe {
         let mut result = MaybeUninit::<Stat>::uninit();
         ret(syscall4(
@@ -586,10 +597,10 @@ pub(crate) fn statat(dirfd: BorrowedFd<'_>, filename: &ZStr, flags: AtFlags) -> 
     }
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
 fn statat_old(dirfd: BorrowedFd<'_>, filename: &ZStr, flags: AtFlags) -> io::Result<Stat> {
     unsafe {
-        let mut result = MaybeUninit::<linux_raw_sys::general::stat64>::uninit();
+        let mut result = MaybeUninit::<linux_stat>::uninit();
         ret(syscall4(
             nr(__NR_fstatat64),
             borrowed_fd(dirfd),
@@ -597,13 +608,13 @@ fn statat_old(dirfd: BorrowedFd<'_>, filename: &ZStr, flags: AtFlags) -> io::Res
             out(&mut result),
             c_uint(flags.bits()),
         ))
-        .and_then(|()| stat64_to_stat(result.assume_init()))
+        .and_then(|()| stat_to_stat(result.assume_init()))
     }
 }
 
 #[inline]
 pub(crate) fn lstat(filename: &ZStr) -> io::Result<Stat> {
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
     {
         if !NO_STATX.load(Relaxed) {
             match statx(
@@ -619,7 +630,8 @@ pub(crate) fn lstat(filename: &ZStr) -> io::Result<Stat> {
         }
         lstat_old(filename)
     }
-    #[cfg(target_pointer_width = "64")]
+
+    #[cfg(all(target_pointer_width = "64", not(target_arch = "mips64")))]
     unsafe {
         let mut result = MaybeUninit::<Stat>::uninit();
         ret(syscall4(
@@ -633,10 +645,10 @@ pub(crate) fn lstat(filename: &ZStr) -> io::Result<Stat> {
     }
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
 fn lstat_old(filename: &ZStr) -> io::Result<Stat> {
     unsafe {
-        let mut result = MaybeUninit::<linux_raw_sys::general::stat64>::uninit();
+        let mut result = MaybeUninit::<linux_stat>::uninit();
         ret(syscall4(
             nr(__NR_fstatat64),
             c_int(AT_FDCWD),
@@ -644,12 +656,12 @@ fn lstat_old(filename: &ZStr) -> io::Result<Stat> {
             out(&mut result),
             c_uint(AT_SYMLINK_NOFOLLOW),
         ))
-        .and_then(|()| stat64_to_stat(result.assume_init()))
+        .and_then(|()| stat_to_stat(result.assume_init()))
     }
 }
 
 /// Convert from a Linux `statx` value to rustix's `Stat`.
-#[cfg(target_pointer_width = "32")]
+#[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
 fn statx_to_stat(x: crate::fs::Statx) -> io::Result<Stat> {
     Ok(Stat {
         st_dev: crate::fs::makedev(x.stx_dev_major, x.stx_dev_minor),
@@ -685,7 +697,7 @@ fn statx_to_stat(x: crate::fs::Statx) -> io::Result<Stat> {
 
 /// Convert from a Linux `stat64` value to rustix's `Stat`.
 #[cfg(target_pointer_width = "32")]
-fn stat64_to_stat(s64: linux_raw_sys::general::stat64) -> io::Result<Stat> {
+fn stat_to_stat(s64: linux_raw_sys::general::stat64) -> io::Result<Stat> {
     Ok(Stat {
         st_dev: s64.st_dev.try_into().map_err(|_| io::Error::OVERFLOW)?,
         st_mode: s64.st_mode.try_into().map_err(|_| io::Error::OVERFLOW)?,
@@ -712,6 +724,38 @@ fn stat64_to_stat(s64: linux_raw_sys::general::stat64) -> io::Result<Stat> {
             .try_into()
             .map_err(|_| io::Error::OVERFLOW)?,
         st_ino: s64.st_ino.try_into().map_err(|_| io::Error::OVERFLOW)?,
+    })
+}
+
+/// Convert from a Linux `stat` value to rustix's `Stat`.
+#[cfg(target_arch = "mips64")]
+fn stat_to_stat(s: linux_raw_sys::general::stat) -> io::Result<Stat> {
+    Ok(Stat {
+        st_dev: s.st_dev.try_into().map_err(|_| io::Error::OVERFLOW)?,
+        st_mode: s.st_mode.try_into().map_err(|_| io::Error::OVERFLOW)?,
+        st_nlink: s.st_nlink.try_into().map_err(|_| io::Error::OVERFLOW)?,
+        st_uid: s.st_uid.try_into().map_err(|_| io::Error::OVERFLOW)?,
+        st_gid: s.st_gid.try_into().map_err(|_| io::Error::OVERFLOW)?,
+        st_rdev: s.st_rdev.try_into().map_err(|_| io::Error::OVERFLOW)?,
+        st_size: s.st_size.try_into().map_err(|_| io::Error::OVERFLOW)?,
+        st_blksize: s.st_blksize.try_into().map_err(|_| io::Error::OVERFLOW)?,
+        st_blocks: s.st_blocks.try_into().map_err(|_| io::Error::OVERFLOW)?,
+        st_atime: s.st_atime.try_into().map_err(|_| io::Error::OVERFLOW)?,
+        st_atime_nsec: s
+            .st_atime_nsec
+            .try_into()
+            .map_err(|_| io::Error::OVERFLOW)?,
+        st_mtime: s.st_mtime.try_into().map_err(|_| io::Error::OVERFLOW)?,
+        st_mtime_nsec: s
+            .st_mtime_nsec
+            .try_into()
+            .map_err(|_| io::Error::OVERFLOW)?,
+        st_ctime: s.st_ctime.try_into().map_err(|_| io::Error::OVERFLOW)?,
+        st_ctime_nsec: s
+            .st_ctime_nsec
+            .try_into()
+            .map_err(|_| io::Error::OVERFLOW)?,
+        st_ino: s.st_ino.try_into().map_err(|_| io::Error::OVERFLOW)?,
     })
 }
 
@@ -749,6 +793,7 @@ pub(crate) fn fstatfs(fd: BorrowedFd<'_>) -> io::Result<StatFs> {
         ))
         .map(|()| result.assume_init())
     }
+
     #[cfg(target_pointer_width = "64")]
     unsafe {
         let mut result = MaybeUninit::<StatFs>::uninit();

--- a/src/imp/linux_raw/fs/types.rs
+++ b/src/imp/linux_raw/fs/types.rs
@@ -515,10 +515,10 @@ pub enum FlockOperation {
 ///
 /// [`statat`]: crate::fs::statat
 /// [`fstat`]: crate::fs::fstat
-// On 32-bit, Linux's `struct stat64` has a 32-bit `st_mtime` and friends, so
-// we use our own struct, populated from `statx` where possible, to avoid the
-// y2038 bug.
-#[cfg(target_pointer_width = "32")]
+// On 32-bit, and mips64, Linux's `struct stat64` has a 32-bit `st_mtime` and
+// friends, so we use our own struct, populated from `statx` where possible,
+// to avoid the y2038 bug.
+#[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 #[allow(missing_docs)]
@@ -545,7 +545,7 @@ pub struct Stat {
 ///
 /// [`statat`]: crate::fs::statat
 /// [`fstat`]: crate::fs::fstat
-#[cfg(target_pointer_width = "64")]
+#[cfg(all(target_pointer_width = "64", not(target_arch = "mips64")))]
 pub type Stat = linux_raw_sys::general::stat;
 
 /// `struct statfs` for use with [`fstatfs`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@
 //!  - In some places, more human-friendly and less historical-accident names
 //!    are used (and documentation aliases are used so that the original names
 //!    can still be searched for).
+//!  - Provide y2038 compatibility, on platforms which support this.
 //!
 //! Things they don't do include:
 //!  - Detecting whether functions are supported at runtime.

--- a/src/termios/constants.rs
+++ b/src/termios/constants.rs
@@ -594,8 +594,8 @@ pub use imp::termios::types::{
 /// Translate from a `Speed` code to a speed value `u32`.
 ///
 /// ```rust
-/// let speed = speed_value(rustix::termios::B57600);
-/// assert_eq!(speed, 57600);
+/// let speed = rustix::termios::speed_value(rustix::termios::B57600);
+/// assert_eq!(speed, Some(57600));
 /// ```
 pub fn speed_value(speed: imp::termios::types::Speed) -> Option<u32> {
     match speed {

--- a/src/termios/constants.rs
+++ b/src/termios/constants.rs
@@ -590,3 +590,130 @@ pub use imp::termios::types::{
     B50, B57600, B600, B75, B9600, ICANON, VDISCARD, VEOF, VEOL, VEOL2, VERASE, VINTR, VKILL,
     VLNEXT, VMIN, VQUIT, VREPRINT, VSTART, VSTOP, VSUSP, VTIME, VWERASE,
 };
+
+/// Translate from a `Speed` code to a speed value `u32`.
+///
+/// ```rust
+/// let speed = speed_value(rustix::termios::B57600);
+/// assert_eq!(speed, 57600);
+/// ```
+pub fn speed_value(speed: imp::termios::types::Speed) -> Option<u32> {
+    match speed {
+        imp::termios::types::B0 => Some(0),
+        imp::termios::types::B50 => Some(50),
+        imp::termios::types::B75 => Some(75),
+        imp::termios::types::B110 => Some(110),
+        imp::termios::types::B134 => Some(134),
+        imp::termios::types::B150 => Some(150),
+        imp::termios::types::B200 => Some(200),
+        imp::termios::types::B300 => Some(300),
+        imp::termios::types::B600 => Some(600),
+        imp::termios::types::B1200 => Some(1200),
+        imp::termios::types::B1800 => Some(1800),
+        imp::termios::types::B2400 => Some(2400),
+        imp::termios::types::B4800 => Some(4800),
+        imp::termios::types::B9600 => Some(9600),
+        imp::termios::types::B19200 => Some(19200),
+        imp::termios::types::B38400 => Some(38400),
+        imp::termios::types::B57600 => Some(57600),
+        imp::termios::types::B115200 => Some(115200),
+        imp::termios::types::B230400 => Some(230400),
+        #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
+        imp::termios::types::B460800 => Some(460800),
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "illumos",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+        )))]
+        imp::termios::types::B500000 => Some(500000),
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "illumos",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+        )))]
+        imp::termios::types::B576000 => Some(576000),
+        #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
+        imp::termios::types::B921600 => Some(921600),
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+        )))]
+        imp::termios::types::B1000000 => Some(1000000),
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+        )))]
+        imp::termios::types::B1152000 => Some(1152000),
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+        )))]
+        imp::termios::types::B1500000 => Some(1500000),
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+        )))]
+        imp::termios::types::B2000000 => Some(2000000),
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+        )))]
+        imp::termios::types::B2500000 => Some(2500000),
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+        )))]
+        imp::termios::types::B3000000 => Some(3000000),
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+        )))]
+        imp::termios::types::B3500000 => Some(3500000),
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+        )))]
+        imp::termios::types::B4000000 => Some(4000000),
+        _ => None,
+    }
+}

--- a/src/termios/mod.rs
+++ b/src/termios/mod.rs
@@ -7,6 +7,7 @@ mod tc;
 mod tty;
 
 pub use cf::{cfgetispeed, cfgetospeed, cfmakeraw, cfsetispeed, cfsetospeed, cfsetspeed};
+pub use constants::speed_value;
 #[cfg(not(any(
     target_os = "dragonfly",
     target_os = "freebsd",

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -1,6 +1,7 @@
 #[cfg(not(target_os = "redox"))]
 #[test]
 fn test_file() {
+    #[cfg(not(target_os = "illumos"))]
     rustix::fs::accessat(
         &rustix::fs::cwd(),
         "Cargo.toml",
@@ -40,10 +41,13 @@ fn test_file() {
     );
 
     #[cfg(not(any(
+        target_os = "dragonfly",
+        target_os = "illumos",
         target_os = "ios",
         target_os = "macos",
         target_os = "netbsd",
-        target_os = "openbsd"
+        target_os = "openbsd",
+        target_os = "redox"
     )))]
     rustix::fs::fadvise(&file, 0, 10, rustix::fs::Advice::Normal).unwrap();
 
@@ -60,7 +64,12 @@ fn test_file() {
     assert!(stat.st_size > 0);
     assert!(stat.st_blocks > 0);
 
-    #[cfg(not(any(target_os = "netbsd", target_os = "wasi")))]
+    #[cfg(not(any(
+        target_os = "illumos",
+        target_os = "netbsd",
+        target_os = "redox",
+        target_os = "wasi"
+    )))]
     // not implemented in libc for netbsd yet
     {
         let statfs = rustix::fs::fstatfs(&file).unwrap();

--- a/tests/fs/futimens.rs
+++ b/tests/fs/futimens.rs
@@ -29,8 +29,14 @@ fn test_futimens() {
     let after = fstat(&foo).unwrap();
 
     assert_eq!(times.last_modification.tv_sec as u64, after.st_mtime as u64);
+    #[cfg(not(target_os = "netbsd"))]
     assert_eq!(
         times.last_modification.tv_nsec as u64,
         after.st_mtime_nsec as u64
+    );
+    #[cfg(target_os = "netbsd")]
+    assert_eq!(
+        times.last_modification.tv_nsec as u64,
+        after.st_mtimensec as u64
     );
 }

--- a/tests/fs/invalid_offset.rs
+++ b/tests/fs/invalid_offset.rs
@@ -31,10 +31,11 @@ fn invalid_offset_seek() {
 }
 
 #[cfg(not(any(
+    target_os = "dragonfly",
+    target_os = "illumos",
     target_os = "netbsd",
     target_os = "openbsd",
-    target_os = "ios",
-    target_os = "macos"
+    target_os = "redox"
 )))]
 #[test]
 fn invalid_offset_fallocate() {
@@ -56,10 +57,13 @@ fn invalid_offset_fallocate() {
 }
 
 #[cfg(not(any(
-    target_os = "netbsd",
-    target_os = "openbsd",
+    target_os = "dragonfly",
+    target_os = "illumos",
     target_os = "ios",
     target_os = "macos",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "redox"
 )))]
 #[test]
 fn invalid_offset_fadvise() {

--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -14,7 +14,9 @@ mod futimens;
 mod invalid_offset;
 mod long_paths;
 #[cfg(not(any(
+    target_os = "dragonfly",
     target_os = "freebsd",
+    target_os = "illumos",
     target_os = "ios",
     target_os = "macos",
     target_os = "netbsd",
@@ -31,7 +33,13 @@ mod openat;
 mod openat2;
 mod readdir;
 mod renameat;
-#[cfg(not(any(target_os = "netbsd", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "illumos",
+    target_os = "netbsd",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 // not implemented in libc for netbsd yet
 mod statfs;
 mod utimensat;
+mod y2038;

--- a/tests/fs/utimensat.rs
+++ b/tests/fs/utimensat.rs
@@ -45,6 +45,17 @@ fn test_utimensat() {
         times.last_modification.tv_nsec as u64,
         after.st_mtimensec as u64
     );
+    assert!(times.last_access.tv_sec as u64 >= after.st_atime as u64);
+    #[cfg(not(target_os = "netbsd"))]
+    assert!(
+        times.last_access.tv_sec as u64 > after.st_atime as u64
+            || times.last_access.tv_nsec as u64 >= after.st_atime_nsec as u64
+    );
+    #[cfg(target_os = "netbsd")]
+    assert!(
+        times.last_access.tv_sec as u64 > after.st_atime as u64
+            || times.last_access.tv_nsec as u64 >= after.st_atimensec as u64
+    );
 }
 
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]

--- a/tests/fs/utimensat.rs
+++ b/tests/fs/utimensat.rs
@@ -35,9 +35,15 @@ fn test_utimensat() {
     let after = statat(&dir, "foo", AtFlags::empty()).unwrap();
 
     assert_eq!(times.last_modification.tv_sec as u64, after.st_mtime as u64);
+    #[cfg(not(target_os = "netbsd"))]
     assert_eq!(
         times.last_modification.tv_nsec as u64,
         after.st_mtime_nsec as u64
+    );
+    #[cfg(target_os = "netbsd")]
+    assert_eq!(
+        times.last_modification.tv_nsec as u64,
+        after.st_mtimensec as u64
     );
 }
 

--- a/tests/fs/y2038.rs
+++ b/tests/fs/y2038.rs
@@ -1,0 +1,89 @@
+/// Test that we can set a file timestamp to a date past the year 2038 with
+/// `utimensat` and read it back again.
+///
+/// See tests/time/y2038.rs for more information about y2038 testing.
+#[test]
+#[cfg(not(all(target_env = "musl", target_pointer_width = "32")))]
+#[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
+#[cfg(not(all(target_os = "emscripten", target_pointer_width = "32")))]
+fn test_y2038_with_utimensat() {
+    use rustix::fs::{cwd, openat, statat, utimensat, AtFlags, Mode, OFlags, Timespec, Timestamps};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = openat(
+        &cwd(),
+        tmp.path(),
+        OFlags::RDONLY | OFlags::PATH,
+        Mode::empty(),
+    )
+    .unwrap();
+
+    let m_sec = 1_u64 << 32;
+    let m_nsec = 17_u32;
+    let a_sec = m_sec + 1;
+    let a_nsec = m_nsec + 1;
+
+    let timestamps = Timestamps {
+        last_modification: Timespec {
+            tv_sec: m_sec as _,
+            tv_nsec: m_nsec as _,
+        },
+        last_access: Timespec {
+            tv_sec: a_sec as _,
+            tv_nsec: a_nsec as _,
+        },
+    };
+    let _ = openat(&dir, "foo", OFlags::CREATE | OFlags::WRONLY, Mode::empty()).unwrap();
+    let _ = utimensat(&dir, "foo", &timestamps, AtFlags::empty()).unwrap();
+    let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();
+
+    assert_eq!(stat.st_mtime, m_sec);
+    assert_eq!(stat.st_mtime_nsec as u32, m_nsec);
+    assert!(stat.st_atime >= a_sec);
+    assert!(stat.st_atime_nsec as u32 >= a_nsec);
+}
+
+/// Test that we can set a file timestamp to a date past the year 2038 with
+/// `futimens` and read it back again.
+///
+/// See tests/time/y2038.rs for more information about y2038 testing.
+#[test]
+#[cfg(not(all(target_env = "musl", target_pointer_width = "32")))]
+#[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
+#[cfg(not(all(target_os = "emscripten", target_pointer_width = "32")))]
+fn test_y2038_with_futimens() {
+    use rustix::fs::{cwd, futimens, openat, statat, AtFlags, Mode, OFlags, Timespec, Timestamps};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = openat(
+        &cwd(),
+        tmp.path(),
+        OFlags::RDONLY | OFlags::PATH,
+        Mode::empty(),
+    )
+    .unwrap();
+
+    let m_sec = 1_u64 << 32;
+    let m_nsec = 17_u32;
+    let a_sec = m_sec + 1;
+    let a_nsec = m_nsec + 1;
+
+    let timestamps = Timestamps {
+        last_modification: Timespec {
+            tv_sec: m_sec as _,
+            tv_nsec: m_nsec as _,
+        },
+        last_access: Timespec {
+            tv_sec: a_sec as _,
+            tv_nsec: a_nsec as _,
+        },
+    };
+    let file = openat(&dir, "foo", OFlags::CREATE | OFlags::WRONLY, Mode::empty()).unwrap();
+    let _ = futimens(&file, &timestamps).unwrap();
+    let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();
+
+    assert_eq!(stat.st_mtime, m_sec);
+    assert_eq!(stat.st_mtime_nsec as u32, m_nsec);
+    assert!(stat.st_atime >= a_sec);
+    assert!(stat.st_atime_nsec as u32 >= a_nsec);
+}

--- a/tests/fs/y2038.rs
+++ b/tests/fs/y2038.rs
@@ -10,13 +10,7 @@ fn test_y2038_with_utimensat() {
     use rustix::fs::{cwd, openat, statat, utimensat, AtFlags, Mode, OFlags, Timespec, Timestamps};
 
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(
-        &cwd(),
-        tmp.path(),
-        OFlags::RDONLY | OFlags::PATH,
-        Mode::empty(),
-    )
-    .unwrap();
+    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
 
     let m_sec = 1_u64 << 32;
     let m_nsec = 17_u32;
@@ -37,9 +31,9 @@ fn test_y2038_with_utimensat() {
     let _ = utimensat(&dir, "foo", &timestamps, AtFlags::empty()).unwrap();
     let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();
 
-    assert_eq!(stat.st_mtime, m_sec);
+    assert_eq!(stat.st_mtime.try_into().unwrap() as u64, m_sec);
     assert_eq!(stat.st_mtime_nsec as u32, m_nsec);
-    assert!(stat.st_atime >= a_sec);
+    assert!(stat.st_atime.try_into().unwrap() as u64 >= a_sec);
     assert!(stat.st_atime_nsec as u32 >= a_nsec);
 }
 
@@ -55,13 +49,7 @@ fn test_y2038_with_futimens() {
     use rustix::fs::{cwd, futimens, openat, statat, AtFlags, Mode, OFlags, Timespec, Timestamps};
 
     let tmp = tempfile::tempdir().unwrap();
-    let dir = openat(
-        &cwd(),
-        tmp.path(),
-        OFlags::RDONLY | OFlags::PATH,
-        Mode::empty(),
-    )
-    .unwrap();
+    let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
 
     let m_sec = 1_u64 << 32;
     let m_nsec = 17_u32;
@@ -82,8 +70,8 @@ fn test_y2038_with_futimens() {
     let _ = futimens(&file, &timestamps).unwrap();
     let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();
 
-    assert_eq!(stat.st_mtime, m_sec);
+    assert_eq!(stat.st_mtime.try_into().unwrap(), m_sec);
     assert_eq!(stat.st_mtime_nsec as u32, m_nsec);
-    assert!(stat.st_atime >= a_sec);
+    assert!(stat.st_atime.try_into().unwrap() >= a_sec);
     assert!(stat.st_atime_nsec as u32 >= a_nsec);
 }

--- a/tests/fs/y2038.rs
+++ b/tests/fs/y2038.rs
@@ -8,6 +8,7 @@
 #[cfg(not(all(target_os = "emscripten", target_pointer_width = "32")))]
 fn test_y2038_with_utimensat() {
     use rustix::fs::{cwd, openat, statat, utimensat, AtFlags, Mode, OFlags, Timespec, Timestamps};
+    use std::convert::TryInto;
 
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
@@ -31,9 +32,12 @@ fn test_y2038_with_utimensat() {
     let _ = utimensat(&dir, "foo", &timestamps, AtFlags::empty()).unwrap();
     let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();
 
-    assert_eq!(stat.st_mtime.try_into().unwrap() as u64, m_sec);
+    assert_eq!(
+        TryInto::<u64>::try_into(stat.st_mtime).unwrap() as u64,
+        m_sec
+    );
     assert_eq!(stat.st_mtime_nsec as u32, m_nsec);
-    assert!(stat.st_atime.try_into().unwrap() as u64 >= a_sec);
+    assert!(TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 >= a_sec);
     assert!(stat.st_atime_nsec as u32 >= a_nsec);
 }
 
@@ -47,6 +51,7 @@ fn test_y2038_with_utimensat() {
 #[cfg(not(all(target_os = "emscripten", target_pointer_width = "32")))]
 fn test_y2038_with_futimens() {
     use rustix::fs::{cwd, futimens, openat, statat, AtFlags, Mode, OFlags, Timespec, Timestamps};
+    use std::convert::TryInto;
 
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
@@ -70,8 +75,8 @@ fn test_y2038_with_futimens() {
     let _ = futimens(&file, &timestamps).unwrap();
     let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();
 
-    assert_eq!(stat.st_mtime.try_into().unwrap(), m_sec);
+    assert_eq!(TryInto::<u64>::try_into(stat.st_mtime).unwrap(), m_sec);
     assert_eq!(stat.st_mtime_nsec as u32, m_nsec);
-    assert!(stat.st_atime.try_into().unwrap() >= a_sec);
+    assert!(TryInto::<u64>::try_into(stat.st_atime).unwrap() >= a_sec);
     assert!(stat.st_atime_nsec as u32 >= a_nsec);
 }

--- a/tests/io/main.rs
+++ b/tests/io/main.rs
@@ -5,15 +5,19 @@
 
 #[cfg(not(feature = "rustc-dep-of-std"))]
 #[cfg(not(windows))]
+#[cfg(not(target_os = "wasi"))]
 mod dup2_to_replace_stdio;
 #[cfg(not(windows))]
+#[cfg(not(target_os = "wasi"))]
 mod dup3;
 #[cfg(not(feature = "rustc-dep-of-std"))] // TODO
 #[cfg(not(windows))]
 #[cfg(feature = "net")]
+#[cfg(not(target_os = "wasi"))]
 mod epoll;
 mod error;
 #[cfg(not(windows))]
+#[cfg(not(target_os = "wasi"))]
 mod eventfd;
 #[cfg(not(windows))]
 mod from_into;

--- a/tests/mm/mmap.rs
+++ b/tests/mm/mmap.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_os = "wasi"))]
 
-#[cfg(not(target_ot = "redox"))]
+#[cfg(not(target_os = "redox"))]
 #[test]
 fn test_mmap() {
     use rustix::fs::{cwd, openat, Mode, OFlags};
@@ -127,7 +127,7 @@ fn test_mlock() {
     }
 }
 
-#[cfg(not(target_ot = "redox"))]
+#[cfg(not(target_os = "redox"))]
 #[test]
 fn test_madvise() {
     use rustix::mm::{madvise, mmap_anonymous, munmap, Advice, MapFlags, ProtFlags};

--- a/tests/process/auxv.rs
+++ b/tests/process/auxv.rs
@@ -1,4 +1,7 @@
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(
+    all(target_os = "android", target_pointer_width = "64"),
+    target_os = "linux"
+))]
 use rustix::process::linux_hwcap;
 use rustix::process::{clock_ticks_per_second, page_size};
 
@@ -19,7 +22,10 @@ fn test_clock_ticks_per_second() {
 }
 
 #[test]
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(
+    all(target_os = "android", target_pointer_width = "64"),
+    target_os = "linux"
+))]
 fn test_linux_hwcap() {
     weak!(fn getauxval(libc::c_ulong) -> libc::c_ulong);
 

--- a/tests/process/main.rs
+++ b/tests/process/main.rs
@@ -9,6 +9,7 @@
 #[macro_use]
 mod weak;
 
+#[cfg(not(target_os = "wasi"))]
 mod auxv;
 mod cpu_set;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have get[gpu]id.
@@ -17,7 +18,7 @@ mod id;
 mod membarrier;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))] // WASI doesn't have [gs]etpriority.
 mod priority;
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 mod rlimit;
 mod sched_yield;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have uname.

--- a/tests/process/uname.rs
+++ b/tests/process/uname.rs
@@ -8,6 +8,6 @@ fn test_uname() {
     assert!(!name.version().to_bytes().is_empty());
     assert!(!name.machine().to_bytes().is_empty());
 
-    #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
+    #[cfg(any(target_os = "android", target_os = "linux"))]
     assert!(!name.domainname().to_bytes().is_empty());
 }

--- a/tests/time/main.rs
+++ b/tests/time/main.rs
@@ -8,7 +8,7 @@
 mod dynamic_clocks;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 mod monotonic;
-#[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 mod timerfd;
 mod timespec;
 mod y2038;

--- a/tests/time/y2038.rs
+++ b/tests/time/y2038.rs
@@ -1,11 +1,34 @@
 /// Test that `Timespec` and `Secs` support a 64-bit number of seconds,
 /// avoiding the y2038 bug.
-#[cfg(not(libc))] // The libc crate does not support a 64-bit time_t.
+///
+/// The Rust Musl target and libc crate are currently using Musl 1.1. It is
+/// expected to update to Musl 1.2 at some point, at which point it'll gain a
+/// 64-bit `time_t`.
+///
+/// 32-bit Android is [not y2038 compatible]. In theory we could use
+/// `libc::syscall` and call the new syscalls ourselves, however that doesn't
+/// seem worth the effort on a platform that will likely never support add
+/// such support itself.
+///
+/// [not y2038 compatible]: https://android.googlesource.com/platform/bionic/+/refs/heads/master/docs/32-bit-abi.md#is-32_bit-on-lp32-y2038
 #[test]
+#[cfg(not(all(target_env = "musl", target_pointer_width = "32")))]
+#[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
+#[cfg(not(all(target_os = "emscripten", target_pointer_width = "32")))]
 fn test_y2038() {
     use rustix::time::{Secs, Timespec};
 
     let tv_sec: i64 = 0;
     let _ = Timespec { tv_sec, tv_nsec: 0 };
     let _: Secs = tv_sec;
+
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    {
+        use rustix::time::Itimerspec;
+
+        let _ = Itimerspec {
+            it_interval: Timespec { tv_sec, tv_nsec: 0 },
+            it_value: Timespec { tv_sec, tv_nsec: 0 },
+        };
+    }
 }

--- a/tests/time/y2038.rs
+++ b/tests/time/y2038.rs
@@ -56,9 +56,10 @@ fn test_y2038_with_timerfd() {
     let _old: Itimerspec = match timerfd_settime(&fd, TimerfdTimerFlags::ABSTIME, &set) {
         Ok(i) => i,
 
-        // On mips and mips64 platforms, accept `EOVERFLOW`, meaning that y2038
-        // support in `timerfd` APIs is not available on this platform.
-        #[cfg(any(target_arch = "mips", target_arch = "mips64"))]
+        // On 32-bit and mips64 platforms, accept `EOVERFLOW`, meaning that
+        // y2038 support in `timerfd` APIs is not available on this platform
+        // or this version of the platform.
+        #[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
         Err(rustix::io::Error::OVERFLOW) => return,
 
         Err(e) => panic!("unexpected error: {:?}", e),


### PR DESCRIPTION
Add support for glibc's y2038 APIs in the libc backend.

The musl and android targets are not y2038 compatible on 32-bit
platforms, however in musl's case, this will be fixed when Rust itself
is updated to musl 1.2, and in android's case, this is because android
itself does not intend to be y2038-compatible on 32-bit platforms.

This strengthen's rustix's y2038 stance to: support y2038 compatibility
on platforms which have support for this.