### PR TITLE
Put `must_use` on `ArgReg`/`RetReg` rather than all the syscall functions.

### DIFF
--- a/src/imp/linux_raw/arch/inline/aarch64.rs
+++ b/src/imp/linux_raw/arch/inline/aarch64.rs
@@ -7,7 +7,6 @@ use core::arch::asm;
 compile_error!("arm64-ilp32 is not supported yet");
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
     let r0;
     asm!(
@@ -20,7 +19,6 @@ pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
     let r0;
     asm!(
@@ -33,7 +31,6 @@ pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>)
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -49,7 +46,6 @@ pub(in crate::imp) unsafe fn syscall1_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "svc 0",
@@ -60,7 +56,6 @@ pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -78,7 +73,6 @@ pub(in crate::imp) unsafe fn syscall2(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -96,7 +90,6 @@ pub(in crate::imp) unsafe fn syscall2_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -116,7 +109,6 @@ pub(in crate::imp) unsafe fn syscall3(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -136,7 +128,6 @@ pub(in crate::imp) unsafe fn syscall3_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -158,7 +149,6 @@ pub(in crate::imp) unsafe fn syscall4(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -180,7 +170,6 @@ pub(in crate::imp) unsafe fn syscall4_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -204,7 +193,6 @@ pub(in crate::imp) unsafe fn syscall5(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -228,7 +216,6 @@ pub(in crate::imp) unsafe fn syscall5_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -254,7 +241,6 @@ pub(in crate::imp) unsafe fn syscall6(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,

--- a/src/imp/linux_raw/arch/inline/arm.rs
+++ b/src/imp/linux_raw/arch/inline/arm.rs
@@ -4,7 +4,6 @@ use crate::imp::reg::{ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2,
 use core::arch::asm;
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
     let r0;
     asm!(
@@ -17,7 +16,6 @@ pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
     let r0;
     asm!(
@@ -30,7 +28,6 @@ pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>)
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -46,7 +43,6 @@ pub(in crate::imp) unsafe fn syscall1_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "svc 0",
@@ -57,7 +53,6 @@ pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -75,7 +70,6 @@ pub(in crate::imp) unsafe fn syscall2(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -93,7 +87,6 @@ pub(in crate::imp) unsafe fn syscall2_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -113,7 +106,6 @@ pub(in crate::imp) unsafe fn syscall3(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -133,7 +125,6 @@ pub(in crate::imp) unsafe fn syscall3_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -155,7 +146,6 @@ pub(in crate::imp) unsafe fn syscall4(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -177,7 +167,6 @@ pub(in crate::imp) unsafe fn syscall4_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -201,7 +190,6 @@ pub(in crate::imp) unsafe fn syscall5(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -225,7 +213,6 @@ pub(in crate::imp) unsafe fn syscall5_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -251,7 +238,6 @@ pub(in crate::imp) unsafe fn syscall6(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,

--- a/src/imp/linux_raw/arch/inline/mips.rs
+++ b/src/imp/linux_raw/arch/inline/mips.rs
@@ -12,7 +12,6 @@ use crate::imp::reg::{
 use core::arch::asm;
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
     let x0;
     let err: usize;
@@ -40,7 +39,6 @@ pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> 
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
     let x0;
     let err: usize;
@@ -69,7 +67,6 @@ pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>)
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -101,7 +98,6 @@ pub(in crate::imp) unsafe fn syscall1_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "syscall",
@@ -112,7 +108,6 @@ pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -146,7 +141,6 @@ pub(in crate::imp) unsafe fn syscall2(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -180,7 +174,6 @@ pub(in crate::imp) unsafe fn syscall2_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -216,7 +209,6 @@ pub(in crate::imp) unsafe fn syscall3(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -252,7 +244,6 @@ pub(in crate::imp) unsafe fn syscall3_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -289,7 +280,6 @@ pub(in crate::imp) unsafe fn syscall4(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -326,7 +316,6 @@ pub(in crate::imp) unsafe fn syscall4_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -370,7 +359,6 @@ pub(in crate::imp) unsafe fn syscall5(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -414,7 +402,6 @@ pub(in crate::imp) unsafe fn syscall5_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -461,7 +448,6 @@ pub(in crate::imp) unsafe fn syscall6(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -508,7 +494,6 @@ pub(in crate::imp) unsafe fn syscall6_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall7_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,

--- a/src/imp/linux_raw/arch/inline/mips64.rs
+++ b/src/imp/linux_raw/arch/inline/mips64.rs
@@ -10,7 +10,6 @@ use crate::imp::reg::{ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2,
 use core::arch::asm;
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
     let x0;
     let err: usize;
@@ -38,7 +37,6 @@ pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> 
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
     let x0;
     let err: usize;
@@ -67,7 +65,6 @@ pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>)
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -99,7 +96,6 @@ pub(in crate::imp) unsafe fn syscall1_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "syscall",
@@ -110,7 +106,6 @@ pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -144,7 +139,6 @@ pub(in crate::imp) unsafe fn syscall2(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -178,7 +172,6 @@ pub(in crate::imp) unsafe fn syscall2_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -214,7 +207,6 @@ pub(in crate::imp) unsafe fn syscall3(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -250,7 +242,6 @@ pub(in crate::imp) unsafe fn syscall3_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -287,7 +278,6 @@ pub(in crate::imp) unsafe fn syscall4(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -324,7 +314,6 @@ pub(in crate::imp) unsafe fn syscall4_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -362,7 +351,6 @@ pub(in crate::imp) unsafe fn syscall5(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -400,7 +388,6 @@ pub(in crate::imp) unsafe fn syscall5_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -439,7 +426,6 @@ pub(in crate::imp) unsafe fn syscall6(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,

--- a/src/imp/linux_raw/arch/inline/powerpc64.rs
+++ b/src/imp/linux_raw/arch/inline/powerpc64.rs
@@ -13,7 +13,6 @@ use crate::imp::reg::{ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2,
 use core::arch::asm;
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
     let r0;
     asm!(
@@ -39,7 +38,6 @@ pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> 
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
     let r0;
     asm!(
@@ -65,7 +63,6 @@ pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>)
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -94,7 +91,6 @@ pub(in crate::imp) unsafe fn syscall1_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "sc",
@@ -105,7 +101,6 @@ pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -135,7 +130,6 @@ pub(in crate::imp) unsafe fn syscall2(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -165,7 +159,6 @@ pub(in crate::imp) unsafe fn syscall2_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -196,7 +189,6 @@ pub(in crate::imp) unsafe fn syscall3(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -227,7 +219,6 @@ pub(in crate::imp) unsafe fn syscall3_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -259,7 +250,6 @@ pub(in crate::imp) unsafe fn syscall4(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -291,7 +281,6 @@ pub(in crate::imp) unsafe fn syscall4_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -324,7 +313,6 @@ pub(in crate::imp) unsafe fn syscall5(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -357,7 +345,6 @@ pub(in crate::imp) unsafe fn syscall5_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -391,7 +378,6 @@ pub(in crate::imp) unsafe fn syscall6(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,

--- a/src/imp/linux_raw/arch/inline/riscv64.rs
+++ b/src/imp/linux_raw/arch/inline/riscv64.rs
@@ -4,7 +4,6 @@ use crate::imp::reg::{ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2,
 use core::arch::asm;
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
     let r0;
     asm!(
@@ -17,7 +16,6 @@ pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
     let r0;
     asm!(
@@ -30,7 +28,6 @@ pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>)
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -46,7 +43,6 @@ pub(in crate::imp) unsafe fn syscall1_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "ecall",
@@ -57,7 +53,6 @@ pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -75,7 +70,6 @@ pub(in crate::imp) unsafe fn syscall2(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -93,7 +87,6 @@ pub(in crate::imp) unsafe fn syscall2_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -113,7 +106,6 @@ pub(in crate::imp) unsafe fn syscall3(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -133,7 +125,6 @@ pub(in crate::imp) unsafe fn syscall3_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -155,7 +146,6 @@ pub(in crate::imp) unsafe fn syscall4(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -177,7 +167,6 @@ pub(in crate::imp) unsafe fn syscall4_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -201,7 +190,6 @@ pub(in crate::imp) unsafe fn syscall5(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -225,7 +213,6 @@ pub(in crate::imp) unsafe fn syscall5_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -251,7 +238,6 @@ pub(in crate::imp) unsafe fn syscall6(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,

--- a/src/imp/linux_raw/arch/inline/x86.rs
+++ b/src/imp/linux_raw/arch/inline/x86.rs
@@ -14,7 +14,6 @@ use crate::imp::vdso_wrappers::SyscallType;
 use core::arch::asm;
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn indirect_syscall0(
     callee: SyscallType,
     nr: SyscallNumber<'_>,
@@ -30,7 +29,6 @@ pub(in crate::imp) unsafe fn indirect_syscall0(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn indirect_syscall1(
     callee: SyscallType,
     nr: SyscallNumber<'_>,
@@ -63,7 +61,6 @@ pub(in crate::imp) unsafe fn indirect_syscall1_noreturn(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn indirect_syscall2(
     callee: SyscallType,
     nr: SyscallNumber<'_>,
@@ -83,7 +80,6 @@ pub(in crate::imp) unsafe fn indirect_syscall2(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn indirect_syscall3(
     callee: SyscallType,
     nr: SyscallNumber<'_>,
@@ -105,7 +101,6 @@ pub(in crate::imp) unsafe fn indirect_syscall3(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn indirect_syscall4(
     callee: SyscallType,
     nr: SyscallNumber<'_>,
@@ -137,7 +132,6 @@ pub(in crate::imp) unsafe fn indirect_syscall4(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn indirect_syscall5(
     callee: SyscallType,
     nr: SyscallNumber<'_>,
@@ -213,7 +207,6 @@ pub(in crate::imp) unsafe fn indirect_syscall6(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
     let r0;
     asm!(
@@ -225,7 +218,6 @@ pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
     let r0;
     asm!(
@@ -238,7 +230,6 @@ pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>)
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -264,7 +255,6 @@ pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -282,7 +272,6 @@ pub(in crate::imp) unsafe fn syscall2(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -300,7 +289,6 @@ pub(in crate::imp) unsafe fn syscall2_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -320,7 +308,6 @@ pub(in crate::imp) unsafe fn syscall3(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -340,7 +327,6 @@ pub(in crate::imp) unsafe fn syscall3_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -366,7 +352,6 @@ pub(in crate::imp) unsafe fn syscall4(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -390,7 +375,6 @@ pub(in crate::imp) unsafe fn syscall4_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -420,7 +404,6 @@ pub(in crate::imp) unsafe fn syscall5(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -447,7 +430,6 @@ pub(in crate::imp) unsafe fn syscall5_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -479,7 +461,6 @@ pub(in crate::imp) unsafe fn syscall6(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,

--- a/src/imp/linux_raw/arch/inline/x86_64.rs
+++ b/src/imp/linux_raw/arch/inline/x86_64.rs
@@ -7,7 +7,6 @@ use core::arch::asm;
 compile_error!("x32 is not yet supported");
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
     let r0;
     asm!(
@@ -21,7 +20,6 @@ pub(in crate::imp) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
     let r0;
     asm!(
@@ -36,7 +34,6 @@ pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>)
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -64,7 +61,6 @@ pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -84,7 +80,6 @@ pub(in crate::imp) unsafe fn syscall2(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -104,7 +99,6 @@ pub(in crate::imp) unsafe fn syscall2_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -126,7 +120,6 @@ pub(in crate::imp) unsafe fn syscall3(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -148,7 +141,6 @@ pub(in crate::imp) unsafe fn syscall3_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -172,7 +164,6 @@ pub(in crate::imp) unsafe fn syscall4(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -196,7 +187,6 @@ pub(in crate::imp) unsafe fn syscall4_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -222,7 +212,6 @@ pub(in crate::imp) unsafe fn syscall5(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -248,7 +237,6 @@ pub(in crate::imp) unsafe fn syscall5_readonly(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -276,7 +264,6 @@ pub(in crate::imp) unsafe fn syscall6(
 }
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6_readonly(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,

--- a/src/imp/linux_raw/arch/outline/nr_last.rs
+++ b/src/imp/linux_raw/arch/outline/nr_last.rs
@@ -78,22 +78,18 @@ extern "C" {
 // Then we define inline wrapper functions that do the reordering.
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall0(nr: SyscallNumber<'_>) -> RetReg<R0> {
     rustix_syscall0_nr_last(nr)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
     rustix_syscall1_nr_last(a0, nr)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     rustix_syscall1_noreturn_nr_last(a0, nr)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -102,7 +98,6 @@ pub(in crate::imp) unsafe fn syscall2(
     rustix_syscall2_nr_last(a0, a1, nr)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -112,7 +107,6 @@ pub(in crate::imp) unsafe fn syscall3(
     rustix_syscall3_nr_last(a0, a1, a2, nr)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -123,7 +117,6 @@ pub(in crate::imp) unsafe fn syscall4(
     rustix_syscall4_nr_last(a0, a1, a2, a3, nr)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -135,7 +128,6 @@ pub(in crate::imp) unsafe fn syscall5(
     rustix_syscall5_nr_last(a0, a1, a2, a3, a4, nr)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -149,7 +141,6 @@ pub(in crate::imp) unsafe fn syscall6(
 }
 #[cfg(target_arch = "mips")]
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall7(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,

--- a/src/imp/linux_raw/arch/outline/x86.rs
+++ b/src/imp/linux_raw/arch/outline/x86.rs
@@ -68,22 +68,18 @@ extern "fastcall" {
 // Then we define inline wrapper functions that do the reordering.
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall0(nr: SyscallNumber<'_>) -> RetReg<R0> {
     rustix_syscall0_nr_last_fastcall(nr)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
     rustix_syscall1_nr_last_fastcall(a0, nr)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     rustix_syscall1_noreturn_nr_last_fastcall(a0, nr)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall2(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -92,7 +88,6 @@ pub(in crate::imp) unsafe fn syscall2(
     rustix_syscall2_nr_last_fastcall(a1, a0, nr)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall3(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -102,7 +97,6 @@ pub(in crate::imp) unsafe fn syscall3(
     rustix_syscall3_nr_last_fastcall(a1, a2, a0, nr)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall4(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -113,7 +107,6 @@ pub(in crate::imp) unsafe fn syscall4(
     rustix_syscall4_nr_last_fastcall(a1, a2, a0, a3, nr)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall5(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -125,7 +118,6 @@ pub(in crate::imp) unsafe fn syscall5(
     rustix_syscall5_nr_last_fastcall(a1, a2, a0, a3, a4, nr)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn syscall6(
     nr: SyscallNumber<'_>,
     a0: ArgReg<'_, A0>,
@@ -214,7 +206,6 @@ extern "fastcall" {
 // Then we define inline wrapper functions that do the reordering.
 
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn indirect_syscall0(
     callee: SyscallType,
     nr: SyscallNumber<'_>,
@@ -222,7 +213,6 @@ pub(in crate::imp) unsafe fn indirect_syscall0(
     rustix_indirect_syscall0_nr_last_fastcall(nr, callee)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn indirect_syscall1(
     callee: SyscallType,
     nr: SyscallNumber<'_>,
@@ -231,7 +221,6 @@ pub(in crate::imp) unsafe fn indirect_syscall1(
     rustix_indirect_syscall1_nr_last_fastcall(a0, nr, callee)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn indirect_syscall1_noreturn(
     callee: SyscallType,
     nr: SyscallNumber<'_>,
@@ -240,7 +229,6 @@ pub(in crate::imp) unsafe fn indirect_syscall1_noreturn(
     rustix_indirect_syscall1_noreturn_nr_last_fastcall(a0, nr, callee)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn indirect_syscall2(
     callee: SyscallType,
     nr: SyscallNumber<'_>,
@@ -250,7 +238,6 @@ pub(in crate::imp) unsafe fn indirect_syscall2(
     rustix_indirect_syscall2_nr_last_fastcall(a1, a0, nr, callee)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn indirect_syscall3(
     callee: SyscallType,
     nr: SyscallNumber<'_>,
@@ -261,7 +248,6 @@ pub(in crate::imp) unsafe fn indirect_syscall3(
     rustix_indirect_syscall3_nr_last_fastcall(a1, a2, a0, nr, callee)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn indirect_syscall4(
     callee: SyscallType,
     nr: SyscallNumber<'_>,
@@ -273,7 +259,6 @@ pub(in crate::imp) unsafe fn indirect_syscall4(
     rustix_indirect_syscall4_nr_last_fastcall(a1, a2, a0, a3, nr, callee)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn indirect_syscall5(
     callee: SyscallType,
     nr: SyscallNumber<'_>,
@@ -286,7 +271,6 @@ pub(in crate::imp) unsafe fn indirect_syscall5(
     rustix_indirect_syscall5_nr_last_fastcall(a1, a2, a0, a3, a4, nr, callee)
 }
 #[inline]
-#[must_use]
 pub(in crate::imp) unsafe fn indirect_syscall6(
     callee: SyscallType,
     nr: SyscallNumber<'_>,

--- a/src/imp/linux_raw/reg.rs
+++ b/src/imp/linux_raw/reg.rs
@@ -25,6 +25,7 @@ pub(super) trait ToAsm: private::Sealed {
     ///
     /// This should be used immediately before the syscall instruction, and
     /// the returned value shouldn't be used for any other purpose.
+    #[must_use]
     unsafe fn to_asm(self) -> *mut Opaque;
 }
 
@@ -36,6 +37,7 @@ pub(super) trait FromAsm: private::Sealed {
     ///
     /// This should be used immediately after the syscall instruction, and
     /// the operand value shouldn't be used for any other purpose.
+    #[must_use]
     unsafe fn from_asm(raw: *mut Opaque) -> Self;
 }
 
@@ -46,14 +48,14 @@ pub(super) trait FromAsm: private::Sealed {
 pub(super) struct Opaque(c::c_void);
 
 // Argument numbers.
-pub(super) struct A0;
-pub(super) struct A1;
-pub(super) struct A2;
-pub(super) struct A3;
-pub(super) struct A4;
-pub(super) struct A5;
+pub(super) struct A0(());
+pub(super) struct A1(());
+pub(super) struct A2(());
+pub(super) struct A3(());
+pub(super) struct A4(());
+pub(super) struct A5(());
 #[cfg(target_arch = "mips")]
-pub(super) struct A6;
+pub(super) struct A6(());
 #[cfg(target_arch = "x86")]
 pub(super) struct SocketArg;
 
@@ -70,7 +72,7 @@ impl ArgNumber for A6 {}
 impl ArgNumber for SocketArg {}
 
 // Return value numbers.
-pub(super) struct R0;
+pub(super) struct R0(());
 
 pub(super) trait RetNumber: private::Sealed {}
 impl RetNumber for R0 {}
@@ -82,6 +84,7 @@ impl RetNumber for R0 {}
 /// once. And it has a lifetime to ensure that it doesn't outlive any resources
 /// it might be pointing to.
 #[repr(transparent)]
+#[must_use]
 pub(super) struct ArgReg<'a, Num: ArgNumber> {
     raw: *mut Opaque,
     _phantom: PhantomData<(&'a (), Num)>,
@@ -100,6 +103,7 @@ impl<'a, Num: ArgNumber> ToAsm for ArgReg<'a, Num> {
 /// This type doesn't implement `Clone` or `Copy`; it should be used exactly
 /// once.
 #[repr(transparent)]
+#[must_use]
 pub(super) struct RetReg<Num: RetNumber> {
     raw: *mut Opaque,
     _phantom: PhantomData<Num>,

--- a/src/imp/linux_raw/vdso_wrappers.rs
+++ b/src/imp/linux_raw/vdso_wrappers.rs
@@ -89,7 +89,6 @@ pub(super) mod x86_via_vdso {
     use crate::imp::arch::asm;
 
     #[inline]
-    #[must_use]
     pub(in crate::imp) unsafe fn syscall0(nr: SyscallNumber<'_>) -> RetReg<R0> {
         let callee = match transmute(super::SYSCALL.load(Relaxed)) {
             Some(callee) => callee,
@@ -99,7 +98,6 @@ pub(super) mod x86_via_vdso {
     }
 
     #[inline]
-    #[must_use]
     pub(in crate::imp) unsafe fn syscall1<'a>(
         nr: SyscallNumber<'a>,
         a0: ArgReg<'a, A0>,
@@ -124,7 +122,6 @@ pub(super) mod x86_via_vdso {
     }
 
     #[inline]
-    #[must_use]
     pub(in crate::imp) unsafe fn syscall2<'a>(
         nr: SyscallNumber<'a>,
         a0: ArgReg<'a, A0>,
@@ -138,7 +135,6 @@ pub(super) mod x86_via_vdso {
     }
 
     #[inline]
-    #[must_use]
     pub(in crate::imp) unsafe fn syscall3<'a>(
         nr: SyscallNumber<'a>,
         a0: ArgReg<'a, A0>,
@@ -153,7 +149,6 @@ pub(super) mod x86_via_vdso {
     }
 
     #[inline]
-    #[must_use]
     pub(in crate::imp) unsafe fn syscall4<'a>(
         nr: SyscallNumber<'a>,
         a0: ArgReg<'a, A0>,
@@ -169,7 +164,6 @@ pub(super) mod x86_via_vdso {
     }
 
     #[inline]
-    #[must_use]
     pub(in crate::imp) unsafe fn syscall5<'a>(
         nr: SyscallNumber<'a>,
         a0: ArgReg<'a, A0>,
@@ -186,7 +180,6 @@ pub(super) mod x86_via_vdso {
     }
 
     #[inline]
-    #[must_use]
     pub(in crate::imp) unsafe fn syscall6<'a>(
         nr: SyscallNumber<'a>,
         a0: ArgReg<'a, A0>,


### PR DESCRIPTION
`ArgReg` and `RetReg` should be `must_use` everywhere, so put the
attribute on the type rather than on functions that use the type.

Also, add `must_use` to `ToAsm::to_asm` and `FromAsm::from_asm`.

And add private members to the argument and return value number types,
to indicate that most code shouldn't directly constructed them.