### PR TITLE
Fix libc removing unsafe on makedev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ once_cell = { version = "1.5.2", optional = true }
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
 linux-raw-sys = { version = "0.0.46", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 libc_errno = { package = "errno", version = "0.2.8", default-features = false, optional = true }
-libc = { version = "0.2.126", features = ["extra_traits"], optional = true }
+libc = { version = "0.2.133", features = ["extra_traits"], optional = true }
 
 # Dependencies for platforms where only libc is supported:
 #
@@ -48,7 +48,7 @@ libc = { version = "0.2.126", features = ["extra_traits"], optional = true }
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.2.8", default-features = false }
-libc = { version = "0.2.126", features = ["extra_traits"] }
+libc = { version = "0.2.133", features = ["extra_traits"] }
 
 # Additional dependencies for Linux with the libc backend:
 #
@@ -69,7 +69,7 @@ features = [
 
 [dev-dependencies]
 tempfile = "3.2.0"
-libc = "0.2.126"
+libc = "0.2.133"
 libc_errno = { package = "errno", version = "0.2.8", default-features = false }
 io-lifetimes = { version = "1.0.0-rc1", default-features = false }
 # Don't upgrade to serial_test 0.7 for now because it depends on a

--- a/src/backend/libc/fs/makedev.rs
+++ b/src/backend/libc/fs/makedev.rs
@@ -5,14 +5,14 @@ use crate::fs::Dev;
 #[cfg(not(any(target_os = "android", target_os = "emscripten")))]
 #[inline]
 pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
-    unsafe { c::makedev(maj, min) }
+    c::makedev(maj, min)
 }
 
 #[cfg(all(target_os = "android", not(target_pointer_width = "32")))]
 #[inline]
 pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
     // Android's `makedev` oddly has signed argument types.
-    unsafe { c::makedev(maj as i32, min as i32) }
+    c::makedev(maj, min)
 }
 
 #[cfg(all(target_os = "android", target_pointer_width = "32"))]
@@ -30,7 +30,7 @@ pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
 #[inline]
 pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
     // Emscripten's `makedev` has a 32-bit return value.
-    Dev::from(unsafe { c::makedev(maj, min) })
+    Dev::from(c::makedev(maj, min))
 }
 
 #[cfg(not(any(target_os = "android", target_os = "emscripten")))]


### PR DESCRIPTION
See #402 
I had to bump to the minimum libc 0.2.133 