### PR TITLE
Change several non-public things from `pub` to `pub(crate)`.

### DIFF
--- a/src/imp/libc/fs/makedev.rs
+++ b/src/imp/libc/fs/makedev.rs
@@ -4,20 +4,20 @@ use crate::fs::Dev;
 
 #[cfg(not(any(target_os = "android", target_os = "emscripten")))]
 #[inline]
-pub fn makedev(maj: u32, min: u32) -> Dev {
+pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
     unsafe { c::makedev(maj, min) }
 }
 
 #[cfg(all(target_os = "android", not(target_arch = "x86")))]
 #[inline]
-pub fn makedev(maj: u32, min: u32) -> Dev {
+pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
     // Android's `makedev` oddly has signed argument types.
     unsafe { c::makedev(maj as i32, min as i32) }
 }
 
 #[cfg(all(target_os = "android", target_arch = "x86"))]
 #[inline]
-pub fn makedev(maj: u32, min: u32) -> Dev {
+pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
     // 32-bit x86 Android's `dev_t` is 32-bit, but its `st_dev` is 64-bit,
     // so we do it ourselves.
     ((u64::from(maj) & 0xffff_f000_u64) << 32)
@@ -28,27 +28,27 @@ pub fn makedev(maj: u32, min: u32) -> Dev {
 
 #[cfg(target_os = "emscripten")]
 #[inline]
-pub fn makedev(maj: u32, min: u32) -> Dev {
+pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
     // Emscripten's `makedev` has a 32-bit return value.
     Dev::from(unsafe { c::makedev(maj, min) })
 }
 
 #[cfg(not(any(target_os = "android", target_os = "emscripten")))]
 #[inline]
-pub fn major(dev: Dev) -> u32 {
+pub(crate) fn major(dev: Dev) -> u32 {
     unsafe { c::major(dev) }
 }
 
 #[cfg(all(target_os = "android", not(target_arch = "x86")))]
 #[inline]
-pub fn major(dev: Dev) -> u32 {
+pub(crate) fn major(dev: Dev) -> u32 {
     // Android's `major` oddly has signed return types.
     (unsafe { c::major(dev) }) as u32
 }
 
 #[cfg(all(target_os = "android", target_arch = "x86"))]
 #[inline]
-pub fn major(dev: Dev) -> u32 {
+pub(crate) fn major(dev: Dev) -> u32 {
     // 32-bit x86 Android's `dev_t` is 32-bit, but its `st_dev` is 64-bit,
     // so we do it ourselves.
     (((dev >> 31 >> 1) & 0xffff_f000) | ((dev >> 8) & 0x0000_0fff)) as u32
@@ -56,27 +56,27 @@ pub fn major(dev: Dev) -> u32 {
 
 #[cfg(target_os = "emscripten")]
 #[inline]
-pub fn major(dev: Dev) -> u32 {
+pub(crate) fn major(dev: Dev) -> u32 {
     // Emscripten's `major` has a 32-bit argument value.
     unsafe { c::major(dev as u32) }
 }
 
 #[cfg(not(any(target_os = "android", target_os = "emscripten")))]
 #[inline]
-pub fn minor(dev: Dev) -> u32 {
+pub(crate) fn minor(dev: Dev) -> u32 {
     unsafe { c::minor(dev) }
 }
 
 #[cfg(all(target_os = "android", not(target_arch = "x86")))]
 #[inline]
-pub fn minor(dev: Dev) -> u32 {
+pub(crate) fn minor(dev: Dev) -> u32 {
     // Android's `minor` oddly has signed return types.
     (unsafe { c::minor(dev) }) as u32
 }
 
 #[cfg(all(target_os = "android", target_arch = "x86"))]
 #[inline]
-pub fn minor(dev: Dev) -> u32 {
+pub(crate) fn minor(dev: Dev) -> u32 {
     // 32-bit x86 Android's `dev_t` is 32-bit, but its `st_dev` is 64-bit,
     // so we do it ourselves.
     (((dev >> 12) & 0xffff_ff00) | (dev & 0x0000_00ff)) as u32
@@ -84,7 +84,7 @@ pub fn minor(dev: Dev) -> u32 {
 
 #[cfg(target_os = "emscripten")]
 #[inline]
-pub fn minor(dev: Dev) -> u32 {
+pub(crate) fn minor(dev: Dev) -> u32 {
     // Emscripten's `minor` has a 32-bit argument value.
     unsafe { c::minor(dev as u32) }
 }

--- a/src/imp/linux_raw/fs/makedev.rs
+++ b/src/imp/linux_raw/fs/makedev.rs
@@ -1,7 +1,7 @@
 use crate::fs::Dev;
 
 #[inline]
-pub fn makedev(maj: u32, min: u32) -> Dev {
+pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
     ((u64::from(maj) & 0xffff_f000_u64) << 32)
         | ((u64::from(maj) & 0x0000_0fff_u64) << 8)
         | ((u64::from(min) & 0xffff_ff00_u64) << 12)
@@ -9,11 +9,11 @@ pub fn makedev(maj: u32, min: u32) -> Dev {
 }
 
 #[inline]
-pub fn major(dev: Dev) -> u32 {
+pub(crate) fn major(dev: Dev) -> u32 {
     (((dev >> 31 >> 1) & 0xffff_f000) | ((dev >> 8) & 0x0000_0fff)) as u32
 }
 
 #[inline]
-pub fn minor(dev: Dev) -> u32 {
+pub(crate) fn minor(dev: Dev) -> u32 {
     (((dev >> 12) & 0xffff_ff00) | (dev & 0x0000_00ff)) as u32
 }

--- a/src/imp/linux_raw/termios/syscalls.rs
+++ b/src/imp/linux_raw/termios/syscalls.rs
@@ -186,19 +186,19 @@ pub(crate) fn tcsetpgrp(fd: BorrowedFd<'_>, pid: Pid) -> io::Result<()> {
 #[inline]
 #[must_use]
 #[allow(clippy::missing_const_for_fn)]
-pub fn cfgetospeed(termios: &Termios) -> u32 {
+pub(crate) fn cfgetospeed(termios: &Termios) -> u32 {
     termios.c_cflag & CBAUD
 }
 
 #[inline]
 #[must_use]
 #[allow(clippy::missing_const_for_fn)]
-pub fn cfgetispeed(termios: &Termios) -> u32 {
+pub(crate) fn cfgetispeed(termios: &Termios) -> u32 {
     termios.c_cflag & CBAUD
 }
 
 #[inline]
-pub fn cfmakeraw(termios: &mut Termios) {
+pub(crate) fn cfmakeraw(termios: &mut Termios) {
     // From the Linux [`cfmakeraw` man page]:
     //
     // [`cfmakeraw` man page]: https://man7.org/linux/man-pages/man3/cfmakeraw.3.html
@@ -214,7 +214,7 @@ pub fn cfmakeraw(termios: &mut Termios) {
 }
 
 #[inline]
-pub fn cfsetospeed(termios: &mut Termios, speed: u32) -> io::Result<()> {
+pub(crate) fn cfsetospeed(termios: &mut Termios, speed: u32) -> io::Result<()> {
     if (speed & !CBAUD) != 0 {
         return Err(io::Error::INVAL);
     }
@@ -224,7 +224,7 @@ pub fn cfsetospeed(termios: &mut Termios, speed: u32) -> io::Result<()> {
 }
 
 #[inline]
-pub fn cfsetispeed(termios: &mut Termios, speed: u32) -> io::Result<()> {
+pub(crate) fn cfsetispeed(termios: &mut Termios, speed: u32) -> io::Result<()> {
     if speed == 0 {
         return Ok(());
     }
@@ -237,7 +237,7 @@ pub fn cfsetispeed(termios: &mut Termios, speed: u32) -> io::Result<()> {
 }
 
 #[inline]
-pub fn cfsetspeed(termios: &mut Termios, speed: u32) -> io::Result<()> {
+pub(crate) fn cfsetspeed(termios: &mut Termios, speed: u32) -> io::Result<()> {
     if (speed & !CBAUD) != 0 {
         return Err(io::Error::INVAL);
     }


### PR DESCRIPTION
This isn't strictly necessary, as they're in non-`pub` modules, however
it makes it clear locally that these items aren't re-exported as `pub`.