### PR TITLE
Tidy up unneeded `cfg`s in the linux_raw backend.

### DIFF
--- a/src/imp/linux_raw/net/addr.rs
+++ b/src/imp/linux_raw/net/addr.rs
@@ -42,7 +42,6 @@ impl SocketAddrUnix {
     }
 
     /// Construct a new abstract Unix-domain address from a byte slice.
-    #[cfg(any(target_os = "android", target_os = "linux"))]
     #[inline]
     pub fn new_abstract_name(name: &[u8]) -> io::Result<Self> {
         let mut unix = Self::init();
@@ -87,7 +86,6 @@ impl SocketAddrUnix {
 
     /// For an abstract address, return the identifier.
     #[inline]
-    #[cfg(any(target_os = "android", target_os = "linux"))]
     pub fn abstract_name(&self) -> Option<&[u8]> {
         let len = self.len();
         if len != 0 && self.unix.sun_path[0] == b'\0' as c::c_char {

--- a/src/imp/linux_raw/time/types.rs
+++ b/src/imp/linux_raw/time/types.rs
@@ -16,7 +16,6 @@ pub type Nsecs = i64;
 ///
 /// [`timerfd_gettime`]: crate::time::timerfd_gettime
 /// [`timerfd_settime`]: crate::time::timerfd_settime
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
 pub type Itimerspec = linux_raw_sys::general::__kernel_itimerspec;
 
 /// `CLOCK_*` constants for use with [`clock_gettime`].


### PR DESCRIPTION
The linux_raw backend only supports Linux-like targets, so it doesn't
need to test for them with `#[cfg(...)]`.