### PR TITLE
Make the linux-raw-sys dependency non-optional on Linux.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,7 @@ jobs:
         armv5te-unknown-linux-gnueabi
         s390x-unknown-linux-gnu
         arm-linux-androideabi
+        aarch64-linux-android
         aarch64-apple-ios
     - name: Install cross-compilation tools
       run: |
@@ -80,6 +81,7 @@ jobs:
     - run: cargo check --workspace --release -vv
     - run: cargo check --workspace --release -vv --features=all-apis
     - run: cargo check --workspace --release -vv --features=use-libc,all-apis
+    - run: cargo check --workspace --release -vv --target=aarch64-linux-android
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-musl --features=all-apis
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-musl --features=use-libc,all-apis
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-gnux32 --features=all-apis
@@ -105,6 +107,7 @@ jobs:
     - run: cargo check --workspace --release -vv --target=s390x-unknown-linux-gnu --features=all-apis
     - run: cargo check --workspace --release -vv --target=arm-linux-androideabi --features=all-apis
     - run: cargo check --workspace --release -vv --target=aarch64-apple-ios --features=all-apis
+    - run: cargo check --workspace --release -vv --target=aarch64-linux-android --features=all-apis
 
   check_no_default_features:
     name: Check --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ libc = { version = "0.2.126", features = ["extra_traits"] }
 # Some syscalls do not have libc wrappers, such as in `io_uring`. For these,
 # the libc backend uses the linux-raw-sys ABI and `libc::syscall`.
 [target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64"))))))))'.dependencies]
-linux-raw-sys = { version = "0.0.46", default-features = false, optional = true, features = ["general", "no_std"] }
+linux-raw-sys = { version = "0.0.46", default-features = false, features = ["general", "no_std"] }
 
 # For the libc backend on Windows, use the Winsock2 API in windows-sys.
 [target.'cfg(windows)'.dependencies.windows-sys]
@@ -128,7 +128,7 @@ use-libc = ["libc_errno", "libc"]
 fs = []
 
 # Enable `rustix::io_uring::*` (on platforms that support it).
-io_uring = ["linux-raw-sys", "fs", "net"]
+io_uring = ["fs", "net"]
 
 # Enable `rustix::net::*`.
 net = []
@@ -152,7 +152,7 @@ procfs = ["once_cell", "itoa"]
 termios = []
 
 # Enable `rustix::mm::*`.
-mm = ["linux-raw-sys"]
+mm = []
 
 # Enable `rustix::rand::*`.
 rand = []

--- a/tests/backends.rs
+++ b/tests/backends.rs
@@ -68,16 +68,6 @@ fn test_backends() {
         "use-default with --cfg=rustix_use_libc does not depend on {}",
         libc_dep
     );
-    assert!(
-        !has_dependency(
-            "test-crates/use-default",
-            &[],
-            &[("RUSTFLAGS", "--cfg=rustix_use_libc")],
-            &[],
-            "linux-raw-sys"
-        ),
-        "use-default with --cfg=rustix_use_libc depends on linux-raw-sys"
-    );
 
     // Test the use-default crate with `--features=rustix/use-libc`.
     assert!(


### PR DESCRIPTION
Rustix's statx code now depends on linux-raw-sys, in order to obtain
Linux's `STATX__RESERVED` value, which musl doesn't export. As such,
always enable the linux-raw-sys dependency on Linux targets.

Fixes #389.