### PR TITLE
Fix dependencies for big-endian mips targets.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,6 +174,7 @@ jobs:
         RUSTFLAGS: -A improper_ctypes_definitions
     - run: rustup component add rust-src
     - run: cargo check -Z build-std=core,alloc,std --target x86_64-unknown-openbsd --all-targets
+    - run: cargo check -Z build-std=core,alloc,std --target mips64-openwrt-linux-musl --all-targets
     # x86_64-uwp-windows-msvc isn't currently working.
     #- run: cargo check -Z build-std=core,alloc,std --target x86_64-uwp-windows-msvc --all-targets
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,18 +34,18 @@ once_cell = { version = "1.5.2", optional = true }
 # On Linux on selected architectures, we have two supported backends: linux_raw
 # and libc. The libc and errno dependencies are only enabled when the libc
 # backend is in use.
-[target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", all(target_endian = "little", any(target_arch = "mips", target_arch = "mips64")))))'.dependencies]
+[target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), all(target_endian = "little", any(target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
 linux-raw-sys = { version = "0.0.46", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 errno = { version = "0.2.8", default-features = false, optional = true }
 libc = { version = "0.2.118", features = ["extra_traits"], optional = true }
 
 # On all other Unix-family platforms, and under Miri, we always use the libc
 # backend, so enable its dependencies unconditionally.
-[target.'cfg(any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", all(target_endian = "little", any(target_arch = "mips", target_arch = "mips64")))))))'.dependencies]
+[target.'cfg(any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), all(target_endian = "little", any(target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))))'.dependencies]
 errno = { version = "0.2.8", default-features = false }
 libc = { version = "0.2.118", features = ["extra_traits"] }
 
-[target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", all(target_endian = "little", any(target_arch = "mips", target_arch = "mips64"))))))))'.dependencies]
+[target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), all(target_endian = "little", any(target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64"))))))))'.dependencies]
 # Some syscalls do not have libc wrappers, such as in `io_uring`. For these,
 # we use the linux-raw-sys ABI and `libc::syscall`.
 linux-raw-sys = { version = "0.0.46", default-features = false, optional = true, features = ["general", "no_std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,18 +34,18 @@ once_cell = { version = "1.5.2", optional = true }
 # On Linux on selected architectures, we have two supported backends: linux_raw
 # and libc. The libc and errno dependencies are only enabled when the libc
 # backend is in use.
-[target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))'.dependencies]
+[target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", all(target_endian = "little", any(target_arch = "mips", target_arch = "mips64")))))'.dependencies]
 linux-raw-sys = { version = "0.0.46", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 errno = { version = "0.2.8", default-features = false, optional = true }
 libc = { version = "0.2.118", features = ["extra_traits"], optional = true }
 
 # On all other Unix-family platforms, and under Miri, we always use the libc
 # backend, so enable its dependencies unconditionally.
-[target.'cfg(any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
+[target.'cfg(any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", all(target_endian = "little", any(target_arch = "mips", target_arch = "mips64")))))))'.dependencies]
 errno = { version = "0.2.8", default-features = false }
 libc = { version = "0.2.118", features = ["extra_traits"] }
 
-[target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64"))))))'.dependencies]
+[target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", all(target_endian = "little", any(target_arch = "mips", target_arch = "mips64"))))))))'.dependencies]
 # Some syscalls do not have libc wrappers, such as in `io_uring`. For these,
 # we use the linux-raw-sys ABI and `libc::syscall`.
 linux-raw-sys = { version = "0.0.46", default-features = false, optional = true, features = ["general", "no_std"] }

--- a/build.rs
+++ b/build.rs
@@ -34,10 +34,8 @@ fn main() {
     // Check for special target variants.
     let is_x32 = arch == "x86_64" && pointer_width == "32";
     let is_arm64_ilp32 = arch == "aarch64" && pointer_width == "32";
-    let is_powerpc64be = arch == "powerpc64" && endian == "big";
-    let is_mipseb = arch == "mips" && endian == "big";
-    let is_mips64eb = arch == "mips64" && endian == "big";
-    let is_unsupported_abi = is_x32 || is_arm64_ilp32 || is_powerpc64be || is_mipseb || is_mips64eb;
+    let is_be = endian == "big";
+    let is_unsupported_abi = is_x32 || is_arm64_ilp32 || is_be;
 
     // Check for `--features=use-libc`. This allows crate users to enable the
     // libc backend.


### PR DESCRIPTION
Big-endian mips and mips64 uses the libc backend, so ensure that libc
and errno are properly depended on under those targets.

This issue is already fixed on main, so this PR is for the 0.34.x branch.