### PR TITLE
Add part of the FreeBSD `procctl` API

### DIFF
--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -453,3 +453,14 @@ pub(crate) unsafe fn prctl(
 ) -> io::Result<c::c_int> {
     ret_c_int(c::prctl(option, arg2, arg3, arg4, arg5))
 }
+
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+#[inline]
+pub(crate) unsafe fn procctl(
+    idtype: c::idtype_t,
+    id: c::id_t,
+    option: c::c_int,
+    data: *mut c::c_void,
+) -> io::Result<()> {
+    ret(c::procctl(idtype, id, option, data))
+}

--- a/src/backend/libc/process/types.rs
+++ b/src/backend/libc/process/types.rs
@@ -381,6 +381,8 @@ pub type RawUid = c::uid_t;
 /// A CPU identifier as a raw integer.
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub type RawCpuid = u32;
+#[cfg(target_os = "freebsd")]
+pub type RawId = c::id_t;
 
 #[cfg(not(target_os = "wasi"))]
 pub(crate) type RawUname = c::utsname;

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -13,6 +13,8 @@ mod membarrier;
 mod prctl;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))] // WASI doesn't have [gs]etpriority.
 mod priority;
+#[cfg(target_os = "freebsd")]
+mod procctl;
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 mod rlimit;
 #[cfg(any(
@@ -59,6 +61,8 @@ pub use priority::{
     getpriority_pgrp, getpriority_process, getpriority_user, setpriority_pgrp, setpriority_process,
     setpriority_user,
 };
+#[cfg(target_os = "freebsd")]
+pub use procctl::*;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use rlimit::prlimit;
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]

--- a/src/process/prctl.rs
+++ b/src/process/prctl.rs
@@ -1,3 +1,8 @@
+//! Bindings for the Linux `prctl` system call.
+//!
+//! There are similarities (but also differences) with FreeBSD's `procctl` system call, whose
+//! interface is located in the `procctl.rs` file.
+
 #![allow(unsafe_code)]
 
 use core::convert::{TryFrom, TryInto};
@@ -67,9 +72,11 @@ const PR_GET_PDEATHSIG: c_int = 2;
 /// Get the current value of the parent process death signal.
 ///
 /// # References
-/// - [`prctl(PR_GET_PDEATHSIG,...)`]
+/// - [Linux: `prctl(PR_GET_PDEATHSIG,...)`]
+/// - [FreeBSD: `procctl(PROC_PDEATHSIG_STATUS,...)`]
 ///
-/// [`prctl(PR_GET_PDEATHSIG,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
+/// [Linux: `prctl(PR_GET_PDEATHSIG,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
+/// [FreeBSD: `procctl(PROC_PDEATHSIG_STATUS,...)`]: https://www.freebsd.org/cgi/man.cgi?query=procctl&sektion=2
 #[inline]
 pub fn parent_process_death_signal() -> io::Result<Option<Signal>> {
     unsafe { prctl_get_at_arg2_optional::<c_int>(PR_GET_PDEATHSIG) }.map(Signal::from_raw)
@@ -80,9 +87,11 @@ const PR_SET_PDEATHSIG: c_int = 1;
 /// Set the parent-death signal of the calling process.
 ///
 /// # References
-/// - [`prctl(PR_SET_PDEATHSIG,...)`]
+/// - [Linux: `prctl(PR_SET_PDEATHSIG,...)`]
+/// - [FreeBSD: `procctl(PROC_PDEATHSIG_CTL,...)`]
 ///
-/// [`prctl(PR_SET_PDEATHSIG,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
+/// [Linux: `prctl(PR_SET_PDEATHSIG,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
+/// [FreeBSD: `procctl(PROC_PDEATHSIG_CTL,...)`]: https://www.freebsd.org/cgi/man.cgi?query=procctl&sektion=2
 #[inline]
 pub fn set_parent_process_death_signal(signal: Option<Signal>) -> io::Result<()> {
     let signal = signal.map_or(0_usize, |signal| signal as usize);
@@ -137,9 +146,13 @@ pub fn dumpable_behavior() -> io::Result<DumpableBehavior> {
 
 const PR_SET_DUMPABLE: c_int = 4;
 
-/// Set the state of the `dumpable` attribute, which determines whether core dumps are produced
-/// for the calling process upon delivery of a signal whose default behavior is to produce
-/// a core dump.
+/// Set the state of the `dumpable` attribute, which determines whether the process can be traced
+/// and whether core dumps are produced for the calling process upon delivery of a signal whose
+/// default behavior is to produce a core dump.
+///
+/// A similar function with the same name is available on FreeBSD (as part of the `procctl`
+/// interface), but it has an extra argument which allows to select a process other then the
+/// current process.
 ///
 /// # References
 /// - [`prctl(PR_SET_DUMPABLE,...)`]

--- a/src/process/procctl.rs
+++ b/src/process/procctl.rs
@@ -1,0 +1,180 @@
+//! Bindings for the FreeBSD `procctl` system call.
+//!
+//! There are similarities (but also differences) with Linux's `prctl` system call, whose interface
+//! is located in the `prctl.rs` file.
+
+#![allow(unsafe_code)]
+
+use core::mem::MaybeUninit;
+
+use crate::backend::c::{c_int, c_uint, c_void};
+use crate::backend::process::syscalls;
+use crate::backend::process::types::{RawId, Signal};
+use crate::io;
+use crate::process::{Pid, RawPid};
+
+//
+// Helper functions.
+//
+
+/// Subset of `idtype_t` C enum, with only the values allowed by `procctl`.
+#[repr(i32)]
+pub enum IdType {
+    /// Process id.
+    Pid = 0,
+    /// Process group id.
+    Pgid = 2,
+}
+
+/// A process selector for use with the `procctl` interface.
+///
+/// `None` represents the current process. `Some((IdType::Pid, pid))` represents the process
+/// with pid `pid`. `Some((IdType::Pgid, pgid))` represents the control processes belonging to
+/// the process group with id `pgid`.
+pub type ProcSelector = Option<(IdType, Pid)>;
+fn proc_selector_to_raw(selector: ProcSelector) -> (IdType, RawPid) {
+    match selector {
+        Some((idtype, id)) => (idtype, id.as_raw_nonzero().get()),
+        None => (IdType::Pid, 0),
+    }
+}
+
+#[inline]
+pub(crate) unsafe fn procctl(
+    option: c_int,
+    process: ProcSelector,
+    data: *mut c_void,
+) -> io::Result<()> {
+    let (idtype, id) = proc_selector_to_raw(process);
+    syscalls::procctl(idtype as c_uint, id as RawId, option, data)
+}
+
+#[inline]
+pub(crate) unsafe fn procctl_set<P>(
+    option: c_int,
+    process: ProcSelector,
+    data: &P,
+) -> io::Result<()> {
+    procctl(option, process, (data as *const P as *mut P).cast())
+}
+
+#[inline]
+pub(crate) unsafe fn procctl_get_optional<P>(
+    option: c_int,
+    process: ProcSelector,
+) -> io::Result<P> {
+    let mut value: MaybeUninit<P> = MaybeUninit::uninit();
+    procctl(option, process, value.as_mut_ptr().cast())?;
+    Ok(value.assume_init())
+}
+
+//
+// PROC_PDEATHSIG_STATUS/PROC_PDEATHSIG_CTL
+//
+
+const PROC_PDEATHSIG_STATUS: c_int = 12;
+
+/// Get the current value of the parent process death signal.
+///
+/// # References
+/// - [Linux: `prctl(PR_GET_PDEATHSIG,...)`]
+/// - [FreeBSD: `procctl(PROC_PDEATHSIG_STATUS,...)`]
+///
+/// [Linux: `prctl(PR_GET_PDEATHSIG,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
+/// [FreeBSD: `procctl(PROC_PDEATHSIG_STATUS,...)`]: https://www.freebsd.org/cgi/man.cgi?query=procctl&sektion=2
+#[inline]
+pub fn parent_process_death_signal() -> io::Result<Option<Signal>> {
+    unsafe { procctl_get_optional::<c_int>(PROC_PDEATHSIG_STATUS, None) }.map(Signal::from_raw)
+}
+
+const PROC_PDEATHSIG_CTL: c_int = 11;
+
+/// Set the parent-death signal of the calling process.
+///
+/// # References
+/// - [Linux: `prctl(PR_SET_PDEATHSIG,...)`]
+/// - [FreeBSD: `procctl(PROC_PDEATHSIG_CTL,...)`]
+///
+/// [Linux: `prctl(PR_SET_PDEATHSIG,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
+/// [FreeBSD: `procctl(PROC_PDEATHSIG_CTL,...)`]: https://www.freebsd.org/cgi/man.cgi?query=procctl&sektion=2
+#[inline]
+pub fn set_parent_process_death_signal(signal: Option<Signal>) -> io::Result<()> {
+    let signal = signal.map_or(0, |signal| signal as c_int);
+    unsafe { procctl_set::<c_int>(PROC_PDEATHSIG_CTL, None, &signal) }
+}
+
+//
+// PROC_TRACE_CTL
+//
+
+const PROC_TRACE_CTL: c_int = 7;
+
+const PROC_TRACE_CTL_ENABLE: i32 = 1;
+const PROC_TRACE_CTL_DISABLE: i32 = 2;
+const PROC_TRACE_CTL_DISABLE_EXEC: i32 = 3;
+
+/// `PROC_TRACE_CTL_*`.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(i32)]
+pub enum DumpableBehavior {
+    /// Not dumpable.
+    NotDumpable = PROC_TRACE_CTL_DISABLE,
+    /// Dumpable.
+    Dumpable = PROC_TRACE_CTL_ENABLE,
+    /// Not dumpable, and this behaviour is preserved across `execve` calls.
+    NotDumpableExecPreserved = PROC_TRACE_CTL_DISABLE_EXEC,
+}
+
+/// Set the state of the `dumpable` attribute for the process indicated by `idtype` and `id`.
+/// This determines whether the process can be traced and whether core dumps are produced for
+/// the process upon delivery of a signal whose default behavior is to produce a core dump.
+///
+/// This is similar to `set_dumpable_behavior` on Linux, with the exception that on FreeBSD
+/// there is an extra argument `process`. When `process` is set to `None`, the operation is
+/// performed for the current process, like on Linux.
+///
+/// # References
+/// - [`procctl(PROC_TRACE_CTL,...)`]
+///
+/// [`procctl(PROC_TRACE_CTL,...)`]: https://www.freebsd.org/cgi/man.cgi?query=procctl&sektion=2
+#[inline]
+pub fn set_dumpable_behavior(process: ProcSelector, config: DumpableBehavior) -> io::Result<()> {
+    unsafe { procctl(PROC_TRACE_CTL, process, config as usize as *mut _) }
+}
+
+//
+// PROC_TRACE_STATUS
+//
+
+const PROC_TRACE_STATUS: c_int = 8;
+
+/// Tracing status as returned by [`trace_status`].
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum TracingStatus {
+    /// Tracing is disabled for the process.
+    NotTraceble,
+    /// Tracing is not disabled for the process, but not debugger/tracer is attached.
+    Tracable,
+    /// The process is being traced by the process whose pid is stored in the first
+    /// component of this variant.
+    BeingTraced(Pid),
+}
+
+/// Get the tracing status of the process indicated by `idtype` and `id`.
+///
+/// # References
+/// - [`procctl(PROC_TRACE_STATUS,...)`]
+///
+/// [`procctl(PROC_TRACE_STATUS,...)`]: https://www.freebsd.org/cgi/man.cgi?query=procctl&sektion=2
+#[inline]
+pub fn trace_status(process: ProcSelector) -> io::Result<TracingStatus> {
+    let val = unsafe { procctl_get_optional::<c_int>(PROC_TRACE_STATUS, process) }?;
+    match val {
+        -1 => Ok(TracingStatus::NotTraceble),
+        0 => Ok(TracingStatus::Tracable),
+        pid => {
+            let pid = unsafe { Pid::from_raw(pid as RawPid) }.ok_or(io::Errno::RANGE)?;
+            Ok(TracingStatus::BeingTraced(pid))
+        }
+    }
+}

--- a/tests/process/main.rs
+++ b/tests/process/main.rs
@@ -19,6 +19,8 @@ mod membarrier;
 mod prctl;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))] // WASI doesn't have [gs]etpriority.
 mod priority;
+#[cfg(target_os = "freebsd")]
+mod procctl;
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 mod rlimit;
 mod sched_yield;

--- a/tests/process/procctl.rs
+++ b/tests/process/procctl.rs
@@ -1,0 +1,11 @@
+use rustix::process::*;
+
+#[test]
+fn test_parent_process_death_signal() {
+    dbg!(parent_process_death_signal().unwrap());
+}
+
+#[test]
+fn test_trace_status() {
+    dbg!(trace_status().unwrap());
+}


### PR DESCRIPTION
Modelled mostly after `prctl.rs`. Includes only parent death signal (`PROC_PDEATHSIG_*`) and tracing (`PROC_TRACE_*`). The former has precisely the same signature as the linux `prctl` versions.

I named the trace control function `set_dumpable_behavior` as it is called on linux, since FreeBSD's traceable flag and Linux's dumpable flag do the same thing: both control the ability to trace as well as the ability to core dump.