### PR TITLE
Fix a few more complication errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ once_cell = { version = "1.5.2", optional = true }
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
 linux-raw-sys = { version = "0.0.46", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 libc_errno = { package = "errno", version = "0.2.8", default-features = false, optional = true }
-libc = { version = "0.2.118", features = ["extra_traits"], optional = true }
+libc = { version = "0.2.126", features = ["extra_traits"], optional = true }
 
 # Dependencies for platforms where only libc is supported:
 #
@@ -48,7 +48,7 @@ libc = { version = "0.2.118", features = ["extra_traits"], optional = true }
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.2.8", default-features = false }
-libc = { version = "0.2.118", features = ["extra_traits"] }
+libc = { version = "0.2.126", features = ["extra_traits"] }
 
 # Additional dependencies for Linux with the libc backend:
 #
@@ -69,7 +69,7 @@ features = [
 
 [dev-dependencies]
 tempfile = "3.2.0"
-libc = "0.2.118"
+libc = "0.2.126"
 libc_errno = { package = "errno", version = "0.2.8" }
 io-lifetimes = { version = "0.7.0", default-features = false }
 # Don't upgrade to serial_test 0.7 for now because it depends on a

--- a/src/imp/linux_raw/net/read_sockaddr.rs
+++ b/src/imp/linux_raw/net/read_sockaddr.rs
@@ -28,7 +28,7 @@ unsafe fn read_ss_family(storage: *const c::sockaddr) -> u16 {
                 __bindgen_anon_1:
                     linux_raw_sys::general::__kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
                         ss_family: 0_u16,
-                        __data: [0_u8; 126],
+                        __data: [0; 126_usize],
                     },
             },
         },


### PR DESCRIPTION
 - Update the version of libc so that rustix works without needing a separate `cargo update`.
 - Fix on place in the linux_raw backend which depended on the signedness of `c_char`.
