### PR TITLE
FreeBSD CI fixes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,17 +28,3 @@ task:
   test_script:
     - . $HOME/.cargo/env
     - cargo test --workspace
-
-task:
-  name: stable x86_64-unknown-freebsd-11
-  freebsd_instance:
-    image_family: freebsd-11-4
-  setup_script:
-    - pkg install -y curl
-    - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh --default-toolchain stable -y --profile=minimal
-    - . $HOME/.cargo/env
-    - rustup default stable
-  test_script:
-    - . $HOME/.cargo/env
-    - cargo test --workspace

--- a/tests/io/ioctl.rs
+++ b/tests/io/ioctl.rs
@@ -5,6 +5,7 @@
 fn test_ioctls() {
     let file = std::fs::File::open("Cargo.toml").unwrap();
 
+    #[cfg(feature = "net")]
     assert_eq!(rustix::io::is_read_write(&file).unwrap(), (true, false));
 
     assert_eq!(


### PR DESCRIPTION
 - Remove FreeBSD 11 from the CirrusCI config, as it is no longer working.
 - Fix compilation of a test on FreeBSD.
 