### PR TITLE
Fix linux-raw inline asm for thumb-mode.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,6 +159,7 @@ jobs:
         rustup target add
         x86_64-unknown-redox
         wasm32-wasi
+        thumbv7neon-unknown-linux-gnueabihf
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-redox --features=all-apis
     - run: cargo check --workspace --release -vv --target=wasm32-wasi --features=all-apis
     - run: cargo check --workspace --release -vv --target=thumbv7neon-unknown-linux-gnueabihf --features=all-apis

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,6 +161,7 @@ jobs:
         wasm32-wasi
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-redox --features=all-apis
     - run: cargo check --workspace --release -vv --target=wasm32-wasi --features=all-apis
+    - run: cargo check --workspace --release -vv --target=thumbv7neon-unknown-linux-gnueabihf --features=all-apis
 
   check_tier3:
     name: Check selected Tier 3 platforms

--- a/src/backend/linux_raw/arch/inline/mod.rs
+++ b/src/backend/linux_raw/arch/inline/mod.rs
@@ -5,7 +5,8 @@
 //! conventions are otherwise the compiler's job. But for now, use inline asm.
 
 #[cfg_attr(target_arch = "aarch64", path = "aarch64.rs")]
-#[cfg_attr(target_arch = "arm", path = "arm.rs")]
+#[cfg_attr(all(target_arch = "arm", not(target_feature = "thumb-mode")), path = "arm.rs")]
+#[cfg_attr(all(target_arch = "arm", target_feature = "thumb-mode"), path = "thumb.rs")]
 #[cfg_attr(target_arch = "mips", path = "mips.rs")]
 #[cfg_attr(target_arch = "mips64", path = "mips64.rs")]
 #[cfg_attr(target_arch = "powerpc64", path = "powerpc64.rs")]

--- a/src/backend/linux_raw/arch/inline/mod.rs
+++ b/src/backend/linux_raw/arch/inline/mod.rs
@@ -5,8 +5,14 @@
 //! conventions are otherwise the compiler's job. But for now, use inline asm.
 
 #[cfg_attr(target_arch = "aarch64", path = "aarch64.rs")]
-#[cfg_attr(all(target_arch = "arm", not(target_feature = "thumb-mode")), path = "arm.rs")]
-#[cfg_attr(all(target_arch = "arm", target_feature = "thumb-mode"), path = "thumb.rs")]
+#[cfg_attr(
+    all(target_arch = "arm", not(target_feature = "thumb-mode")),
+    path = "arm.rs"
+)]
+#[cfg_attr(
+    all(target_arch = "arm", target_feature = "thumb-mode"),
+    path = "thumb.rs"
+)]
 #[cfg_attr(target_arch = "mips", path = "mips.rs")]
 #[cfg_attr(target_arch = "mips64", path = "mips64.rs")]
 #[cfg_attr(target_arch = "powerpc64", path = "powerpc64.rs")]

--- a/src/backend/linux_raw/arch/inline/thumb.rs
+++ b/src/backend/linux_raw/arch/inline/thumb.rs
@@ -1,0 +1,325 @@
+//! arm Linux system calls, using thumb-mode.
+//!
+//! In thumb-mode, r7 is the frame pointer and is not permitted to be used in
+//! an inline asm operand, so we have to use a different register and copy it
+//! into r7 inside the inline asm.
+
+use crate::backend::reg::{
+    ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0,
+};
+use core::arch::asm;
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        lateout("r0") r0,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        in("r0") a0.to_asm(),
+        options(noreturn)
+    )
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        in("r2") a2.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        in("r2") a2.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        in("r2") a2.to_asm(),
+        in("r3") a3.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        in("r2") a2.to_asm(),
+        in("r3") a3.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        in("r2") a2.to_asm(),
+        in("r3") a3.to_asm(),
+        in("r4") a4.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        in("r2") a2.to_asm(),
+        in("r3") a3.to_asm(),
+        in("r4") a4.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        in("r2") a2.to_asm(),
+        in("r3") a3.to_asm(),
+        in("r4") a4.to_asm(),
+        in("r5") a5.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        in("r2") a2.to_asm(),
+        in("r3") a3.to_asm(),
+        in("r4") a4.to_asm(),
+        in("r5") a5.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}

--- a/src/backend/linux_raw/arch/inline/thumb.rs
+++ b/src/backend/linux_raw/arch/inline/thumb.rs
@@ -63,12 +63,9 @@ pub(in crate::backend) unsafe fn syscall1_readonly(
 #[inline]
 pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
-        "mov {tmp}, r7",
         "mov r7, {nr}",
         "svc 0",
-        "mov r7, {tmp}",
         nr = in(reg) nr.to_asm(),
-        tmp = out(reg) _,
         in("r0") a0.to_asm(),
         options(noreturn)
     )


### PR DESCRIPTION
In thumb-mode, r7 is reserved as the frame pointer and isn't permitted as an inline asm operand. It's still the syscall-number operand in syscalls though, so pass the syscall-number operand in in a separate register, copy it into r7 inside the inline asm, and then restore the value of r7 when we're done.
