### PR TITLE
Add a `Result` to `getpgid`, and add `getpgrp`.

### DIFF
--- a/examples/process.rs
+++ b/examples/process.rs
@@ -10,6 +10,13 @@ fn main() -> io::Result<()> {
 
     println!("Pid: {}", getpid().as_raw_nonzero());
     println!("Parent Pid: {}", Pid::as_raw(getppid()));
+    println!("Group Pid: {}", getpgrp().as_raw_nonzero());
+    if let Some(ppid) = getppid() {
+        println!(
+            "Parent Group Pid: {}",
+            getpgid(Some(ppid)).unwrap().as_raw_nonzero()
+        );
+    }
     println!("Uid: {}", getuid().as_raw());
     println!("Gid: {}", getgid().as_raw());
     #[cfg(any(

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -125,7 +125,7 @@ pub(crate) fn getpgrp() -> Pid {
     #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     unsafe {
         let pgid: i32 =
-            ret_usize_infallible(syscall_readonly!(__NR_getpgrp), c_uint(0)) as __kernel_pid_t;
+            ret_usize_infallible(syscall_readonly!(__NR_getpgid, c_uint(0))) as __kernel_pid_t;
         debug_assert!(pgid > 0);
         Pid::from_raw_nonzero(RawNonZeroPid::new_unchecked(pgid as u32))
     }

--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -277,8 +277,22 @@ pub fn getppid() -> Option<Pid> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/getpgid.2.html
 #[inline]
 #[must_use]
-pub fn getpgid(pid: Option<Pid>) -> Pid {
+pub fn getpgid(pid: Option<Pid>) -> io::Result<Pid> {
     backend::process::syscalls::getpgid(pid)
+}
+
+/// `getpgrp()`—Returns the process' group ID.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpgrp.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/getpgrp.2.html
+#[inline]
+#[must_use]
+pub fn getpgrp() -> Pid {
+    backend::process::syscalls::getpgrp()
 }
 
 /// `setsid()`—Create a new session.

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -39,7 +39,7 @@ pub use exit::{EXIT_FAILURE, EXIT_SUCCESS};
 pub use id::Cpuid;
 #[cfg(not(target_os = "wasi"))]
 pub use id::{
-    getegid, geteuid, getgid, getpgid, getpid, getppid, getuid, setsid, Gid, Pid, RawGid,
+    getegid, geteuid, getgid, getpgid, getpgrp, getpid, getppid, getuid, setsid, Gid, Pid, RawGid,
     RawNonZeroPid, RawPid, RawUid, Uid,
 };
 #[cfg(not(target_os = "wasi"))]

--- a/tests/process/id.rs
+++ b/tests/process/id.rs
@@ -67,11 +67,36 @@ fn test_getppid() {
 #[test]
 fn test_getpgid() {
     assert_eq!(process::getpgid(None), process::getpgid(None));
+    assert_eq!(
+        process::getpgid(Some(process::getpid())),
+        process::getpgid(Some(process::getpid()))
+    );
     unsafe {
         assert_eq!(
-            process::getpgid(None).as_raw_nonzero().get() as libc::pid_t,
+            process::getpgid(None).unwrap().as_raw_nonzero().get() as libc::pid_t,
             libc::getpgid(0)
         );
-        assert_eq!(process::getpgid(None).is_init(), libc::getpgid(0) == 1);
+        assert_eq!(
+            process::getpgid(None).unwrap().is_init(),
+            libc::getpgid(0) == 1
+        );
+        assert_eq!(
+            process::getpgid(Some(process::getpid()))
+                .unwrap()
+                .as_raw_nonzero()
+                .get() as libc::pid_t,
+            libc::getpgid(libc::getpid())
+        );
+    }
+}
+
+#[test]
+fn test_getpgrp() {
+    assert_eq!(process::getpgrp(), process::getpgrp());
+    unsafe {
+        assert_eq!(
+            process::getpgrp().as_raw_nonzero().get() as libc::pid_t,
+            libc::getpgrp()
+        );
     }
 }


### PR DESCRIPTION
Add a `Result` return type to `getpgid`, as it can fail if there's no
process with the given pid.

And, add a a `getpgrp` function, which is similar to `getpgid`, but
doesn't take a pid argument and always operates on the current process,
which means it doesn't need a `Result` return type.