### PR TITLE
Pass `--target=$TARGET` when running `rustc` in `build.rs`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -174,10 +174,13 @@ fn can_compile(code: &str) -> bool {
     use std::process::Stdio;
     let out_dir = var("OUT_DIR").unwrap();
     let rustc = var("RUSTC").unwrap();
+    let target = var("TARGET").unwrap();
 
     let mut child = std::process::Command::new(rustc)
         .arg("--crate-type=rlib") // Don't require `main`.
         .arg("--emit=metadata") // Do as little as possible but still parse.
+        .arg("--target")
+        .arg(target)
         .arg("--out-dir")
         .arg(out_dir) // Put the output somewhere inconsequential.
         .arg("-") // Read from stdin.


### PR DESCRIPTION
I'm using this in an environment where only the `$TARGET` rust standard library is available, which means `use std::arch::asm;` doesn't work for the host platform when cross compiling, even when it works for the target platform. Also in general, this is trying to detect things about the target, not the host.

For context, I'm using [Bazel](https://bazel.build/) with [rules_rust's cargo_build_script](http://bazelbuild.github.io/rules_rust/flatten.html#cargo_build_script), via [cargo-raze](https://github.com/google/cargo-raze). Native x86_64-unknown-linux-gnu compilation works fine without this patch, but cross compiling to aarch64-unknown-linux-gnu requires this patch.