### PR TITLE
Tidy up several comments.

### DIFF
--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -299,8 +299,8 @@ pub fn utimensat<P: path::Arg, Fd: AsFd>(
 /// The flags argument is fixed to 0, so `AT_SYMLINK_NOFOLLOW` is not
 /// supported. <details>Platform support for this flag varies widely.</details>
 ///
-/// Note that this implementation does not support `O_PATH` file descriptors,
-/// even on platforms where the host libc emulates it.
+/// This implementation does not support `O_PATH` file descriptors, even on
+/// platforms where the host libc emulates it.
 ///
 /// # References
 ///  - [POSIX]

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -99,8 +99,8 @@ pub fn tell<Fd: AsFd>(fd: Fd) -> io::Result<u64> {
 
 /// `fchmod(fd)`—Sets open file or directory permissions.
 ///
-/// Note that this implementation does not support `O_PATH` file descriptors,
-/// even on platforms where the host libc emulates it.
+/// This implementation does not support `O_PATH` file descriptors, even on
+/// platforms where the host libc emulates it.
 ///
 /// # References
 ///  - [POSIX]
@@ -242,8 +242,8 @@ pub(crate) fn _is_file_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)
 /// `fsync(fd)`—Ensures that file data and metadata is written to the
 /// underlying storage device.
 ///
-/// Note that on iOS and macOS this isn't sufficient to ensure that data has
-/// reached persistent storage; use [`fcntl_fullfsync`] to ensure that.
+/// On iOS and macOS this isn't sufficient to ensure that data has reached
+/// persistent storage; use [`fcntl_fullfsync`] to ensure that.
 ///
 /// # References
 ///  - [POSIX]

--- a/src/fs/statx.rs
+++ b/src/fs/statx.rs
@@ -8,8 +8,8 @@ pub use imp::fs::types::{Statx, StatxFlags, StatxTimestamp};
 
 /// `statx(dirfd, path, flags, mask, statxbuf)`
 ///
-/// Note that this isn't available on Linux before 4.11; returns `ENOSYS` in
-/// that case.
+/// This isn't available on Linux before 4.11; it returns `ENOSYS` in that
+/// case.
 ///
 /// # References
 ///  - [Linux]

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -147,9 +147,10 @@ weak!(fn __utimensat64(c::c_int, *const c::c_char, *const LibcTimespec, c::c_int
 ))]
 weak!(fn __futimens64(c::c_int, *const LibcTimespec) -> c::c_int);
 
+/// Use a direct syscall (via libc) for `openat`.
+///
+/// This is only currently necessary as a workaround for old glibc; see below.
 #[cfg(all(unix, target_env = "gnu"))]
-/// Use direct syscall (via libc) for openat().
-/// Only currently necessary as a workaround for old glibc; see below.
 fn openat_via_syscall(
     dirfd: BorrowedFd<'_>,
     path: &ZStr,
@@ -636,7 +637,7 @@ pub(crate) fn chmodat(dirfd: BorrowedFd<'_>, path: &ZStr, mode: Mode) -> io::Res
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub(crate) fn chmodat(dirfd: BorrowedFd<'_>, path: &ZStr, mode: Mode) -> io::Result<()> {
-    // Note that Linux's `fchmodat` does not have a flags argument.
+    // Linux's `fchmodat` does not have a flags argument.
     unsafe {
         // Pass `mode` as a `c_uint` even if `mode_t` is narrower, since
         // `libc_openat` is declared as a variadic function and narrower

--- a/src/imp/libc/mod.rs
+++ b/src/imp/libc/mod.rs
@@ -65,7 +65,7 @@ pub(crate) mod io_uring;
 #[cfg(not(windows))]
 #[cfg(any(feature = "mm", feature = "time", target_arch = "x86"))] // vdso.rs uses `madvise`
 pub(crate) mod mm;
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))] // WASI doesn't support `net` yet.
+#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[cfg(feature = "net")]
 pub(crate) mod net;
 #[cfg(not(windows))]

--- a/src/imp/linux_raw/arch/inline/x86.rs
+++ b/src/imp/linux_raw/arch/inline/x86.rs
@@ -4,8 +4,8 @@
 //! through the vDSO when possible, and plain forms, which use the `int 0x80`
 //! instruction.
 //!
-//! Note that most `rustix` syscalls use the vsyscall mechanism rather than
-//! going using `int 0x80` sequences.
+//! Most `rustix` syscalls use the vsyscall mechanism rather than going using
+//! `int 0x80` sequences.
 
 #![allow(dead_code)]
 
@@ -118,9 +118,9 @@ pub(in crate::imp) unsafe fn indirect_syscall4(
     // a3 should go in esi, but `asm!` won't let us use it as an operand.
     // temporarily swap it into place, and then swap it back afterward.
     //
-    // Note that we hard-code the callee operand to use edi instead of
-    // `in(reg)` because even though we can't name esi as an operand,
-    // the compiler can use esi to satisfy `in(reg)`.
+    // We hard-code the callee operand to use edi instead of `in(reg)` because
+    // even though we can't name esi as an operand, the compiler can use esi to
+    // satisfy `in(reg)`.
     asm!(
         "xchg esi, {a3}",
         "call edi",

--- a/src/imp/linux_raw/reg.rs
+++ b/src/imp/linux_raw/reg.rs
@@ -78,9 +78,9 @@ impl RetNumber for R0 {}
 /// Syscall arguments use register-sized types. We use a newtype to
 /// discourage accidental misuse of the raw integer values.
 ///
-/// Note that it doesn't implement `Clone` or `Copy`; it should be used
-/// exactly once. And it has a lifetime to ensure that it doesn't outlive
-/// any resources it might be pointing to.
+/// This type doesn't implement `Clone` or `Copy`; it should be used exactly
+/// once. And it has a lifetime to ensure that it doesn't outlive any resources
+/// it might be pointing to.
 #[repr(transparent)]
 pub(super) struct ArgReg<'a, Num: ArgNumber> {
     raw: *mut Opaque,
@@ -97,8 +97,8 @@ impl<'a, Num: ArgNumber> ToAsm for ArgReg<'a, Num> {
 /// Syscall return values use register-sized types. We use a newtype to
 /// discourage accidental misuse of the raw integer values.
 ///
-/// Note that it doesn't implement `Clone` or `Copy`; it should be used
-/// exactly once.
+/// This type doesn't implement `Clone` or `Copy`; it should be used exactly
+/// once.
 #[repr(transparent)]
 pub(super) struct RetReg<Num: RetNumber> {
     raw: *mut Opaque,

--- a/src/io/dup.rs
+++ b/src/io/dup.rs
@@ -10,8 +10,8 @@ pub use imp::io::types::DupFlags;
 /// `dup(fd)`—Creates a new `OwnedFd` instance that shares the same
 /// underlying [file description] as `fd`.
 ///
-/// Note that this function does not set the `O_CLOEXEC` flag. To do a `dup`
-/// that does set `O_CLOEXEC`, use [`fcntl_dupfd_cloexec`].
+/// This function does not set the `O_CLOEXEC` flag. To do a `dup` that does
+/// set `O_CLOEXEC`, use [`fcntl_dupfd_cloexec`].
 ///
 /// POSIX guarantees that `dup` will use the lowest unused file descriptor,
 /// however it is not safe in general to rely on this, as file descriptors may
@@ -35,9 +35,9 @@ pub fn dup<Fd: AsFd>(fd: Fd) -> io::Result<OwnedFd> {
 /// same underlying [file description] as the existing `OwnedFd` instance,
 /// closing `new` and reusing its file descriptor.
 ///
-/// Note that this function does not set the `O_CLOEXEC` flag. To do a `dup2`
-/// that does set `O_CLOEXEC`, use [`dup3`] with [`DupFlags::CLOEXEC`] on
-/// platforms which support it.
+/// This function does not set the `O_CLOEXEC` flag. To do a `dup2` that does
+/// set `O_CLOEXEC`, use [`dup3`] with [`DupFlags::CLOEXEC`] on platforms which
+/// support it.
 ///
 /// # References
 ///  - [POSIX]

--- a/src/io/fd/owned.rs
+++ b/src/io/fd/owned.rs
@@ -127,11 +127,11 @@ impl Drop for OwnedFd {
     #[inline]
     fn drop(&mut self) {
         unsafe {
-            // Note that errors are ignored when closing a file descriptor. The
-            // reason for this is that if an error occurs we don't actually know if
+            // Errors are ignored when closing a file descriptor. The reason
+            // for this is that if an error occurs we don't actually know if
             // the file descriptor was closed or not, and if we retried (for
-            // something like EINTR), we might close another valid file descriptor
-            // opened after we closed ours.
+            // something like EINTR), we might close another valid file
+            // descriptor opened after we closed ours.
             let _ = close(self.fd as _);
         }
     }

--- a/src/io/fd/raw.rs
+++ b/src/io/fd/raw.rs
@@ -37,7 +37,7 @@ pub trait AsRawFd {
     /// use std::os::wasi::io::{AsRawFd, RawFd};
     ///
     /// let mut f = File::open("foo.txt")?;
-    /// // Note that `raw_fd` is only valid as long as `f` exists.
+    /// // `raw_fd` is only valid as long as `f` exists.
     /// #[cfg(any(unix, target_os = "wasi"))]
     /// let raw_fd: RawFd = f.as_raw_fd();
     /// # Ok::<(), io::Error>(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,8 +145,8 @@ fn as_mut_ptr<T>(t: &mut T) -> *mut T {
 /// Users can use this to avoid needing to import anything else to use the same
 /// versions of these types and traits.
 ///
-/// Note that rustix APIs that use `OwnedFd` use [`rustix::io::OwnedFd`]
-/// instead, which allows rustix to implement `close` for them.
+/// Rustix APIs that use `OwnedFd` use [`rustix::io::OwnedFd`] instead, which
+/// allows rustix to implement `close` for them.
 ///
 /// [`rustix::io::OwnedFd`]: crate::io::OwnedFd
 pub mod fd {
@@ -184,7 +184,7 @@ pub mod io_uring;
 #[cfg(feature = "mm")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "mm")))]
 pub mod mm;
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))] // WASI doesn't support `net` yet.
+#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[cfg(feature = "net")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "net")))]
 pub mod net;

--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -35,9 +35,9 @@ pub struct Gid(RawGid);
 
 /// `pid_t`—A non-zero Unix process ID.
 ///
-/// Note that this is a pid, and not a pidfd. It is not a file descriptor,
-/// and the process it refers to could disappear at any time and be replaced
-/// by another, unrelated, process.
+/// This is a pid, and not a pidfd. It is not a file descriptor, and the
+/// process it refers to could disappear at any time and be replaced by
+/// another, unrelated, process.
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub struct Pid(RawNonZeroPid);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -96,9 +96,9 @@ pub unsafe fn exit_thread(status: i32) -> ! {
 ///
 /// This is equivalent to `_exit` and `_Exit` in libc.
 ///
-/// Note that this does not all any `__cxa_atexit`, `atexit`, or any other
-/// destructors. Most programs should use [`std::process::exit`] instead
-/// of calling this directly.
+/// This does not all any `__cxa_atexit`, `atexit`, or any other destructors.
+/// Most programs should use [`std::process::exit`] instead of calling this
+/// directly.
 ///
 /// # References
 ///  - [POSIX `_Exit`]

--- a/tests/net/main.rs
+++ b/tests/net/main.rs
@@ -2,7 +2,7 @@
 
 #![cfg(feature = "net")]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
-#![cfg(not(any(target_os = "redox", target_os = "wasi")))] // WASI doesn't support `net` yet.
+#![cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 
 mod addr;


### PR DESCRIPTION
Instead of saying "Note that ...", just say the "..." part in most cases.

And, remove several "WASI doesn't support `net` yet." comments; it's not
necessary to document that at every cfg.