### PR TITLE
Change `dup2`'s second operand from `&OwnedFd` to `AsFd`.

### DIFF
--- a/examples/dup2_to_replace_stdio.rs
+++ b/examples/dup2_to_replace_stdio.rs
@@ -19,10 +19,6 @@ fn main() {
     let (stdin, stdout) = unsafe { (rustix::io::take_stdin(), rustix::io::take_stdout()) };
 
     // Use `dup2` to copy our new file descriptors over the stdio file descriptors.
-    //
-    // These take their second argument as an `&OwnedFd` rather than the usual
-    // `impl AsFd` because they conceptually do a `close` on the original file
-    // descriptor, which one shouldn't be able to do with just a `BorrowedFd`.
     dup2(&reader, &stdin).unwrap();
     dup2(&writer, &stdout).unwrap();
 

--- a/src/imp/linux_raw/io/syscalls.rs
+++ b/src/imp/linux_raw/io/syscalls.rs
@@ -15,7 +15,7 @@ use super::super::conv::{
 };
 #[cfg(target_pointer_width = "32")]
 use super::super::conv::{hi, lo};
-use crate::fd::{AsFd, BorrowedFd, RawFd};
+use crate::fd::{BorrowedFd, RawFd};
 use crate::io::{
     self, epoll, DupFlags, EventfdFlags, IoSlice, IoSliceMut, OwnedFd, PipeFlags, PollFd,
     ReadWriteFlags,
@@ -392,7 +392,7 @@ pub(crate) fn dup(fd: BorrowedFd<'_>) -> io::Result<OwnedFd> {
 }
 
 #[inline]
-pub(crate) fn dup2(fd: BorrowedFd<'_>, new: &OwnedFd) -> io::Result<()> {
+pub(crate) fn dup2(fd: BorrowedFd<'_>, new: BorrowedFd<'_>) -> io::Result<()> {
     #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     {
         // `dup3` fails if the old and new file descriptors have the same
@@ -406,13 +406,13 @@ pub(crate) fn dup2(fd: BorrowedFd<'_>, new: &OwnedFd) -> io::Result<()> {
 
     #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
     unsafe {
-        ret_discarded_fd(syscall_readonly!(__NR_dup2, fd, new.as_fd()))
+        ret_discarded_fd(syscall_readonly!(__NR_dup2, fd, new))
     }
 }
 
 #[inline]
-pub(crate) fn dup3(fd: BorrowedFd<'_>, new: &OwnedFd, flags: DupFlags) -> io::Result<()> {
-    unsafe { ret_discarded_fd(syscall_readonly!(__NR_dup3, fd, new.as_fd(), flags)) }
+pub(crate) fn dup3(fd: BorrowedFd<'_>, new: BorrowedFd<'_>, flags: DupFlags) -> io::Result<()> {
+    unsafe { ret_discarded_fd(syscall_readonly!(__NR_dup3, fd, new, flags)) }
 }
 
 #[inline]

--- a/src/io/dup.rs
+++ b/src/io/dup.rs
@@ -31,13 +31,16 @@ pub fn dup<Fd: AsFd>(fd: Fd) -> io::Result<OwnedFd> {
     imp::io::syscalls::dup(fd.as_fd())
 }
 
-/// `dup2(fd, new)`—Creates a new `OwnedFd` instance that shares the
-/// same underlying [file description] as the existing `OwnedFd` instance,
-/// closing `new` and reusing its file descriptor.
+/// `dup2(fd, new)`—Changes the [file description] of a file descriptor.
+///
+/// `dup2` conceptually closes `new` and then sets the file description for
+/// `new` to be the same as the one for `fd`. This is a very unusual operation,
+/// and should only be used on file descriptors where you know how `new` will
+/// be subsequently used.
 ///
 /// This function does not set the `O_CLOEXEC` flag. To do a `dup2` that does
 /// set `O_CLOEXEC`, use [`dup3`] with [`DupFlags::CLOEXEC`] on platforms which
-/// support it.
+/// support it, or [`fcntl_dupfd_cloexec`]
 ///
 /// # References
 ///  - [POSIX]
@@ -46,15 +49,15 @@ pub fn dup<Fd: AsFd>(fd: Fd) -> io::Result<OwnedFd> {
 /// [file description]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_258
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/dup2.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/dup2.2.html
+/// [`fcntl_dupfd_cloexec`]: crate::fs::fcntl_dupfd_cloexec
 #[cfg(not(target_os = "wasi"))]
 #[inline]
-pub fn dup2<Fd: AsFd>(fd: Fd, new: &OwnedFd) -> io::Result<()> {
-    imp::io::syscalls::dup2(fd.as_fd(), new)
+pub fn dup2<Fd: AsFd, NewFd: AsFd>(fd: Fd, new: NewFd) -> io::Result<()> {
+    imp::io::syscalls::dup2(fd.as_fd(), new.as_fd())
 }
 
-/// `dup3(fd, new, flags)`—Creates a new `OwnedFd` instance that shares the
-/// same underlying [file description] as the existing `OwnedFd` instance,
-/// closing `new` and reusing its file descriptor, with flags.
+/// `dup3(fd, new, flags)`—Changes the [file description] of a file
+/// descriptor, with flags.
 ///
 /// `dup3` is the same as [`dup2`] but adds an additional flags operand,
 /// and it fails in the case that `fd` and `new` have the same file descriptor
@@ -70,6 +73,6 @@ pub fn dup2<Fd: AsFd>(fd: Fd, new: &OwnedFd) -> io::Result<()> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/dup2.2.html
 #[cfg(not(target_os = "wasi"))]
 #[inline]
-pub fn dup3<Fd: AsFd>(fd: Fd, new: &OwnedFd, flags: DupFlags) -> io::Result<()> {
-    imp::io::syscalls::dup3(fd.as_fd(), new, flags)
+pub fn dup3<Fd: AsFd, NewFd: AsFd>(fd: Fd, new: NewFd, flags: DupFlags) -> io::Result<()> {
+    imp::io::syscalls::dup3(fd.as_fd(), new.as_fd(), flags)
 }


### PR DESCRIPTION
And similar for `dup3`.

The idea behind using `&OwnedFd` was that `dup2`'s second operand isn't like a
normal borrow. It effectively closes the old file descriptor, and
creates a new one with the same index. This could break assumptions of
classes that have an `AsFd` to allow users to do special I/O operations,
but which don't expect users can close and reopen their file descriptor
as some completely unrelated resource.

However, the existence of things like [`FilelikeView`], as well as the
`ManuallyDrop` pattern, mean that `&OwnedFd` doesn't actually prevent
users from using `dup2` on a `BorrowedFd`. Even using `&mut OwnedFd`
wouldn't be sufficient, because one can obtain mutable `FilelikeView`
objects, in order to use them with functions like [`std::io::Read::read`].

So instead of trying to prohibit it, change `rustix`'s stance to allow
it. Unwise use of `dup2` may cause libraries to behave strangely, but it
should not cause them to have Undefined Behavior.

[`FilelikeView`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/views/struct.FilelikeView.html
[`std::io::Read::read`]: https://doc.rust-lang.org/stable/std/io/trait.Read.html#tymethod.read