### PR TITLE
Remove a few unnecessary `allow(unsafe_code)` annotations.

### DIFF
--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -4,8 +4,6 @@
 //!
 //! See the `rustix::backend::syscalls` module documentation for details.
 
-#![allow(unsafe_code)]
-
 use super::super::c;
 use super::super::conv::{borrowed_fd, ret, ret_pid_t};
 use crate::fd::BorrowedFd;

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -552,7 +552,6 @@ pub const IORING_OFF_SQES: u64 = sys::IORING_OFF_SQES as _;
 /// `IORING_REGISTER_FILES_SKIP`
 #[inline]
 #[doc(alias = "IORING_REGISTER_FILES_SKIP")]
-#[allow(unsafe_code)]
 pub const fn io_uring_register_files_skip() -> BorrowedFd<'static> {
     let files_skip = sys::IORING_REGISTER_FILES_SKIP as RawFd;
 


### PR DESCRIPTION
Following up on the discussion in https://github.com/bytecodealliance/rustix/pull/395#issuecomment-1241106887, I did a quick check to see if any of the existing `allow(unsafe_code)` annotations could be removed, and found two that were easy.
