### PR TITLE
Use fewer `linux_raw_sys::general::` qualifiers in implementation code.

### DIFF
--- a/src/imp/linux_raw/fs/dir.rs
+++ b/src/imp/linux_raw/fs/dir.rs
@@ -8,7 +8,7 @@ use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 use core::fmt;
 use core::mem::size_of;
-use linux_raw_sys::general::linux_dirent64;
+use linux_raw_sys::general::{linux_dirent64, SEEK_SET};
 
 /// `DIR*`
 pub struct Dir {
@@ -51,11 +51,7 @@ impl Dir {
     /// `readdir(self)`, where `None` means the end of the directory.
     pub fn read(&mut self) -> Option<io::Result<DirEntry>> {
         if let Some(next) = self.next.take() {
-            match crate::imp::fs::syscalls::_seek(
-                self.fd.as_fd(),
-                next as i64,
-                linux_raw_sys::general::SEEK_SET,
-            ) {
+            match crate::imp::fs::syscalls::_seek(self.fd.as_fd(), next as i64, SEEK_SET) {
                 Ok(_) => (),
                 Err(err) => return Some(Err(err)),
             }

--- a/src/imp/linux_raw/io/syscalls.rs
+++ b/src/imp/linux_raw/io/syscalls.rs
@@ -24,7 +24,9 @@ use crate::io::{
 use crate::net::{RecvFlags, SendFlags};
 use core::cmp;
 use core::mem::MaybeUninit;
-use linux_raw_sys::general::{epoll_event, EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD};
+use linux_raw_sys::general::{
+    epoll_event, EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD, UIO_MAXIOV,
+};
 use linux_raw_sys::ioctl::{BLKPBSZGET, BLKSSZGET, FIONBIO, FIONREAD, TIOCEXCL, TIOCNXCL};
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use {
@@ -281,7 +283,7 @@ pub(crate) fn pwritev2(
 /// The maximum number of buffers that can be passed into a vectored I/O system
 /// call on the current platform.
 const fn max_iov() -> usize {
-    linux_raw_sys::general::UIO_MAXIOV as usize
+    UIO_MAXIOV as usize
 }
 
 #[inline]

--- a/src/imp/linux_raw/mm/syscalls.rs
+++ b/src/imp/linux_raw/mm/syscalls.rs
@@ -17,6 +17,7 @@ use crate::fd::BorrowedFd;
 use crate::io::{self, OwnedFd};
 #[cfg(target_pointer_width = "32")]
 use core::convert::TryInto;
+use linux_raw_sys::general::MAP_ANONYMOUS;
 
 #[inline]
 pub(crate) fn madvise(addr: *mut c::c_void, len: usize, advice: Advice) -> io::Result<()> {
@@ -95,7 +96,7 @@ pub(crate) unsafe fn mmap_anonymous(
             addr,
             pass_usize(length),
             prot,
-            c_uint(flags.bits() | linux_raw_sys::general::MAP_ANONYMOUS),
+            c_uint(flags.bits() | MAP_ANONYMOUS),
             no_fd(),
             pass_usize(0)
         ))
@@ -107,7 +108,7 @@ pub(crate) unsafe fn mmap_anonymous(
             addr,
             pass_usize(length),
             prot,
-            c_uint(flags.bits() | linux_raw_sys::general::MAP_ANONYMOUS),
+            c_uint(flags.bits() | MAP_ANONYMOUS),
             no_fd(),
             loff_t_from_u64(0)
         ))

--- a/src/imp/linux_raw/process/types.rs
+++ b/src/imp/linux_raw/process/types.rs
@@ -1,4 +1,5 @@
 use super::super::c;
+use linux_raw_sys::general::membarrier_cmd;
 
 /// A command for use with [`membarrier`] and [`membarrier_cpu`].
 ///
@@ -13,31 +14,25 @@ pub enum MembarrierCommand {
     /// `MEMBARRIER_CMD_GLOBAL`
     #[doc(alias = "Shared")]
     #[doc(alias = "MEMBARRIER_CMD_SHARED")]
-    Global = linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_GLOBAL as _,
+    Global = membarrier_cmd::MEMBARRIER_CMD_GLOBAL as _,
     /// `MEMBARRIER_CMD_GLOBAL_EXPEDITED`
-    GlobalExpedited = linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_GLOBAL_EXPEDITED as _,
+    GlobalExpedited = membarrier_cmd::MEMBARRIER_CMD_GLOBAL_EXPEDITED as _,
     /// `MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED`
-    RegisterGlobalExpedited =
-        linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED as _,
+    RegisterGlobalExpedited = membarrier_cmd::MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED as _,
     /// `MEMBARRIER_CMD_PRIVATE_EXPEDITED`
-    PrivateExpedited =
-        linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_PRIVATE_EXPEDITED as _,
+    PrivateExpedited = membarrier_cmd::MEMBARRIER_CMD_PRIVATE_EXPEDITED as _,
     /// `MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED`
-    RegisterPrivateExpedited =
-        linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED as _,
+    RegisterPrivateExpedited = membarrier_cmd::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED as _,
     /// `MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE`
-    PrivateExpeditedSyncCore =
-        linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE as _,
+    PrivateExpeditedSyncCore = membarrier_cmd::MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE as _,
     /// `MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_SYNC_CORE`
     RegisterPrivateExpeditedSyncCore =
-        linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_SYNC_CORE
-            as _,
+        membarrier_cmd::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_SYNC_CORE as _,
     /// `MEMBARRIER_CMD_PRIVATE_EXPEDITED_RSEQ` (since Linux 5.10)
-    PrivateExpeditedRseq =
-        linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_PRIVATE_EXPEDITED_RSEQ as _,
+    PrivateExpeditedRseq = membarrier_cmd::MEMBARRIER_CMD_PRIVATE_EXPEDITED_RSEQ as _,
     /// `MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_RSEQ` (since Linux 5.10)
     RegisterPrivateExpeditedRseq =
-        linux_raw_sys::general::membarrier_cmd::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_RSEQ as _,
+        membarrier_cmd::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_RSEQ as _,
 }
 
 /// A resource value for use with [`getrlimit`], [`setrlimit`], and


### PR DESCRIPTION
This is a minor code cleanup to add `use linux_raw_sys::general::`
declarations to eliminate some explicit qualifiers in the code.