### PR TITLE
Fix compilation of libc backend without std

### DIFF
--- a/src/backend/libc/io/epoll.rs
+++ b/src/backend/libc/io/epoll.rs
@@ -261,7 +261,7 @@ impl<'context, T: AsFd + Into<OwnedFd> + From<OwnedFd>> Context for Owning<'cont
         // being released, so we can create a new `OwnedFd` that assumes
         // ownership.
         let raw_fd = target.consume().as_raw_fd();
-        unsafe { T::from(io_lifetimes::OwnedFd::from_raw_fd(raw_fd).into()) }
+        unsafe { T::from(OwnedFd::from_raw_fd(raw_fd).into()) }
     }
 }
 

--- a/src/backend/libc/io/io_slice.rs
+++ b/src/backend/libc/io/io_slice.rs
@@ -2,6 +2,8 @@
 //! library/std/src/sys/unix/io.rs
 //! dca3f1b786efd27be3b325ed1e01e247aa589c3b.
 
+#![allow(missing_docs)]
+
 use super::super::c;
 use core::marker::PhantomData;
 use core::slice;


### PR DESCRIPTION
Compilation failed without std for the libc backend (not the linux_raw one). This fixes the issues. Hopefully I didn't break anything else.

* Allow missing docs in `backend/libc/io/io_slice.rs` (`std` filler code)
* Use crate local `OwnedFd` instead of the one in `io_lifetimes` in `backend/libc/io/epoll.rs`
* Add missing BSD specific argument to `SocketAddrV6` constructor in `src/addr/net.rs` (`std` filler code)

I have to say I wonder why system specific `SocketAddrV4/6` representations are used in the `no_std` case while with `std` the platform independent `std::net::SocketAddrV4/6` are used. The platform specific representation feels like a portability hazard (as the final issue shows).