### PR TITLE
Implement `statvfs` and `fstatvfs`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ features = [
 [dev-dependencies]
 tempfile = "3.2.0"
 libc = "0.2.126"
-libc_errno = { package = "errno", version = "0.2.8" }
+libc_errno = { package = "errno", version = "0.2.8", default-features = false }
 io-lifetimes = { version = "0.7.0", default-features = false }
 # Don't upgrade to serial_test 0.7 for now because it depends on a
 # `parking_lot_core` version which is not compatible with our MSRV of 1.48.

--- a/src/backend/libc/fs/dir.rs
+++ b/src/backend/libc/fs/dir.rs
@@ -12,8 +12,10 @@ use crate::fs::{fcntl_getfl, fstat, openat, Mode, OFlags, Stat};
     target_os = "netbsd",
     target_os = "redox",
     target_os = "wasi",
-)))] // not implemented in libc for netbsd yet
+)))]
 use crate::fs::{fstatfs, StatFs};
+#[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "wasi")))]
+use crate::fs::{fstatvfs, StatVfs};
 use crate::io;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 use crate::process::fchdir;
@@ -133,10 +135,17 @@ impl Dir {
         target_os = "netbsd",
         target_os = "redox",
         target_os = "wasi",
-    )))] // not implemented in libc for netbsd yet
+    )))]
     #[inline]
     pub fn statfs(&self) -> io::Result<StatFs> {
         fstatfs(unsafe { BorrowedFd::borrow_raw(c::dirfd(self.0.as_ptr())) })
+    }
+
+    /// `fstatvfs(self)`
+    #[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "wasi")))]
+    #[inline]
+    pub fn statvfs(&self) -> io::Result<StatVfs> {
+        fstatvfs(unsafe { BorrowedFd::borrow_raw(c::dirfd(self.0.as_ptr())) })
     }
 
     /// `fchdir(self)`

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -778,6 +778,46 @@ bitflags! {
     }
 }
 
+#[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "wasi",)))]
+bitflags! {
+    /// `ST_*` constants for use with [`StatVfs`].
+    pub struct StatVfsMountFlags: u64 {
+        /// `ST_MANDLOCK`
+        #[cfg(any(target_os = "android", target_os = "emscripten", target_os = "fuchsia", target_os = "linux"))]
+        const MANDLOCK = libc::ST_MANDLOCK as u64;
+
+        /// `ST_NOATIME`
+        #[cfg(any(target_os = "android", target_os = "emscripten", target_os = "fuchsia", target_os = "linux"))]
+        const NOATIME = libc::ST_NOATIME as u64;
+
+        /// `ST_NODEV`
+        #[cfg(any(target_os = "android", target_os = "emscripten", target_os = "fuchsia", target_os = "linux"))]
+        const NODEV = libc::ST_NODEV as u64;
+
+        /// `ST_NODIRATIME`
+        #[cfg(any(target_os = "android", target_os = "emscripten", target_os = "fuchsia", target_os = "linux"))]
+        const NODIRATIME = libc::ST_NODIRATIME as u64;
+
+        /// `ST_NOEXEC`
+        #[cfg(any(target_os = "android", target_os = "emscripten", target_os = "fuchsia", target_os = "linux"))]
+        const NOEXEC = libc::ST_NOEXEC as u64;
+
+        /// `ST_NOSUID`
+        const NOSUID = libc::ST_NOSUID as u64;
+
+        /// `ST_RDONLY`
+        const RDONLY = libc::ST_RDONLY as u64;
+
+        /// `ST_RELATIME`
+        #[cfg(any(target_os = "android", all(target_os = "linux", target_env = "gnu")))]
+        const RELATIME = libc::ST_RELATIME as u64;
+
+        /// `ST_SYNCHRONOUS`
+        #[cfg(any(target_os = "android", target_os = "emscripten", target_os = "fuchsia", target_os = "linux"))]
+        const SYNCHRONOUS = libc::ST_SYNCHRONOUS as u64;
+    }
+}
+
 /// `LOCK_*` constants for use with [`flock`]
 ///
 /// [`flock`]: crate::fs::flock
@@ -891,28 +931,21 @@ pub type StatFs = c::statfs64;
 ///
 /// [`statvfs`]: crate::fs::statvfs
 /// [`fstatvfs`]: crate::fs::fstatvfs
-#[cfg(not(any(
-    target_os = "android",
-    target_os = "emscripten",
-    target_os = "illumos",
-    target_os = "linux",
-    target_os = "l4re",
-    target_os = "redox",
-    target_os = "wasi",
-)))]
-pub type StatVfs = c::statvfs;
-
-/// `struct statvfs` for use with [`statvfs`] and [`fstatvfs`].
-///
-/// [`statvfs`]: crate::fs::statvfs
-/// [`fstatvfs`]: crate::fs::fstatvfs
-#[cfg(any(
-    target_os = "android",
-    target_os = "linux",
-    target_os = "emscripten",
-    target_os = "l4re",
-))]
-pub type StatVfs = c::statvfs64;
+#[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "wasi",)))]
+#[allow(missing_docs)]
+pub struct StatVfs {
+    pub f_bsize: u64,
+    pub f_frsize: u64,
+    pub f_blocks: u64,
+    pub f_bfree: u64,
+    pub f_bavail: u64,
+    pub f_files: u64,
+    pub f_ffree: u64,
+    pub f_favail: u64,
+    pub f_fsid: u64,
+    pub f_flag: StatVfsMountFlags,
+    pub f_namemax: u64,
+}
 
 /// `struct statx` for use with [`statx`].
 ///

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -858,8 +858,9 @@ pub struct Stat {
     pub st_ino: u64,
 }
 
-/// `struct statfs` for use with [`fstatfs`].
+/// `struct statfs` for use with [`statfs`] and [`fstatfs`].
 ///
+/// [`statfs`]: crate::fs::statfs
 /// [`fstatfs`]: crate::fs::fstatfs
 #[cfg(not(any(
     target_os = "android",
@@ -874,8 +875,9 @@ pub struct Stat {
 #[allow(clippy::module_name_repetitions)]
 pub type StatFs = c::statfs;
 
-/// `struct statfs` for use with [`fstatfs`].
+/// `struct statfs` for use with [`statfs`] and [`fstatfs`].
 ///
+/// [`statfs`]: crate::fs::statfs
 /// [`fstatfs`]: crate::fs::fstatfs
 #[cfg(any(
     target_os = "android",
@@ -884,6 +886,33 @@ pub type StatFs = c::statfs;
     target_os = "l4re",
 ))]
 pub type StatFs = c::statfs64;
+
+/// `struct statvfs` for use with [`statvfs`] and [`fstatvfs`].
+///
+/// [`statvfs`]: crate::fs::statvfs
+/// [`fstatvfs`]: crate::fs::fstatvfs
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "emscripten",
+    target_os = "illumos",
+    target_os = "linux",
+    target_os = "l4re",
+    target_os = "redox",
+    target_os = "wasi",
+)))]
+pub type StatVfs = c::statvfs;
+
+/// `struct statvfs` for use with [`statvfs`] and [`fstatvfs`].
+///
+/// [`statvfs`]: crate::fs::statvfs
+/// [`fstatvfs`]: crate::fs::fstatvfs
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "emscripten",
+    target_os = "l4re",
+))]
+pub type StatVfs = c::statvfs64;
 
 /// `struct statx` for use with [`statx`].
 ///

--- a/src/backend/libc/offset.rs
+++ b/src/backend/libc/offset.rs
@@ -351,6 +351,17 @@ pub(super) use c::posix_fallocate64 as libc_posix_fallocate;
     target_os = "wasi",
 )))]
 pub(super) use {c::fstatfs as libc_fstatfs, c::statfs as libc_statfs};
+#[cfg(not(any(
+    windows,
+    target_os = "android",
+    target_os = "emscripten",
+    target_os = "illumos",
+    target_os = "linux",
+    target_os = "l4re",
+    target_os = "redox",
+    target_os = "wasi",
+)))]
+pub(super) use {c::fstatvfs as libc_fstatvfs, c::statvfs as libc_statvfs};
 
 #[cfg(any(
     target_os = "android",
@@ -358,4 +369,7 @@ pub(super) use {c::fstatfs as libc_fstatfs, c::statfs as libc_statfs};
     target_os = "emscripten",
     target_os = "l4re",
 ))]
-pub(super) use {c::fstatfs64 as libc_fstatfs, c::statfs64 as libc_statfs};
+pub(super) use {
+    c::fstatfs64 as libc_fstatfs, c::fstatvfs64 as libc_fstatvfs, c::statfs64 as libc_statfs,
+    c::statvfs64 as libc_statvfs,
+};

--- a/src/backend/linux_raw/fs/dir.rs
+++ b/src/backend/linux_raw/fs/dir.rs
@@ -1,6 +1,8 @@
 use crate::fd::{AsFd, BorrowedFd};
 use crate::ffi::{CStr, CString};
-use crate::fs::{fcntl_getfl, fstat, fstatfs, openat, FileType, Mode, OFlags, Stat, StatFs};
+use crate::fs::{
+    fcntl_getfl, fstat, fstatfs, fstatvfs, openat, FileType, Mode, OFlags, Stat, StatFs, StatVfs,
+};
 use crate::io::{self, OwnedFd};
 use crate::process::fchdir;
 use crate::utils::as_ptr;
@@ -160,6 +162,12 @@ impl Dir {
     #[inline]
     pub fn statfs(&self) -> io::Result<StatFs> {
         fstatfs(&self.fd)
+    }
+
+    /// `fstatvfs(self)`
+    #[inline]
+    pub fn statvfs(&self) -> io::Result<StatVfs> {
+        fstatvfs(&self.fd)
     }
 
     /// `fchdir(self)`

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -819,12 +819,12 @@ fn statfs_to_statvfs(statfs: StatFs) -> StatVfs {
         } else {
             statfs.f_bsize
         } as u64,
-        f_blocks: statfs.f_blocks,
-        f_bfree: statfs.f_bfree,
-        f_bavail: statfs.f_bavail,
-        f_files: statfs.f_files,
-        f_ffree: statfs.f_ffree,
-        f_favail: statfs.f_ffree,
+        f_blocks: statfs.f_blocks as u64,
+        f_bfree: statfs.f_bfree as u64,
+        f_bavail: statfs.f_bavail as u64,
+        f_files: statfs.f_files as u64,
+        f_ffree: statfs.f_ffree as u64,
+        f_favail: statfs.f_ffree as u64,
         f_fsid: statfs.f_fsid.val[0] as u64,
         f_flag: statfs.f_flags as u64,
         f_namemax: statfs.f_namelen as u64,

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -25,7 +25,8 @@ use crate::fd::{BorrowedFd, RawFd};
 use crate::ffi::CStr;
 use crate::fs::{
     Access, Advice, AtFlags, FallocateFlags, FdFlags, FileType, FlockOperation, MemfdFlags, Mode,
-    OFlags, RenameFlags, ResolveFlags, SealFlags, Stat, StatFs, StatVfs, StatxFlags, Timestamps,
+    OFlags, RenameFlags, ResolveFlags, SealFlags, Stat, StatFs, StatVfs, StatVfsMountFlags,
+    StatxFlags, Timestamps,
 };
 use crate::io::{self, OwnedFd, SeekFrom};
 use crate::process::{Gid, Uid};
@@ -830,7 +831,7 @@ fn statfs_to_statvfs(statfs: StatFs) -> StatVfs {
         f_ffree: statfs.f_ffree as u64,
         f_favail: statfs.f_ffree as u64,
         f_fsid: f_fsid_val0 as u32 as u64 | ((f_fsid_val1 as u32 as u64) << 32),
-        f_flag: statfs.f_flags as u64,
+        f_flag: unsafe { StatVfsMountFlags::from_bits_unchecked(statfs.f_flags as u64) },
         f_namemax: statfs.f_namelen as u64,
     }
 }

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -551,19 +551,31 @@ pub struct Stat {
 #[cfg(all(target_pointer_width = "64", not(target_arch = "mips64")))]
 pub type Stat = linux_raw_sys::general::stat;
 
-/// `struct statfs` for use with [`fstatfs`].
+/// `struct statfs` for use with [`statfs`] and [`fstatfs`].
 ///
+/// [`statfs`]: crate::fs::statfs
 /// [`fstatfs`]: crate::fs::fstatfs
-#[cfg(target_pointer_width = "32")]
 #[allow(clippy::module_name_repetitions)]
 pub type StatFs = linux_raw_sys::general::statfs64;
 
-/// `struct statfs` for use with [`fstatfs`].
+/// `struct statvfs` for use with [`statvfs`] and [`fstatvfs`].
 ///
-/// [`fstatfs`]: crate::fs::fstatfs
-#[cfg(target_pointer_width = "64")]
-#[allow(clippy::module_name_repetitions)]
-pub type StatFs = linux_raw_sys::general::statfs64;
+/// [`statvfs`]: crate::fs::statvfs
+/// [`fstatvfs`]: crate::fs::fstatvfs
+#[allow(missing_docs)]
+pub struct StatVfs {
+    pub f_bsize: u64,
+    pub f_frsize: u64,
+    pub f_blocks: u64,
+    pub f_bfree: u64,
+    pub f_bavail: u64,
+    pub f_files: u64,
+    pub f_ffree: u64,
+    pub f_favail: u64,
+    pub f_fsid: u64,
+    pub f_flag: u64,
+    pub f_namemax: u64,
+}
 
 /// `struct statx` for use with [`statx`].
 ///

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -494,6 +494,38 @@ bitflags! {
     }
 }
 
+bitflags! {
+    /// `ST_*` constants for use with [`StatVfs`].
+    pub struct StatVfsMountFlags: u64 {
+        /// `ST_MANDLOCK`
+        const MANDLOCK = linux_raw_sys::general::MS_MANDLOCK as u64;
+
+        /// `ST_NOATIME`
+        const NOATIME = linux_raw_sys::general::MS_NOATIME as u64;
+
+        /// `ST_NODEV`
+        const NODEV = linux_raw_sys::general::MS_NODEV as u64;
+
+        /// `ST_NODIRATIME`
+        const NODIRATIME = linux_raw_sys::general::MS_NODIRATIME as u64;
+
+        /// `ST_NOEXEC`
+        const NOEXEC = linux_raw_sys::general::MS_NOEXEC as u64;
+
+        /// `ST_NOSUID`
+        const NOSUID = linux_raw_sys::general::MS_NOSUID as u64;
+
+        /// `ST_RDONLY`
+        const RDONLY = linux_raw_sys::general::MS_RDONLY as u64;
+
+        /// `ST_RELATIME`
+        const RELATIME = linux_raw_sys::general::MS_RELATIME as u64;
+
+        /// `ST_SYNCHRONOUS`
+        const SYNCHRONOUS = linux_raw_sys::general::MS_SYNCHRONOUS as u64;
+    }
+}
+
 /// `LOCK_*` constants for use with [`flock`]
 ///
 /// [`flock`]: crate::fs::flock
@@ -573,7 +605,7 @@ pub struct StatVfs {
     pub f_ffree: u64,
     pub f_favail: u64,
     pub f_fsid: u64,
-    pub f_flag: u64,
+    pub f_flag: StatVfsMountFlags,
     pub f_namemax: u64,
 }
 

--- a/src/fs/abs.rs
+++ b/src/fs/abs.rs
@@ -15,6 +15,9 @@ use {
 
 /// `statfs`—Queries filesystem metadata.
 ///
+/// Compared to [`statvfs`], this function often provides more information,
+/// though it's less portable.
+///
 /// # References
 ///  - [Linux]
 ///
@@ -31,6 +34,11 @@ pub fn statfs<P: path::Arg>(path: P) -> io::Result<StatFs> {
 }
 
 /// `statvfs`—Queries filesystem metadata, POSIX version.
+///
+/// Compared to [`statfs`], this function often provides less information,
+/// but it is more portable. But even so, filesystems are very diverse and not
+/// all the fields are meaningful for every filesystem. And `f_fsid` doesn't
+/// seem to have a clear meaning anywhere.
 ///
 /// # References
 ///  - [POSIX]

--- a/src/fs/abs.rs
+++ b/src/fs/abs.rs
@@ -7,13 +7,11 @@
     target_os = "wasi",
 )))]
 use crate::fs::StatFs;
-#[cfg(not(any(
-    target_os = "illumos",
-    target_os = "netbsd",
-    target_os = "redox",
-    target_os = "wasi",
-)))]
-use crate::{backend, io, path};
+#[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "wasi")))]
+use {
+    crate::fs::StatVfs,
+    crate::{backend, io, path},
+};
 
 /// `statfs`—Queries filesystem metadata.
 ///
@@ -30,4 +28,18 @@ use crate::{backend, io, path};
 #[inline]
 pub fn statfs<P: path::Arg>(path: P) -> io::Result<StatFs> {
     path.into_with_c_str(backend::fs::syscalls::statfs)
+}
+
+/// `statvfs`—Queries filesystem metadata, POSIX version.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/statvfs.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/statvfs.2.html
+#[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "wasi")))]
+#[inline]
+pub fn statvfs<P: path::Arg>(path: P) -> io::Result<StatVfs> {
+    path.into_with_c_str(backend::fs::syscalls::statvfs)
 }

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -149,6 +149,9 @@ pub fn fstat<Fd: AsFd>(fd: Fd) -> io::Result<Stat> {
 
 /// `fstatfs(fd)`—Queries filesystem statistics for an open file or directory.
 ///
+/// Compared to [`fstatvfs`], this function often provides more information,
+/// though it's less portable.
+///
 /// # References
 ///  - [Linux]
 ///
@@ -166,6 +169,11 @@ pub fn fstatfs<Fd: AsFd>(fd: Fd) -> io::Result<StatFs> {
 
 /// `fstatvfs(fd)`—Queries filesystem statistics for an open file or
 /// directory, POSIX version.
+///
+/// Compared to [`fstatfs`], this function often provides less information,
+/// but it is more portable. But even so, filesystems are very diverse and not
+/// all the fields are meaningful for every filesystem. And `f_fsid` doesn't
+/// seem to have a clear meaning anywhere.
 ///
 /// # References
 ///  - [POSIX]

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -30,6 +30,9 @@ pub use backend::fs::types::Stat;
 )))]
 pub use backend::fs::types::StatFs;
 
+#[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "wasi")))]
+pub use backend::fs::types::StatVfs;
+
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use backend::fs::types::FsWord;
 
@@ -155,10 +158,25 @@ pub fn fstat<Fd: AsFd>(fd: Fd) -> io::Result<Stat> {
     target_os = "netbsd",
     target_os = "redox",
     target_os = "wasi",
-)))] // not implemented in libc for netbsd yet
+)))]
 #[inline]
 pub fn fstatfs<Fd: AsFd>(fd: Fd) -> io::Result<StatFs> {
     backend::fs::syscalls::fstatfs(fd.as_fd())
+}
+
+/// `fstatvfs(fd)`—Queries filesystem statistics for an open file or
+/// directory, POSIX version.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/fstatvfs.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/fstatvfs.2.html
+#[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "wasi")))]
+#[inline]
+pub fn fstatvfs<Fd: AsFd>(fd: Fd) -> io::Result<StatVfs> {
+    backend::fs::syscalls::fstatvfs(fd.as_fd())
 }
 
 /// `futimens(fd, times)`—Sets timestamps for an open file or directory.

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -31,7 +31,7 @@ pub use backend::fs::types::Stat;
 pub use backend::fs::types::StatFs;
 
 #[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "wasi")))]
-pub use backend::fs::types::StatVfs;
+pub use backend::fs::types::{StatVfs, StatVfsMountFlags};
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use backend::fs::types::FsWord;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -163,7 +163,7 @@ pub use fd::{fstat, fsync, ftruncate, futimens, is_file_read_write, seek, tell, 
 )))]
 pub use fd::{fstatfs, StatFs};
 #[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "wasi")))]
-pub use fd::{fstatvfs, StatVfs};
+pub use fd::{fstatvfs, StatVfs, StatVfsMountFlags};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use fd::{FsWord, NFS_SUPER_MAGIC, PROC_SUPER_MAGIC};
 pub use file_type::FileType;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -62,6 +62,9 @@ mod statx;
 )))]
 #[cfg(feature = "fs")]
 pub use abs::statfs;
+#[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "wasi")))]
+#[cfg(feature = "fs")]
+pub use abs::statvfs;
 #[cfg(not(any(target_os = "illumos", target_os = "redox")))]
 #[cfg(feature = "fs")]
 pub use at::accessat;
@@ -158,8 +161,9 @@ pub use fd::{fstat, fsync, ftruncate, futimens, is_file_read_write, seek, tell, 
     target_os = "redox",
     target_os = "wasi",
 )))]
-// not implemented in libc for netbsd yet
 pub use fd::{fstatfs, StatFs};
+#[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "wasi")))]
+pub use fd::{fstatvfs, StatVfs};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use fd::{FsWord, NFS_SUPER_MAGIC, PROC_SUPER_MAGIC};
 pub use file_type::FileType;

--- a/src/fs/statvfs.rs
+++ b/src/fs/statvfs.rs
@@ -1,0 +1,4 @@
+use crate::backend;
+
+
+imp

--- a/src/fs/statvfs.rs
+++ b/src/fs/statvfs.rs
@@ -1,4 +1,0 @@
-use crate::backend;
-
-
-imp

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -70,10 +70,15 @@ fn test_file() {
         target_os = "redox",
         target_os = "wasi",
     )))]
-    // not implemented in libc for netbsd yet
     {
         let statfs = rustix::fs::fstatfs(&file).unwrap();
         assert!(statfs.f_blocks > 0);
+    }
+
+    #[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "wasi")))]
+    {
+        let statvfs = rustix::fs::fstatvfs(&file).unwrap();
+        assert!(statvfs.f_frsize > 0);
     }
 
     #[cfg(feature = "net")]

--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -35,13 +35,7 @@ mod openat;
 mod openat2;
 mod readdir;
 mod renameat;
-#[cfg(not(any(
-    target_os = "illumos",
-    target_os = "netbsd",
-    target_os = "redox",
-    target_os = "wasi",
-)))]
-// not implemented in libc for netbsd yet
+#[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "wasi")))]
 mod statfs;
 mod utimensat;
 mod y2038;

--- a/tests/process/working_directory.rs
+++ b/tests/process/working_directory.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "fs")]
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "macos")))]
 use rustix::fs::{Mode, OFlags};
 use tempfile::{tempdir, TempDir};
 
@@ -17,6 +17,8 @@ fn test_changing_working_directory() {
     let tmpdir = tmpdir();
 
     let orig_cwd = rustix::process::getcwd(Vec::new()).expect("get the cwd");
+
+    #[cfg(not(target_os = "fuchsia"))]
     let orig_fd_cwd = rustix::fs::openat(rustix::fs::cwd(), ".", OFlags::RDONLY, Mode::empty())
         .expect("get a fd for the current directory");
 

--- a/tests/termios/main.rs
+++ b/tests/termios/main.rs
@@ -6,5 +6,5 @@
 
 #[cfg(not(windows))]
 mod isatty;
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "fuchsia")))]
 mod ttyname;


### PR DESCRIPTION
On libc, just go with whatever the libc `statvfs` gives us. On
linux_raw, translate the fields from `statfs` in the manner of
libc implementations.