### PR TITLE
Don't pass `BorrowedFd` by reference, in even more places.

### DIFF
--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -324,8 +324,8 @@ pub fn chmodat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, mode: Mode) -> io::Re
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 #[inline]
 pub fn fclonefileat<Fd: AsFd, DstFd: AsFd, P: path::Arg>(
-    src: &Fd,
-    dst_dir: &DstFd,
+    src: Fd,
+    dst_dir: DstFd,
     dst: P,
     flags: CloneFlags,
 ) -> io::Result<()> {

--- a/src/fs/copy_file_range.rs
+++ b/src/fs/copy_file_range.rs
@@ -10,9 +10,9 @@ use imp::fd::AsFd;
 /// [Linux]: https://man7.org/linux/man-pages/man2/copy_file_range.2.html
 #[inline]
 pub fn copy_file_range<InFd: AsFd, OutFd: AsFd>(
-    fd_in: &InFd,
+    fd_in: InFd,
     off_in: Option<&mut u64>,
-    fd_out: &OutFd,
+    fd_out: OutFd,
     off_out: Option<&mut u64>,
     len: u64,
 ) -> io::Result<u64> {

--- a/src/fs/fcopyfile.rs
+++ b/src/fs/fcopyfile.rs
@@ -18,8 +18,8 @@ pub use imp::fs::types::copyfile_state_t;
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/fcopyfile.3.html
 #[inline]
 pub unsafe fn fcopyfile<FromFd: AsFd, ToFd: AsFd>(
-    from: &FromFd,
-    to: &ToFd,
+    from: FromFd,
+    to: ToFd,
     state: copyfile_state_t,
     flags: CopyfileFlags,
 ) -> io::Result<()> {

--- a/src/time/timerfd.rs
+++ b/src/time/timerfd.rs
@@ -23,7 +23,7 @@ pub fn timerfd_create(clockid: TimerfdClockId, flags: TimerfdFlags) -> io::Resul
 /// [Linux]: https://man7.org/linux/man-pages/man2/timerfd_settime.2.html
 #[inline]
 pub fn timerfd_settime<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     flags: TimerfdTimerFlags,
     new_value: &Itimerspec,
 ) -> io::Result<Itimerspec> {
@@ -37,6 +37,6 @@ pub fn timerfd_settime<Fd: AsFd>(
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/timerfd_gettime.2.html
 #[inline]
-pub fn timerfd_gettime<Fd: AsFd>(fd: &Fd) -> io::Result<Itimerspec> {
+pub fn timerfd_gettime<Fd: AsFd>(fd: Fd) -> io::Result<Itimerspec> {
     imp::time::syscalls::timerfd_gettime(fd.as_fd())
 }


### PR DESCRIPTION
Following up on 2fb59ecd05209c54378eb1add6b3df19065900ff and
3026bf6079efcc937bba09783f5443199f06aa4f, fix even more places to
avoid needlessly passing `BorrowedFd` by reference.