### PR TITLE
Detect when `statx` isn't available on older versions of Docker.

### DIFF
--- a/src/fs/statx.rs
+++ b/src/fs/statx.rs
@@ -1,15 +1,19 @@
 //! Linux `statx`.
 
+use crate::fd::{AsFd, BorrowedFd};
+use crate::ffi::CStr;
 use crate::fs::AtFlags;
 use crate::{imp, io, path};
-use imp::fd::AsFd;
+use core::sync::atomic::{AtomicU8, Ordering};
 
 pub use imp::fs::types::{Statx, StatxFlags, StatxTimestamp};
 
 /// `statx(dirfd, path, flags, mask, statxbuf)`
 ///
-/// This isn't available on Linux before 4.11; it returns `ENOSYS` in that
-/// case.
+/// This function returns [`io::Errno::NOSYS`] if `statx` is not available on
+/// the platform, such as Linux before 4.11. This also includes older Docker
+/// versions where the actual syscall fails with different error codes; Rustix
+/// handles this and translates them into `NOSYS`.
 ///
 /// # References
 ///  - [Linux]
@@ -22,5 +26,66 @@ pub fn statx<P: path::Arg, Fd: AsFd>(
     flags: AtFlags,
     mask: StatxFlags,
 ) -> io::Result<Statx> {
-    path.into_with_c_str(|path| imp::fs::syscalls::statx(dirfd.as_fd(), path, flags, mask))
+    path.into_with_c_str(|path| _statx(dirfd.as_fd(), path, flags, mask))
+}
+
+// Linux kernel prior to 4.11 old versions of Docker don't support `statx`. We
+// store the availability in a global to avoid unnecessary syscalls.
+//
+// 0: Unknown
+// 1: Not available
+// 2: Available
+static STATX_STATE: AtomicU8 = AtomicU8::new(0);
+
+#[inline]
+fn _statx(
+    dirfd: BorrowedFd<'_>,
+    path: &CStr,
+    flags: AtFlags,
+    mask: StatxFlags,
+) -> io::Result<Statx> {
+    match STATX_STATE.load(Ordering::Relaxed) {
+        0 => statx_init(dirfd, path, flags, mask),
+        1 => Err(io::Errno::NOSYS),
+        _ => imp::fs::syscalls::statx(dirfd, path, flags, mask),
+    }
+}
+
+/// The first `statx` call. We don't know if `statx` is available yet.
+fn statx_init(
+    dirfd: BorrowedFd<'_>,
+    path: &CStr,
+    flags: AtFlags,
+    mask: StatxFlags,
+) -> io::Result<Statx> {
+    match imp::fs::syscalls::statx(dirfd, path, flags, mask) {
+        Err(io::Errno::NOSYS) => statx_error_nosys(),
+        Err(io::Errno::PERM) => statx_error_perm(),
+        result => {
+            STATX_STATE.store(2, Ordering::Relaxed);
+            result
+        }
+    }
+}
+
+/// The first `statx` call failed with `NOSYS` (or something we're treating
+/// like `NOSYS`).
+#[cold]
+fn statx_error_nosys() -> io::Result<Statx> {
+    STATX_STATE.store(1, Ordering::Relaxed);
+    Err(io::Errno::NOSYS)
+}
+
+/// The first `statx` call failed with `PERM`.
+#[cold]
+fn statx_error_perm() -> io::Result<Statx> {
+    // Some old versions of Docker have `statx` fail with `PERM` when it isn't
+    // recognized. Check whether `statx` really is available, and if so, fail
+    // with `PERM`, and if not, treat it like `NOSYS`.
+    if imp::fs::syscalls::is_statx_available() {
+        STATX_STATE.store(2, Ordering::Relaxed);
+        Err(io::Errno::PERM)
+    } else {
+        statx_error_nosys()
+    }
 }

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -350,7 +350,7 @@ pub(crate) fn statat(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io::
     {
         match statx(dirfd, path, flags, StatxFlags::BASIC_STATS) {
             Ok(x) => return statx_to_stat(x),
-            Err(io::Error::NOSYS) => statat_old(dirfd, path, flags),
+            Err(io::Errno::NOSYS) => statat_old(dirfd, path, flags),
             Err(e) => return Err(e),
         }
     }
@@ -908,7 +908,7 @@ pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
     {
         match statx(fd, cstr!(""), AtFlags::EMPTY_PATH, StatxFlags::BASIC_STATS) {
             Ok(x) => return statx_to_stat(x),
-            Err(io::Error::NOSYS) => fstat_old(fd),
+            Err(io::Errno::NOSYS) => fstat_old(fd),
             Err(e) => return Err(e),
         }
     }

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -1381,6 +1381,7 @@ fn stat64_to_stat(s64: c::stat64) -> io::Result<Stat> {
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
+#[allow(non_upper_case_globals)]
 mod sys {
     use super::{c, BorrowedFd, Statx};
 

--- a/src/imp/libc/fs/syscalls.rs
+++ b/src/imp/libc/fs/syscalls.rs
@@ -125,11 +125,6 @@ use core::ptr::null;
     target_os = "macos"
 ))]
 use core::ptr::null_mut;
-#[cfg(all(
-    any(target_os = "android", target_os = "linux"),
-    any(target_pointer_width = "32", target_arch = "mips64")
-))]
-use core::sync::atomic::{AtomicBool, Ordering::Relaxed};
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 use {
     super::super::conv::nonnegative_ret,

--- a/src/imp/linux_raw/fs/syscalls.rs
+++ b/src/imp/linux_raw/fs/syscalls.rs
@@ -31,8 +31,6 @@ use crate::io::{self, OwnedFd, SeekFrom};
 use crate::process::{Gid, Uid};
 use core::convert::TryInto;
 use core::mem::MaybeUninit;
-#[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
-use core::sync::atomic::{AtomicBool, Ordering::Relaxed};
 #[cfg(target_arch = "mips64")]
 use linux_raw_sys::general::stat as linux_stat64;
 use linux_raw_sys::general::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,8 @@
 //!    are used (and documentation aliases are used so that the original names
 //!    can still be searched for).
 //!  - Provide y2038 compatibility, on platforms which support this.
+//!  - Correct selected platform bugs, such as behavioral differences when
+//!    running under seccomp.
 //!
 //! Things they don't do include:
 //!  - Detecting whether functions are supported at runtime.


### PR DESCRIPTION
In older versions of Docker, `statx` can fail with `EPERM` meaning it
isn't available. Recognize this, and translate it into `ENOSYS`. Also,
have `statx` remember this and fail quickly in future calls.

This is more emulation than rustix usually likes to do, but in this
case, this is the behavior seems likely to be what most users will
want, and we might as well put the code in one place.

Fixes #352.