### PR TITLE
Sync rustix with Windows Unix ioctls.

### DIFF
--- a/src/imp/libc/io/windows_syscalls.rs
+++ b/src/imp/libc/io/windows_syscalls.rs
@@ -7,9 +7,18 @@ use crate::fd::{BorrowedFd, RawFd};
 use crate::io;
 use crate::io::PollFd;
 use core::convert::TryInto;
+use core::mem::MaybeUninit;
 
 pub(crate) unsafe fn close(raw_fd: RawFd) {
     let _ = c::close(raw_fd as LibcFd);
+}
+
+pub(crate) fn ioctl_fionread(fd: BorrowedFd<'_>) -> io::Result<u64> {
+    let mut nread = MaybeUninit::<c::c_ulong>::uninit();
+    unsafe {
+        ret(c::ioctl(borrowed_fd(fd), c::FIONREAD, nread.as_mut_ptr()))?;
+        Ok(u64::from(nread.assume_init()))
+    }
 }
 
 pub(crate) fn ioctl_fionbio(fd: BorrowedFd<'_>, value: bool) -> io::Result<()> {

--- a/src/imp/libc/winsock_c.rs
+++ b/src/imp/libc/winsock_c.rs
@@ -7,7 +7,7 @@ use windows_sys::Win32::Networking::WinSock;
 
 pub(crate) use libc::{
     c_char, c_int, c_long, c_longlong, c_schar, c_short, c_uchar, c_uint, c_ulong, c_ulonglong,
-    c_ushort, ssize_t,
+    c_ushort, c_void, ssize_t,
 };
 pub(crate) type socklen_t = i32;
 

--- a/src/io/ioctl.rs
+++ b/src/io/ioctl.rs
@@ -57,7 +57,7 @@ pub fn ioctl_fioclex<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 ///  - [Winsock2]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/ioctl.2.html
-/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-ioctlsocket
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/winsock/winsock-ioctls#unix-ioctl-codes
 #[inline]
 #[doc(alias = "FIONBIO")]
 pub fn ioctl_fionbio<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
@@ -71,9 +71,11 @@ pub fn ioctl_fionbio<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 ///
 /// # References
 ///  - [Linux]
+///  - [Winsock2]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/ioctl_tty.2.html
-#[cfg(not(any(windows, target_os = "redox")))]
+/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/winsock/winsock-ioctls#unix-ioctl-codes
+#[cfg(not(target_os = "redox"))]
 #[inline]
 #[doc(alias = "FIONREAD")]
 pub fn ioctl_fionread<Fd: AsFd>(fd: Fd) -> io::Result<u64> {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -36,7 +36,7 @@ pub use eventfd::{eventfd, EventfdFlags};
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 pub use ioctl::ioctl_fioclex;
 pub use ioctl::ioctl_fionbio;
-#[cfg(not(any(windows, target_os = "redox")))]
+#[cfg(not(target_os = "redox"))]
 pub use ioctl::ioctl_fionread;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use ioctl::{ioctl_blkpbszget, ioctl_blksszget};

--- a/tests/io/ioctl.rs
+++ b/tests/io/ioctl.rs
@@ -1,0 +1,14 @@
+// `is_read_write` is not yet implemented on Windows. And `ioctl_fionread`
+// on Windows doesn't work on files.
+#[cfg(not(windows))]
+#[test]
+fn test_ioctls() {
+    let file = std::fs::File::open("Cargo.toml").unwrap();
+
+    assert_eq!(rustix::io::is_read_write(&file).unwrap(), (true, false));
+
+    assert_eq!(
+        rustix::io::ioctl_fionread(&file).unwrap(),
+        file.metadata().unwrap().len()
+    );
+}

--- a/tests/io/main.rs
+++ b/tests/io/main.rs
@@ -18,6 +18,8 @@ mod error;
 mod eventfd;
 #[cfg(not(windows))]
 mod from_into;
+#[cfg(not(target_os = "redox"))]
+mod ioctl;
 mod poll;
 #[cfg(all(feature = "procfs", any(target_os = "android", target_os = "linux")))]
 mod procfs;

--- a/tests/net/poll.rs
+++ b/tests/net/poll.rs
@@ -45,8 +45,10 @@ fn server(ready: Arc<(Mutex<u16>, Condvar)>) {
     assert!(fds[0].revents().intersects(PollFlags::IN));
     assert!(!fds[0].revents().intersects(PollFlags::OUT));
 
+    let expected_nread = rustix::io::ioctl_fionread(&data_socket).unwrap();
     let nread = recv(&data_socket, &mut buffer, RecvFlags::empty()).unwrap();
     assert_eq!(String::from_utf8_lossy(&buffer[..nread]), "hello, world");
+    assert_eq!(expected_nread, nread as u64);
 
     let mut fds = [PollFd::new(&data_socket, PollFlags::OUT)];
     assert_eq!(poll(&mut fds, -1).unwrap(), 1);
@@ -89,8 +91,10 @@ fn client(ready: Arc<(Mutex<u16>, Condvar)>) {
     assert!(fds[0].revents().intersects(PollFlags::IN));
     assert!(!fds[0].revents().intersects(PollFlags::OUT));
 
+    let expected_nread = rustix::io::ioctl_fionread(&data_socket).unwrap();
     let nread = recv(&data_socket, &mut buffer, RecvFlags::empty()).unwrap();
     assert_eq!(String::from_utf8_lossy(&buffer[..nread]), "goodnight, moon");
+    assert_eq!(expected_nread, nread as u64);
 }
 
 #[test]


### PR DESCRIPTION
Define `FIONREAD` on Windows.