### PR TITLE
Add "close" to io-lifetimes feature set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ features = [
 tempfile = "3.2.0"
 libc = "0.2.133"
 libc_errno = { package = "errno", version = "0.2.8", default-features = false }
-io-lifetimes = { version = "1.0.0-rc1", default-features = false }
+io-lifetimes = { version = "1.0.0-rc1", default-features = false, features = ["close"] }
 # Don't upgrade to serial_test 0.7 for now because it depends on a
 # `parking_lot_core` version which is not compatible with our MSRV of 1.48.
 serial_test = "0.6"


### PR DESCRIPTION
Without this feature enabled the eventfd test crashes on my box:

    ---- eventfd::test_eventfd stdout ----
    thread 'eventfd::test_eventfd' panicked at 'internal error: entered unreachable code: drop called without the "close" feature in io-lifetimes', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/io-lifetimes-1.0.0-rc1/src/types.rs:763:13
    stack backtrace:
       0: rust_begin_unwind
                 at /datastore/rpmbuild/BUILD/rustc-1.57.0-src/library/std/src/panicking.rs:517:5
       1: core::panicking::panic_fmt
                 at /datastore/rpmbuild/BUILD/rustc-1.57.0-src/library/core/src/panicking.rs:100:14
       2: <io_lifetimes::types::OwnedFd as core::ops::drop::Drop>::drop
                 at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/io-lifetimes-1.0.0-rc1/src/types.rs:763:13
       3: core::ptr::drop_in_place<io_lifetimes::types::OwnedFd>
                 at /datastore/rpmbuild/BUILD/rustc-1.57.0-src/library/core/src/ptr/mod.rs:188:1
       4: io::eventfd::test_eventfd
                 at ./tests/io/eventfd.rs:24:1
       5: io::eventfd::test_eventfd::{{closure}}
                 at ./tests/io/eventfd.rs:3:1
       6: core::ops::function::FnOnce::call_once
                 at /datastore/rpmbuild/BUILD/rustc-1.57.0-src/library/core/src/ops/function.rs:227:5
       7: core::ops::function::FnOnce::call_once
                 at /datastore/rpmbuild/BUILD/rustc-1.57.0-src/library/core/src/ops/function.rs:227:5
    note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.