### PR TITLE
Don't use `syscall_readonly` in `set_thread_area`.

### DIFF
--- a/src/imp/linux_raw/runtime/syscalls.rs
+++ b/src/imp/linux_raw/runtime/syscalls.rs
@@ -64,7 +64,7 @@ pub(crate) mod tls {
     #[cfg(target_arch = "x86")]
     #[inline]
     pub(crate) unsafe fn set_thread_area(u_info: &mut UserDesc) -> io::Result<()> {
-        ret(syscall_readonly!(__NR_set_thread_area, by_mut(u_info)))
+        ret(syscall!(__NR_set_thread_area, by_mut(u_info)))
     }
 
     #[cfg(target_arch = "arm")]


### PR DESCRIPTION
`set_thread_area` updates the `entry_number` field of the struct passed
to it, so don't use `syscall_readonly`.