### PR TITLE
Enable `MapFlags::FIXED` on all platforms.

### DIFF
--- a/src/imp/libc/mm/types.rs
+++ b/src/imp/libc/mm/types.rs
@@ -82,12 +82,6 @@ bitflags! {
         )))]
         const DENYWRITE = c::MAP_DENYWRITE;
         /// `MAP_FIXED`
-        #[cfg(not(any(
-            target_os = "android",
-            target_os = "emscripten",
-            target_os = "fuchsia",
-            target_os = "redox",
-        )))]
         const FIXED = c::MAP_FIXED;
         /// `MAP_FIXED_NOREPLACE`
         #[cfg(not(any(


### PR DESCRIPTION
As a followup to #320, it appears like all platforms rustix supports
support `MAP_FIXED` now.