### PR TITLE
More fixes for compilation on x86_64-unknown-dragonfly.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,10 +184,11 @@ jobs:
         # See the comments in the libc crate
         RUSTFLAGS: -A improper_ctypes_definitions
     - run: rustup component add rust-src
-    - run: cargo check -Z build-std=core,alloc,std --target x86_64-unknown-openbsd --all-targets --features=all-apis
-    - run: cargo check -Z build-std=core,alloc,std --target mips64-openwrt-linux-musl --all-targets --features=all-apis
+    - run: cargo check -Z build-std --target x86_64-unknown-openbsd --all-targets --features=all-apis
+    - run: cargo check -Z build-std --target mips64-openwrt-linux-musl --all-targets --features=all-apis
+    - run: cargo check -Z build-std --target x86_64-unknown-dragonfly --all-targets --features=all-apis
     # x86_64-uwp-windows-msvc isn't currently working.
-    #- run: cargo check -Z build-std=core,alloc,std --target x86_64-uwp-windows-msvc --all-targets --features=all-apis
+    #- run: cargo check -Z build-std --target x86_64-uwp-windows-msvc --all-targets --features=all-apis
 
   test:
     name: Test

--- a/examples/process.rs
+++ b/examples/process.rs
@@ -53,6 +53,7 @@ fn main() -> io::Result<()> {
     #[cfg(not(target_os = "openbsd"))]
     println!("As Limit: {:?}", getrlimit(Resource::As));
     #[cfg(not(any(
+        target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "ios",
         target_os = "macos",
@@ -62,6 +63,7 @@ fn main() -> io::Result<()> {
     )))]
     println!("Locks Limit: {:?}", getrlimit(Resource::Locks));
     #[cfg(not(any(
+        target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "ios",
         target_os = "macos",
@@ -71,6 +73,7 @@ fn main() -> io::Result<()> {
     )))]
     println!("Sigpending Limit: {:?}", getrlimit(Resource::Sigpending));
     #[cfg(not(any(
+        target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "ios",
         target_os = "macos",
@@ -80,6 +83,7 @@ fn main() -> io::Result<()> {
     )))]
     println!("Msgqueue Limit: {:?}", getrlimit(Resource::Msgqueue));
     #[cfg(not(any(
+        target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "ios",
         target_os = "macos",
@@ -89,6 +93,7 @@ fn main() -> io::Result<()> {
     )))]
     println!("Nice Limit: {:?}", getrlimit(Resource::Nice));
     #[cfg(not(any(
+        target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "ios",
         target_os = "macos",
@@ -99,6 +104,7 @@ fn main() -> io::Result<()> {
     println!("Rtprio Limit: {:?}", getrlimit(Resource::Rtprio));
     #[cfg(not(any(
         target_os = "android",
+        target_os = "dragonfly",
         target_os = "emscripten",
         target_os = "freebsd",
         target_os = "ios",

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -214,6 +214,7 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
                 print!(" CRDLY");
             }
             #[cfg(not(any(
+                target_os = "dragonfly",
                 target_os = "ios",
                 target_os = "macos",
                 target_os = "netbsd",

--- a/src/backend/libc/process/types.rs
+++ b/src/backend/libc/process/types.rs
@@ -380,7 +380,7 @@ pub(crate) fn raw_cpu_set_new() -> RawCpuSet {
     set
 }
 
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux",))]
+#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
 pub(crate) const CPU_SETSIZE: usize = c::CPU_SETSIZE as usize;
 #[cfg(target_os = "dragonfly")]
 pub(crate) const CPU_SETSIZE: usize = 256;

--- a/src/backend/libc/termios/types.rs
+++ b/src/backend/libc/termios/types.rs
@@ -381,6 +381,7 @@ pub const CR3: c::c_uint = c::CR3;
 
 /// `TABDLY`
 #[cfg(not(any(
+    target_os = "dragonfly",
     target_os = "ios",
     target_os = "macos",
     target_os = "netbsd",
@@ -393,6 +394,7 @@ pub const TABDLY: c::c_uint = c::TABDLY;
 
 /// `TAB0`
 #[cfg(not(any(
+    target_os = "dragonfly",
     target_os = "fuchsia",
     target_os = "illumos",
     target_os = "ios",
@@ -441,6 +443,7 @@ pub const TAB2: c::c_uint = c::TAB2;
 /// `TAB3`
 #[cfg(not(any(
     target_env = "musl",
+    target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "fuchsia",
     target_os = "illumos",
@@ -651,7 +654,12 @@ pub const B115200: Speed = c::B115200;
 pub const B230400: Speed = c::B230400;
 
 /// `B460800`
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
+#[cfg(not(any(
+    target_os = "dragonfly",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "openbsd"
+)))]
 pub const B460800: Speed = c::B460800;
 
 /// `B500000`
@@ -681,7 +689,12 @@ pub const B500000: Speed = c::B500000;
 pub const B576000: Speed = c::B576000;
 
 /// `B921600`
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
+#[cfg(not(any(
+    target_os = "dragonfly",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "openbsd"
+)))]
 pub const B921600: Speed = c::B921600;
 
 /// `B1000000`

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -82,7 +82,7 @@ pub use abs::statfs;
 )))]
 #[cfg(feature = "fs")]
 pub use abs::statvfs;
-#[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "solaris",)))]
+#[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "solaris")))]
 #[cfg(feature = "fs")]
 pub use at::accessat;
 #[cfg(any(target_os = "ios", target_os = "macos"))]

--- a/src/termios/constants.rs
+++ b/src/termios/constants.rs
@@ -79,7 +79,12 @@ pub use backend::termios::types::B3500000;
     target_os = "solaris",
 )))]
 pub use backend::termios::types::B4000000;
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
+#[cfg(not(any(
+    target_os = "dragonfly",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "openbsd"
+)))]
 pub use backend::termios::types::B460800;
 #[cfg(not(any(
     target_os = "dragonfly",
@@ -103,7 +108,12 @@ pub use backend::termios::types::B500000;
     target_os = "solaris",
 )))]
 pub use backend::termios::types::B576000;
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
+#[cfg(not(any(
+    target_os = "dragonfly",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "openbsd"
+)))]
 pub use backend::termios::types::B921600;
 #[cfg(not(any(target_os = "ios", target_os = "macos")))]
 pub use backend::termios::types::BRKINT;
@@ -493,6 +503,7 @@ pub use backend::termios::types::PARODD;
 #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
 pub use backend::termios::types::PENDIN;
 #[cfg(not(any(
+    target_os = "dragonfly",
     target_os = "fuchsia",
     target_os = "illumos",
     target_os = "ios",
@@ -535,6 +546,7 @@ pub use backend::termios::types::TAB1;
 pub use backend::termios::types::TAB2;
 #[cfg(not(any(
     all(libc, target_env = "musl"),
+    target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "fuchsia",
     target_os = "illumos",
@@ -547,6 +559,7 @@ pub use backend::termios::types::TAB2;
 )))]
 pub use backend::termios::types::TAB3;
 #[cfg(not(any(
+    target_os = "dragonfly",
     target_os = "ios",
     target_os = "macos",
     target_os = "netbsd",
@@ -657,7 +670,12 @@ pub fn speed_value(speed: backend::termios::types::Speed) -> Option<u32> {
         backend::termios::types::B57600 => Some(57600),
         backend::termios::types::B115200 => Some(115_200),
         backend::termios::types::B230400 => Some(230_400),
-        #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "openbsd"
+        )))]
         backend::termios::types::B460800 => Some(460_800),
         #[cfg(not(any(
             target_os = "dragonfly",
@@ -681,7 +699,12 @@ pub fn speed_value(speed: backend::termios::types::Speed) -> Option<u32> {
             target_os = "solaris",
         )))]
         backend::termios::types::B576000 => Some(576_000),
-        #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "openbsd"
+        )))]
         backend::termios::types::B921600 => Some(921_600),
         #[cfg(not(any(
             target_os = "dragonfly",

--- a/src/termios/mod.rs
+++ b/src/termios/mod.rs
@@ -87,7 +87,12 @@ pub use constants::B3500000;
     target_os = "solaris",
 )))]
 pub use constants::B4000000;
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
+#[cfg(not(any(
+    target_os = "dragonfly",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "openbsd"
+)))]
 pub use constants::B460800;
 #[cfg(not(any(
     target_os = "dragonfly",
@@ -111,7 +116,12 @@ pub use constants::B500000;
     target_os = "solaris",
 )))]
 pub use constants::B576000;
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
+#[cfg(not(any(
+    target_os = "dragonfly",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "openbsd"
+)))]
 pub use constants::B921600;
 #[cfg(not(any(target_os = "ios", target_os = "macos")))]
 pub use constants::BRKINT;
@@ -501,6 +511,7 @@ pub use constants::PARODD;
 #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
 pub use constants::PENDIN;
 #[cfg(not(any(
+    target_os = "dragonfly",
     target_os = "fuchsia",
     target_os = "illumos",
     target_os = "ios",
@@ -543,6 +554,7 @@ pub use constants::TAB1;
 pub use constants::TAB2;
 #[cfg(not(any(
     all(libc, target_env = "musl"),
+    target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "fuchsia",
     target_os = "illumos",
@@ -555,6 +567,7 @@ pub use constants::TAB2;
 )))]
 pub use constants::TAB3;
 #[cfg(not(any(
+    target_os = "dragonfly",
     target_os = "ios",
     target_os = "macos",
     target_os = "netbsd",

--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -89,7 +89,7 @@ fn test_sockopts() {
             target_os = "netbsd",
             target_os = "openbsd",
         )))]
-        assert!(rustix::net::sockopt::get_socket_broadcast(&s).unwrap(),);
+        assert!(rustix::net::sockopt::get_socket_broadcast(&s).unwrap());
     }
 
     // Set a linger.

--- a/tests/thread/clocks.rs
+++ b/tests/thread/clocks.rs
@@ -1,4 +1,5 @@
 #[cfg(not(any(
+    target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "freebsd",
     target_os = "ios",
@@ -48,6 +49,7 @@ fn test_invalid_nanosleep() {
 }
 
 #[cfg(not(any(
+    target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "freebsd",
     target_os = "ios",
@@ -101,6 +103,7 @@ fn test_invalid_nanosleep_absolute() {
 }
 
 #[cfg(not(any(
+    target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "freebsd",
     target_os = "ios",
@@ -166,6 +169,7 @@ fn test_zero_nanosleep() {
 }
 
 #[cfg(not(any(
+    target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "freebsd",
     target_os = "ios",
@@ -189,6 +193,7 @@ fn test_zero_nanosleep_absolute() {
 }
 
 #[cfg(not(any(
+    target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "freebsd",
     target_os = "ios",


### PR DESCRIPTION
Add a tier-3 CI check for x86_64-unknown-dragonfly, and fix the compilation errors needed to compile with --features=all-apis.

This builds on top of #409!