### PR TITLE
Add a `proc_self_status` function for reading /proc/self/status on Linux

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -66,7 +66,9 @@ pub use pipe::PIPE_BUF;
 pub use pipe::{pipe_with, PipeFlags};
 pub use poll::{poll, PollFd, PollFlags};
 #[cfg(all(feature = "procfs", any(target_os = "android", target_os = "linux")))]
-pub use procfs::{proc_self_fd, proc_self_fdinfo_fd, proc_self_maps, proc_self_pagemap};
+pub use procfs::{
+    proc_self_fd, proc_self_fdinfo_fd, proc_self_maps, proc_self_pagemap, proc_self_status,
+};
 #[cfg(not(windows))]
 pub use read_write::{pread, pwrite, read, readv, write, writev, IoSlice, IoSliceMut};
 #[cfg(not(any(

--- a/src/io/procfs.rs
+++ b/src/io/procfs.rs
@@ -410,6 +410,21 @@ pub fn proc_self_maps() -> io::Result<OwnedFd> {
     proc_self_file(cstr!("maps"))
 }
 
+/// Returns a handle to a Linux `/proc/self/status` file.
+///
+/// This ensures that `/proc/self/status` is `procfs`, that nothing is
+/// mounted on top of it, and that it looks normal.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man5/proc.5.html
+#[inline]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
+pub fn proc_self_status() -> io::Result<OwnedFd> {
+    proc_self_file(cstr!("status"))
+}
+
 /// Open a file under `/proc/self`.
 fn proc_self_file(name: &CStr) -> io::Result<OwnedFd> {
     let (proc_self, proc_self_stat) = proc_self()?;

--- a/tests/process/proc.rs
+++ b/tests/process/proc.rs
@@ -1,5 +1,6 @@
 #[test]
 fn test_proc_funcs() {
     let _maps = rustix::io::proc_self_maps().unwrap();
+    let _status = rustix::io::proc_self_status().unwrap();
     let _pagemap = rustix::io::proc_self_pagemap().unwrap();
 }


### PR DESCRIPTION
Fixes #423.