### PR TITLE
Update the comment about the Rust version requirement for no_std.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ targets = [
 default = ["std", "use-libc-auxv"]
 
 # This enables use of std. Disabling this enables `#![no_std], and requires
-# nightly Rust.
+# Rust 1.64 or newer.
 std = ["io-lifetimes"]
 
 # This is used in the port of std to rustix.


### PR DESCRIPTION
Fixes #426.