### PR TITLE
Remove the `madvise` from the vDSO checking code.

### DIFF
--- a/src/backend/libc/mod.rs
+++ b/src/backend/libc/mod.rs
@@ -64,7 +64,7 @@ pub(crate) mod io;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "io_uring")))]
 pub(crate) mod io_uring;
 #[cfg(not(any(windows, target_os = "wasi")))]
-#[cfg(any(feature = "mm", feature = "time", target_arch = "x86"))] // vdso.rs uses `madvise`
+#[cfg(feature = "mm")]
 pub(crate) mod mm;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[cfg(feature = "net")]

--- a/src/backend/libc/offset.rs
+++ b/src/backend/libc/offset.rs
@@ -34,7 +34,7 @@ pub(super) use c::{
     target_os = "l4re",
     target_os = "wasi",
 )))]
-#[cfg(any(feature = "mm", feature = "time", target_arch = "x86"))] // vdso.rs uses `madvise`
+#[cfg(feature = "mm")]
 pub(super) use c::mmap as libc_mmap;
 
 #[cfg(not(any(
@@ -83,7 +83,7 @@ pub(super) use c::{getrlimit64 as libc_getrlimit, setrlimit64 as libc_setrlimit}
     target_os = "emscripten",
     target_os = "l4re",
 ))]
-#[cfg(any(feature = "mm", feature = "time", target_arch = "x86"))] // vdso.rs uses `madvise`
+#[cfg(feature = "mm")]
 pub(super) use c::mmap64 as libc_mmap;
 
 // `prlimit64` wasn't supported in glibc until 2.13.

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -369,7 +369,7 @@ impl<'a, Num: ArgNumber> From<crate::io::epoll::CreateFlags> for ArgReg<'a, Num>
     }
 }
 
-#[cfg(any(feature = "mm", feature = "time", target_arch = "x86"))] // vdso.rs uses `madvise`
+#[cfg(feature = "mm")]
 impl<'a, Num: ArgNumber> From<crate::backend::mm::types::ProtFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::backend::mm::types::ProtFlags) -> Self {
@@ -377,7 +377,7 @@ impl<'a, Num: ArgNumber> From<crate::backend::mm::types::ProtFlags> for ArgReg<'
     }
 }
 
-#[cfg(any(feature = "mm", feature = "time", target_arch = "x86"))] // vdso.rs uses `madvise`
+#[cfg(feature = "mm")]
 impl<'a, Num: ArgNumber> From<crate::backend::mm::types::MsyncFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::backend::mm::types::MsyncFlags) -> Self {
@@ -385,7 +385,7 @@ impl<'a, Num: ArgNumber> From<crate::backend::mm::types::MsyncFlags> for ArgReg<
     }
 }
 
-#[cfg(any(feature = "mm", feature = "time", target_arch = "x86"))] // vdso.rs uses `madvise`
+#[cfg(feature = "mm")]
 impl<'a, Num: ArgNumber> From<crate::backend::mm::types::MremapFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::backend::mm::types::MremapFlags) -> Self {
@@ -393,7 +393,7 @@ impl<'a, Num: ArgNumber> From<crate::backend::mm::types::MremapFlags> for ArgReg
     }
 }
 
-#[cfg(any(feature = "mm", feature = "time", target_arch = "x86"))] // vdso.rs uses `madvise`
+#[cfg(feature = "mm")]
 impl<'a, Num: ArgNumber> From<crate::backend::mm::types::MlockFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::backend::mm::types::MlockFlags) -> Self {
@@ -401,7 +401,7 @@ impl<'a, Num: ArgNumber> From<crate::backend::mm::types::MlockFlags> for ArgReg<
     }
 }
 
-#[cfg(any(feature = "mm", feature = "time", target_arch = "x86"))] // vdso.rs uses `madvise`
+#[cfg(feature = "mm")]
 impl<'a, Num: ArgNumber> From<crate::backend::mm::types::MapFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::backend::mm::types::MapFlags) -> Self {
@@ -409,7 +409,7 @@ impl<'a, Num: ArgNumber> From<crate::backend::mm::types::MapFlags> for ArgReg<'a
     }
 }
 
-#[cfg(any(feature = "mm", feature = "time", target_arch = "x86"))] // vdso.rs uses `madvise`
+#[cfg(feature = "mm")]
 impl<'a, Num: ArgNumber> From<crate::backend::mm::types::MprotectFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::backend::mm::types::MprotectFlags) -> Self {
@@ -417,7 +417,7 @@ impl<'a, Num: ArgNumber> From<crate::backend::mm::types::MprotectFlags> for ArgR
     }
 }
 
-#[cfg(any(feature = "mm", feature = "time", target_arch = "x86"))] // vdso.rs uses `madvise`
+#[cfg(feature = "mm")]
 impl<'a, Num: ArgNumber> From<crate::backend::mm::types::UserfaultfdFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::backend::mm::types::UserfaultfdFlags) -> Self {

--- a/src/backend/linux_raw/mod.rs
+++ b/src/backend/linux_raw/mod.rs
@@ -37,7 +37,7 @@ pub(crate) mod io;
 #[cfg(feature = "io_uring")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "io_uring")))]
 pub(crate) mod io_uring;
-#[cfg(any(feature = "mm", feature = "time", target_arch = "x86"))] // vdso.rs uses `madvise`
+#[cfg(feature = "mm")]
 pub(crate) mod mm;
 #[cfg(feature = "net")]
 pub(crate) mod net;

--- a/src/backend/linux_raw/vdso.rs
+++ b/src/backend/linux_raw/vdso.rs
@@ -14,8 +14,6 @@
 
 use super::c;
 use super::elf::*;
-use super::mm::syscalls::madvise;
-use super::mm::types::Advice;
 use crate::ffi::CStr;
 use crate::io;
 use core::ffi::c_void;
@@ -215,11 +213,6 @@ unsafe fn check_vdso_base<'vdso>(base: *const Elf_Ehdr) -> Option<&'vdso Elf_Ehd
     */
 
     let hdr = &*make_pointer::<Elf_Ehdr>(base.cast())?;
-
-    // Check that the vDSO is page-aligned and appropriately mapped. We call
-    // this after `make_pointer` so that we don't do a syscall if there's no
-    // chance the pointer is valid.
-    madvise(base as *mut c_void, size_of::<Elf_Ehdr>(), Advice::Normal).ok()?;
 
     if hdr.e_ident[..SELFMAG] != ELFMAG {
         return None; // Wrong ELF magic


### PR DESCRIPTION
The `madvise` was there to test whether the `AT_SYSINFO_EHDR` pointer
was a valid pointer before dereferencing it. However, in situation where
the `madvise` would fail, plain dereferences should reliably segfault,
which is sufficient for this code.