### PR TITLE
Fix several clippy lints.

### DIFF
--- a/src/imp/libc/conv.rs
+++ b/src/imp/libc/conv.rs
@@ -139,7 +139,7 @@ pub(super) fn ret_pid_t(raw: c::pid_t) -> io::Result<c::pid_t> {
     }
 }
 
-/// Convert a c_int returned from a libc function to an `OwnedFd`, if valid.
+/// Convert a `c_int` returned from a libc function to an `OwnedFd`, if valid.
 ///
 /// # Safety
 ///
@@ -172,7 +172,7 @@ pub(super) fn ret_discarded_char_ptr(raw: *mut c::c_char) -> io::Result<()> {
     }
 }
 
-/// Convert a c_long returned from `syscall` to an `OwnedFd`, if valid.
+/// Convert a `c_long` returned from `syscall` to an `OwnedFd`, if valid.
 ///
 /// # Safety
 ///

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -164,9 +164,9 @@ fn openat_via_syscall(
         let mode = c::c_uint::from(mode.bits());
         ret_owned_fd(c::syscall(
             c::SYS_openat,
-            dirfd as c::c_long,
+            c::c_long::from(dirfd),
             path,
-            oflags as c::c_long,
+            c::c_long::from(oflags),
             mode as c::c_long,
         ) as c::c_int)
     }
@@ -707,7 +707,7 @@ pub(crate) fn mknodat(
             borrowed_fd(dirfd),
             c_str(path),
             (mode.bits() | file_type.as_raw_mode()) as c::mode_t,
-            dev.try_into().map_err(|_| io::Errno::PERM)?,
+            dev.try_into().map_err(|_e| io::Errno::PERM)?,
         ))
     }
 }

--- a/src/imp/libc/io/epoll.rs
+++ b/src/imp/libc/io/epoll.rs
@@ -428,7 +428,7 @@ impl<'context, T: AsFd + IntoFd + FromFd> AsFd for Epoll<Owning<'context, T>> {
 
 #[cfg(not(feature = "rustc-dep-of-std"))]
 impl<'context, T: AsFd + IntoFd + FromFd> From<Epoll<Owning<'context, T>>> for OwnedFd {
-    fn from(epoll: Epoll<Owning<'context, T>>) -> OwnedFd {
+    fn from(epoll: Epoll<Owning<'context, T>>) -> Self {
         epoll.epoll_fd
     }
 }

--- a/src/imp/libc/io/syscalls.rs
+++ b/src/imp/libc/io/syscalls.rs
@@ -302,7 +302,7 @@ pub(crate) fn ioctl_fionread(fd: BorrowedFd<'_>) -> io::Result<u64> {
         // `FIONREAD` returns the number of bytes silently casted to a `c_int`,
         // even when this is lossy. The best we can do is convert it back to a
         // `u64` without sign-extending it back first.
-        Ok(nread.assume_init() as c::c_uint as u64)
+        Ok(u64::from(nread.assume_init() as c::c_uint))
     }
 }
 

--- a/src/imp/libc/mm/types.rs
+++ b/src/imp/libc/mm/types.rs
@@ -269,6 +269,7 @@ bitflags! {
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(i32)]
+#[non_exhaustive]
 pub enum Advice {
     /// `POSIX_MADV_NORMAL`
     #[cfg(not(target_os = "android"))]

--- a/src/imp/libc/net/addr.rs
+++ b/src/imp/libc/net/addr.rs
@@ -36,7 +36,7 @@ impl SocketAddrUnix {
     /// Construct a new Unix-domain address from a filesystem path.
     #[inline]
     pub fn new<P: path::Arg>(path: P) -> io::Result<Self> {
-        path.into_with_z_str(|path| Self::_new(path))
+        path.into_with_z_str(Self::_new)
     }
 
     #[inline]

--- a/src/imp/libc/net/syscalls.rs
+++ b/src/imp/libc/net/syscalls.rs
@@ -376,7 +376,7 @@ pub(crate) fn socketpair(
     unsafe {
         let mut fds = MaybeUninit::<[OwnedFd; 2]>::uninit();
         ret(c::socketpair(
-            domain.0 as c::c_int,
+            c::c_int::from(domain.0),
             type_.0 as c::c_int | flags.bits(),
             protocol.0,
             fds.as_mut_ptr().cast::<c::c_int>(),
@@ -501,7 +501,7 @@ pub(crate) mod sockopt {
             if linger.subsec_nanos() != 0 {
                 l_linger = l_linger.checked_add(1).ok_or(io::Errno::INVAL)?;
             }
-            l_linger.try_into().map_err(|_| io::Errno::INVAL)?
+            l_linger.try_into().map_err(|_e| io::Errno::INVAL)?
         } else {
             0
         };

--- a/src/imp/libc/offset.rs
+++ b/src/imp/libc/offset.rs
@@ -67,7 +67,7 @@ pub(super) use c::{getrlimit as libc_getrlimit, setrlimit as libc_setrlimit};
     target_os = "emscripten",
     target_os = "l4re",
 ))]
-pub(super) const LIBC_RLIM_INFINITY: u64 = !0u64;
+pub(super) const LIBC_RLIM_INFINITY: u64 = !0_u64;
 
 #[cfg(any(
     target_os = "android",

--- a/src/imp/libc/process/syscalls.rs
+++ b/src/imp/libc/process/syscalls.rs
@@ -326,12 +326,13 @@ fn rlimit_from_libc(lim: libc_rlimit) -> Rlimit {
 /// Convert a C `libc_rlimit` to a Rust `Rlimit`.
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 fn rlimit_to_libc(lim: Rlimit) -> io::Result<libc_rlimit> {
-    let rlim_cur = match lim.current {
-        Some(r) => r.try_into().map_err(|_| io::Errno::INVAL)?,
+    let Rlimit { current, maximum } = lim;
+    let rlim_cur = match current {
+        Some(r) => r.try_into().map_err(|_e| io::Errno::INVAL)?,
         None => LIBC_RLIM_INFINITY as _,
     };
-    let rlim_max = match lim.maximum {
-        Some(r) => r.try_into().map_err(|_| io::Errno::INVAL)?,
+    let rlim_max = match maximum {
+        Some(r) => r.try_into().map_err(|_e| io::Errno::INVAL)?,
         None => LIBC_RLIM_INFINITY as _,
     };
     Ok(libc_rlimit { rlim_cur, rlim_max })

--- a/src/imp/libc/weak.rs
+++ b/src/imp/libc/weak.rs
@@ -140,23 +140,23 @@ macro_rules! syscall {
 
             trait AsSyscallArg {
                 type SyscallArgType;
-                fn as_syscall_arg(self) -> Self::SyscallArgType;
+                fn into_syscall_arg(self) -> Self::SyscallArgType;
             }
 
             // Pass pointer types as pointers, to preserve provenance.
             impl<T> AsSyscallArg for *mut T {
                 type SyscallArgType = *mut T;
-                fn as_syscall_arg(self) -> Self::SyscallArgType { self }
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self }
             }
             impl<T> AsSyscallArg for *const T {
                 type SyscallArgType = *const T;
-                fn as_syscall_arg(self) -> Self::SyscallArgType { self }
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self }
             }
 
             // Pass `BorrowedFd` values as the integer value.
             impl AsSyscallArg for $crate::fd::BorrowedFd<'_> {
                 type SyscallArgType = c::c_long;
-                fn as_syscall_arg(self) -> Self::SyscallArgType {
+                fn into_syscall_arg(self) -> Self::SyscallArgType {
                     $crate::fd::AsRawFd::as_raw_fd(&self) as _
                 }
             }
@@ -164,15 +164,15 @@ macro_rules! syscall {
             // Coerce integer values into `c_long`.
             impl AsSyscallArg for i32 {
                 type SyscallArgType = c::c_long;
-                fn as_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
             }
             impl AsSyscallArg for u32 {
                 type SyscallArgType = c::c_long;
-                fn as_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
             }
             impl AsSyscallArg for usize {
                 type SyscallArgType = c::c_long;
-                fn as_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
             }
 
             // `concat_idents is unstable, so we take an extra `sys_name`
@@ -180,11 +180,11 @@ macro_rules! syscall {
             /*
             syscall(
                 concat_idents!(SYS_, $name),
-                $($arg_name.as_syscall_arg()),*
+                $($arg_name.into_syscall_arg()),*
             ) as $ret
             */
 
-            syscall($sys_name, $($arg_name.as_syscall_arg()),*) as $ret
+            syscall($sys_name, $($arg_name.into_syscall_arg()),*) as $ret
         }
     )
 }

--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -180,40 +180,40 @@ pub(super) fn no_fd<'a, Num: ArgNumber>() -> ArgReg<'a, Num> {
 }
 
 #[inline]
-pub(super) fn slice_just_addr<'a, T: Sized, Num: ArgNumber>(v: &'a [T]) -> ArgReg<'a, Num> {
+pub(super) fn slice_just_addr<T: Sized, Num: ArgNumber>(v: &[T]) -> ArgReg<Num> {
     let mut_ptr = v.as_ptr() as *mut T;
     raw_arg(mut_ptr.cast())
 }
 
 #[inline]
-pub(super) fn slice<'a, T: Sized, Num0: ArgNumber, Num1: ArgNumber>(
-    v: &'a [T],
-) -> (ArgReg<'a, Num0>, ArgReg<'a, Num1>) {
+pub(super) fn slice<T: Sized, Num0: ArgNumber, Num1: ArgNumber>(
+    v: &[T],
+) -> (ArgReg<Num0>, ArgReg<Num1>) {
     (slice_just_addr(v), pass_usize(v.len()))
 }
 
 #[inline]
-pub(super) fn slice_mut<'a, T: Sized, Num0: ArgNumber, Num1: ArgNumber>(
+pub(super) fn slice_mut<T: Sized, Num0: ArgNumber, Num1: ArgNumber>(
     v: &mut [T],
-) -> (ArgReg<'a, Num0>, ArgReg<'a, Num1>) {
+) -> (ArgReg<Num0>, ArgReg<Num1>) {
     (raw_arg(v.as_mut_ptr().cast()), pass_usize(v.len()))
 }
 
 #[inline]
-pub(super) fn by_ref<'a, T: Sized, Num: ArgNumber>(t: &'a T) -> ArgReg<'a, Num> {
+pub(super) fn by_ref<T: Sized, Num: ArgNumber>(t: &T) -> ArgReg<Num> {
     let mut_ptr = as_ptr(t) as *mut T;
     raw_arg(mut_ptr.cast())
 }
 
 #[inline]
-pub(super) fn by_mut<'a, T: Sized, Num: ArgNumber>(t: &'a mut T) -> ArgReg<'a, Num> {
+pub(super) fn by_mut<T: Sized, Num: ArgNumber>(t: &mut T) -> ArgReg<Num> {
     raw_arg(as_mut_ptr(t).cast())
 }
 
 /// Convert an optional mutable reference into a `usize` for passing to a
 /// syscall.
 #[inline]
-pub(super) fn opt_mut<'a, T: Sized, Num: ArgNumber>(t: Option<&'a mut T>) -> ArgReg<'a, Num> {
+pub(super) fn opt_mut<T: Sized, Num: ArgNumber>(t: Option<&mut T>) -> ArgReg<Num> {
     // This optimizes into the equivalent of `transmute(t)`, and has the
     // advantage of not requiring `unsafe`.
     match t {

--- a/src/imp/linux_raw/io/syscalls.rs
+++ b/src/imp/linux_raw/io/syscalls.rs
@@ -305,7 +305,7 @@ pub(crate) fn ioctl_fionread(fd: BorrowedFd<'_>) -> io::Result<u64> {
 #[inline]
 pub(crate) fn ioctl_fionbio(fd: BorrowedFd<'_>, value: bool) -> io::Result<()> {
     unsafe {
-        let data = value as c::c_int;
+        let data = c::c_int::from(value);
         ret(syscall_readonly!(
             __NR_ioctl,
             fd,

--- a/src/imp/linux_raw/mm/types.rs
+++ b/src/imp/linux_raw/mm/types.rs
@@ -141,6 +141,7 @@ bitflags! {
 /// [`madvise`]: crate::mm::madvise
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum Advice {
     /// `POSIX_MADV_NORMAL`
     Normal = linux_raw_sys::general::MADV_NORMAL,

--- a/src/imp/linux_raw/net/syscalls.rs
+++ b/src/imp/linux_raw/net/syscalls.rs
@@ -901,12 +901,12 @@ pub(crate) mod sockopt {
             if linger.subsec_nanos() != 0 {
                 l_linger = l_linger.checked_add(1).ok_or(io::Errno::INVAL)?;
             }
-            l_linger.try_into().map_err(|_| io::Errno::INVAL)?
+            l_linger.try_into().map_err(|_e| io::Errno::INVAL)?
         } else {
             0
         };
         let linger = c::linger {
-            l_onoff: linger.is_some() as c::c_int,
+            l_onoff: c::c_int::from(linger.is_some()),
             l_linger,
         };
         setsockopt(fd, c::SOL_SOCKET as _, c::SO_LINGER, linger)
@@ -1030,7 +1030,7 @@ pub(crate) mod sockopt {
                 }
                 let mut timeout = __kernel_timespec {
                     tv_sec: timeout.as_secs().try_into().unwrap_or(i64::MAX),
-                    tv_nsec: timeout.subsec_nanos() as _,
+                    tv_nsec: timeout.subsec_nanos().into(),
                 };
                 if timeout.tv_sec == 0 && timeout.tv_nsec == 0 {
                     timeout.tv_nsec = 1;
@@ -1225,7 +1225,7 @@ pub(crate) mod sockopt {
 
     #[inline]
     fn from_bool(value: bool) -> c::c_uint {
-        value as c::c_uint
+        c::c_uint::from(value)
     }
 
     #[inline]

--- a/src/imp/linux_raw/process/syscalls.rs
+++ b/src/imp/linux_raw/process/syscalls.rs
@@ -416,6 +416,7 @@ fn rlimit_to_linux(lim: Rlimit) -> io::Result<linux_raw_sys::general::rlimit64> 
 }
 
 /// Like `rlimit_from_linux` but uses Linux's old 32-bit `rlimit`.
+#[allow(clippy::useless_conversion)]
 fn rlimit_from_linux_old(lim: linux_raw_sys::general::rlimit) -> Rlimit {
     let current = if lim.rlim_cur == linux_raw_sys::general::RLIM_INFINITY as _ {
         None
@@ -431,13 +432,14 @@ fn rlimit_from_linux_old(lim: linux_raw_sys::general::rlimit) -> Rlimit {
 }
 
 /// Like `rlimit_to_linux` but uses Linux's old 32-bit `rlimit`.
+#[allow(clippy::useless_conversion)]
 fn rlimit_to_linux_old(lim: Rlimit) -> io::Result<linux_raw_sys::general::rlimit> {
     let rlim_cur = match lim.current {
-        Some(r) => r.try_into().map_err(|_| io::Errno::INVAL)?,
+        Some(r) => r.try_into().map_err(|_e| io::Errno::INVAL)?,
         None => linux_raw_sys::general::RLIM_INFINITY as _,
     };
     let rlim_max = match lim.maximum {
-        Some(r) => r.try_into().map_err(|_| io::Errno::INVAL)?,
+        Some(r) => r.try_into().map_err(|_e| io::Errno::INVAL)?,
         None => linux_raw_sys::general::RLIM_INFINITY as _,
     };
     Ok(linux_raw_sys::general::rlimit { rlim_cur, rlim_max })

--- a/src/imp/linux_raw/reg.rs
+++ b/src/imp/linux_raw/reg.rs
@@ -46,16 +46,16 @@ pub(super) trait FromAsm: private::Sealed {
 pub(super) struct Opaque(c::c_void);
 
 // Argument numbers.
-pub(super) struct A0 {}
-pub(super) struct A1 {}
-pub(super) struct A2 {}
-pub(super) struct A3 {}
-pub(super) struct A4 {}
-pub(super) struct A5 {}
+pub(super) struct A0;
+pub(super) struct A1;
+pub(super) struct A2;
+pub(super) struct A3;
+pub(super) struct A4;
+pub(super) struct A5;
 #[cfg(target_arch = "mips")]
-pub(super) struct A6 {}
+pub(super) struct A6;
 #[cfg(target_arch = "x86")]
-pub(super) struct SocketArg {}
+pub(super) struct SocketArg;
 
 pub(super) trait ArgNumber: private::Sealed {}
 impl ArgNumber for A0 {}
@@ -70,7 +70,7 @@ impl ArgNumber for A6 {}
 impl ArgNumber for SocketArg {}
 
 // Return value numbers.
-pub(super) struct R0 {}
+pub(super) struct R0;
 
 pub(super) trait RetNumber: private::Sealed {}
 impl RetNumber for R0 {}

--- a/src/io/procfs.rs
+++ b/src/io/procfs.rs
@@ -35,7 +35,7 @@ const PROC_ROOT_INO: u64 = 1;
 
 // Identify an entry within "/proc", to determine which anomalies to
 // check for.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 enum Kind {
     Proc,
     Pid,

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -547,18 +547,14 @@ pub const IORING_OFF_SQES: u64 = sys::IORING_OFF_SQES as _;
 /// TODO: Make this a const fn. It needs borrow_raw to be a const fn.
 #[inline]
 #[doc(alias = "IORING_REGISTER_FILES_SKIP")]
+#[allow(unsafe_code)]
 pub fn io_uring_register_files_skip() -> BorrowedFd<'static> {
     let files_skip = sys::IORING_REGISTER_FILES_SKIP as RawFd;
 
-    // # Safety
-    //
-    // `IORING_REGISTER_FILES_SKIP` is a reserved value that is never
+    // Safety: `IORING_REGISTER_FILES_SKIP` is a reserved value that is never
     // dynamically allocated, so it'll remain valid for the duration of
     // `'static`.
-    #[allow(unsafe_code)]
-    unsafe {
-        BorrowedFd::<'static>::borrow_raw(files_skip)
-    }
+    unsafe { BorrowedFd::<'static>::borrow_raw(files_skip) }
 }
 
 /// A pointer in the io_uring API.
@@ -657,6 +653,7 @@ impl Default for io_uring_user_data {
     #[inline]
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        // Safety: All of Linux's io_uring structs may be zero-initialized.
         unsafe {
             ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
             s.assume_init()
@@ -666,7 +663,7 @@ impl Default for io_uring_user_data {
 
 impl core::fmt::Debug for io_uring_user_data {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // Just format as a `u64`, since formatting doesn't preserve
+        // Safety: Just format as a `u64`, since formatting doesn't preserve
         // provenance, and we don't have a discriminant.
         unsafe { self.u64_.fmt(fmt) }
     }
@@ -689,7 +686,7 @@ pub struct io_uring_sqe {
     pub buf: buf_union,
     pub personality: u16,
     pub splice_fd_in_or_file_index: splice_fd_in_or_file_index_union,
-    pub __pad2: [u64; 2usize],
+    pub __pad2: [u64; 2_usize],
 }
 
 #[allow(missing_docs)]
@@ -768,7 +765,7 @@ pub struct io_uring_restriction {
     pub opcode: IoringRestrictionOp,
     pub register_or_sqe_op_or_sqe_flags: register_or_sqe_op_or_sqe_flags_union,
     pub resv: u8,
-    pub resv2: [u32; 3usize],
+    pub resv2: [u32; 3_usize],
 }
 
 #[allow(missing_docs)]
@@ -791,7 +788,7 @@ pub struct io_uring_params {
     pub sq_thread_idle: u32,
     pub features: IoringFeatureFlags,
     pub wq_fd: u32,
-    pub resv: [u32; 3usize],
+    pub resv: [u32; 3_usize],
     pub sq_off: io_sqring_offsets,
     pub cq_off: io_cqring_offsets,
 }
@@ -833,7 +830,7 @@ pub struct io_uring_probe {
     pub last_op: IoringOp,
     pub ops_len: u8,
     pub resv: u16,
-    pub resv2: [u32; 3usize],
+    pub resv2: [u32; 3_usize],
     pub ops: sys::__IncompleteArrayField<io_uring_probe_op>,
 }
 
@@ -927,6 +924,7 @@ impl Default for off_or_addr2_union {
     #[inline]
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        // Safety: All of Linux's io_uring structs may be zero-initialized.
         unsafe {
             ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
             s.assume_init()
@@ -938,6 +936,7 @@ impl Default for addr_or_splice_off_in_union {
     #[inline]
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        // Safety: All of Linux's io_uring structs may be zero-initialized.
         unsafe {
             ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
             s.assume_init()
@@ -949,6 +948,7 @@ impl Default for op_flags_union {
     #[inline]
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        // Safety: All of Linux's io_uring structs may be zero-initialized.
         unsafe {
             ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
             s.assume_init()
@@ -960,6 +960,7 @@ impl Default for buf_union {
     #[inline]
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        // Safety: All of Linux's io_uring structs may be zero-initialized.
         unsafe {
             ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
             s.assume_init()
@@ -971,6 +972,7 @@ impl Default for splice_fd_in_or_file_index_union {
     #[inline]
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        // Safety: All of Linux's io_uring structs may be zero-initialized.
         unsafe {
             ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
             s.assume_init()
@@ -982,6 +984,7 @@ impl Default for register_or_sqe_op_or_sqe_flags_union {
     #[inline]
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        // Safety: All of Linux's io_uring structs may be zero-initialized.
         unsafe {
             ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
             s.assume_init()

--- a/src/termios/constants.rs
+++ b/src/termios/constants.rs
@@ -616,10 +616,10 @@ pub fn speed_value(speed: imp::termios::types::Speed) -> Option<u32> {
         imp::termios::types::B19200 => Some(19200),
         imp::termios::types::B38400 => Some(38400),
         imp::termios::types::B57600 => Some(57600),
-        imp::termios::types::B115200 => Some(115200),
-        imp::termios::types::B230400 => Some(230400),
+        imp::termios::types::B115200 => Some(115_200),
+        imp::termios::types::B230400 => Some(230_400),
         #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
-        imp::termios::types::B460800 => Some(460800),
+        imp::termios::types::B460800 => Some(460_800),
         #[cfg(not(any(
             target_os = "dragonfly",
             target_os = "freebsd",
@@ -629,7 +629,7 @@ pub fn speed_value(speed: imp::termios::types::Speed) -> Option<u32> {
             target_os = "netbsd",
             target_os = "openbsd",
         )))]
-        imp::termios::types::B500000 => Some(500000),
+        imp::termios::types::B500000 => Some(500_000),
         #[cfg(not(any(
             target_os = "dragonfly",
             target_os = "freebsd",
@@ -639,9 +639,9 @@ pub fn speed_value(speed: imp::termios::types::Speed) -> Option<u32> {
             target_os = "netbsd",
             target_os = "openbsd",
         )))]
-        imp::termios::types::B576000 => Some(576000),
+        imp::termios::types::B576000 => Some(576_000),
         #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
-        imp::termios::types::B921600 => Some(921600),
+        imp::termios::types::B921600 => Some(921_600),
         #[cfg(not(any(
             target_os = "dragonfly",
             target_os = "freebsd",
@@ -650,7 +650,7 @@ pub fn speed_value(speed: imp::termios::types::Speed) -> Option<u32> {
             target_os = "netbsd",
             target_os = "openbsd",
         )))]
-        imp::termios::types::B1000000 => Some(1000000),
+        imp::termios::types::B1000000 => Some(1_000_000),
         #[cfg(not(any(
             target_os = "dragonfly",
             target_os = "freebsd",
@@ -659,7 +659,7 @@ pub fn speed_value(speed: imp::termios::types::Speed) -> Option<u32> {
             target_os = "netbsd",
             target_os = "openbsd",
         )))]
-        imp::termios::types::B1152000 => Some(1152000),
+        imp::termios::types::B1152000 => Some(1_152_000),
         #[cfg(not(any(
             target_os = "dragonfly",
             target_os = "freebsd",
@@ -668,7 +668,7 @@ pub fn speed_value(speed: imp::termios::types::Speed) -> Option<u32> {
             target_os = "netbsd",
             target_os = "openbsd",
         )))]
-        imp::termios::types::B1500000 => Some(1500000),
+        imp::termios::types::B1500000 => Some(1_500_000),
         #[cfg(not(any(
             target_os = "dragonfly",
             target_os = "freebsd",
@@ -677,7 +677,7 @@ pub fn speed_value(speed: imp::termios::types::Speed) -> Option<u32> {
             target_os = "netbsd",
             target_os = "openbsd",
         )))]
-        imp::termios::types::B2000000 => Some(2000000),
+        imp::termios::types::B2000000 => Some(2_000_000),
         #[cfg(not(any(
             target_os = "dragonfly",
             target_os = "freebsd",
@@ -686,7 +686,7 @@ pub fn speed_value(speed: imp::termios::types::Speed) -> Option<u32> {
             target_os = "netbsd",
             target_os = "openbsd",
         )))]
-        imp::termios::types::B2500000 => Some(2500000),
+        imp::termios::types::B2500000 => Some(2_500_000),
         #[cfg(not(any(
             target_os = "dragonfly",
             target_os = "freebsd",
@@ -695,7 +695,7 @@ pub fn speed_value(speed: imp::termios::types::Speed) -> Option<u32> {
             target_os = "netbsd",
             target_os = "openbsd",
         )))]
-        imp::termios::types::B3000000 => Some(3000000),
+        imp::termios::types::B3000000 => Some(3_000_000),
         #[cfg(not(any(
             target_os = "dragonfly",
             target_os = "freebsd",
@@ -704,7 +704,7 @@ pub fn speed_value(speed: imp::termios::types::Speed) -> Option<u32> {
             target_os = "netbsd",
             target_os = "openbsd",
         )))]
-        imp::termios::types::B3500000 => Some(3500000),
+        imp::termios::types::B3500000 => Some(3_500_000),
         #[cfg(not(any(
             target_os = "dragonfly",
             target_os = "freebsd",
@@ -713,7 +713,7 @@ pub fn speed_value(speed: imp::termios::types::Speed) -> Option<u32> {
             target_os = "netbsd",
             target_os = "openbsd",
         )))]
-        imp::termios::types::B4000000 => Some(4000000),
+        imp::termios::types::B4000000 => Some(4_000_000),
         _ => None,
     }
 }


### PR DESCRIPTION
Use fewer `as` casts, make sure that Safety comments for `unsafe` blocks
are properly formatted, and others.