### PR TITLE
Rename `rustix::io::Error` to `rustix::io::Errno`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,17 +32,17 @@ compiler_builtins = { version = '0.1.49', optional = true }
 once_cell = { version = "1.5.2", optional = true }
 
 # On Linux on selected architectures, we have two supported backends: linux_raw
-# and libc. The libc and errno dependencies are only enabled when the libc
+# and libc. The libc and libc_errno dependencies are only enabled when the libc
 # backend is in use.
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), all(target_arch = "powerpc64", target_endian = "little"), target_arch = "riscv64", all(target_arch = "mips", target_endian = "little"), all(target_arch = "mips64", target_endian = "little"))))'.dependencies]
 linux-raw-sys = { version = "0.0.46", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
-errno = { version = "0.2.8", default-features = false, optional = true }
+libc_errno = { package = "errno", version = "0.2.8", default-features = false, optional = true }
 libc = { version = "0.2.118", features = ["extra_traits"], optional = true }
 
 # On all other Unix-family platforms, and under Miri, we always use the libc
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), all(target_arch = "powerpc64", target_endian = "little"), target_arch = "riscv64", all(target_arch = "mips", target_endian = "little"), all(target_arch = "mips64", target_endian = "little"))))))'.dependencies]
-errno = { version = "0.2.8", default-features = false }
+libc_errno = { package = "errno", version = "0.2.8", default-features = false }
 libc = { version = "0.2.118", features = ["extra_traits"] }
 
 [target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), all(target_arch = "powerpc64", target_endian = "little"), target_arch = "riscv64", all(target_arch = "mips", target_endian = "little"), all(target_arch = "mips64", target_endian = "little")))))))'.dependencies]
@@ -63,7 +63,7 @@ features = [
 [dev-dependencies]
 tempfile = "3.2.0"
 libc = "0.2.118"
-errno = "0.2.8"
+libc_errno = { package = "errno", version = "0.2.8" }
 serial_test = "0.6"
 memoffset = "0.6.5"
 
@@ -101,7 +101,7 @@ rustc-dep-of-std = [
 ]
 
 # Enable this to request the libc backend.
-use-libc = ["errno", "libc"]
+use-libc = ["libc_errno", "libc"]
 
 # Enable `rustix::fs::*`.
 fs = []

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ and [`scall`] crates, though `rustix` can use either the unstable Rust `asm!`
 macro or out-of-line `.s` files so it supports both Stable and Nightly Rust.
 `rustix` can also use Linux's vDSO mechanism to optimize Linux `clock_gettime`
 on all architectures, and all Linux system calls on x86. And `rustix`'s
-syscalls report errors using an optimized `Error` type.
+syscalls report errors using an optimized `Errno` type.
 
 `rustix`'s `*at` functions are similar to the [`openat`] crate, but `rustix`
 provides them as free functions rather than associated functions of a `Dir`
@@ -126,4 +126,4 @@ version of this crate.
 [provenance]: https://github.com/rust-lang/rust/issues/95228
 [`OwnedFd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/struct.OwnedFd.html
 [`AsFd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/trait.AsFd.html
-[`NOSYS`]: https://docs.rs/rustix/latest/rustix/io/struct.Error.html#associatedconstant.NOSYS
+[`NOSYS`]: https://docs.rs/rustix/latest/rustix/io/struct.Errno.html#associatedconstant.NOSYS

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -26,7 +26,7 @@ fn main() -> std::io::Result<()> {
 
             // `write` can be interrupted before doing any work; if that
             // happens, retry it.
-            Err(rustix::io::Error::INTR) => (),
+            Err(rustix::io::Errno::INTR) => (),
 
             // `write` can also fail for external reasons, such as running out
             // of storage space.

--- a/src/ffi/z_str.rs
+++ b/src/ffi/z_str.rs
@@ -1150,10 +1150,10 @@ impl fmt::Display for NulError {
 }
 
 #[cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))]
-impl From<NulError> for io::Error {
-    /// Converts a [`NulError`] into a [`io::Error`].
-    fn from(_: NulError) -> io::Error {
-        io::Error::INVAL
+impl From<NulError> for io::Errno {
+    /// Converts a [`NulError`] into a [`io::Errno`].
+    fn from(_: NulError) -> io::Errno {
+        io::Errno::INVAL
     }
 }
 

--- a/src/imp/libc/conv.rs
+++ b/src/imp/libc/conv.rs
@@ -41,7 +41,7 @@ pub(super) fn ret(raw: c::c_int) -> io::Result<()> {
     if raw == 0 {
         Ok(())
     } else {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     }
 }
 
@@ -50,7 +50,7 @@ pub(super) fn syscall_ret(raw: c::c_long) -> io::Result<()> {
     if raw == 0 {
         Ok(())
     } else {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     }
 }
 
@@ -59,19 +59,19 @@ pub(super) fn nonnegative_ret(raw: c::c_int) -> io::Result<()> {
     if raw >= 0 {
         Ok(())
     } else {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     }
 }
 
 #[inline]
 pub(super) unsafe fn ret_infallible(raw: c::c_int) {
-    debug_assert_eq!(raw, 0, "unexpected error: {:?}", io::Error::last_os_error());
+    debug_assert_eq!(raw, 0, "unexpected error: {:?}", io::Errno::last_os_error());
 }
 
 #[inline]
 pub(super) fn ret_c_int(raw: c::c_int) -> io::Result<c::c_int> {
     if raw == -1 {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     } else {
         Ok(raw)
     }
@@ -80,7 +80,7 @@ pub(super) fn ret_c_int(raw: c::c_int) -> io::Result<c::c_int> {
 #[inline]
 pub(super) fn ret_u32(raw: c::c_int) -> io::Result<u32> {
     if raw == -1 {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     } else {
         Ok(raw as u32)
     }
@@ -89,7 +89,7 @@ pub(super) fn ret_u32(raw: c::c_int) -> io::Result<u32> {
 #[inline]
 pub(super) fn ret_ssize_t(raw: c::ssize_t) -> io::Result<c::ssize_t> {
     if raw == -1 {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     } else {
         Ok(raw)
     }
@@ -98,7 +98,7 @@ pub(super) fn ret_ssize_t(raw: c::ssize_t) -> io::Result<c::ssize_t> {
 #[inline]
 pub(super) fn syscall_ret_ssize_t(raw: c::c_long) -> io::Result<c::ssize_t> {
     if raw == -1 {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     } else {
         Ok(raw as c::ssize_t)
     }
@@ -108,7 +108,7 @@ pub(super) fn syscall_ret_ssize_t(raw: c::c_long) -> io::Result<c::ssize_t> {
 #[inline]
 pub(super) fn syscall_ret_u32(raw: c::c_long) -> io::Result<u32> {
     if raw == -1 {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     } else {
         let r32 = raw as u32;
 
@@ -123,7 +123,7 @@ pub(super) fn syscall_ret_u32(raw: c::c_long) -> io::Result<u32> {
 #[inline]
 pub(super) fn ret_off_t(raw: libc_off_t) -> io::Result<libc_off_t> {
     if raw == -1 {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     } else {
         Ok(raw)
     }
@@ -133,7 +133,7 @@ pub(super) fn ret_off_t(raw: libc_off_t) -> io::Result<libc_off_t> {
 #[inline]
 pub(super) fn ret_pid_t(raw: c::pid_t) -> io::Result<c::pid_t> {
     if raw == -1 {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     } else {
         Ok(raw)
     }
@@ -148,7 +148,7 @@ pub(super) fn ret_pid_t(raw: c::pid_t) -> io::Result<c::pid_t> {
 #[inline]
 pub(super) unsafe fn ret_owned_fd(raw: LibcFd) -> io::Result<OwnedFd> {
     if raw == !0 {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     } else {
         Ok(OwnedFd::from_raw_fd(raw as RawFd))
     }
@@ -157,7 +157,7 @@ pub(super) unsafe fn ret_owned_fd(raw: LibcFd) -> io::Result<OwnedFd> {
 #[inline]
 pub(super) fn ret_discarded_fd(raw: LibcFd) -> io::Result<()> {
     if raw == !0 {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     } else {
         Ok(())
     }
@@ -166,7 +166,7 @@ pub(super) fn ret_discarded_fd(raw: LibcFd) -> io::Result<()> {
 #[inline]
 pub(super) fn ret_discarded_char_ptr(raw: *mut c::c_char) -> io::Result<()> {
     if raw.is_null() {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     } else {
         Ok(())
     }
@@ -182,7 +182,7 @@ pub(super) fn ret_discarded_char_ptr(raw: *mut c::c_char) -> io::Result<()> {
 #[inline]
 pub(super) unsafe fn syscall_ret_owned_fd(raw: c::c_long) -> io::Result<OwnedFd> {
     if raw == -1 {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     } else {
         Ok(OwnedFd::from_raw_fd(raw as RawFd))
     }

--- a/src/imp/libc/fs/dir.rs
+++ b/src/imp/libc/fs/dir.rs
@@ -44,7 +44,7 @@ use c::{dirent64 as libc_dirent, readdir64 as libc_readdir};
 use core::fmt;
 use core::mem::zeroed;
 use core::ptr::NonNull;
-use errno::{errno, set_errno, Errno};
+use libc_errno::{errno, set_errno, Errno};
 
 /// `DIR*`
 #[repr(transparent)]
@@ -75,7 +75,7 @@ impl Dir {
             if let Some(libc_dir) = NonNull::new(libc_dir) {
                 Ok(Self(libc_dir))
             } else {
-                let e = io::Error::last_os_error();
+                let e = io::Errno::last_os_error();
                 let _ = c::close(raw);
                 Err(e)
             }
@@ -99,7 +99,7 @@ impl Dir {
                 None
             } else {
                 // `errno` is unknown or non-zero, so an error occurred.
-                Some(Err(io::Error(curr_errno)))
+                Some(Err(io::Errno(curr_errno)))
             }
         } else {
             // We successfully read an entry.

--- a/src/imp/libc/io/errno.rs
+++ b/src/imp/libc/io/errno.rs
@@ -1,10 +1,10 @@
-//! The `rustix` `Error` type.
+//! The `rustix` `Errno` type.
 //!
 //! This type holds an OS error code, which conceptually corresponds to an
 //! `errno` value.
 
 use super::super::c;
-use errno::errno;
+use libc_errno::errno;
 
 /// The error type for `rustix` APIs.
 ///
@@ -13,9 +13,9 @@ use errno::errno;
 #[repr(transparent)]
 #[doc(alias = "errno")]
 #[derive(Eq, PartialEq, Hash, Copy, Clone)]
-pub struct Error(pub(crate) c::c_int);
+pub struct Errno(pub(crate) c::c_int);
 
-impl Error {
+impl Errno {
     /// `EACCES`
     #[doc(alias = "ACCES")]
     pub const ACCESS: Self = Self(c::EACCES);
@@ -966,8 +966,8 @@ impl Error {
     pub const XFULL: Self = Self(c::EXFULL);
 }
 
-impl Error {
-    /// Extract an `Error` value from a `std::io::Error`.
+impl Errno {
+    /// Extract an `Errno` value from a `std::io::Error`.
     ///
     /// This isn't a `From` conversion because it's expected to be relatively
     /// uncommon.
@@ -985,7 +985,7 @@ impl Error {
         self.0
     }
 
-    /// Construct an `Error` from a raw OS error number.
+    /// Construct an `Errno` from a raw OS error number.
     #[inline]
     pub const fn from_raw_os_error(raw: i32) -> Self {
         Self(raw)

--- a/src/imp/libc/io/mod.rs
+++ b/src/imp/libc/io/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod error;
+pub(crate) mod errno;
 #[cfg(not(windows))]
 #[cfg(not(feature = "std"))]
 pub(crate) mod io_slice;

--- a/src/imp/libc/io/syscalls.rs
+++ b/src/imp/libc/io/syscalls.rs
@@ -23,7 +23,7 @@ use core::cmp::min;
 use core::convert::TryInto;
 use core::mem::MaybeUninit;
 #[cfg(feature = "net")]
-use errno::errno;
+use libc_errno::errno;
 
 pub(crate) fn read(fd: BorrowedFd<'_>, buf: &mut [u8]) -> io::Result<usize> {
     let nread = unsafe {
@@ -338,7 +338,7 @@ pub(crate) fn is_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
                 match errno().0 {
                     c::EAGAIN | c::EWOULDBLOCK => (),
                     c::ENOTSOCK => not_socket = true,
-                    err => return Err(io::Error(err)),
+                    err => return Err(io::Errno(err)),
                 }
             }
             _ => (),
@@ -354,7 +354,7 @@ pub(crate) fn is_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
                     c::EAGAIN | c::EWOULDBLOCK => (),
                     c::ENOTSOCK => (),
                     c::EPIPE => write = false,
-                    err => return Err(io::Error(err)),
+                    err => return Err(io::Errno(err)),
                 }
             }
             _ => (),
@@ -410,7 +410,7 @@ pub(crate) fn dup3(fd: BorrowedFd<'_>, new: &OwnedFd, _flags: DupFlags) -> io::R
     // when the file descriptors are equal.
     use std::os::unix::io::AsRawFd;
     if fd.as_raw_fd() == new.as_raw_fd() {
-        return Err(io::Error::INVAL);
+        return Err(io::Errno::INVAL);
     }
     dup2(fd, new)
 }
@@ -455,7 +455,7 @@ pub(crate) fn poll(fds: &mut [PollFd<'_>], timeout: c::c_int) -> io::Result<usiz
     let nfds = fds
         .len()
         .try_into()
-        .map_err(|_convert_err| io::Error::INVAL)?;
+        .map_err(|_convert_err| io::Errno::INVAL)?;
 
     ret_c_int(unsafe { c::poll(fds.as_mut_ptr().cast(), nfds, timeout) })
         .map(|nready| nready as usize)

--- a/src/imp/libc/io/windows_syscalls.rs
+++ b/src/imp/libc/io/windows_syscalls.rs
@@ -23,7 +23,7 @@ pub(crate) fn poll(fds: &mut [PollFd<'_>], timeout: c::c_int) -> io::Result<usiz
     let nfds = fds
         .len()
         .try_into()
-        .map_err(|_convert_err| io::Error::INVAL)?;
+        .map_err(|_convert_err| io::Errno::INVAL)?;
 
     ret_c_int(unsafe { c::poll(fds.as_mut_ptr().cast(), nfds, timeout) })
         .map(|nready| nready as usize)

--- a/src/imp/libc/mm/syscalls.rs
+++ b/src/imp/libc/mm/syscalls.rs
@@ -37,7 +37,7 @@ pub(crate) fn madvise(addr: *mut c::c_void, len: usize, advice: Advice) -> io::R
         if err == 0 {
             Ok(())
         } else {
-            Err(io::Error(err))
+            Err(io::Errno(err))
         }
     }
 
@@ -61,7 +61,7 @@ pub(crate) unsafe fn msync(addr: *mut c::c_void, len: usize, flags: MsyncFlags) 
     if err == 0 {
         Ok(())
     } else {
-        Err(io::Error(err))
+        Err(io::Errno(err))
     }
 }
 
@@ -87,7 +87,7 @@ pub(crate) unsafe fn mmap(
         offset as i64,
     );
     if res == c::MAP_FAILED {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     } else {
         Ok(res)
     }
@@ -113,7 +113,7 @@ pub(crate) unsafe fn mmap_anonymous(
         0,
     );
     if res == c::MAP_FAILED {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     } else {
         Ok(res)
     }
@@ -146,7 +146,7 @@ pub(crate) unsafe fn mremap(
 ) -> io::Result<*mut c::c_void> {
     let res = c::mremap(old_address, old_size, new_size, flags.bits());
     if res == c::MAP_FAILED {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     } else {
         Ok(res)
     }
@@ -173,7 +173,7 @@ pub(crate) unsafe fn mremap_fixed(
         new_address,
     );
     if res == c::MAP_FAILED {
-        Err(io::Error::last_os_error())
+        Err(io::Errno::last_os_error())
     } else {
         Ok(res)
     }

--- a/src/imp/libc/net/addr.rs
+++ b/src/imp/libc/net/addr.rs
@@ -44,7 +44,7 @@ impl SocketAddrUnix {
         let mut unix = Self::init();
         let bytes = path.to_bytes_with_nul();
         if bytes.len() > unix.sun_path.len() {
-            return Err(io::Error::NAMETOOLONG);
+            return Err(io::Errno::NAMETOOLONG);
         }
         for (i, b) in bytes.iter().enumerate() {
             unix.sun_path[i] = *b as c::c_char;
@@ -82,7 +82,7 @@ impl SocketAddrUnix {
     pub fn new_abstract_name(name: &[u8]) -> io::Result<Self> {
         let mut unix = Self::init();
         if 1 + name.len() > unix.sun_path.len() {
-            return Err(io::Error::NAMETOOLONG);
+            return Err(io::Errno::NAMETOOLONG);
         }
         unix.sun_path[0] = b'\0' as c::c_char;
         for (i, b) in name.iter().enumerate() {

--- a/src/imp/libc/net/read_sockaddr.rs
+++ b/src/imp/libc/net/read_sockaddr.rs
@@ -93,12 +93,12 @@ pub(crate) unsafe fn read_sockaddr(
     let offsetof_sun_path = super::addr::offsetof_sun_path();
 
     if len < size_of::<c::sa_family_t>() {
-        return Err(io::Error::INVAL);
+        return Err(io::Errno::INVAL);
     }
     match read_ss_family(storage).into() {
         c::AF_INET => {
             if len < size_of::<c::sockaddr_in>() {
-                return Err(io::Error::INVAL);
+                return Err(io::Errno::INVAL);
             }
             let decode = *storage.cast::<c::sockaddr_in>();
             Ok(SocketAddrAny::V4(SocketAddrV4::new(
@@ -108,7 +108,7 @@ pub(crate) unsafe fn read_sockaddr(
         }
         c::AF_INET6 => {
             if len < size_of::<c::sockaddr_in6>() {
-                return Err(io::Error::INVAL);
+                return Err(io::Errno::INVAL);
             }
             let decode = *storage.cast::<c::sockaddr_in6>();
             #[cfg(not(windows))]
@@ -129,7 +129,7 @@ pub(crate) unsafe fn read_sockaddr(
         #[cfg(unix)]
         c::AF_UNIX => {
             if len < offsetof_sun_path {
-                return Err(io::Error::INVAL);
+                return Err(io::Errno::INVAL);
             }
             if len == offsetof_sun_path {
                 Ok(SocketAddrAny::Unix(SocketAddrUnix::new(&[][..]).unwrap()))
@@ -146,7 +146,7 @@ pub(crate) unsafe fn read_sockaddr(
                     // Otherwise, use the provided length.
                     let provided_len = len - 1 - offsetof_sun_path;
                     if decode.sun_path[provided_len] != b'\0' as c::c_char {
-                        return Err(io::Error::INVAL);
+                        return Err(io::Errno::INVAL);
                     }
                     debug_assert_eq!(
                         ZStr::from_ptr(decode.sun_path.as_ptr().cast())
@@ -163,7 +163,7 @@ pub(crate) unsafe fn read_sockaddr(
                 ))
             }
         }
-        _ => Err(io::Error::INVAL),
+        _ => Err(io::Errno::INVAL),
     }
 }
 

--- a/src/imp/libc/net/syscalls.rs
+++ b/src/imp/libc/net/syscalls.rs
@@ -499,9 +499,9 @@ pub(crate) mod sockopt {
         let l_linger = if let Some(linger) = linger {
             let mut l_linger = linger.as_secs();
             if linger.subsec_nanos() != 0 {
-                l_linger = l_linger.checked_add(1).ok_or(io::Error::INVAL)?;
+                l_linger = l_linger.checked_add(1).ok_or(io::Errno::INVAL)?;
             }
-            l_linger.try_into().map_err(|_| io::Error::INVAL)?
+            l_linger.try_into().map_err(|_| io::Errno::INVAL)?
         } else {
             0
         };
@@ -550,7 +550,7 @@ pub(crate) mod sockopt {
         let timeout = match timeout {
             Some(timeout) => {
                 if timeout == DURATION_ZERO {
-                    return Err(io::Error::INVAL);
+                    return Err(io::Errno::INVAL);
                 }
 
                 let tv_sec = timeout.as_secs().try_into();
@@ -580,14 +580,14 @@ pub(crate) mod sockopt {
         let timeout: u32 = match timeout {
             Some(timeout) => {
                 if timeout == DURATION_ZERO {
-                    return Err(io::Error::INVAL);
+                    return Err(io::Errno::INVAL);
                 }
 
                 // `as_millis` rounds down, so we use `as_nanos` and
                 // manually round up.
                 let mut timeout: u32 = ((timeout.as_nanos() + 999999) / 1000000)
                     .try_into()
-                    .map_err(|_convert_err| io::Error::INVAL)?;
+                    .map_err(|_convert_err| io::Errno::INVAL)?;
                 if timeout == 0 {
                     timeout = 1;
                 }

--- a/src/imp/libc/process/syscalls.rs
+++ b/src/imp/libc/process/syscalls.rs
@@ -199,9 +199,9 @@ pub(crate) fn uname() -> RawUname {
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 #[inline]
 pub(crate) fn nice(inc: i32) -> io::Result<i32> {
-    errno::set_errno(errno::Errno(0));
+    libc_errno::set_errno(libc_errno::Errno(0));
     let r = unsafe { c::nice(inc) };
-    if errno::errno().0 != 0 {
+    if libc_errno::errno().0 != 0 {
         ret_c_int(r)
     } else {
         Ok(r)
@@ -211,9 +211,9 @@ pub(crate) fn nice(inc: i32) -> io::Result<i32> {
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 #[inline]
 pub(crate) fn getpriority_user(uid: Uid) -> io::Result<i32> {
-    errno::set_errno(errno::Errno(0));
+    libc_errno::set_errno(libc_errno::Errno(0));
     let r = unsafe { c::getpriority(c::PRIO_USER, uid.as_raw() as _) };
-    if errno::errno().0 != 0 {
+    if libc_errno::errno().0 != 0 {
         ret_c_int(r)
     } else {
         Ok(r)
@@ -223,9 +223,9 @@ pub(crate) fn getpriority_user(uid: Uid) -> io::Result<i32> {
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 #[inline]
 pub(crate) fn getpriority_pgrp(pgid: Option<Pid>) -> io::Result<i32> {
-    errno::set_errno(errno::Errno(0));
+    libc_errno::set_errno(libc_errno::Errno(0));
     let r = unsafe { c::getpriority(c::PRIO_PGRP, Pid::as_raw(pgid) as _) };
-    if errno::errno().0 != 0 {
+    if libc_errno::errno().0 != 0 {
         ret_c_int(r)
     } else {
         Ok(r)
@@ -235,9 +235,9 @@ pub(crate) fn getpriority_pgrp(pgid: Option<Pid>) -> io::Result<i32> {
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 #[inline]
 pub(crate) fn getpriority_process(pid: Option<Pid>) -> io::Result<i32> {
-    errno::set_errno(errno::Errno(0));
+    libc_errno::set_errno(libc_errno::Errno(0));
     let r = unsafe { c::getpriority(c::PRIO_PROCESS, Pid::as_raw(pid) as _) };
-    if errno::errno().0 != 0 {
+    if libc_errno::errno().0 != 0 {
         ret_c_int(r)
     } else {
         Ok(r)
@@ -327,11 +327,11 @@ fn rlimit_from_libc(lim: libc_rlimit) -> Rlimit {
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 fn rlimit_to_libc(lim: Rlimit) -> io::Result<libc_rlimit> {
     let rlim_cur = match lim.current {
-        Some(r) => r.try_into().map_err(|_| io::Error::INVAL)?,
+        Some(r) => r.try_into().map_err(|_| io::Errno::INVAL)?,
         None => LIBC_RLIM_INFINITY as _,
     };
     let rlim_max = match lim.maximum {
-        Some(r) => r.try_into().map_err(|_| io::Error::INVAL)?,
+        Some(r) => r.try_into().map_err(|_| io::Errno::INVAL)?,
         None => LIBC_RLIM_INFINITY as _,
     };
     Ok(libc_rlimit { rlim_cur, rlim_max })

--- a/src/imp/libc/termios/syscalls.rs
+++ b/src/imp/libc/termios/syscalls.rs
@@ -16,7 +16,7 @@ use crate::io;
 use crate::process::{Pid, RawNonZeroPid};
 use crate::termios::{Action, OptionalActions, QueueSelector, Speed, Termios, Winsize};
 use core::mem::MaybeUninit;
-use errno::errno;
+use libc_errno::errno;
 
 pub(crate) fn tcgetattr(fd: BorrowedFd<'_>) -> io::Result<Termios> {
     let mut result = MaybeUninit::<Termios>::uninit();

--- a/src/imp/libc/time/syscalls.rs
+++ b/src/imp/libc/time/syscalls.rs
@@ -168,7 +168,7 @@ pub(crate) fn clock_gettime_dynamic(id: DynamicClockId<'_>) -> io::Result<Timesp
             #[cfg(not(any(target_os = "android", target_os = "linux")))]
             DynamicClockId::Dynamic(_fd) => {
                 // Dynamic clocks are not supported on this platform.
-                return Err(io::Error::INVAL);
+                return Err(io::Errno::INVAL);
             }
 
             #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -301,7 +301,7 @@ unsafe fn timerfd_settime_old(
                 .it_interval
                 .tv_sec
                 .try_into()
-                .map_err(|_| io::Error::OVERFLOW)?,
+                .map_err(|_| io::Errno::OVERFLOW)?,
             tv_nsec: new_value.it_interval.tv_nsec as _,
         },
         it_value: c::timespec {
@@ -309,7 +309,7 @@ unsafe fn timerfd_settime_old(
                 .it_value
                 .tv_sec
                 .try_into()
-                .map_err(|_| io::Error::OVERFLOW)?,
+                .map_err(|_| io::Errno::OVERFLOW)?,
             tv_nsec: new_value.it_value.tv_nsec as _,
         },
     };
@@ -328,7 +328,7 @@ unsafe fn timerfd_settime_old(
                 .it_interval
                 .tv_sec
                 .try_into()
-                .map_err(|_| io::Error::OVERFLOW)?,
+                .map_err(|_| io::Errno::OVERFLOW)?,
             tv_nsec: old_result.it_interval.tv_nsec as _,
         },
         it_value: Timespec {
@@ -336,7 +336,7 @@ unsafe fn timerfd_settime_old(
                 .it_interval
                 .tv_sec
                 .try_into()
-                .map_err(|_| io::Error::OVERFLOW)?,
+                .map_err(|_| io::Errno::OVERFLOW)?,
             tv_nsec: old_result.it_interval.tv_nsec as _,
         },
     })
@@ -389,7 +389,7 @@ unsafe fn timerfd_gettime_old(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
                 .it_interval
                 .tv_sec
                 .try_into()
-                .map_err(|_| io::Error::OVERFLOW)?,
+                .map_err(|_| io::Errno::OVERFLOW)?,
             tv_nsec: old_result.it_interval.tv_nsec as _,
         },
         it_value: Timespec {
@@ -397,7 +397,7 @@ unsafe fn timerfd_gettime_old(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
                 .it_interval
                 .tv_sec
                 .try_into()
-                .map_err(|_| io::Error::OVERFLOW)?,
+                .map_err(|_| io::Errno::OVERFLOW)?,
             tv_nsec: old_result.it_interval.tv_nsec as _,
         },
     })

--- a/src/imp/libc/weak.rs
+++ b/src/imp/libc/weak.rs
@@ -123,7 +123,7 @@ macro_rules! syscall {
             if let Some(fun) = $name.get() {
                 fun($($arg_name),*)
             } else {
-                errno::set_errno(errno::Errno(libc::ENOSYS));
+                libc_errno::set_errno(libc_errno::Errno(libc::ENOSYS));
                 -1
             }
         }
@@ -199,7 +199,7 @@ macro_rules! weakcall {
             if let Some(fun) = $name.get() {
                 fun($($arg_name),*)
             } else {
-                errno::set_errno(errno::Errno(libc::ENOSYS));
+                libc_errno::set_errno(libc_errno::Errno(libc::ENOSYS));
                 -1
             }
         }

--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -16,12 +16,12 @@
 use super::c;
 use super::fd::{AsRawFd, BorrowedFd, FromRawFd, RawFd};
 #[cfg(not(debug_assertions))]
-use super::io::error::decode_usize_infallible;
+use super::io::errno::decode_usize_infallible;
 #[cfg(feature = "runtime")]
-use super::io::error::try_decode_error;
+use super::io::errno::try_decode_error;
 #[cfg(target_pointer_width = "64")]
-use super::io::error::try_decode_u64;
-use super::io::error::{
+use super::io::errno::try_decode_u64;
+use super::io::errno::{
     try_decode_c_int, try_decode_c_uint, try_decode_raw_fd, try_decode_usize, try_decode_void,
     try_decode_void_star,
 };
@@ -442,7 +442,7 @@ pub(super) fn dev_t<'a, Num: ArgNumber>(dev: u64) -> ArgReg<'a, Num> {
 #[inline]
 pub(super) fn dev_t<'a, Num: ArgNumber>(dev: u64) -> io::Result<ArgReg<'a, Num>> {
     use core::convert::TryInto;
-    Ok(pass_usize(dev.try_into().map_err(|_err| io::Error::INVAL)?))
+    Ok(pass_usize(dev.try_into().map_err(|_err| io::Errno::INVAL)?))
 }
 
 #[cfg(target_pointer_width = "32")]
@@ -651,7 +651,7 @@ pub(super) unsafe fn ret(raw: RetReg<R0>) -> io::Result<()> {
 /// doesn't return on success.
 #[cfg(feature = "runtime")]
 #[inline]
-pub(super) unsafe fn ret_error(raw: RetReg<R0>) -> io::Error {
+pub(super) unsafe fn ret_error(raw: RetReg<R0>) -> io::Errno {
     try_decode_error(raw)
 }
 

--- a/src/imp/linux_raw/fs/syscalls.rs
+++ b/src/imp/linux_raw/fs/syscalls.rs
@@ -427,7 +427,7 @@ pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
         if !NO_STATX.load(Relaxed) {
             match statx(fd, zstr!(""), AtFlags::EMPTY_PATH, StatxFlags::ALL) {
                 Ok(x) => return statx_to_stat(x),
-                Err(io::Error::NOSYS) => NO_STATX.store(true, Relaxed),
+                Err(io::Errno::NOSYS) => NO_STATX.store(true, Relaxed),
                 Err(e) => return Err(e),
             }
         }
@@ -470,7 +470,7 @@ pub(crate) fn stat(filename: &ZStr) -> io::Result<Stat> {
                 StatxFlags::ALL,
             ) {
                 Ok(x) => return statx_to_stat(x),
-                Err(io::Error::NOSYS) => NO_STATX.store(true, Relaxed),
+                Err(io::Errno::NOSYS) => NO_STATX.store(true, Relaxed),
                 Err(e) => return Err(e),
             }
         }
@@ -527,7 +527,7 @@ pub(crate) fn statat(dirfd: BorrowedFd<'_>, filename: &ZStr, flags: AtFlags) -> 
         if !NO_STATX.load(Relaxed) {
             match statx(dirfd, filename, flags, StatxFlags::ALL) {
                 Ok(x) => return statx_to_stat(x),
-                Err(io::Error::NOSYS) => NO_STATX.store(true, Relaxed),
+                Err(io::Errno::NOSYS) => NO_STATX.store(true, Relaxed),
                 Err(e) => return Err(e),
             }
         }
@@ -589,7 +589,7 @@ pub(crate) fn lstat(filename: &ZStr) -> io::Result<Stat> {
                 StatxFlags::ALL,
             ) {
                 Ok(x) => return statx_to_stat(x),
-                Err(io::Error::NOSYS) => NO_STATX.store(true, Relaxed),
+                Err(io::Errno::NOSYS) => NO_STATX.store(true, Relaxed),
                 Err(e) => return Err(e),
             }
         }
@@ -649,26 +649,26 @@ fn statx_to_stat(x: crate::fs::Statx) -> io::Result<Stat> {
         st_uid: x.stx_uid.into(),
         st_gid: x.stx_gid.into(),
         st_rdev: crate::fs::makedev(x.stx_rdev_major, x.stx_rdev_minor),
-        st_size: x.stx_size.try_into().map_err(|_| io::Error::OVERFLOW)?,
+        st_size: x.stx_size.try_into().map_err(|_| io::Errno::OVERFLOW)?,
         st_blksize: x.stx_blksize.into(),
         st_blocks: x.stx_blocks.into(),
         st_atime: x
             .stx_atime
             .tv_sec
             .try_into()
-            .map_err(|_| io::Error::OVERFLOW)?,
+            .map_err(|_| io::Errno::OVERFLOW)?,
         st_atime_nsec: x.stx_atime.tv_nsec.into(),
         st_mtime: x
             .stx_mtime
             .tv_sec
             .try_into()
-            .map_err(|_| io::Error::OVERFLOW)?,
+            .map_err(|_| io::Errno::OVERFLOW)?,
         st_mtime_nsec: x.stx_mtime.tv_nsec.into(),
         st_ctime: x
             .stx_ctime
             .tv_sec
             .try_into()
-            .map_err(|_| io::Error::OVERFLOW)?,
+            .map_err(|_| io::Errno::OVERFLOW)?,
         st_ctime_nsec: x.stx_ctime.tv_nsec.into(),
         st_ino: x.stx_ino.into(),
     })
@@ -678,31 +678,31 @@ fn statx_to_stat(x: crate::fs::Statx) -> io::Result<Stat> {
 #[cfg(target_pointer_width = "32")]
 fn stat_to_stat(s64: linux_raw_sys::general::stat64) -> io::Result<Stat> {
     Ok(Stat {
-        st_dev: s64.st_dev.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_mode: s64.st_mode.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_nlink: s64.st_nlink.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_uid: s64.st_uid.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_gid: s64.st_gid.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_rdev: s64.st_rdev.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_size: s64.st_size.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_blksize: s64.st_blksize.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_blocks: s64.st_blocks.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_atime: s64.st_atime.try_into().map_err(|_| io::Error::OVERFLOW)?,
+        st_dev: s64.st_dev.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_mode: s64.st_mode.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_nlink: s64.st_nlink.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_uid: s64.st_uid.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_gid: s64.st_gid.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_rdev: s64.st_rdev.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_size: s64.st_size.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_blksize: s64.st_blksize.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_blocks: s64.st_blocks.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_atime: s64.st_atime.try_into().map_err(|_| io::Errno::OVERFLOW)?,
         st_atime_nsec: s64
             .st_atime_nsec
             .try_into()
-            .map_err(|_| io::Error::OVERFLOW)?,
-        st_mtime: s64.st_mtime.try_into().map_err(|_| io::Error::OVERFLOW)?,
+            .map_err(|_| io::Errno::OVERFLOW)?,
+        st_mtime: s64.st_mtime.try_into().map_err(|_| io::Errno::OVERFLOW)?,
         st_mtime_nsec: s64
             .st_mtime_nsec
             .try_into()
-            .map_err(|_| io::Error::OVERFLOW)?,
-        st_ctime: s64.st_ctime.try_into().map_err(|_| io::Error::OVERFLOW)?,
+            .map_err(|_| io::Errno::OVERFLOW)?,
+        st_ctime: s64.st_ctime.try_into().map_err(|_| io::Errno::OVERFLOW)?,
         st_ctime_nsec: s64
             .st_ctime_nsec
             .try_into()
-            .map_err(|_| io::Error::OVERFLOW)?,
-        st_ino: s64.st_ino.try_into().map_err(|_| io::Error::OVERFLOW)?,
+            .map_err(|_| io::Errno::OVERFLOW)?,
+        st_ino: s64.st_ino.try_into().map_err(|_| io::Errno::OVERFLOW)?,
     })
 }
 
@@ -710,31 +710,31 @@ fn stat_to_stat(s64: linux_raw_sys::general::stat64) -> io::Result<Stat> {
 #[cfg(target_arch = "mips64")]
 fn stat_to_stat(s: linux_raw_sys::general::stat) -> io::Result<Stat> {
     Ok(Stat {
-        st_dev: s.st_dev.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_mode: s.st_mode.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_nlink: s.st_nlink.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_uid: s.st_uid.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_gid: s.st_gid.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_rdev: s.st_rdev.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_size: s.st_size.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_blksize: s.st_blksize.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_blocks: s.st_blocks.try_into().map_err(|_| io::Error::OVERFLOW)?,
-        st_atime: s.st_atime.try_into().map_err(|_| io::Error::OVERFLOW)?,
+        st_dev: s.st_dev.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_mode: s.st_mode.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_nlink: s.st_nlink.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_uid: s.st_uid.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_gid: s.st_gid.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_rdev: s.st_rdev.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_size: s.st_size.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_blksize: s.st_blksize.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_blocks: s.st_blocks.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+        st_atime: s.st_atime.try_into().map_err(|_| io::Errno::OVERFLOW)?,
         st_atime_nsec: s
             .st_atime_nsec
             .try_into()
-            .map_err(|_| io::Error::OVERFLOW)?,
-        st_mtime: s.st_mtime.try_into().map_err(|_| io::Error::OVERFLOW)?,
+            .map_err(|_| io::Errno::OVERFLOW)?,
+        st_mtime: s.st_mtime.try_into().map_err(|_| io::Errno::OVERFLOW)?,
         st_mtime_nsec: s
             .st_mtime_nsec
             .try_into()
-            .map_err(|_| io::Error::OVERFLOW)?,
-        st_ctime: s.st_ctime.try_into().map_err(|_| io::Error::OVERFLOW)?,
+            .map_err(|_| io::Errno::OVERFLOW)?,
+        st_ctime: s.st_ctime.try_into().map_err(|_| io::Errno::OVERFLOW)?,
         st_ctime_nsec: s
             .st_ctime_nsec
             .try_into()
-            .map_err(|_| io::Error::OVERFLOW)?,
-        st_ino: s.st_ino.try_into().map_err(|_| io::Error::OVERFLOW)?,
+            .map_err(|_| io::Errno::OVERFLOW)?,
+        st_ino: s.st_ino.try_into().map_err(|_| io::Errno::OVERFLOW)?,
     })
 }
 
@@ -1238,7 +1238,7 @@ fn _utimensat(
             by_ref(times),
             flags
         )) {
-            Err(io::Error::NOSYS) => _utimensat_old(dirfd, pathname, times, flags),
+            Err(io::Errno::NOSYS) => _utimensat_old(dirfd, pathname, times, flags),
             otherwise => otherwise,
         }
     }
@@ -1269,24 +1269,24 @@ unsafe fn _utimensat_old(
                 .last_access
                 .tv_sec
                 .try_into()
-                .map_err(|_| io::Error::INVAL)?,
+                .map_err(|_| io::Errno::INVAL)?,
             tv_nsec: times
                 .last_access
                 .tv_nsec
                 .try_into()
-                .map_err(|_| io::Error::INVAL)?,
+                .map_err(|_| io::Errno::INVAL)?,
         },
         __kernel_old_timespec {
             tv_sec: times
                 .last_modification
                 .tv_sec
                 .try_into()
-                .map_err(|_| io::Error::INVAL)?,
+                .map_err(|_| io::Errno::INVAL)?,
             tv_nsec: times
                 .last_modification
                 .tv_nsec
                 .try_into()
-                .map_err(|_| io::Error::INVAL)?,
+                .map_err(|_| io::Errno::INVAL)?,
         },
     ];
     // The length of the array is fixed and not passed into the syscall.
@@ -1320,11 +1320,11 @@ pub(crate) fn accessat(
     }
 
     if flags.bits() != linux_raw_sys::general::AT_EACCESS {
-        return Err(io::Error::INVAL);
+        return Err(io::Errno::INVAL);
     }
 
     // TODO: Use faccessat2 in newer Linux versions.
-    Err(io::Error::NOSYS)
+    Err(io::Errno::NOSYS)
 }
 
 #[inline]

--- a/src/imp/linux_raw/io/errno.rs
+++ b/src/imp/linux_raw/io/errno.rs
@@ -1,4 +1,4 @@
-//! The `rustix` `Error` type.
+//! The `rustix` `Errno` type.
 //!
 //! This type holds an OS error code, which conceptually corresponds to an
 //! `errno` value.
@@ -27,10 +27,10 @@ use linux_raw_sys::errno;
 // error codes are in `-4095..0`.
 #[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_start(0xf001))]
 #[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_end(0xffff))]
-pub struct Error(u16);
+pub struct Errno(u16);
 
-impl Error {
-    /// Extract an `Error` value from a `std::io::Error`.
+impl Errno {
+    /// Extract an `Errno` value from a `std::io::Error`.
     ///
     /// This isn't a `From` conversion because it's expected to be relatively
     /// uncommon.
@@ -54,13 +54,13 @@ impl Error {
         (self.0 as i16 as i32).wrapping_neg()
     }
 
-    /// Construct an `Error` from a raw OS error number.
+    /// Construct an `Errno` from a raw OS error number.
     #[inline]
     pub const fn from_raw_os_error(raw: i32) -> Self {
         Self::from_errno(raw as u32)
     }
 
-    /// Convert from a C errno value (which is positive) to an `Error`.
+    /// Convert from a C errno value (which is positive) to an `Errno`.
     const fn from_errno(raw: u32) -> Self {
         // We store error values in negated form, so that we don't have to negate
         // them after every syscall.
@@ -82,7 +82,7 @@ pub(in crate::imp) fn try_decode_c_int<Num: RetNumber>(raw: RetReg<Num>) -> io::
     if raw.is_in_range(-4095..0) {
         // Safety: `raw` must be in `-4095..0`, and we just checked that raw is
         // in that range.
-        return Err(unsafe { Error(raw.decode_error_code()) });
+        return Err(unsafe { Errno(raw.decode_error_code()) });
     }
 
     Ok(raw.decode_c_int())
@@ -95,7 +95,7 @@ pub(in crate::imp) fn try_decode_c_uint<Num: RetNumber>(raw: RetReg<Num>) -> io:
     if raw.is_in_range(-4095..0) {
         // Safety: `raw` must be in `-4095..0`, and we just checked that raw is
         // in that range.
-        return Err(unsafe { Error(raw.decode_error_code()) });
+        return Err(unsafe { Errno(raw.decode_error_code()) });
     }
 
     Ok(raw.decode_c_uint())
@@ -108,7 +108,7 @@ pub(in crate::imp) fn try_decode_usize<Num: RetNumber>(raw: RetReg<Num>) -> io::
     if raw.is_in_range(-4095..0) {
         // Safety: `raw` must be in `-4095..0`, and we just checked that raw is
         // in that range.
-        return Err(unsafe { Error(raw.decode_error_code()) });
+        return Err(unsafe { Errno(raw.decode_error_code()) });
     }
 
     Ok(raw.decode_usize())
@@ -123,7 +123,7 @@ pub(in crate::imp) fn try_decode_void_star<Num: RetNumber>(
     if raw.is_in_range(-4095..0) {
         // Safety: `raw` must be in `-4095..0`, and we just checked that raw is
         // in that range.
-        return Err(unsafe { Error(raw.decode_error_code()) });
+        return Err(unsafe { Errno(raw.decode_error_code()) });
     }
 
     Ok(raw.decode_void_star())
@@ -137,7 +137,7 @@ pub(in crate::imp) fn try_decode_u64<Num: RetNumber>(raw: RetReg<Num>) -> io::Re
     if raw.is_in_range(-4095..0) {
         // Safety: `raw` must be in `-4095..0`, and we just checked that raw is
         // in that range.
-        return Err(unsafe { Error(raw.decode_error_code()) });
+        return Err(unsafe { Errno(raw.decode_error_code()) });
     }
 
     Ok(raw.decode_u64())
@@ -167,7 +167,7 @@ pub(in crate::imp) unsafe fn try_decode_raw_fd<Num: RetNumber>(
             core::intrinsics::assume(raw.is_in_range(-4095..0));
         }
 
-        return Err(Error(raw.decode_error_code()));
+        return Err(Errno(raw.decode_error_code()));
     }
 
     Ok(raw.decode_raw_fd())
@@ -194,7 +194,7 @@ pub(in crate::imp) unsafe fn try_decode_void<Num: RetNumber>(raw: RetReg<Num>) -
             core::intrinsics::assume(raw.is_in_range(-4095..0));
         }
 
-        return Err(Error(raw.decode_error_code()));
+        return Err(Errno(raw.decode_error_code()));
     }
 
     raw.decode_void();
@@ -210,7 +210,7 @@ pub(in crate::imp) unsafe fn try_decode_void<Num: RetNumber>(raw: RetReg<Num>) -
 /// This must only be used with syscalls which do not return on success.
 #[cfg(feature = "runtime")]
 #[inline]
-pub(in crate::imp) unsafe fn try_decode_error<Num: RetNumber>(raw: RetReg<Num>) -> io::Error {
+pub(in crate::imp) unsafe fn try_decode_error<Num: RetNumber>(raw: RetReg<Num>) -> io::Errno {
     debug_assert!(raw.is_in_range(-4095..0));
 
     // Tell the optimizer that we know the value is in the error range.
@@ -220,7 +220,7 @@ pub(in crate::imp) unsafe fn try_decode_error<Num: RetNumber>(raw: RetReg<Num>) 
         core::intrinsics::assume(raw.is_in_range(-4095..0));
     }
 
-    Error(raw.decode_error_code())
+    Errno(raw.decode_error_code())
 }
 
 /// Return the contained `usize` value.
@@ -230,7 +230,7 @@ pub(in crate::imp) fn decode_usize_infallible<Num: RetNumber>(raw: RetReg<Num>) 
     raw.decode_usize()
 }
 
-impl Error {
+impl Errno {
     /// `EACCES`
     #[doc(alias = "ACCES")]
     pub const ACCESS: Self = Self::from_errno(errno::EACCES);

--- a/src/imp/linux_raw/io/mod.rs
+++ b/src/imp/linux_raw/io/mod.rs
@@ -1,5 +1,5 @@
 pub mod epoll;
-pub(crate) mod error;
+pub(crate) mod errno;
 #[cfg(not(feature = "std"))]
 pub(crate) mod io_slice;
 pub(crate) mod poll_fd;

--- a/src/imp/linux_raw/io/syscalls.rs
+++ b/src/imp/linux_raw/io/syscalls.rs
@@ -361,8 +361,8 @@ pub(crate) fn is_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
             Err(err) => {
                 #[allow(unreachable_patterns)] // `EAGAIN` may equal `EWOULDBLOCK`
                 match err {
-                    io::Error::AGAIN | io::Error::WOULDBLOCK => (),
-                    io::Error::NOTSOCK => not_socket = true,
+                    io::Errno::AGAIN | io::Errno::WOULDBLOCK => (),
+                    io::Errno::NOTSOCK => not_socket = true,
                     _ => return Err(err),
                 }
             }
@@ -375,10 +375,10 @@ pub(crate) fn is_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
         #[allow(unreachable_patterns)] // `EAGAIN` equals `EWOULDBLOCK`
         match super::super::net::syscalls::send(fd, &[], SendFlags::DONTWAIT) {
             // TODO or-patterns when we don't need 1.51
-            Err(io::Error::AGAIN) => (),
-            Err(io::Error::WOULDBLOCK) => (),
-            Err(io::Error::NOTSOCK) => (),
-            Err(io::Error::PIPE) => write = false,
+            Err(io::Errno::AGAIN) => (),
+            Err(io::Errno::WOULDBLOCK) => (),
+            Err(io::Errno::NOTSOCK) => (),
+            Err(io::Errno::PIPE) => write = false,
             Err(err) => return Err(err),
             Ok(_) => (),
         }

--- a/src/imp/linux_raw/mm/syscalls.rs
+++ b/src/imp/linux_raw/mm/syscalls.rs
@@ -60,7 +60,7 @@ pub(crate) unsafe fn mmap(
             (offset / 4096)
                 .try_into()
                 .map(|scaled_offset| pass_usize(scaled_offset))
-                .map_err(|_| io::Error::INVAL)?
+                .map_err(|_| io::Errno::INVAL)?
         ))
     }
     #[cfg(target_pointer_width = "64")]

--- a/src/imp/linux_raw/net/addr.rs
+++ b/src/imp/linux_raw/net/addr.rs
@@ -31,7 +31,7 @@ impl SocketAddrUnix {
         let mut unix = Self::init();
         let bytes = path.to_bytes_with_nul();
         if bytes.len() > unix.sun_path.len() {
-            return Err(io::Error::NAMETOOLONG);
+            return Err(io::Errno::NAMETOOLONG);
         }
         for (i, b) in bytes.iter().enumerate() {
             unix.sun_path[i] = *b as c::c_char;
@@ -47,7 +47,7 @@ impl SocketAddrUnix {
     pub fn new_abstract_name(name: &[u8]) -> io::Result<Self> {
         let mut unix = Self::init();
         if 1 + name.len() > unix.sun_path.len() {
-            return Err(io::Error::NAMETOOLONG);
+            return Err(io::Errno::NAMETOOLONG);
         }
         unix.sun_path[0] = b'\0' as c::c_char;
         for (i, b) in name.iter().enumerate() {

--- a/src/imp/linux_raw/net/read_sockaddr.rs
+++ b/src/imp/linux_raw/net/read_sockaddr.rs
@@ -57,12 +57,12 @@ pub(crate) unsafe fn read_sockaddr(
     let offsetof_sun_path = super::addr::offsetof_sun_path();
 
     if len < size_of::<c::sa_family_t>() {
-        return Err(io::Error::INVAL);
+        return Err(io::Errno::INVAL);
     }
     match read_ss_family(storage).into() {
         c::AF_INET => {
             if len < size_of::<c::sockaddr_in>() {
-                return Err(io::Error::INVAL);
+                return Err(io::Errno::INVAL);
             }
             let decode = *storage.cast::<c::sockaddr_in>();
             Ok(SocketAddrAny::V4(SocketAddrV4::new(
@@ -72,7 +72,7 @@ pub(crate) unsafe fn read_sockaddr(
         }
         c::AF_INET6 => {
             if len < size_of::<c::sockaddr_in6>() {
-                return Err(io::Error::INVAL);
+                return Err(io::Errno::INVAL);
             }
             let decode = *storage.cast::<c::sockaddr_in6>();
             Ok(SocketAddrAny::V6(SocketAddrV6::new(
@@ -84,7 +84,7 @@ pub(crate) unsafe fn read_sockaddr(
         }
         c::AF_UNIX => {
             if len < offsetof_sun_path {
-                return Err(io::Error::INVAL);
+                return Err(io::Errno::INVAL);
             }
             if len == offsetof_sun_path {
                 Ok(SocketAddrAny::Unix(SocketAddrUnix::new(&[][..])?))
@@ -102,7 +102,7 @@ pub(crate) unsafe fn read_sockaddr(
                 )?))
             }
         }
-        _ => Err(io::Error::NOTSUP),
+        _ => Err(io::Errno::NOTSUP),
     }
 }
 

--- a/src/imp/linux_raw/net/syscalls.rs
+++ b/src/imp/linux_raw/net/syscalls.rs
@@ -899,9 +899,9 @@ pub(crate) mod sockopt {
         let l_linger = if let Some(linger) = linger {
             let mut l_linger = linger.as_secs();
             if linger.subsec_nanos() != 0 {
-                l_linger = l_linger.checked_add(1).ok_or(io::Error::INVAL)?;
+                l_linger = l_linger.checked_add(1).ok_or(io::Errno::INVAL)?;
             }
-            l_linger.try_into().map_err(|_| io::Error::INVAL)?
+            l_linger.try_into().map_err(|_| io::Errno::INVAL)?
         } else {
             0
         };
@@ -945,7 +945,7 @@ pub(crate) mod sockopt {
             Timeout::Send => SO_SNDTIMEO_NEW,
         };
         match setsockopt(fd, SOL_SOCKET, optname, time) {
-            Err(io::Error::NOPROTOOPT) if SO_RCVTIMEO_NEW != SO_RCVTIMEO_OLD => {
+            Err(io::Errno::NOPROTOOPT) if SO_RCVTIMEO_NEW != SO_RCVTIMEO_OLD => {
                 set_socket_timeout_old(fd, id, timeout)
             }
             otherwise => otherwise,
@@ -977,7 +977,7 @@ pub(crate) mod sockopt {
             Timeout::Send => SO_SNDTIMEO_NEW,
         };
         let time: __kernel_timespec = match getsockopt(fd, SOL_SOCKET, optname) {
-            Err(io::Error::NOPROTOOPT) if SO_RCVTIMEO_NEW != SO_RCVTIMEO_OLD => {
+            Err(io::Errno::NOPROTOOPT) if SO_RCVTIMEO_NEW != SO_RCVTIMEO_OLD => {
                 return get_socket_timeout_old(fd, id)
             }
             otherwise => otherwise?,
@@ -1026,7 +1026,7 @@ pub(crate) mod sockopt {
         Ok(match timeout {
             Some(timeout) => {
                 if timeout == DURATION_ZERO {
-                    return Err(io::Error::INVAL);
+                    return Err(io::Errno::INVAL);
                 }
                 let mut timeout = __kernel_timespec {
                     tv_sec: timeout.as_secs().try_into().unwrap_or(i64::MAX),
@@ -1049,7 +1049,7 @@ pub(crate) mod sockopt {
         Ok(match timeout {
             Some(timeout) => {
                 if timeout == DURATION_ZERO {
-                    return Err(io::Error::INVAL);
+                    return Err(io::Errno::INVAL);
                 }
 
                 // `subsec_micros` rounds down, so we use `subsec_nanos` and

--- a/src/imp/linux_raw/process/syscalls.rs
+++ b/src/imp/linux_raw/process/syscalls.rs
@@ -305,7 +305,7 @@ pub(crate) fn getrlimit(limit: Resource) -> Rlimit {
         )) {
             Ok(()) => rlimit_from_linux(result.assume_init()),
             Err(e) => {
-                debug_assert_eq!(e, io::Error::NOSYS);
+                debug_assert_eq!(e, io::Errno::NOSYS);
                 getrlimit_old(limit)
             }
         }
@@ -354,7 +354,7 @@ pub(crate) fn setrlimit(limit: Resource, new: Rlimit) -> io::Result<()> {
             null_mut::<c::c_void>()
         )) {
             Ok(()) => Ok(()),
-            Err(io::Error::NOSYS) => setrlimit_old(limit, new),
+            Err(io::Errno::NOSYS) => setrlimit_old(limit, new),
             Err(e) => Err(e),
         }
     }
@@ -433,11 +433,11 @@ fn rlimit_from_linux_old(lim: linux_raw_sys::general::rlimit) -> Rlimit {
 /// Like `rlimit_to_linux` but uses Linux's old 32-bit `rlimit`.
 fn rlimit_to_linux_old(lim: Rlimit) -> io::Result<linux_raw_sys::general::rlimit> {
     let rlim_cur = match lim.current {
-        Some(r) => r.try_into().map_err(|_| io::Error::INVAL)?,
+        Some(r) => r.try_into().map_err(|_| io::Errno::INVAL)?,
         None => linux_raw_sys::general::RLIM_INFINITY as _,
     };
     let rlim_max = match lim.maximum {
-        Some(r) => r.try_into().map_err(|_| io::Error::INVAL)?,
+        Some(r) => r.try_into().map_err(|_| io::Errno::INVAL)?,
         None => linux_raw_sys::general::RLIM_INFINITY as _,
     };
     Ok(linux_raw_sys::general::rlimit { rlim_cur, rlim_max })

--- a/src/imp/linux_raw/runtime/syscalls.rs
+++ b/src/imp/linux_raw/runtime/syscalls.rs
@@ -37,7 +37,7 @@ pub(crate) unsafe fn execveat(
     args: *const *const u8,
     env_vars: *const *const u8,
     flags: AtFlags,
-) -> io::Error {
+) -> io::Errno {
     ret_error(syscall_readonly!(
         __NR_execveat,
         dirfd,
@@ -52,7 +52,7 @@ pub(crate) unsafe fn execve(
     path: &ZStr,
     args: *const *const u8,
     env_vars: *const *const u8,
-) -> io::Error {
+) -> io::Errno {
     ret_error(syscall_readonly!(__NR_execve, path, args, env_vars))
 }
 

--- a/src/imp/linux_raw/termios/syscalls.rs
+++ b/src/imp/linux_raw/termios/syscalls.rs
@@ -170,7 +170,7 @@ pub(crate) fn cfmakeraw(termios: &mut Termios) {
 #[inline]
 pub(crate) fn cfsetospeed(termios: &mut Termios, speed: u32) -> io::Result<()> {
     if (speed & !CBAUD) != 0 {
-        return Err(io::Error::INVAL);
+        return Err(io::Errno::INVAL);
     }
     termios.c_cflag &= !CBAUD;
     termios.c_cflag |= speed;
@@ -183,7 +183,7 @@ pub(crate) fn cfsetispeed(termios: &mut Termios, speed: u32) -> io::Result<()> {
         return Ok(());
     }
     if (speed & !CBAUD) != 0 {
-        return Err(io::Error::INVAL);
+        return Err(io::Errno::INVAL);
     }
     termios.c_cflag &= !CBAUD;
     termios.c_cflag |= speed;
@@ -193,7 +193,7 @@ pub(crate) fn cfsetispeed(termios: &mut Termios, speed: u32) -> io::Result<()> {
 #[inline]
 pub(crate) fn cfsetspeed(termios: &mut Termios, speed: u32) -> io::Result<()> {
     if (speed & !CBAUD) != 0 {
-        return Err(io::Error::INVAL);
+        return Err(io::Errno::INVAL);
     }
     termios.c_cflag &= !CBAUD;
     termios.c_cflag |= speed;
@@ -215,7 +215,7 @@ pub(crate) fn ttyname(fd: BorrowedFd<'_>, buf: &mut [u8]) -> io::Result<usize> {
 
     // Quick check: if `fd` isn't a character device, it's not a tty.
     if FileType::from_raw_mode(fd_stat.st_mode) != FileType::CharacterDevice {
-        return Err(crate::io::Error::NOTTY);
+        return Err(crate::io::Errno::NOTTY);
     }
 
     // Check that `fd` is really a tty.
@@ -232,7 +232,7 @@ pub(crate) fn ttyname(fd: BorrowedFd<'_>, buf: &mut [u8]) -> io::Result<usize> {
     // have occurred. This check also ensures that we have enough space for
     // adding a NUL terminator.
     if r == buf.len() {
-        return Err(io::Error::RANGE);
+        return Err(io::Errno::RANGE);
     }
     buf[r] = b'\0';
 
@@ -241,7 +241,7 @@ pub(crate) fn ttyname(fd: BorrowedFd<'_>, buf: &mut [u8]) -> io::Result<usize> {
 
     let path_stat = super::super::fs::syscalls::stat(path)?;
     if path_stat.st_dev != fd_stat.st_dev || path_stat.st_ino != fd_stat.st_ino {
-        return Err(crate::io::Error::NODEV);
+        return Err(crate::io::Errno::NODEV);
     }
 
     Ok(r)

--- a/src/imp/linux_raw/thread/syscalls.rs
+++ b/src/imp/linux_raw/thread/syscalls.rs
@@ -35,14 +35,14 @@ pub(crate) fn clock_nanosleep_relative(
         .or_else(|err| {
             // See the comments in `rustix_clock_gettime_via_syscall` about
             // emulation.
-            if err == io::Error::NOSYS {
+            if err == io::Errno::NOSYS {
                 clock_nanosleep_relative_old(id, req, &mut rem)
             } else {
                 Err(err)
             }
         }) {
             Ok(()) => NanosleepRelativeResult::Ok,
-            Err(io::Error::INTR) => NanosleepRelativeResult::Interrupted(rem.assume_init()),
+            Err(io::Errno::INTR) => NanosleepRelativeResult::Interrupted(rem.assume_init()),
             Err(err) => NanosleepRelativeResult::Err(err),
         }
     }
@@ -57,7 +57,7 @@ pub(crate) fn clock_nanosleep_relative(
             &mut rem
         )) {
             Ok(()) => NanosleepRelativeResult::Ok,
-            Err(io::Error::INTR) => NanosleepRelativeResult::Interrupted(rem.assume_init()),
+            Err(io::Errno::INTR) => NanosleepRelativeResult::Interrupted(rem.assume_init()),
             Err(err) => NanosleepRelativeResult::Err(err),
         }
     }
@@ -70,8 +70,8 @@ unsafe fn clock_nanosleep_relative_old(
     rem: &mut MaybeUninit<__kernel_timespec>,
 ) -> io::Result<()> {
     let old_req = __kernel_old_timespec {
-        tv_sec: req.tv_sec.try_into().map_err(|_| io::Error::INVAL)?,
-        tv_nsec: req.tv_nsec.try_into().map_err(|_| io::Error::INVAL)?,
+        tv_sec: req.tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
+        tv_nsec: req.tv_nsec.try_into().map_err(|_| io::Errno::INVAL)?,
     };
     let mut old_rem = MaybeUninit::<__kernel_old_timespec>::uninit();
     ret(syscall!(
@@ -107,7 +107,7 @@ pub(crate) fn clock_nanosleep_absolute(id: ClockId, req: &__kernel_timespec) -> 
         .or_else(|err| {
             // See the comments in `rustix_clock_gettime_via_syscall` about
             // emulation.
-            if err == io::Error::NOSYS {
+            if err == io::Errno::NOSYS {
                 clock_nanosleep_absolute_old(id, req)
             } else {
                 Err(err)
@@ -129,8 +129,8 @@ pub(crate) fn clock_nanosleep_absolute(id: ClockId, req: &__kernel_timespec) -> 
 #[cfg(target_pointer_width = "32")]
 unsafe fn clock_nanosleep_absolute_old(id: ClockId, req: &__kernel_timespec) -> io::Result<()> {
     let old_req = __kernel_old_timespec {
-        tv_sec: req.tv_sec.try_into().map_err(|_| io::Error::INVAL)?,
-        tv_nsec: req.tv_nsec.try_into().map_err(|_| io::Error::INVAL)?,
+        tv_sec: req.tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
+        tv_nsec: req.tv_nsec.try_into().map_err(|_| io::Errno::INVAL)?,
     };
     ret(syscall_readonly!(
         __NR_clock_nanosleep,
@@ -156,14 +156,14 @@ pub(crate) fn nanosleep(req: &__kernel_timespec) -> NanosleepRelativeResult {
         .or_else(|err| {
             // See the comments in `rustix_clock_gettime_via_syscall` about
             // emulation.
-            if err == io::Error::NOSYS {
+            if err == io::Errno::NOSYS {
                 nanosleep_old(req, &mut rem)
             } else {
                 Err(err)
             }
         }) {
             Ok(()) => NanosleepRelativeResult::Ok,
-            Err(io::Error::INTR) => NanosleepRelativeResult::Interrupted(rem.assume_init()),
+            Err(io::Errno::INTR) => NanosleepRelativeResult::Interrupted(rem.assume_init()),
             Err(err) => NanosleepRelativeResult::Err(err),
         }
     }
@@ -172,7 +172,7 @@ pub(crate) fn nanosleep(req: &__kernel_timespec) -> NanosleepRelativeResult {
         let mut rem = MaybeUninit::<__kernel_timespec>::uninit();
         match ret(syscall!(__NR_nanosleep, by_ref(req), &mut rem)) {
             Ok(()) => NanosleepRelativeResult::Ok,
-            Err(io::Error::INTR) => NanosleepRelativeResult::Interrupted(rem.assume_init()),
+            Err(io::Errno::INTR) => NanosleepRelativeResult::Interrupted(rem.assume_init()),
             Err(err) => NanosleepRelativeResult::Err(err),
         }
     }
@@ -184,8 +184,8 @@ unsafe fn nanosleep_old(
     rem: &mut MaybeUninit<__kernel_timespec>,
 ) -> io::Result<()> {
     let old_req = __kernel_old_timespec {
-        tv_sec: req.tv_sec.try_into().map_err(|_| io::Error::INVAL)?,
-        tv_nsec: req.tv_nsec.try_into().map_err(|_| io::Error::INVAL)?,
+        tv_sec: req.tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
+        tv_nsec: req.tv_nsec.try_into().map_err(|_| io::Errno::INVAL)?,
     };
     let mut old_rem = MaybeUninit::<__kernel_old_timespec>::uninit();
     ret(syscall!(__NR_nanosleep, by_ref(&old_req), &mut old_rem))?;
@@ -235,7 +235,7 @@ pub(crate) unsafe fn futex(
         .or_else(|err| {
             // See the comments in `rustix_clock_gettime_via_syscall` about
             // emulation.
-            if err == io::Error::NOSYS {
+            if err == io::Errno::NOSYS {
                 futex_old(uaddr, op, flags, val, utime, uaddr2, val3)
             } else {
                 Err(err)
@@ -265,8 +265,8 @@ unsafe fn futex_old(
     val3: u32,
 ) -> io::Result<usize> {
     let old_utime = __kernel_old_timespec {
-        tv_sec: (*utime).tv_sec.try_into().map_err(|_| io::Error::INVAL)?,
-        tv_nsec: (*utime).tv_nsec.try_into().map_err(|_| io::Error::INVAL)?,
+        tv_sec: (*utime).tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
+        tv_nsec: (*utime).tv_nsec.try_into().map_err(|_| io::Errno::INVAL)?,
     };
     ret_usize(syscall!(
         __NR_futex,

--- a/src/imp/linux_raw/time/syscalls.rs
+++ b/src/imp/linux_raw/time/syscalls.rs
@@ -37,7 +37,7 @@ pub(crate) fn clock_getres(which_clock: ClockId) -> __kernel_timespec {
         if let Err(err) = ret(syscall!(__NR_clock_getres_time64, which_clock, &mut result)) {
             // See the comments in `rustix_clock_gettime_via_syscall` about
             // emulation.
-            debug_assert_eq!(err, io::Error::NOSYS);
+            debug_assert_eq!(err, io::Errno::NOSYS);
             clock_getres_old(which_clock, &mut result);
         }
         result.assume_init()
@@ -104,7 +104,7 @@ pub(crate) fn timerfd_settime(
         .or_else(|err| {
             // See the comments in `rustix_clock_gettime_via_syscall` about
             // emulation.
-            if err == io::Error::NOSYS {
+            if err == io::Errno::NOSYS {
                 timerfd_settime_old(fd, flags, new_value, &mut result)
             } else {
                 Err(err)
@@ -129,24 +129,24 @@ unsafe fn timerfd_settime_old(
                 .it_interval
                 .tv_sec
                 .try_into()
-                .map_err(|_| io::Error::INVAL)?,
+                .map_err(|_| io::Errno::INVAL)?,
             tv_nsec: new_value
                 .it_interval
                 .tv_nsec
                 .try_into()
-                .map_err(|_| io::Error::INVAL)?,
+                .map_err(|_| io::Errno::INVAL)?,
         },
         it_value: __kernel_old_timespec {
             tv_sec: new_value
                 .it_value
                 .tv_sec
                 .try_into()
-                .map_err(|_| io::Error::INVAL)?,
+                .map_err(|_| io::Errno::INVAL)?,
             tv_nsec: new_value
                 .it_value
                 .tv_nsec
                 .try_into()
-                .map_err(|_| io::Error::INVAL)?,
+                .map_err(|_| io::Errno::INVAL)?,
         },
     };
     ret(syscall!(
@@ -190,7 +190,7 @@ pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
             .or_else(|err| {
                 // See the comments in `rustix_clock_gettime_via_syscall` about
                 // emulation.
-                if err == io::Error::NOSYS {
+                if err == io::Errno::NOSYS {
                     timerfd_gettime_old(fd, &mut result)
                 } else {
                     Err(err)

--- a/src/imp/linux_raw/vdso.rs
+++ b/src/imp/linux_raw/vdso.rs
@@ -271,7 +271,7 @@ unsafe fn check_vdso_base<'vdso>(base: *const Elf_Ehdr) -> Option<&'vdso Elf_Ehd
     {
         use super::conv::ret;
         use super::time::types::ClockId;
-        if ret(syscall!(__NR_clock_getres, ClockId::Monotonic, base)) != Err(io::Error::FAULT) {
+        if ret(syscall!(__NR_clock_getres, ClockId::Monotonic, base)) != Err(io::Errno::FAULT) {
             // We can't gracefully fail here because we would seem to have just
             // mutated some unknown memory.
             #[cfg(feature = "std")]

--- a/src/imp/linux_raw/vdso_wrappers.rs
+++ b/src/imp/linux_raw/vdso_wrappers.rs
@@ -76,7 +76,7 @@ pub(crate) fn clock_gettime_dynamic(which_clock: DynamicClockId<'_>) -> io::Resu
         };
         match callee(id, timespec.as_mut_ptr()) {
             0 => (),
-            EINVAL => return Err(io::Error::INVAL),
+            EINVAL => return Err(io::Errno::INVAL),
             _ => _rustix_clock_gettime_via_syscall(id, timespec.as_mut_ptr())?,
         }
         Ok(timespec.assume_init())
@@ -260,7 +260,7 @@ unsafe fn _rustix_clock_gettime_via_syscall(
 ) -> io::Result<()> {
     let r0 = syscall!(__NR_clock_gettime64, c_int(clockid), res);
     match ret(r0) {
-        Err(io::Error::NOSYS) => _rustix_clock_gettime_via_syscall_old(clockid, res),
+        Err(io::Errno::NOSYS) => _rustix_clock_gettime_via_syscall_old(clockid, res),
         otherwise => otherwise,
     }
 }

--- a/src/io/errno.rs
+++ b/src/io/errno.rs
@@ -1,4 +1,4 @@
-//! The `Error` type, which is a minimal wrapper around an error code.
+//! The `Errno` type, which is a minimal wrapper around an error code.
 //!
 //! We define the error constants as individual `const`s instead of an
 //! enum because we may not know about all of the host's error values
@@ -10,7 +10,7 @@ use core::{fmt, result};
 use std::error;
 
 /// A specialized `Result` type for `rustix` APIs.
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T> = result::Result<T, Errno>;
 
 /// `errno`—An error code.
 ///
@@ -23,9 +23,9 @@ pub type Result<T> = result::Result<T, Error>;
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/errno.html
 /// [Linux]: https://man7.org/linux/man-pages/man3/errno.3.html
-pub use imp::io::error::Error;
+pub use imp::io::errno::Errno;
 
-impl Error {
+impl Errno {
     /// Shorthand for `std::io::Error::from(self).kind()`.
     #[cfg(feature = "std")]
     #[inline]
@@ -34,7 +34,7 @@ impl Error {
     }
 }
 
-impl fmt::Display for Error {
+impl fmt::Display for Errno {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         #[cfg(feature = "std")]
         {
@@ -47,7 +47,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl fmt::Debug for Error {
+impl fmt::Debug for Errno {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         #[cfg(feature = "std")]
         {
@@ -61,22 +61,22 @@ impl fmt::Debug for Error {
 }
 
 #[cfg(feature = "std")]
-impl error::Error for Error {}
+impl error::Error for Errno {}
 
 #[cfg(feature = "std")]
-impl From<Error> for std::io::Error {
+impl From<Errno> for std::io::Error {
     #[inline]
-    fn from(err: Error) -> Self {
+    fn from(err: Errno) -> Self {
         Self::from_raw_os_error(err.raw_os_error() as _)
     }
 }
 
-/// Call `f` until it either succeeds or fails other than [`Error::INTR`].
+/// Call `f` until it either succeeds or fails other than [`Errno::INTR`].
 #[inline]
 pub fn with_retrying<T, F: FnMut() -> Result<T>>(mut f: F) -> Result<T> {
     loop {
         match f() {
-            Err(Error::INTR) => (),
+            Err(Errno::INTR) => (),
             result => return result,
         }
     }

--- a/src/io/fd/owned.rs
+++ b/src/io/fd/owned.rs
@@ -174,7 +174,7 @@ pub trait AsFd {
     /// let mut f = File::open("foo.txt")?;
     /// # #[cfg(any(unix, target_os = "wasi"))]
     /// let borrowed_fd: BorrowedFd<'_> = f.as_fd();
-    /// # Ok::<(), io::Error>(())
+    /// # Ok::<(), io::Errno>(())
     /// ```
     #[cfg_attr(staged_api, unstable(feature = "io_safety", issue = "87074"))]
     fn as_fd(&self) -> BorrowedFd<'_>;

--- a/src/io/fd/raw.rs
+++ b/src/io/fd/raw.rs
@@ -40,7 +40,7 @@ pub trait AsRawFd {
     /// // `raw_fd` is only valid as long as `f` exists.
     /// #[cfg(any(unix, target_os = "wasi"))]
     /// let raw_fd: RawFd = f.as_raw_fd();
-    /// # Ok::<(), io::Error>(())
+    /// # Ok::<(), io::Errno>(())
     /// ```
     #[cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))]
     fn as_raw_fd(&self) -> RawFd;
@@ -80,7 +80,7 @@ pub trait FromRawFd {
     /// // is only one owner for the file descriptor.
     /// # #[cfg(any(unix, target_os = "wasi"))]
     /// let f = unsafe { File::from_raw_fd(raw_fd) };
-    /// # Ok::<(), io::Error>(())
+    /// # Ok::<(), io::Errno>(())
     /// ```
     #[cfg_attr(staged_api, stable(feature = "from_raw_os", since = "1.1.0"))]
     unsafe fn from_raw_fd(fd: RawFd) -> Self;
@@ -109,7 +109,7 @@ pub trait IntoRawFd {
     /// let f = File::open("foo.txt")?;
     /// #[cfg(any(unix, target_os = "wasi"))]
     /// let raw_fd: RawFd = f.into_raw_fd();
-    /// # Ok::<(), io::Error>(())
+    /// # Ok::<(), io::Errno>(())
     /// ```
     #[cfg_attr(staged_api, stable(feature = "into_raw_os", since = "1.4.0"))]
     fn into_raw_fd(self) -> RawFd;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -3,7 +3,7 @@
 mod close;
 #[cfg(not(windows))]
 mod dup;
-mod error;
+mod errno;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod eventfd;
 #[cfg(not(feature = "std"))]
@@ -30,7 +30,7 @@ pub use crate::imp::io::epoll;
 pub use close::close;
 #[cfg(not(any(windows, target_os = "wasi")))]
 pub use dup::{dup, dup2, dup3, DupFlags};
-pub use error::{with_retrying, Error, Result};
+pub use errno::{with_retrying, Errno, Result};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use eventfd::{eventfd, EventfdFlags};
 #[cfg(any(target_os = "ios", target_os = "macos"))]

--- a/src/net/wsa.rs
+++ b/src/net/wsa.rs
@@ -24,7 +24,7 @@ pub fn wsa_startup() -> io::Result<WSAData> {
         if ret == 0 {
             Ok(data.assume_init())
         } else {
-            Err(io::Error::from_raw_os_error(WSAGetLastError()))
+            Err(io::Errno::from_raw_os_error(WSAGetLastError()))
         }
     }
 }
@@ -43,7 +43,7 @@ pub fn wsa_cleanup() -> io::Result<()> {
         if WSACleanup() == 0 {
             Ok(())
         } else {
-            Err(io::Error::from_raw_os_error(WSAGetLastError()))
+            Err(io::Errno::from_raw_os_error(WSAGetLastError()))
         }
     }
 }

--- a/src/path/arg.rs
+++ b/src/path/arg.rs
@@ -125,7 +125,7 @@ impl Arg for &str {
     #[inline]
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
-            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -135,7 +135,7 @@ impl Arg for &str {
         Self: 'b,
     {
         Ok(Cow::Owned(
-            ZString::new(self).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -163,7 +163,7 @@ impl Arg for &String {
     #[inline]
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
-            ZString::new(String::as_str(self).as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(String::as_str(self).as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -199,7 +199,7 @@ impl Arg for String {
     #[inline]
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
-            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -209,7 +209,7 @@ impl Arg for String {
         Self: 'b,
     {
         Ok(Cow::Owned(
-            ZString::new(self).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -219,7 +219,7 @@ impl Arg for String {
         Self: Sized,
         F: FnOnce(&ZStr) -> io::Result<T>,
     {
-        f(&ZString::new(self).map_err(|_cstr_err| io::Error::INVAL)?)
+        f(&ZString::new(self).map_err(|_cstr_err| io::Errno::INVAL)?)
     }
 }
 
@@ -227,7 +227,7 @@ impl Arg for String {
 impl Arg for &OsStr {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        self.to_str().ok_or(io::Error::INVAL)
+        self.to_str().ok_or(io::Errno::INVAL)
     }
 
     #[inline]
@@ -238,7 +238,7 @@ impl Arg for &OsStr {
     #[inline]
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
-            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -248,7 +248,7 @@ impl Arg for &OsStr {
         Self: 'b,
     {
         Ok(Cow::Owned(
-            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -266,7 +266,7 @@ impl Arg for &OsStr {
 impl Arg for &OsString {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        OsString::as_os_str(self).to_str().ok_or(io::Error::INVAL)
+        OsString::as_os_str(self).to_str().ok_or(io::Errno::INVAL)
     }
 
     #[inline]
@@ -278,7 +278,7 @@ impl Arg for &OsString {
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
             ZString::new(OsString::as_os_str(self).as_bytes())
-                .map_err(|_cstr_err| io::Error::INVAL)?,
+                .map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -304,7 +304,7 @@ impl Arg for &OsString {
 impl Arg for OsString {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        self.as_os_str().to_str().ok_or(io::Error::INVAL)
+        self.as_os_str().to_str().ok_or(io::Errno::INVAL)
     }
 
     #[inline]
@@ -315,7 +315,7 @@ impl Arg for OsString {
     #[inline]
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
-            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -325,7 +325,7 @@ impl Arg for OsString {
         Self: 'b,
     {
         Ok(Cow::Owned(
-            ZString::new(self.into_vec()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.into_vec()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -335,7 +335,7 @@ impl Arg for OsString {
         Self: Sized,
         F: FnOnce(&ZStr) -> io::Result<T>,
     {
-        f(&ZString::new(self.into_vec()).map_err(|_cstr_err| io::Error::INVAL)?)
+        f(&ZString::new(self.into_vec()).map_err(|_cstr_err| io::Errno::INVAL)?)
     }
 }
 
@@ -343,7 +343,7 @@ impl Arg for OsString {
 impl Arg for &Path {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        self.as_os_str().to_str().ok_or(io::Error::INVAL)
+        self.as_os_str().to_str().ok_or(io::Errno::INVAL)
     }
 
     #[inline]
@@ -354,7 +354,7 @@ impl Arg for &Path {
     #[inline]
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
-            ZString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -364,7 +364,7 @@ impl Arg for &Path {
         Self: 'b,
     {
         Ok(Cow::Owned(
-            ZString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -385,7 +385,7 @@ impl Arg for &PathBuf {
         PathBuf::as_path(self)
             .as_os_str()
             .to_str()
-            .ok_or(io::Error::INVAL)
+            .ok_or(io::Errno::INVAL)
     }
 
     #[inline]
@@ -397,7 +397,7 @@ impl Arg for &PathBuf {
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
             ZString::new(PathBuf::as_path(self).as_os_str().as_bytes())
-                .map_err(|_cstr_err| io::Error::INVAL)?,
+                .map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -423,7 +423,7 @@ impl Arg for &PathBuf {
 impl Arg for PathBuf {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        self.as_os_str().to_str().ok_or(io::Error::INVAL)
+        self.as_os_str().to_str().ok_or(io::Errno::INVAL)
     }
 
     #[inline]
@@ -434,7 +434,7 @@ impl Arg for PathBuf {
     #[inline]
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
-            ZString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -444,7 +444,7 @@ impl Arg for PathBuf {
         Self: 'b,
     {
         Ok(Cow::Owned(
-            ZString::new(self.into_os_string().into_vec()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.into_os_string().into_vec()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -456,7 +456,7 @@ impl Arg for PathBuf {
     {
         f(
             &ZString::new(self.into_os_string().into_vec())
-                .map_err(|_cstr_err| io::Error::INVAL)?,
+                .map_err(|_cstr_err| io::Errno::INVAL)?,
         )
     }
 }
@@ -464,7 +464,7 @@ impl Arg for PathBuf {
 impl Arg for &ZStr {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        self.to_str().map_err(|_utf8_err| io::Error::INVAL)
+        self.to_str().map_err(|_utf8_err| io::Errno::INVAL)
     }
 
     #[inline]
@@ -532,7 +532,7 @@ impl Arg for &ZString {
 impl Arg for ZString {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        self.to_str().map_err(|_utf8_err| io::Error::INVAL)
+        self.to_str().map_err(|_utf8_err| io::Errno::INVAL)
     }
 
     #[inline]
@@ -577,7 +577,7 @@ impl<'a> Arg for Cow<'a, str> {
     #[inline]
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
-            ZString::new(self.as_ref()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_ref()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -591,7 +591,7 @@ impl<'a> Arg for Cow<'a, str> {
                 Cow::Owned(s) => ZString::new(s),
                 Cow::Borrowed(s) => ZString::new(s),
             }
-            .map_err(|_cstr_err| io::Error::INVAL)?,
+            .map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -609,7 +609,7 @@ impl<'a> Arg for Cow<'a, str> {
 impl<'a> Arg for Cow<'a, OsStr> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        (**self).to_str().ok_or(io::Error::INVAL)
+        (**self).to_str().ok_or(io::Errno::INVAL)
     }
 
     #[inline]
@@ -620,7 +620,7 @@ impl<'a> Arg for Cow<'a, OsStr> {
     #[inline]
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
-            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -634,7 +634,7 @@ impl<'a> Arg for Cow<'a, OsStr> {
                 Cow::Owned(os) => ZString::new(os.into_vec()),
                 Cow::Borrowed(os) => ZString::new(os.as_bytes()),
             }
-            .map_err(|_cstr_err| io::Error::INVAL)?,
+            .map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -651,7 +651,7 @@ impl<'a> Arg for Cow<'a, OsStr> {
 impl<'a> Arg for Cow<'a, ZStr> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        self.to_str().map_err(|_utf8_err| io::Error::INVAL)
+        self.to_str().map_err(|_utf8_err| io::Errno::INVAL)
     }
 
     #[inline]
@@ -687,7 +687,7 @@ impl<'a> Arg for Cow<'a, ZStr> {
 impl<'a> Arg for Component<'a> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        self.as_os_str().to_str().ok_or(io::Error::INVAL)
+        self.as_os_str().to_str().ok_or(io::Errno::INVAL)
     }
 
     #[inline]
@@ -698,7 +698,7 @@ impl<'a> Arg for Component<'a> {
     #[inline]
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
-            ZString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -708,7 +708,7 @@ impl<'a> Arg for Component<'a> {
         Self: 'b,
     {
         Ok(Cow::Owned(
-            ZString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -726,7 +726,7 @@ impl<'a> Arg for Component<'a> {
 impl<'a> Arg for Components<'a> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        self.as_path().to_str().ok_or(io::Error::INVAL)
+        self.as_path().to_str().ok_or(io::Errno::INVAL)
     }
 
     #[inline]
@@ -738,7 +738,7 @@ impl<'a> Arg for Components<'a> {
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
             ZString::new(self.as_path().as_os_str().as_bytes())
-                .map_err(|_cstr_err| io::Error::INVAL)?,
+                .map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -749,7 +749,7 @@ impl<'a> Arg for Components<'a> {
     {
         Ok(Cow::Owned(
             ZString::new(self.as_path().as_os_str().as_bytes())
-                .map_err(|_cstr_err| io::Error::INVAL)?,
+                .map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -767,7 +767,7 @@ impl<'a> Arg for Components<'a> {
 impl<'a> Arg for Iter<'a> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        self.as_path().to_str().ok_or(io::Error::INVAL)
+        self.as_path().to_str().ok_or(io::Errno::INVAL)
     }
 
     #[inline]
@@ -779,7 +779,7 @@ impl<'a> Arg for Iter<'a> {
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
             ZString::new(self.as_path().as_os_str().as_bytes())
-                .map_err(|_cstr_err| io::Error::INVAL)?,
+                .map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -790,7 +790,7 @@ impl<'a> Arg for Iter<'a> {
     {
         Ok(Cow::Owned(
             ZString::new(self.as_path().as_os_str().as_bytes())
-                .map_err(|_cstr_err| io::Error::INVAL)?,
+                .map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -807,7 +807,7 @@ impl<'a> Arg for Iter<'a> {
 impl Arg for &[u8] {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        str::from_utf8(self).map_err(|_utf8_err| io::Error::INVAL)
+        str::from_utf8(self).map_err(|_utf8_err| io::Errno::INVAL)
     }
 
     #[inline]
@@ -818,7 +818,7 @@ impl Arg for &[u8] {
     #[inline]
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
-            ZString::new(*self).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(*self).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -828,7 +828,7 @@ impl Arg for &[u8] {
         Self: 'b,
     {
         Ok(Cow::Owned(
-            ZString::new(self).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -845,7 +845,7 @@ impl Arg for &[u8] {
 impl Arg for &Vec<u8> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        str::from_utf8(self).map_err(|_utf8_err| io::Error::INVAL)
+        str::from_utf8(self).map_err(|_utf8_err| io::Errno::INVAL)
     }
 
     #[inline]
@@ -856,7 +856,7 @@ impl Arg for &Vec<u8> {
     #[inline]
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
-            ZString::new(self.as_slice()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_slice()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -866,7 +866,7 @@ impl Arg for &Vec<u8> {
         Self: 'b,
     {
         Ok(Cow::Owned(
-            ZString::new(self.as_slice()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_slice()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -883,7 +883,7 @@ impl Arg for &Vec<u8> {
 impl Arg for Vec<u8> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        str::from_utf8(self).map_err(|_utf8_err| io::Error::INVAL)
+        str::from_utf8(self).map_err(|_utf8_err| io::Errno::INVAL)
     }
 
     #[inline]
@@ -894,7 +894,7 @@ impl Arg for Vec<u8> {
     #[inline]
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
-            ZString::new(self.as_slice()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_slice()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -904,7 +904,7 @@ impl Arg for Vec<u8> {
         Self: 'b,
     {
         Ok(Cow::Owned(
-            ZString::new(self).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -914,7 +914,7 @@ impl Arg for Vec<u8> {
         Self: Sized,
         F: FnOnce(&ZStr) -> io::Result<T>,
     {
-        f(&ZString::new(self).map_err(|_cstr_err| io::Error::INVAL)?)
+        f(&ZString::new(self).map_err(|_cstr_err| io::Errno::INVAL)?)
     }
 }
 
@@ -933,7 +933,7 @@ impl Arg for DecInt {
     #[inline]
     fn as_cow_z_str(&self) -> io::Result<Cow<'_, ZStr>> {
         Ok(Cow::Owned(
-            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -943,7 +943,7 @@ impl Arg for DecInt {
         Self: 'b,
     {
         Ok(Cow::Owned(
-            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
+            ZString::new(self.as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
         ))
     }
 
@@ -976,7 +976,7 @@ where
     let mut buffer: [u8; SMALL_PATH_BUFFER_SIZE] = [0_u8; SMALL_PATH_BUFFER_SIZE];
     // Copy the bytes in; the buffer already has zeros for the trailing NUL.
     buffer[..bytes.len()].copy_from_slice(bytes);
-    f(ZStr::from_bytes_with_nul(&buffer[..=bytes.len()]).map_err(|_cstr_err| io::Error::INVAL)?)
+    f(ZStr::from_bytes_with_nul(&buffer[..=bytes.len()]).map_err(|_cstr_err| io::Errno::INVAL)?)
 }
 
 /// The slow path which handles any length. In theory OS's only support up
@@ -986,5 +986,5 @@ fn with_z_str_slow_path<T, F>(bytes: &[u8], f: F) -> io::Result<T>
 where
     F: FnOnce(&ZStr) -> io::Result<T>,
 {
-    f(&ZString::new(bytes).map_err(|_cstr_err| io::Error::INVAL)?)
+    f(&ZString::new(bytes).map_err(|_cstr_err| io::Errno::INVAL)?)
 }

--- a/src/process/chdir.rs
+++ b/src/process/chdir.rs
@@ -57,7 +57,7 @@ fn _getcwd(mut buffer: Vec<u8>) -> io::Result<ZString> {
 
     loop {
         match imp::process::syscalls::getcwd(&mut buffer) {
-            Err(io::Error::RANGE) => {
+            Err(io::Errno::RANGE) => {
                 buffer.reserve(1); // use `Vec` reallocation strategy to grow capacity exponentially
                 buffer.resize(buffer.capacity(), 0_u8);
             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -242,7 +242,7 @@ pub unsafe fn execveat<Fd: AsFd>(
     argv: *const *const u8,
     envp: *const *const u8,
     flags: AtFlags,
-) -> io::Error {
+) -> io::Errno {
     imp::runtime::syscalls::execveat(dirfd.as_fd(), path, argv, envp, flags)
 }
 
@@ -260,6 +260,6 @@ pub unsafe fn execveat<Fd: AsFd>(
 /// [Linux]: https://man7.org/linux/man-pages/man2/execve.2.html
 #[inline]
 #[cfg(linux_raw)]
-pub unsafe fn execve(path: &ZStr, argv: *const *const u8, envp: *const *const u8) -> io::Error {
+pub unsafe fn execve(path: &ZStr, argv: *const *const u8, envp: *const *const u8) -> io::Errno {
     imp::runtime::syscalls::execve(path, argv, envp)
 }

--- a/src/termios/tty.rs
+++ b/src/termios/tty.rs
@@ -58,7 +58,7 @@ fn _ttyname(dirfd: BorrowedFd<'_>, mut buffer: Vec<u8>) -> io::Result<ZString> {
 
     loop {
         match imp::termios::syscalls::ttyname(dirfd, &mut buffer) {
-            Err(io::Error::RANGE) => {
+            Err(io::Errno::RANGE) => {
                 buffer.reserve(1); // use `Vec` reallocation strategy to grow capacity exponentially
                 buffer.resize(buffer.capacity(), 0_u8);
             }

--- a/src/thread/clock.rs
+++ b/src/thread/clock.rs
@@ -92,5 +92,5 @@ pub enum NanosleepRelativeResult {
     /// The sleep was interrupted, the remaining time is returned.
     Interrupted(Timespec),
     /// An invalid time value was provided.
-    Err(io::Error),
+    Err(io::Errno),
 }

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -18,7 +18,7 @@ fn test_file() {
             rustix::fs::Mode::empty(),
         )
         .unwrap_err(),
-        rustix::io::Error::NOENT
+        rustix::io::Errno::NOENT
     );
 
     let file = rustix::fs::openat(
@@ -37,7 +37,7 @@ fn test_file() {
             rustix::fs::Mode::empty(),
         )
         .unwrap_err(),
-        rustix::io::Error::NOTDIR
+        rustix::io::Errno::NOTDIR
     );
 
     #[cfg(not(any(

--- a/tests/fs/openat.rs
+++ b/tests/fs/openat.rs
@@ -22,9 +22,9 @@ fn test_openat_tmpfile() {
     ) {
         Ok(f) => Ok(Some(File::from_fd(f.into_fd()))),
         // TODO: Factor out the `Err`, once we no longer support Rust 1.48.
-        Err(rustix::io::Error::OPNOTSUPP)
-        | Err(rustix::io::Error::ISDIR)
-        | Err(rustix::io::Error::NOENT) => Ok(None),
+        Err(rustix::io::Errno::OPNOTSUPP)
+        | Err(rustix::io::Errno::ISDIR)
+        | Err(rustix::io::Errno::NOENT) => Ok(None),
         Err(e) => Err(e),
     };
     if let Some(mut f) = f.unwrap() {

--- a/tests/fs/openat2.rs
+++ b/tests/fs/openat2.rs
@@ -16,7 +16,7 @@ fn openat2_more<Fd: AsFd, P: path::Arg>(
     loop {
         match openat2(dirfd.as_fd(), &path, oflags, mode, resolve) {
             Ok(file) => return Ok(file),
-            Err(io::Error::AGAIN) => continue,
+            Err(io::Errno::AGAIN) => continue,
             Err(err) => return Err(err),
         }
     }
@@ -36,7 +36,7 @@ fn test_openat2() {
         ResolveFlags::empty(),
     ) {
         Ok(_file) => (),
-        Err(io::Error::NOSYS) => return,
+        Err(io::Errno::NOSYS) => return,
         Err(_err) => return,
     }
 

--- a/tests/fs/renameat.rs
+++ b/tests/fs/renameat.rs
@@ -46,7 +46,7 @@ fn test_renameat_with() {
 
     match renameat_with(&dir, "foo", &dir, "red", RenameFlags::empty()) {
         Ok(()) => (),
-        Err(e) if e == rustix::io::Error::NOSYS => return,
+        Err(e) if e == rustix::io::Errno::NOSYS => return,
         Err(e) => unreachable!("unexpected error from renameat_with: {:?}", e),
     }
 

--- a/tests/fs/utimensat.rs
+++ b/tests/fs/utimensat.rs
@@ -84,7 +84,7 @@ fn test_utimensat_noent() {
     };
     assert_eq!(
         utimensat(&dir, "foo", &times, AtFlags::empty()).unwrap_err(),
-        rustix::io::Error::NOENT
+        rustix::io::Errno::NOENT
     );
 }
 
@@ -122,6 +122,6 @@ fn test_utimensat_notdir() {
     };
     assert_eq!(
         utimensat(&foo, "bar", &times, AtFlags::empty()).unwrap_err(),
-        rustix::io::Error::NOTDIR
+        rustix::io::Errno::NOTDIR
     );
 }

--- a/tests/fs/y2038.rs
+++ b/tests/fs/y2038.rs
@@ -38,7 +38,7 @@ fn test_y2038_with_utimensat() {
         // On 32-bit platforms, accept `EOVERFLOW`, meaning that y2038 support
         // is not available in this version of the OS.
         #[cfg(target_pointer_width = "32")]
-        Err(rustix::io::Error::OVERFLOW) => return,
+        Err(rustix::io::Errno::OVERFLOW) => return,
 
         Err(e) => panic!("unexpected error: {:?}", e),
     }
@@ -113,7 +113,7 @@ fn test_y2038_with_futimens() {
         // On 32-bit platforms, accept `EOVERFLOW`, meaning that y2038 support
         // is not available in this version of the OS.
         #[cfg(target_pointer_width = "32")]
-        Err(rustix::io::Error::OVERFLOW) => return,
+        Err(rustix::io::Errno::OVERFLOW) => return,
 
         Err(e) => panic!("unexpected error: {:?}", e),
     }

--- a/tests/io/dup3.rs
+++ b/tests/io/dup3.rs
@@ -16,11 +16,11 @@ fn test_dup3() {
     let (a, b) = rustix::io::pipe().unwrap();
     assert_eq!(
         rustix::io::dup3(&a, &a, DupFlags::empty()),
-        Err(rustix::io::Error::INVAL)
+        Err(rustix::io::Errno::INVAL)
     );
     assert_eq!(
         rustix::io::dup3(&b, &b, DupFlags::empty()),
-        Err(rustix::io::Error::INVAL)
+        Err(rustix::io::Errno::INVAL)
     );
     #[cfg(not(any(
         target_os = "android",
@@ -31,11 +31,11 @@ fn test_dup3() {
     {
         assert_eq!(
             rustix::io::dup3(&a, &a, DupFlags::CLOEXEC),
-            Err(rustix::io::Error::INVAL)
+            Err(rustix::io::Errno::INVAL)
         );
         assert_eq!(
             rustix::io::dup3(&b, &b, DupFlags::CLOEXEC),
-            Err(rustix::io::Error::INVAL)
+            Err(rustix::io::Errno::INVAL)
         );
     }
 }

--- a/tests/io/error.rs
+++ b/tests/io/error.rs
@@ -1,14 +1,14 @@
 #[test]
 fn test_error() {
     assert_eq!(
-        rustix::io::Error::INVAL,
-        rustix::io::Error::from_raw_os_error(rustix::io::Error::INVAL.raw_os_error())
+        rustix::io::Errno::INVAL,
+        rustix::io::Errno::from_raw_os_error(rustix::io::Errno::INVAL.raw_os_error())
     );
     #[cfg(not(windows))]
-    assert_eq!(rustix::io::Error::INVAL.raw_os_error(), libc::EINVAL);
+    assert_eq!(rustix::io::Errno::INVAL.raw_os_error(), libc::EINVAL);
     #[cfg(windows)]
     assert_eq!(
-        rustix::io::Error::INVAL.raw_os_error(),
+        rustix::io::Errno::INVAL.raw_os_error(),
         windows_sys::Win32::Networking::WinSock::WSAEINVAL
     );
 }

--- a/tests/io/read_write.rs
+++ b/tests/io/read_write.rs
@@ -27,7 +27,7 @@ fn test_readwrite_pv() {
     {
         match pwritev(&foo, &[IoSlice::new(b"hello")], 200) {
             Ok(_) => (),
-            Err(rustix::io::Error::NOSYS) => return,
+            Err(rustix::io::Errno::NOSYS) => return,
             Err(err) => Err(err).unwrap(),
         }
     }

--- a/tests/io/seals.rs
+++ b/tests/io/seals.rs
@@ -10,7 +10,7 @@ fn test_seals() {
 
     let fd = match memfd_create("test", MemfdFlags::CLOEXEC | MemfdFlags::ALLOW_SEALING) {
         Ok(fd) => fd,
-        Err(rustix::io::Error::NOSYS) => return,
+        Err(rustix::io::Errno::NOSYS) => return,
         Err(err) => Err(err).unwrap(),
     };
     let mut file = File::from_fd(fd.into());

--- a/tests/mm/mlock.rs
+++ b/tests/mm/mlock.rs
@@ -12,7 +12,7 @@ fn test_mlock() {
         match rustix::mm::mlock(buf.as_mut_ptr().cast::<c_void>(), buf.len()) {
             Ok(()) => rustix::mm::munlock(buf.as_mut_ptr().cast::<c_void>(), buf.len()).unwrap(),
             // Tests won't always have enough memory or permissions, and that's ok.
-            Err(rustix::io::Error::PERM) | Err(rustix::io::Error::NOMEM) => {}
+            Err(rustix::io::Errno::PERM) | Err(rustix::io::Errno::NOMEM) => {}
             // But they shouldn't fail otherwise.
             Err(other) => Err(other).unwrap(),
         }
@@ -32,9 +32,9 @@ fn test_mlock_with() {
         ) {
             Ok(()) => rustix::mm::munlock(buf.as_mut_ptr().cast::<c_void>(), buf.len()).unwrap(),
             // Tests won't always have enough memory or permissions, and that's ok.
-            Err(rustix::io::Error::PERM)
-            | Err(rustix::io::Error::NOMEM)
-            | Err(rustix::io::Error::NOSYS) => {}
+            Err(rustix::io::Errno::PERM)
+            | Err(rustix::io::Errno::NOMEM)
+            | Err(rustix::io::Errno::NOSYS) => {}
             // But they shouldn't fail otherwise.
             Err(other) => Err(other).unwrap(),
         }
@@ -53,7 +53,7 @@ fn test_mlock_with_onfault() {
     // syscall directly to test for `ENOSYS`, before running the main
     // test below.
     unsafe {
-        if libc::syscall(libc::SYS_mlock2, 0, 0) == -1 && errno::errno().0 == libc::ENOSYS {
+        if libc::syscall(libc::SYS_mlock2, 0, 0) == -1 && libc_errno::errno().0 == libc::ENOSYS {
             return;
         }
     }
@@ -68,9 +68,9 @@ fn test_mlock_with_onfault() {
         ) {
             Ok(()) => rustix::mm::munlock(buf.as_mut_ptr().cast::<c_void>(), buf.len()).unwrap(),
             // Tests won't always have enough memory or permissions, and that's ok.
-            Err(rustix::io::Error::PERM)
-            | Err(rustix::io::Error::NOMEM)
-            | Err(rustix::io::Error::NOSYS) => {}
+            Err(rustix::io::Errno::PERM)
+            | Err(rustix::io::Errno::NOMEM)
+            | Err(rustix::io::Errno::NOSYS) => {}
             // But they shouldn't fail otherwise.
             Err(other) => Err(other).unwrap(),
         }

--- a/tests/mm/mmap.rs
+++ b/tests/mm/mmap.rs
@@ -107,7 +107,7 @@ fn test_mlock() {
         #[cfg(any(target_os = "android", target_os = "linux"))]
         {
             match mlock_with(addr, 8192, MlockFlags::empty()) {
-                Err(rustix::io::Error::NOSYS) => (),
+                Err(rustix::io::Errno::NOSYS) => (),
                 Err(err) => Err(err).unwrap(),
                 Ok(()) => munlock(addr, 8192).unwrap(),
             }
@@ -115,7 +115,7 @@ fn test_mlock() {
             #[cfg(linux_raw)] // libc doesn't expose `MLOCK_UNFAULT` yet.
             {
                 match mlock_with(addr, 8192, MlockFlags::ONFAULT) {
-                    Err(rustix::io::Error::NOSYS) => (),
+                    Err(rustix::io::Errno::NOSYS) => (),
                     Err(err) => Err(err).unwrap(),
                     Ok(()) => munlock(addr, 8192).unwrap(),
                 }

--- a/tests/path/arg.rs
+++ b/tests/path/arg.rs
@@ -187,7 +187,7 @@ fn test_invalid() {
     use std::borrow::Borrow;
 
     let t: &[u8] = b"hello\xc0world";
-    assert_eq!(t.as_str().unwrap_err(), io::Error::INVAL);
+    assert_eq!(t.as_str().unwrap_err(), io::Errno::INVAL);
     assert_eq!("hello\u{fffd}world".to_owned(), Arg::to_string_lossy(&t));
     assert_eq!(
         b"hello\xc0world\0",
@@ -204,6 +204,6 @@ fn test_embedded_nul() {
     let t: &[u8] = b"hello\0world";
     assert_eq!("hello\0world", t.as_str().unwrap());
     assert_eq!("hello\0world".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(t.as_cow_z_str().unwrap_err(), io::Error::INVAL);
-    assert_eq!(t.clone().into_z_str().unwrap_err(), io::Error::INVAL);
+    assert_eq!(t.as_cow_z_str().unwrap_err(), io::Errno::INVAL);
+    assert_eq!(t.clone().into_z_str().unwrap_err(), io::Errno::INVAL);
 }

--- a/tests/process/rlimit.rs
+++ b/tests/process/rlimit.rs
@@ -31,7 +31,7 @@ fn test_setrlimit() {
 
         let old = match rustix::process::prlimit(None, Resource::Core, new.clone()) {
             Ok(rlimit) => rlimit,
-            Err(rustix::io::Error::NOSYS) => return,
+            Err(rustix::io::Errno::NOSYS) => return,
             Err(e) => Err(e).unwrap(),
         };
 

--- a/tests/thread/clocks.rs
+++ b/tests/thread/clocks.rs
@@ -21,14 +21,14 @@ fn test_invalid_nanosleep() {
         tv_sec: 0,
         tv_nsec: 1000000000,
     }) {
-        NanosleepRelativeResult::Err(io::Error::INVAL) => (),
+        NanosleepRelativeResult::Err(io::Errno::INVAL) => (),
         otherwise => panic!("unexpected resut: {:?}", otherwise),
     }
     match nanosleep(&Timespec {
         tv_sec: 0,
         tv_nsec: -1 as _,
     }) {
-        NanosleepRelativeResult::Err(io::Error::INVAL) => (),
+        NanosleepRelativeResult::Err(io::Errno::INVAL) => (),
         otherwise => panic!("unexpected resut: {:?}", otherwise),
     }
 }
@@ -51,7 +51,7 @@ fn test_invalid_nanosleep_absolute() {
             tv_nsec: 1000000000,
         },
     ) {
-        Err(io::Error::INVAL) => (),
+        Err(io::Errno::INVAL) => (),
         otherwise => panic!("unexpected resut: {:?}", otherwise),
     }
     match clock_nanosleep_absolute(
@@ -61,7 +61,7 @@ fn test_invalid_nanosleep_absolute() {
             tv_nsec: -1 as _,
         },
     ) {
-        Err(io::Error::INVAL) => (),
+        Err(io::Errno::INVAL) => (),
         otherwise => panic!("unexpected resut: {:?}", otherwise),
     }
 }
@@ -84,7 +84,7 @@ fn test_invalid_nanosleep_relative() {
             tv_nsec: 1000000000,
         },
     ) {
-        NanosleepRelativeResult::Err(io::Error::INVAL) => (),
+        NanosleepRelativeResult::Err(io::Errno::INVAL) => (),
         otherwise => panic!("unexpected resut: {:?}", otherwise),
     }
     match clock_nanosleep_relative(
@@ -94,7 +94,7 @@ fn test_invalid_nanosleep_relative() {
             tv_nsec: -1 as _,
         },
     ) {
-        NanosleepRelativeResult::Err(io::Error::INVAL) => (),
+        NanosleepRelativeResult::Err(io::Errno::INVAL) => (),
         otherwise => panic!("unexpected resut: {:?}", otherwise),
     }
 }

--- a/tests/time/y2038.rs
+++ b/tests/time/y2038.rs
@@ -60,7 +60,7 @@ fn test_y2038_with_timerfd() {
         // y2038 support in `timerfd` APIs is not available on this platform
         // or this version of the platform.
         #[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
-        Err(rustix::io::Error::OVERFLOW) => return,
+        Err(rustix::io::Errno::OVERFLOW) => return,
 
         Err(e) => panic!("unexpected error: {:?}", e),
     };


### PR DESCRIPTION
Fixes #254.