### PR TITLE
Simplify the linux-raw implementation of `accessat`.

### DIFF
--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -615,6 +615,13 @@ impl<'a, Num: ArgNumber> From<(crate::thread::FutexOperation, crate::thread::Fut
     }
 }
 
+impl<'a, Num: ArgNumber> From<crate::fs::Access> for ArgReg<'a, Num> {
+    #[inline]
+    fn from(access: crate::fs::Access) -> Self {
+        c_uint(access.bits())
+    }
+}
+
 #[cfg(feature = "net")]
 impl<'a, Num: ArgNumber> From<crate::net::SocketType> for ArgReg<'a, Num> {
     #[inline]

--- a/src/imp/linux_raw/fs/syscalls.rs
+++ b/src/imp/linux_raw/fs/syscalls.rs
@@ -1318,7 +1318,7 @@ pub(crate) fn accessat(
             && crate::process::getuid() == crate::process::geteuid()
             && crate::process::getgid() == crate::process::getegid())
     {
-        return _accessat(dirfd, path, access.bits());
+        return unsafe { ret(syscall_readonly!(__NR_faccessat, dirfd, path, access)) };
     }
 
     if flags.bits() != linux_raw_sys::general::AT_EACCESS {
@@ -1327,18 +1327,6 @@ pub(crate) fn accessat(
 
     // TODO: Use faccessat2 in newer Linux versions.
     Err(io::Errno::NOSYS)
-}
-
-#[inline]
-fn _accessat(dirfd: BorrowedFd<'_>, pathname: &ZStr, mode: c::c_uint) -> io::Result<()> {
-    unsafe {
-        ret(syscall_readonly!(
-            __NR_faccessat,
-            dirfd,
-            pathname,
-            c_uint(mode)
-        ))
-    }
 }
 
 #[inline]


### PR DESCRIPTION
Move the conversion of `Access` into an `ArgReg` conversion, and inline
a trivial helper function.