### PR TITLE
Update to io-lifetimes 1.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ cc = { version = "1.0.68", optional = true }
 [dependencies]
 bitflags = "1.2.1"
 itoa = { version = "1.0.1", default-features = false, optional = true }
-io-lifetimes = { version = "0.7.0", default-features = false, optional = true }
+io-lifetimes = { version = "1.0.0-rc0", default-features = false, optional = true }
 
 # Special dependencies used in rustc-dep-of-std mode.
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
@@ -71,7 +71,7 @@ features = [
 tempfile = "3.2.0"
 libc = "0.2.126"
 libc_errno = { package = "errno", version = "0.2.8", default-features = false }
-io-lifetimes = { version = "0.7.0", default-features = false }
+io-lifetimes = { version = "1.0.0-rc0", default-features = false }
 # Don't upgrade to serial_test 0.7 for now because it depends on a
 # `parking_lot_core` version which is not compatible with our MSRV of 1.48.
 serial_test = "0.6"

--- a/src/backend/libc/io_lifetimes.rs
+++ b/src/backend/libc/io_lifetimes.rs
@@ -75,35 +75,3 @@ impl<T: AsSocket> AsFd for T {
         self.as_socket()
     }
 }
-
-/// A version of [`IntoFd`] for use with Winsock2 API.
-///
-/// [`IntoFd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/trait.IntoFd.html
-pub trait IntoFd {
-    /// A version of [`into_fd`] for use with Winsock2 API.
-    ///
-    /// [`into_fd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/trait.IntoFd.html#tymethod.into_fd
-    fn into_fd(self) -> OwnedFd;
-}
-impl<T: IntoSocket> IntoFd for T {
-    #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.into_socket()
-    }
-}
-
-/// A version of [`FromFd`] for use with Winsock2 API.
-///
-/// [`FromFd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/trait.FromFd.html
-pub trait FromFd {
-    /// A version of [`from_fd`] for use with Winsock2 API.
-    ///
-    /// [`from_fd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/trait.FromFd.html#tymethod.from_fd
-    fn from_fd(fd: OwnedFd) -> Self;
-}
-impl<T: FromSocket> FromFd for T {
-    #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_socket(fd)
-    }
-}

--- a/src/backend/libc/io_lifetimes.rs
+++ b/src/backend/libc/io_lifetimes.rs
@@ -9,7 +9,7 @@ pub use std::os::windows::io::RawSocket as RawFd;
 pub(crate) use windows_sys::Win32::Networking::WinSock::SOCKET as LibcFd;
 
 // Re-export the `Socket` traits so that users can implement them.
-pub use io_lifetimes::{AsSocket, FromSocket, IntoSocket};
+pub use io_lifetimes::AsSocket;
 
 /// A version of [`AsRawFd`] for use with Winsock2 API.
 ///

--- a/src/backend/linux_raw/io/epoll.rs
+++ b/src/backend/linux_raw/io/epoll.rs
@@ -63,7 +63,7 @@ use super::super::c;
 use crate::backend::io::syscalls::{epoll_add, epoll_create, epoll_del, epoll_mod, epoll_wait};
 use crate::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 #[cfg(feature = "std")]
-use crate::fd::{FromFd, FromRawFd, IntoFd, IntoRawFd};
+use crate::fd::{FromRawFd, IntoRawFd};
 use crate::io::{self, OwnedFd};
 use alloc::vec::Vec;
 use bitflags::bitflags;
@@ -207,17 +207,17 @@ impl<'a> Context for Borrowing<'a> {
 }
 
 /// A type implementing [`Context`] where the `Data` type is `T`, a type
-/// implementing `IntoFd` and `FromFd`.
+/// implementing `From<OwnedFd>` and `From<T> of OwnedFd`.
 ///
 /// This may be used with [`OwnedFd`], or higher-level types like
 /// [`std::fs::File`] or [`std::net::TcpStream`].
 #[cfg(feature = "std")]
-pub struct Owning<'context, T: IntoFd + FromFd> {
+pub struct Owning<'context, T: Into<OwnedFd> + From<OwnedFd>> {
     _phantom: PhantomData<&'context T>,
 }
 
 #[cfg(feature = "std")]
-impl<'context, T: IntoFd + FromFd> Owning<'context, T> {
+impl<'context, T: Into<OwnedFd> + From<OwnedFd>> Owning<'context, T> {
     /// Creates a new empty `Owning`.
     #[allow(clippy::new_without_default)] // This is a specialized type that doesn't need to be generically constructible.
     #[inline]
@@ -229,16 +229,16 @@ impl<'context, T: IntoFd + FromFd> Owning<'context, T> {
 }
 
 #[cfg(feature = "std")]
-impl<'context, T: AsFd + IntoFd + FromFd> Context for Owning<'context, T> {
+impl<'context, T: AsFd + Into<OwnedFd> + From<OwnedFd>> Context for Owning<'context, T> {
     type Data = T;
     type Target = BorrowedFd<'context>;
 
     #[inline]
     fn acquire<'call>(&self, data: Self::Data) -> Ref<'call, Self::Target> {
-        let raw_fd = data.into_fd().into_raw_fd();
+        let raw_fd = data.into().into_raw_fd();
         // Safety: `epoll` will assign ownership of the file descriptor to the
-        // kernel epoll object. We use `IntoFd`+`IntoRawFd` to consume the
-        // `Data` and extract the raw file descriptor and then "borrow" it
+        // kernel epoll object. We use `Into<OwnedFd>`+`IntoRawFd` to consume
+        // the `Data` and extract the raw file descriptor and then "borrow" it
         // with `borrow_raw` knowing that the borrow won't outlive the
         // kernel epoll object.
         unsafe { Ref::new(BorrowedFd::<'context>::borrow_raw(raw_fd)) }
@@ -261,7 +261,7 @@ impl<'context, T: AsFd + IntoFd + FromFd> Context for Owning<'context, T> {
         // Safety: The file descriptor was held by the kernel epoll object and
         // is now being released, so we can create a new `OwnedFd` that assumes
         // ownership.
-        unsafe { T::from_fd(io_lifetimes::OwnedFd::from_raw_fd(raw_fd)) }
+        unsafe { T::from(io_lifetimes::OwnedFd::from_raw_fd(raw_fd).into()) }
     }
 }
 
@@ -388,21 +388,21 @@ impl<Context: self::Context> Epoll<Context> {
 }
 
 #[cfg(feature = "std")]
-impl<'context, T: AsFd + IntoFd + FromFd> AsRawFd for Epoll<Owning<'context, T>> {
+impl<'context, T: AsFd + Into<OwnedFd> + From<OwnedFd>> AsRawFd for Epoll<Owning<'context, T>> {
     fn as_raw_fd(&self) -> RawFd {
         self.epoll_fd.as_raw_fd()
     }
 }
 
 #[cfg(feature = "std")]
-impl<'context, T: AsFd + IntoFd + FromFd> IntoRawFd for Epoll<Owning<'context, T>> {
+impl<'context, T: AsFd + Into<OwnedFd> + From<OwnedFd>> IntoRawFd for Epoll<Owning<'context, T>> {
     fn into_raw_fd(self) -> RawFd {
         self.epoll_fd.into_raw_fd()
     }
 }
 
 #[cfg(feature = "std")]
-impl<'context, T: AsFd + IntoFd + FromFd> FromRawFd for Epoll<Owning<'context, T>> {
+impl<'context, T: AsFd + Into<OwnedFd> + From<OwnedFd>> FromRawFd for Epoll<Owning<'context, T>> {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         Self {
             epoll_fd: OwnedFd::from_raw_fd(fd),
@@ -412,21 +412,25 @@ impl<'context, T: AsFd + IntoFd + FromFd> FromRawFd for Epoll<Owning<'context, T
 }
 
 #[cfg(feature = "std")]
-impl<'context, T: AsFd + IntoFd + FromFd> AsFd for Epoll<Owning<'context, T>> {
+impl<'context, T: AsFd + Into<OwnedFd> + From<OwnedFd>> AsFd for Epoll<Owning<'context, T>> {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.epoll_fd.as_fd()
     }
 }
 
 #[cfg(feature = "std")]
-impl<'context, T: AsFd + IntoFd + FromFd> From<Epoll<Owning<'context, T>>> for OwnedFd {
+impl<'context, T: AsFd + Into<OwnedFd> + From<OwnedFd>> From<Epoll<Owning<'context, T>>>
+    for OwnedFd
+{
     fn from(epoll: Epoll<Owning<'context, T>>) -> Self {
         epoll.epoll_fd
     }
 }
 
 #[cfg(feature = "std")]
-impl<'context, T: AsFd + IntoFd + FromFd> From<OwnedFd> for Epoll<Owning<'context, T>> {
+impl<'context, T: AsFd + Into<OwnedFd> + From<OwnedFd>> From<OwnedFd>
+    for Epoll<Owning<'context, T>>
+{
     fn from(fd: OwnedFd) -> Self {
         Self {
             epoll_fd: fd,

--- a/src/io/owned_fd.rs
+++ b/src/io/owned_fd.rs
@@ -202,6 +202,7 @@ impl From<OwnedFd> for crate::backend::fd::OwnedFd {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<OwnedFd> for std::fs::File {
     fn from(owned: OwnedFd) -> Self {
         let owned: crate::backend::fd::OwnedFd = owned.into();
@@ -209,6 +210,7 @@ impl From<OwnedFd> for std::fs::File {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<OwnedFd> for std::net::TcpListener {
     fn from(owned: OwnedFd) -> Self {
         let owned: crate::backend::fd::OwnedFd = owned.into();
@@ -216,6 +218,7 @@ impl From<OwnedFd> for std::net::TcpListener {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<OwnedFd> for std::net::TcpStream {
     fn from(owned: OwnedFd) -> Self {
         let owned: crate::backend::fd::OwnedFd = owned.into();
@@ -223,6 +226,7 @@ impl From<OwnedFd> for std::net::TcpStream {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<OwnedFd> for std::net::UdpSocket {
     fn from(owned: OwnedFd) -> Self {
         let owned: crate::backend::fd::OwnedFd = owned.into();
@@ -231,6 +235,7 @@ impl From<OwnedFd> for std::net::UdpSocket {
 }
 
 #[cfg(unix)]
+#[cfg(feature = "std")]
 impl From<OwnedFd> for std::os::unix::net::UnixStream {
     fn from(owned: OwnedFd) -> Self {
         let owned: crate::backend::fd::OwnedFd = owned.into();
@@ -239,6 +244,7 @@ impl From<OwnedFd> for std::os::unix::net::UnixStream {
 }
 
 #[cfg(unix)]
+#[cfg(feature = "std")]
 impl From<OwnedFd> for std::os::unix::net::UnixListener {
     fn from(owned: OwnedFd) -> Self {
         let owned: crate::backend::fd::OwnedFd = owned.into();
@@ -247,6 +253,7 @@ impl From<OwnedFd> for std::os::unix::net::UnixListener {
 }
 
 #[cfg(unix)]
+#[cfg(feature = "std")]
 impl From<OwnedFd> for std::os::unix::net::UnixDatagram {
     fn from(owned: OwnedFd) -> Self {
         let owned: crate::backend::fd::OwnedFd = owned.into();

--- a/src/io/owned_fd.rs
+++ b/src/io/owned_fd.rs
@@ -203,6 +203,7 @@ impl From<OwnedFd> for crate::backend::fd::OwnedFd {
 }
 
 #[cfg(feature = "std")]
+#[cfg(any(unix, target_os = "wasi"))]
 impl From<OwnedFd> for std::fs::File {
     fn from(owned: OwnedFd) -> Self {
         let owned: crate::backend::fd::OwnedFd = owned.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,6 @@ pub mod fd {
     pub use backend::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
     #[cfg(windows)]
     pub use backend::fd::{AsSocket, FromSocket, IntoSocket};
-    #[cfg(feature = "std")]
-    pub use backend::fd::{FromFd, IntoFd};
 }
 
 // The public API modules.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,9 +146,9 @@ mod backend;
 /// [`rustix::io::OwnedFd`]: crate::io::OwnedFd
 pub mod fd {
     use super::backend;
-    pub use backend::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
     #[cfg(windows)]
-    pub use backend::fd::{AsSocket, FromSocket, IntoSocket};
+    pub use backend::fd::AsSocket;
+    pub use backend::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 }
 
 // The public API modules.

--- a/tests/fs/openat.rs
+++ b/tests/fs/openat.rs
@@ -1,6 +1,5 @@
 use std::fs::File;
 
-use io_lifetimes::{FromFd, IntoFd};
 use rustix::fs::{cwd, openat, Mode, OFlags};
 use std::io::Write;
 
@@ -20,7 +19,7 @@ fn test_openat_tmpfile() {
         OFlags::WRONLY | OFlags::CLOEXEC | OFlags::TMPFILE,
         Mode::from_bits_truncate(0o644),
     ) {
-        Ok(f) => Ok(Some(File::from_fd(f.into_fd()))),
+        Ok(f) => Ok(Some(File::from(f))),
         // TODO: Factor out the `Err`, once we no longer support Rust 1.48.
         Err(rustix::io::Errno::OPNOTSUPP)
         | Err(rustix::io::Errno::ISDIR)

--- a/tests/io/seals.rs
+++ b/tests/io/seals.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "fs")]
 #[test]
 fn test_seals() {
-    use rustix::fd::FromFd;
     use rustix::fs::{
         fcntl_add_seals, fcntl_get_seals, ftruncate, memfd_create, MemfdFlags, SealFlags,
     };
@@ -13,7 +12,7 @@ fn test_seals() {
         Err(rustix::io::Errno::NOSYS) => return,
         Err(err) => Err(err).unwrap(),
     };
-    let mut file = File::from_fd(fd.into());
+    let mut file = File::from(fd);
 
     let old = fcntl_get_seals(&file).unwrap();
     assert_eq!(old, SealFlags::empty());


### PR DESCRIPTION
The main change here is the removal of `FromFd` and `IntoFd` in favor of
`From<OwnedFd>` and `impl<T> or OwnedFd`.

This also adds impls for std types for rustix::io::OwnedFd to make it
less inconvenient to work with.