### PR TITLE
Add logic to build.rs to autodetect whether we need to use thumb-mode.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -101,6 +101,11 @@ fn main() {
         }
     }
 
+    // Detect whether the compiler requires us to use thumb mode on ARM.
+    if arch == "arm" && use_thumb_mode() {
+        use_feature("thumb_mode");
+    }
+
     println!("cargo:rerun-if-env-changed=CARGO_CFG_RUSTIX_USE_EXPERIMENTAL_ASM");
 }
 
@@ -149,6 +154,11 @@ fn link_in_librustix_outline(arch: &str, asm_name: &str) {
             );
         }
     }
+}
+
+fn use_thumb_mode() -> bool {
+    // In thumb mode, r7 is reserved.
+    !can_compile("pub unsafe fn f() { core::arch::asm!(\"udf #16\", in(\"r7\") 0); }")
 }
 
 fn use_feature_or_nothing(feature: &str) {

--- a/src/backend/linux_raw/arch/inline/mod.rs
+++ b/src/backend/linux_raw/arch/inline/mod.rs
@@ -5,14 +5,8 @@
 //! conventions are otherwise the compiler's job. But for now, use inline asm.
 
 #[cfg_attr(target_arch = "aarch64", path = "aarch64.rs")]
-#[cfg_attr(
-    all(target_arch = "arm", not(target_feature = "thumb-mode")),
-    path = "arm.rs"
-)]
-#[cfg_attr(
-    all(target_arch = "arm", target_feature = "thumb-mode"),
-    path = "thumb.rs"
-)]
+#[cfg_attr(all(target_arch = "arm", not(thumb_mode)), path = "arm.rs")]
+#[cfg_attr(all(target_arch = "arm", thumb_mode), path = "thumb.rs")]
 #[cfg_attr(target_arch = "mips", path = "mips.rs")]
 #[cfg_attr(target_arch = "mips64", path = "mips64.rs")]
 #[cfg_attr(target_arch = "powerpc64", path = "powerpc64.rs")]


### PR DESCRIPTION
`#[cfg(target_feature = "thumb-mode")]` isn't available on stable, so use a build.rs script to detect whether we can use `r7` in inline asm on ARM targets.