### PR TITLE
Exclude tests, examples, and benchmarks from the crates.io package.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/bytecodealliance/rustix"
 edition = "2018"
 keywords = ["api", "file", "network", "safe", "syscall"]
 categories = ["os::unix-apis", "date-and-time", "filesystem", "network-programming"]
-include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "./*.md"]
+include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
 
 [build-dependencies]
 cc = { version = "1.0.68", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/bytecodealliance/rustix"
 edition = "2018"
 keywords = ["api", "file", "network", "safe", "syscall"]
 categories = ["os::unix-apis", "date-and-time", "filesystem", "network-programming"]
-exclude = ["/.*", "test-crates"]
+include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "./*.md"]
 
 [build-dependencies]
 cc = { version = "1.0.68", optional = true }


### PR DESCRIPTION
This shrinks the generated package size from 296K to 260K.