### PR TITLE
Temporarily disable the async-std, tokio, mio, and socket2 impls.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,10 +183,13 @@ all-apis = [
 use-libc-auxv = ["libc"]
 
 # Expose io-lifetimes' features for third-party crate impls.
-async-std = ["io-lifetimes/async-std"]
-tokio = ["io-lifetimes/tokio"]
+# Some of these are temporarily disabled, until the upstream creates add the
+# needed trait implementations.
+#async-std = ["io-lifetimes/async-std"]
+#tokio = ["io-lifetimes/tokio"]
 os_pipe = ["io-lifetimes/os_pipe"]
-socket2 = ["io-lifetimes/socket2"]
-mio = ["io-lifetimes/mio"]
+#socket2 = ["io-lifetimes/socket2"]
+#mio = ["io-lifetimes/mio"]
 fs-err = ["io-lifetimes/fs-err"]
-all-impls = ["async-std", "tokio", "os_pipe", "socket2", "mio", "fs-err"]
+#all-impls = ["async-std", "tokio", "os_pipe", "socket2", "mio", "fs-err"]
+all-impls = ["os_pipe", "fs-err"]


### PR DESCRIPTION
Temporarily disable io-lifetimes impls for third-party crates which don't yet have have trait impls for the I/O safety traits.