### PR TITLE
Support io::MapFlags::FIXED on FreeBSD and OpenBSD

### DIFF
--- a/src/imp/libc/mm/types.rs
+++ b/src/imp/libc/mm/types.rs
@@ -85,9 +85,7 @@ bitflags! {
         #[cfg(not(any(
             target_os = "android",
             target_os = "emscripten",
-            target_os = "freebsd",
             target_os = "fuchsia",
-            target_os = "openbsd",
             target_os = "redox",
         )))]
         const FIXED = c::MAP_FIXED;


### PR DESCRIPTION
MAP_FIXED is part of POSIX and is supported on both FreeBSD and OpenBSD.