### PR TITLE
Move `as_ptr` and `as_mut_ptr` into a `utils` module.

### DIFF
--- a/src/imp/libc/fs/dir.rs
+++ b/src/imp/libc/fs/dir.rs
@@ -358,7 +358,7 @@ struct libc_dirent {
 /// minimally matches libc's.
 #[cfg(target_os = "openbsd")]
 fn check_dirent_layout(dirent: &c::dirent) {
-    use crate::as_ptr;
+    use crate::utils::as_ptr;
     use core::mem::{align_of, size_of};
 
     // Check that the basic layouts match.

--- a/src/imp/libc/io_uring/syscalls.rs
+++ b/src/imp/libc/io_uring/syscalls.rs
@@ -3,9 +3,8 @@
 use super::super::c;
 use super::super::conv::{borrowed_fd, syscall_ret, syscall_ret_owned_fd, syscall_ret_u32};
 use crate::fd::BorrowedFd;
-use crate::io::OwnedFd;
+use crate::io::{self, OwnedFd};
 use crate::io_uring::{io_uring_params, IoringEnterFlags, IoringRegisterOp};
-use crate::{as_mut_ptr, io};
 use linux_raw_sys::general::{__NR_io_uring_enter, __NR_io_uring_register, __NR_io_uring_setup};
 
 #[inline]
@@ -14,7 +13,7 @@ pub(crate) fn io_uring_setup(entries: u32, params: &mut io_uring_params) -> io::
         syscall_ret_owned_fd(c::syscall(
             __NR_io_uring_setup as _,
             entries as usize,
-            as_mut_ptr(params),
+            params,
         ))
     }
 }

--- a/src/imp/libc/net/addr.rs
+++ b/src/imp/libc/net/addr.rs
@@ -316,5 +316,5 @@ pub(crate) fn offsetof_sun_path() -> usize {
         )))]
         sun_path: [0; 108],
     };
-    (crate::as_ptr(&z.sun_path) as usize) - (crate::as_ptr(&z) as usize)
+    (crate::utils::as_ptr(&z.sun_path) as usize) - (crate::utils::as_ptr(&z) as usize)
 }

--- a/src/imp/libc/net/read_sockaddr.rs
+++ b/src/imp/libc/net/read_sockaddr.rs
@@ -3,8 +3,6 @@ use super::super::c;
 use super::addr::SocketAddrUnix;
 use super::ext::{in6_addr_s6_addr, in_addr_s_addr, sockaddr_in6_sin6_scope_id};
 #[cfg(not(windows))]
-use crate::as_ptr;
-#[cfg(not(windows))]
 use crate::ffi::ZStr;
 use crate::io;
 use crate::net::{Ipv4Addr, Ipv6Addr, SocketAddrAny, SocketAddrV4, SocketAddrV6};
@@ -201,55 +199,7 @@ unsafe fn inner_read_sockaddr_os(
     len: usize,
 ) -> SocketAddrAny {
     #[cfg(unix)]
-    let z = c::sockaddr_un {
-        #[cfg(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))]
-        sun_len: 0_u8,
-        #[cfg(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))]
-        sun_family: 0_u8,
-        #[cfg(not(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        )))]
-        sun_family: 0_u16,
-        #[cfg(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))]
-        sun_path: [0; 104],
-        #[cfg(not(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        )))]
-        sun_path: [0; 108],
-    };
-    #[cfg(unix)]
-    let offsetof_sun_path = (as_ptr(&z.sun_path) as usize) - (as_ptr(&z) as usize);
+    let offsetof_sun_path = super::addr::offsetof_sun_path();
 
     assert!(len >= size_of::<c::sa_family_t>());
     match family {

--- a/src/imp/libc/net/syscalls.rs
+++ b/src/imp/libc/net/syscalls.rs
@@ -15,10 +15,10 @@ use super::send_recv::{RecvFlags, SendFlags};
 use super::types::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType};
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 use super::write_sockaddr::{encode_sockaddr_v4, encode_sockaddr_v6};
-use crate::as_ptr;
 use crate::fd::BorrowedFd;
 use crate::io::{self, OwnedFd};
 use crate::net::{SocketAddrAny, SocketAddrV4, SocketAddrV6};
+use crate::utils::as_ptr;
 use core::convert::TryInto;
 use core::mem::{size_of, MaybeUninit};
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
@@ -390,9 +390,10 @@ pub(crate) fn socketpair(
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) mod sockopt {
     use super::{c, in6_addr_new, in_addr_new, BorrowedFd};
+    use crate::io;
     use crate::net::sockopt::Timeout;
     use crate::net::{Ipv4Addr, Ipv6Addr, SocketType};
-    use crate::{as_mut_ptr, io};
+    use crate::utils::as_mut_ptr;
     use core::convert::TryInto;
     use core::time::Duration;
     #[cfg(windows)]

--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -28,7 +28,7 @@ use crate::ffi::ZStr;
 use crate::fs::{FileType, Mode, OFlags};
 use crate::io::{self, OwnedFd};
 use crate::process::{Pid, Resource, Signal};
-use crate::{as_mut_ptr, as_ptr};
+use crate::utils::{as_mut_ptr, as_ptr};
 use core::mem::MaybeUninit;
 use core::ptr::null_mut;
 #[cfg(any(feature = "thread", feature = "time", target_arch = "x86"))]

--- a/src/imp/linux_raw/fs/dir.rs
+++ b/src/imp/linux_raw/fs/dir.rs
@@ -1,9 +1,9 @@
-use crate::as_ptr;
 use crate::fd::{AsFd, BorrowedFd};
 use crate::ffi::{ZStr, ZString};
 use crate::fs::{fcntl_getfl, fstat, fstatfs, openat, FileType, Mode, OFlags, Stat, StatFs};
 use crate::io::{self, OwnedFd};
 use crate::process::fchdir;
+use crate::utils::as_ptr;
 use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 use core::fmt;

--- a/src/imp/linux_raw/net/addr.rs
+++ b/src/imp/linux_raw/net/addr.rs
@@ -170,5 +170,5 @@ pub(crate) fn offsetof_sun_path() -> usize {
         sun_family: 0_u16,
         sun_path: [0; 108],
     };
-    (crate::as_ptr(&z.sun_path) as usize) - (crate::as_ptr(&z) as usize)
+    (crate::utils::as_ptr(&z.sun_path) as usize) - (crate::utils::as_ptr(&z) as usize)
 }

--- a/src/imp/linux_raw/net/read_sockaddr.rs
+++ b/src/imp/linux_raw/net/read_sockaddr.rs
@@ -3,8 +3,8 @@
 #![allow(unsafe_code)]
 
 use super::super::c;
+use crate::io;
 use crate::net::{Ipv4Addr, Ipv6Addr, SocketAddrAny, SocketAddrUnix, SocketAddrV4, SocketAddrV6};
-use crate::{as_ptr, io};
 use alloc::vec::Vec;
 use core::mem::size_of;
 use linux_raw_sys::general::{__kernel_sockaddr_storage, sockaddr};
@@ -128,11 +128,7 @@ pub(crate) unsafe fn maybe_read_sockaddr_os(
 ///
 /// `storage` must point to a valid socket address returned from the OS.
 pub(crate) unsafe fn read_sockaddr_os(storage: *const sockaddr, len: usize) -> SocketAddrAny {
-    let z = c::sockaddr_un {
-        sun_family: 0_u16,
-        sun_path: [0; 108],
-    };
-    let offsetof_sun_path = (as_ptr(&z.sun_path) as usize) - (as_ptr(&z) as usize);
+    let offsetof_sun_path = super::addr::offsetof_sun_path();
 
     assert!(len >= size_of::<c::sa_family_t>());
     match read_ss_family(storage).into() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,19 +126,19 @@
 #[cfg(not(feature = "rustc-dep-of-std"))]
 extern crate alloc;
 
-/// Convert a `&T` into a `*const T` without using an `as`.
-#[inline]
-#[allow(dead_code)]
-const fn as_ptr<T>(t: &T) -> *const T {
-    t
-}
+// Internal utilities.
+#[cfg(not(windows))]
+#[macro_use]
+pub(crate) mod zstr;
+#[macro_use]
+pub(crate) mod const_assert;
+pub(crate) mod utils;
 
-/// Convert a `&mut T` into a `*mut T` without using an `as`.
-#[inline]
-#[allow(dead_code)]
-fn as_mut_ptr<T>(t: &mut T) -> *mut T {
-    t
-}
+// Pick the backend implementation to use.
+#[cfg_attr(libc, path = "imp/libc/mod.rs")]
+#[cfg_attr(linux_raw, path = "imp/linux_raw/mod.rs")]
+#[cfg_attr(wasi, path = "imp/wasi/mod.rs")]
+mod imp;
 
 /// Export `*Fd` types and traits that used in rustix's public API.
 ///
@@ -157,17 +157,6 @@ pub mod fd {
     #[cfg(feature = "std")]
     pub use imp::fd::{FromFd, IntoFd};
 }
-
-#[cfg(not(windows))]
-#[macro_use]
-pub(crate) mod zstr;
-#[macro_use]
-pub(crate) mod const_assert;
-
-#[cfg_attr(libc, path = "imp/libc/mod.rs")]
-#[cfg_attr(linux_raw, path = "imp/linux_raw/mod.rs")]
-#[cfg_attr(wasi, path = "imp/wasi/mod.rs")]
-mod imp;
 
 #[cfg(not(windows))]
 pub mod ffi;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,13 @@
+/// Convert a `&T` into a `*const T` without using an `as`.
+#[inline]
+#[allow(dead_code)]
+pub(crate) const fn as_ptr<T>(t: &T) -> *const T {
+    t
+}
+
+/// Convert a `&mut T` into a `*mut T` without using an `as`.
+#[inline]
+#[allow(dead_code)]
+pub(crate) fn as_mut_ptr<T>(t: &mut T) -> *mut T {
+    t
+}


### PR DESCRIPTION
This tidies up the top-level lib.rs.

While here, replace the manual implementations of `offsetof_sun_path`
with calls to the actual `offsetof_sun_path`, so that we have fewer
uses of `as_ptr`.