### PR TITLE
Minor code cleanup: avoid `map(|()| ...)`.

### DIFF
--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -302,8 +302,8 @@ pub(crate) fn prlimit(pid: Option<Pid>, limit: Resource, new: Rlimit) -> io::Res
             limit as _,
             &lim,
             result.as_mut_ptr(),
-        ))
-        .map(|()| rlimit_from_libc(result.assume_init()))
+        ))?;
+        Ok(rlimit_from_libc(result.assume_init()))
     }
 }
 

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -21,7 +21,8 @@ use libc_errno::errno;
 pub(crate) fn tcgetattr(fd: BorrowedFd<'_>) -> io::Result<Termios> {
     let mut result = MaybeUninit::<Termios>::uninit();
     unsafe {
-        ret(c::tcgetattr(borrowed_fd(fd), result.as_mut_ptr())).map(|()| result.assume_init())
+        ret(c::tcgetattr(borrowed_fd(fd), result.as_mut_ptr()))?;
+        Ok(result.assume_init())
     }
 }
 

--- a/src/backend/libc/time/syscalls.rs
+++ b/src/backend/libc/time/syscalls.rs
@@ -259,8 +259,8 @@ pub(crate) fn timerfd_settime(
                 flags.bits(),
                 &new_value.clone().into(),
                 result.as_mut_ptr(),
-            ))
-            .map(|()| result.assume_init().into())
+            ))?;
+            Ok(result.assume_init().into())
         } else {
             timerfd_settime_old(fd, flags, new_value)
         }
@@ -276,8 +276,8 @@ pub(crate) fn timerfd_settime(
             flags.bits(),
             new_value,
             result.as_mut_ptr(),
-        ))
-        .map(|()| result.assume_init())
+        ))?;
+        Ok(result.assume_init())
     }
 }
 
@@ -363,8 +363,8 @@ pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
     ))]
     unsafe {
         if let Some(libc_timerfd_gettime) = __timerfd_gettime64.get() {
-            ret(libc_timerfd_gettime(borrowed_fd(fd), result.as_mut_ptr()))
-                .map(|()| result.assume_init().into())
+            ret(libc_timerfd_gettime(borrowed_fd(fd), result.as_mut_ptr()))?;
+            Ok(result.assume_init().into())
         } else {
             timerfd_gettime_old(fd)
         }
@@ -375,7 +375,8 @@ pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
         target_env = "gnu",
     )))]
     unsafe {
-        ret(c::timerfd_gettime(borrowed_fd(fd), result.as_mut_ptr())).map(|()| result.assume_init())
+        ret(c::timerfd_gettime(borrowed_fd(fd), result.as_mut_ptr()))?;
+        Ok(result.assume_init())
     }
 }
 

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -233,8 +233,8 @@ pub(crate) fn _seek(fd: BorrowedFd<'_>, offset: i64, whence: c::c_uint) -> io::R
             pass_usize(offset as usize),
             &mut result,
             c_uint(whence)
-        ))
-        .map(|()| result.assume_init())
+        ))?;
+        Ok(result.assume_init())
     }
     #[cfg(target_pointer_width = "64")]
     unsafe {
@@ -422,7 +422,8 @@ pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
     #[cfg(all(target_pointer_width = "64", not(target_arch = "mips64")))]
     unsafe {
         let mut result = MaybeUninit::<Stat>::uninit();
-        ret(syscall!(__NR_fstat, fd, &mut result)).map(|()| result.assume_init())
+        ret(syscall!(__NR_fstat, fd, &mut result))?;
+        Ok(result.assume_init())
     }
 }
 
@@ -468,8 +469,8 @@ pub(crate) fn stat(filename: &CStr) -> io::Result<Stat> {
             filename,
             &mut result,
             c_uint(0)
-        ))
-        .map(|()| result.assume_init())
+        ))?;
+        Ok(result.assume_init())
     }
 }
 
@@ -522,8 +523,8 @@ pub(crate) fn statat(dirfd: BorrowedFd<'_>, filename: &CStr, flags: AtFlags) -> 
             filename,
             &mut result,
             flags
-        ))
-        .map(|()| result.assume_init())
+        ))?;
+        Ok(result.assume_init())
     }
 }
 
@@ -581,8 +582,8 @@ pub(crate) fn lstat(filename: &CStr) -> io::Result<Stat> {
             filename,
             &mut result,
             c_uint(AT_SYMLINK_NOFOLLOW)
-        ))
-        .map(|()| result.assume_init())
+        ))?;
+        Ok(result.assume_init())
     }
 }
 
@@ -730,8 +731,8 @@ pub(crate) fn statx(
             flags,
             mask,
             &mut statx_buf
-        ))
-        .map(|()| statx_buf.assume_init())
+        ))?;
+        Ok(statx_buf.assume_init())
     }
 }
 
@@ -764,14 +765,15 @@ pub(crate) fn fstatfs(fd: BorrowedFd<'_>) -> io::Result<StatFs> {
             fd,
             size_of::<StatFs, _>(),
             &mut result
-        ))
-        .map(|()| result.assume_init())
+        ))?;
+        Ok(result.assume_init())
     }
 
     #[cfg(target_pointer_width = "64")]
     unsafe {
         let mut result = MaybeUninit::<StatFs>::uninit();
-        ret(syscall!(__NR_fstatfs, fd, &mut result)).map(|()| result.assume_init())
+        ret(syscall!(__NR_fstatfs, fd, &mut result))?;
+        Ok(result.assume_init())
     }
 }
 
@@ -794,13 +796,14 @@ pub(crate) fn statfs(filename: &CStr) -> io::Result<StatFs> {
             filename,
             size_of::<StatFs, _>(),
             &mut result
-        ))
-        .map(|()| result.assume_init())
+        ))?;
+        Ok(result.assume_init())
     }
     #[cfg(target_pointer_width = "64")]
     unsafe {
         let mut result = MaybeUninit::<StatFs>::uninit();
-        ret(syscall!(__NR_statfs, filename, &mut result)).map(|()| result.assume_init())
+        ret(syscall!(__NR_statfs, filename, &mut result))?;
+        Ok(result.assume_init())
     }
 }
 

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -301,8 +301,8 @@ pub(crate) fn eventfd(initval: u32, flags: EventfdFlags) -> io::Result<OwnedFd> 
 pub(crate) fn ioctl_fionread(fd: BorrowedFd<'_>) -> io::Result<u64> {
     unsafe {
         let mut result = MaybeUninit::<c::c_int>::uninit();
-        ret(syscall!(__NR_ioctl, fd, c_uint(FIONREAD), &mut result))
-            .map(|()| result.assume_init() as u64)
+        ret(syscall!(__NR_ioctl, fd, c_uint(FIONREAD), &mut result))?;
+        Ok(result.assume_init() as u64)
     }
 }
 
@@ -333,8 +333,8 @@ pub(crate) fn ioctl_tiocnxcl(fd: BorrowedFd<'_>) -> io::Result<()> {
 pub(crate) fn ioctl_blksszget(fd: BorrowedFd) -> io::Result<u32> {
     let mut result = MaybeUninit::<c::c_uint>::uninit();
     unsafe {
-        ret(syscall!(__NR_ioctl, fd, c_uint(BLKSSZGET), &mut result))
-            .map(|()| result.assume_init() as u32)
+        ret(syscall!(__NR_ioctl, fd, c_uint(BLKSSZGET), &mut result))?;
+        Ok(result.assume_init() as u32)
     }
 }
 
@@ -342,8 +342,8 @@ pub(crate) fn ioctl_blksszget(fd: BorrowedFd) -> io::Result<u32> {
 pub(crate) fn ioctl_blkpbszget(fd: BorrowedFd) -> io::Result<u32> {
     let mut result = MaybeUninit::<c::c_uint>::uninit();
     unsafe {
-        ret(syscall!(__NR_ioctl, fd, c_uint(BLKPBSZGET), &mut result))
-            .map(|()| result.assume_init() as u32)
+        ret(syscall!(__NR_ioctl, fd, c_uint(BLKPBSZGET), &mut result))?;
+        Ok(result.assume_init() as u32)
     }
 }
 

--- a/src/backend/linux_raw/net/syscalls.rs
+++ b/src/backend/linux_raw/net/syscalls.rs
@@ -102,11 +102,9 @@ pub(crate) fn socketpair(
             (type_, flags),
             protocol,
             &mut result
-        ))
-        .map(|()| {
-            let [fd0, fd1] = result.assume_init();
-            (fd0, fd1)
-        })
+        ))?;
+        let [fd0, fd1] = result.assume_init();
+        Ok((fd0, fd1))
     }
     #[cfg(target_arch = "x86")]
     unsafe {
@@ -120,11 +118,9 @@ pub(crate) fn socketpair(
                 protocol.into(),
                 (&mut result).into(),
             ])
-        ))
-        .map(|()| {
-            let [fd0, fd1] = result.assume_init();
-            (fd0, fd1)
-        })
+        ))?;
+        let [fd0, fd1] = result.assume_init();
+        Ok((fd0, fd1))
     }
 }
 

--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -27,8 +27,8 @@ use linux_raw_sys::ioctl::{
 pub(crate) fn tcgetwinsize(fd: BorrowedFd<'_>) -> io::Result<Winsize> {
     unsafe {
         let mut result = MaybeUninit::<Winsize>::uninit();
-        ret(syscall!(__NR_ioctl, fd, c_uint(TIOCGWINSZ), &mut result))
-            .map(|()| result.assume_init())
+        ret(syscall!(__NR_ioctl, fd, c_uint(TIOCGWINSZ), &mut result))?;
+        Ok(result.assume_init())
     }
 }
 
@@ -36,7 +36,8 @@ pub(crate) fn tcgetwinsize(fd: BorrowedFd<'_>) -> io::Result<Winsize> {
 pub(crate) fn tcgetattr(fd: BorrowedFd<'_>) -> io::Result<Termios> {
     unsafe {
         let mut result = MaybeUninit::<Termios>::uninit();
-        ret(syscall!(__NR_ioctl, fd, c_uint(TCGETS), &mut result)).map(|()| result.assume_init())
+        ret(syscall!(__NR_ioctl, fd, c_uint(TCGETS), &mut result))?;
+        Ok(result.assume_init())
     }
 }
 
@@ -44,11 +45,10 @@ pub(crate) fn tcgetattr(fd: BorrowedFd<'_>) -> io::Result<Termios> {
 pub(crate) fn tcgetpgrp(fd: BorrowedFd<'_>) -> io::Result<Pid> {
     unsafe {
         let mut result = MaybeUninit::<__kernel_pid_t>::uninit();
-        ret(syscall!(__NR_ioctl, fd, c_uint(TIOCGPGRP), &mut result)).map(|()| {
-            let pid = result.assume_init();
-            debug_assert!(pid > 0);
-            Pid::from_raw_nonzero(RawNonZeroPid::new_unchecked(pid as u32))
-        })
+        ret(syscall!(__NR_ioctl, fd, c_uint(TIOCGPGRP), &mut result))?;
+        let pid = result.assume_init();
+        debug_assert!(pid > 0);
+        Ok(Pid::from_raw_nonzero(RawNonZeroPid::new_unchecked(pid as u32)))
     }
 }
 
@@ -113,11 +113,10 @@ pub(crate) fn tcflow(fd: BorrowedFd, action: Action) -> io::Result<()> {
 pub(crate) fn tcgetsid(fd: BorrowedFd) -> io::Result<Pid> {
     unsafe {
         let mut result = MaybeUninit::<__kernel_pid_t>::uninit();
-        ret(syscall!(__NR_ioctl, fd, c_uint(TIOCGSID), &mut result)).map(|()| {
-            let pid = result.assume_init();
-            debug_assert!(pid > 0);
-            Pid::from_raw_nonzero(RawNonZeroPid::new_unchecked(pid as u32))
-        })
+        ret(syscall!(__NR_ioctl, fd, c_uint(TIOCGSID), &mut result))?;
+        let pid = result.assume_init();
+        debug_assert!(pid > 0);
+        Ok(Pid::from_raw_nonzero(RawNonZeroPid::new_unchecked(pid as u32)))
     }
 }
 

--- a/src/backend/linux_raw/time/syscalls.rs
+++ b/src/backend/linux_raw/time/syscalls.rs
@@ -88,8 +88,8 @@ pub(crate) fn timerfd_settime(
             flags,
             by_ref(new_value),
             &mut result
-        ))
-        .map(|()| result.assume_init())
+        ))?;
+        Ok(result.assume_init())
     }
 
     #[cfg(target_pointer_width = "32")]
@@ -109,8 +109,8 @@ pub(crate) fn timerfd_settime(
             } else {
                 Err(err)
             }
-        })
-        .map(|()| result.assume_init())
+        })?;
+        Ok(result.assume_init())
     }
 }
 
@@ -183,22 +183,22 @@ pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
 
     #[cfg(target_pointer_width = "64")]
     unsafe {
-        ret(syscall!(__NR_timerfd_gettime, fd, &mut result)).map(|()| result.assume_init())
+        ret(syscall!(__NR_timerfd_gettime, fd, &mut result))?;
+        Ok(result.assume_init())
     }
 
     #[cfg(target_pointer_width = "32")]
     unsafe {
-        ret(syscall!(__NR_timerfd_gettime64, fd, &mut result))
-            .or_else(|err| {
-                // See the comments in `rustix_clock_gettime_via_syscall` about
-                // emulation.
-                if err == io::Errno::NOSYS {
-                    timerfd_gettime_old(fd, &mut result)
-                } else {
-                    Err(err)
-                }
-            })
-            .map(|()| result.assume_init())
+        ret(syscall!(__NR_timerfd_gettime64, fd, &mut result)).or_else(|err| {
+            // See the comments in `rustix_clock_gettime_via_syscall` about
+            // emulation.
+            if err == io::Errno::NOSYS {
+                timerfd_gettime_old(fd, &mut result)
+            } else {
+                Err(err)
+            }
+        })?;
+        Ok(result.assume_init())
     }
 }
 


### PR DESCRIPTION
Instead of `ret(a).map(|()| b)`, use `ret(a)?; Ok(b)`, which is a little
easier to read and debug.