### PR TITLE
Disable the internal `fs` module when the "fs" feature isn't enabled.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ time = []
 param = []
 
 # Enable this to enable `rustix::io::proc_self_*` (on Linux) and `ttyname`.
-procfs = ["once_cell", "itoa"]
+procfs = ["once_cell", "itoa", "fs"]
 
 # Enable `rustix::termios::*`.
 termios = []

--- a/src/backend/libc/conv.rs
+++ b/src/backend/libc/conv.rs
@@ -7,6 +7,7 @@
 use super::c;
 use super::fd::{AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, LibcFd, OwnedFd, RawFd};
 #[cfg(not(windows))]
+#[cfg(feature = "fs")]
 use super::offset::libc_off_t;
 #[cfg(not(windows))]
 use crate::ffi::CStr;
@@ -120,6 +121,7 @@ pub(super) fn syscall_ret_u32(raw: c::c_long) -> io::Result<u32> {
 }
 
 #[cfg(not(windows))]
+#[cfg(feature = "fs")]
 #[inline]
 pub(super) fn ret_off_t(raw: libc_off_t) -> io::Result<libc_off_t> {
     if raw == -1 {

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -30,7 +30,7 @@ use core::convert::TryInto;
 use core::mem::MaybeUninit;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use core::ptr;
-#[cfg(feature = "net")]
+#[cfg(all(feature = "fs", feature = "net"))]
 use libc_errno::errno;
 
 pub(crate) fn read(fd: BorrowedFd<'_>, buf: &mut [u8]) -> io::Result<usize> {
@@ -322,7 +322,7 @@ pub(crate) fn ioctl_fionbio(fd: BorrowedFd<'_>, value: bool) -> io::Result<()> {
 }
 
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
-#[cfg(feature = "net")]
+#[cfg(all(feature = "fs", feature = "net"))]
 pub(crate) fn is_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
     let (mut read, mut write) = crate::fs::fd::_is_file_read_write(fd)?;
     let mut not_socket = false;
@@ -369,7 +369,7 @@ pub(crate) fn is_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
 }
 
 #[cfg(target_os = "wasi")]
-#[cfg(feature = "net")]
+#[cfg(all(feature = "fs", feature = "net"))]
 pub(crate) fn is_read_write(_fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
     todo!("Implement is_read_write for WASI in terms of fd_fdstat_get");
 }

--- a/src/backend/libc/mod.rs
+++ b/src/backend/libc/mod.rs
@@ -56,7 +56,7 @@ pub(crate) mod c;
 pub(crate) use libc as c;
 
 #[cfg(not(windows))]
-// #[cfg(feature = "fs")] // TODO: Enable this once `OwnedFd` moves out of the tree.
+#[cfg(feature = "fs")]
 pub(crate) mod fs;
 pub(crate) mod io;
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/backend/libc/offset.rs
+++ b/src/backend/libc/offset.rs
@@ -10,6 +10,7 @@ use super::c;
     target_os = "l4re",
     target_os = "linux",
 )))]
+#[cfg(feature = "fs")]
 pub(super) use c::{
     fstat as libc_fstat, fstatat as libc_fstatat, ftruncate as libc_ftruncate, lseek as libc_lseek,
     off_t as libc_off_t,
@@ -21,10 +22,19 @@ pub(super) use c::{
     target_os = "l4re",
     target_os = "linux",
 ))]
+#[cfg(feature = "fs")]
 pub(super) use c::{
     fstat64 as libc_fstat, fstatat64 as libc_fstatat, ftruncate64 as libc_ftruncate,
-    lseek64 as libc_lseek, off64_t as libc_off_t, rlimit64 as libc_rlimit,
+    lseek64 as libc_lseek, off64_t as libc_off_t,
 };
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "emscripten",
+    target_os = "l4re",
+    target_os = "linux",
+))]
+pub(super) use c::rlimit64 as libc_rlimit;
 
 #[cfg(not(any(
     windows,
@@ -150,6 +160,7 @@ pub(super) unsafe fn libc_prlimit(
     target_os = "l4re",
     target_os = "redox",
 )))]
+#[cfg(feature = "fs")]
 pub(super) use c::openat as libc_openat;
 #[cfg(any(
     target_os = "android",
@@ -157,11 +168,14 @@ pub(super) use c::openat as libc_openat;
     target_os = "emscripten",
     target_os = "l4re",
 ))]
+#[cfg(feature = "fs")]
 pub(super) use c::openat64 as libc_openat;
 
 #[cfg(target_os = "fuchsia")]
+#[cfg(feature = "fs")]
 pub(super) use c::fallocate as libc_fallocate;
 #[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(feature = "fs")]
 pub(super) use c::fallocate64 as libc_fallocate;
 #[cfg(not(any(
     windows,
@@ -179,6 +193,7 @@ pub(super) use c::fallocate64 as libc_fallocate;
     target_os = "redox",
     target_os = "solaris",
 )))]
+#[cfg(feature = "fs")]
 pub(super) use c::posix_fadvise as libc_posix_fadvise;
 #[cfg(any(
     target_os = "android",
@@ -186,6 +201,7 @@ pub(super) use c::posix_fadvise as libc_posix_fadvise;
     target_os = "linux",
     target_os = "l4re",
 ))]
+#[cfg(feature = "fs")]
 pub(super) use c::posix_fadvise64 as libc_posix_fadvise;
 
 #[cfg(all(not(any(
@@ -342,8 +358,10 @@ pub(super) use readwrite_pv::{preadv as libc_preadv, pwritev as libc_pwritev};
     target_os = "redox",
     target_os = "solaris",
 )))]
+#[cfg(feature = "fs")]
 pub(super) use c::posix_fallocate as libc_posix_fallocate;
 #[cfg(any(target_os = "l4re"))]
+#[cfg(feature = "fs")]
 pub(super) use c::posix_fallocate64 as libc_posix_fallocate;
 #[cfg(not(any(
     windows,
@@ -358,6 +376,7 @@ pub(super) use c::posix_fallocate64 as libc_posix_fallocate;
     target_os = "solaris",
     target_os = "wasi",
 )))]
+#[cfg(feature = "fs")]
 pub(super) use {c::fstatfs as libc_fstatfs, c::statfs as libc_statfs};
 #[cfg(not(any(
     windows,
@@ -371,6 +390,7 @@ pub(super) use {c::fstatfs as libc_fstatfs, c::statfs as libc_statfs};
     target_os = "solaris",
     target_os = "wasi",
 )))]
+#[cfg(feature = "fs")]
 pub(super) use {c::fstatvfs as libc_fstatvfs, c::statvfs as libc_statvfs};
 
 #[cfg(any(
@@ -379,6 +399,7 @@ pub(super) use {c::fstatvfs as libc_fstatvfs, c::statvfs as libc_statvfs};
     target_os = "emscripten",
     target_os = "l4re",
 ))]
+#[cfg(feature = "fs")]
 pub(super) use {
     c::fstatfs64 as libc_fstatfs, c::fstatvfs64 as libc_fstatvfs, c::statfs64 as libc_statfs,
     c::statvfs64 as libc_statvfs,

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -32,6 +32,7 @@ use super::time::types::ClockId;
 use super::time::types::TimerfdClockId;
 use crate::fd::OwnedFd;
 use crate::ffi::CStr;
+#[cfg(feature = "fs")]
 use crate::fs::{FileType, Mode, OFlags};
 use crate::io;
 use crate::process::{Pid, Resource, Signal};
@@ -45,6 +46,7 @@ use linux_raw_sys::general::__kernel_loff_t;
 #[cfg(feature = "net")]
 use linux_raw_sys::general::socklen_t;
 #[cfg(target_pointer_width = "32")]
+#[cfg(feature = "fs")]
 use linux_raw_sys::general::O_LARGEFILE;
 
 /// Convert `SYS_*` constants for socketcall.
@@ -157,6 +159,7 @@ impl<'a, Num: ArgNumber> From<BorrowedFd<'a>> for ArgReg<'a, Num> {
 #[inline]
 pub(super) unsafe fn raw_fd<'a, Num: ArgNumber>(fd: RawFd) -> ArgReg<'a, Num> {
     // Use `no_fd` when passing `-1` is intended.
+    #[cfg(feature = "fs")]
     debug_assert!(fd == crate::fs::cwd().as_raw_fd() || fd >= 0);
 
     // Don't pass the `io_uring_register_files_skip` sentry value this way.
@@ -286,6 +289,7 @@ pub(super) fn socklen_t<'a, Num: ArgNumber>(i: socklen_t) -> ArgReg<'a, Num> {
     pass_usize(i as usize)
 }
 
+#[cfg(feature = "fs")]
 impl<'a, Num: ArgNumber> From<Mode> for ArgReg<'a, Num> {
     #[inline]
     fn from(mode: Mode) -> Self {
@@ -293,6 +297,7 @@ impl<'a, Num: ArgNumber> From<Mode> for ArgReg<'a, Num> {
     }
 }
 
+#[cfg(feature = "fs")]
 impl<'a, Num: ArgNumber> From<(Mode, FileType)> for ArgReg<'a, Num> {
     #[inline]
     fn from(pair: (Mode, FileType)) -> Self {
@@ -300,6 +305,7 @@ impl<'a, Num: ArgNumber> From<(Mode, FileType)> for ArgReg<'a, Num> {
     }
 }
 
+#[cfg(feature = "fs")]
 impl<'a, Num: ArgNumber> From<crate::fs::AtFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::fs::AtFlags) -> Self {
@@ -307,6 +313,7 @@ impl<'a, Num: ArgNumber> From<crate::fs::AtFlags> for ArgReg<'a, Num> {
     }
 }
 
+#[cfg(feature = "fs")]
 impl<'a, Num: ArgNumber> From<crate::fs::MemfdFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::fs::MemfdFlags) -> Self {
@@ -314,6 +321,7 @@ impl<'a, Num: ArgNumber> From<crate::fs::MemfdFlags> for ArgReg<'a, Num> {
     }
 }
 
+#[cfg(feature = "fs")]
 impl<'a, Num: ArgNumber> From<crate::fs::RenameFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::fs::RenameFlags) -> Self {
@@ -321,6 +329,7 @@ impl<'a, Num: ArgNumber> From<crate::fs::RenameFlags> for ArgReg<'a, Num> {
     }
 }
 
+#[cfg(feature = "fs")]
 impl<'a, Num: ArgNumber> From<crate::fs::StatxFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::fs::StatxFlags) -> Self {
@@ -328,6 +337,7 @@ impl<'a, Num: ArgNumber> From<crate::fs::StatxFlags> for ArgReg<'a, Num> {
     }
 }
 
+#[cfg(feature = "fs")]
 impl<'a, Num: ArgNumber> From<crate::fs::FdFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::fs::FdFlags) -> Self {
@@ -456,6 +466,7 @@ pub(super) fn dev_t<'a, Num: ArgNumber>(dev: u64) -> io::Result<ArgReg<'a, Num>>
 }
 
 #[cfg(target_pointer_width = "32")]
+#[cfg(feature = "fs")]
 #[inline]
 fn oflags_bits(oflags: OFlags) -> c::c_uint {
     let mut bits = oflags.bits();
@@ -468,11 +479,13 @@ fn oflags_bits(oflags: OFlags) -> c::c_uint {
 }
 
 #[cfg(target_pointer_width = "64")]
+#[cfg(feature = "fs")]
 #[inline]
 const fn oflags_bits(oflags: OFlags) -> c::c_uint {
     oflags.bits()
 }
 
+#[cfg(feature = "fs")]
 impl<'a, Num: ArgNumber> From<OFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(oflags: OFlags) -> Self {
@@ -481,11 +494,13 @@ impl<'a, Num: ArgNumber> From<OFlags> for ArgReg<'a, Num> {
 }
 
 /// Convert an `OFlags` into a `u64` for use in the `open_how` struct.
+#[cfg(feature = "fs")]
 #[inline]
 pub(super) fn oflags_for_open_how(oflags: OFlags) -> u64 {
     u64::from(oflags_bits(oflags))
 }
 
+#[cfg(feature = "fs")]
 impl<'a, Num: ArgNumber> From<crate::fs::FallocateFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::fs::FallocateFlags) -> Self {
@@ -520,6 +535,7 @@ impl<'a, Num: ArgNumber> From<Signal> for ArgReg<'a, Num> {
     }
 }
 
+#[cfg(feature = "fs")]
 impl<'a, Num: ArgNumber> From<crate::fs::Advice> for ArgReg<'a, Num> {
     #[inline]
     fn from(advice: crate::fs::Advice) -> Self {
@@ -527,6 +543,7 @@ impl<'a, Num: ArgNumber> From<crate::fs::Advice> for ArgReg<'a, Num> {
     }
 }
 
+#[cfg(feature = "fs")]
 impl<'a, Num: ArgNumber> From<crate::fs::SealFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::fs::SealFlags) -> Self {
@@ -618,6 +635,7 @@ impl<'a, Num: ArgNumber> From<(crate::thread::FutexOperation, crate::thread::Fut
     }
 }
 
+#[cfg(feature = "fs")]
 impl<'a, Num: ArgNumber> From<crate::fs::Access> for ArgReg<'a, Num> {
     #[inline]
     fn from(access: crate::fs::Access) -> Self {

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -22,7 +22,7 @@ use crate::io::{
     self, epoll, DupFlags, EventfdFlags, IoSlice, IoSliceMut, IoSliceRaw, PipeFlags, PollFd,
     ReadWriteFlags,
 };
-#[cfg(feature = "net")]
+#[cfg(all(feature = "fs", feature = "net"))]
 use crate::net::{RecvFlags, SendFlags};
 use core::cmp;
 use core::mem::MaybeUninit;
@@ -349,7 +349,7 @@ pub(crate) fn ioctl_blkpbszget(fd: BorrowedFd) -> io::Result<u32> {
     }
 }
 
-#[cfg(feature = "net")]
+#[cfg(all(feature = "fs", feature = "net"))]
 pub(crate) fn is_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
     let (mut read, mut write) = crate::fs::fd::_is_file_read_write(fd)?;
     let mut not_socket = false;

--- a/src/backend/linux_raw/mod.rs
+++ b/src/backend/linux_raw/mod.rs
@@ -24,14 +24,7 @@ mod vdso;
 #[cfg(any(feature = "time", target_arch = "x86"))]
 mod vdso_wrappers;
 
-#[cfg(any(
-    feature = "param",
-    feature = "runtime",
-    feature = "time",
-    target_arch = "x86",
-))]
-pub(crate) mod param;
-// #[cfg(feature = "fs")] // TODO: Enable once `OwnedFd` moves out of the tree.
+#[cfg(feature = "fs")]
 pub(crate) mod fs;
 pub(crate) mod io;
 #[cfg(feature = "io_uring")]
@@ -41,6 +34,13 @@ pub(crate) mod io_uring;
 pub(crate) mod mm;
 #[cfg(feature = "net")]
 pub(crate) mod net;
+#[cfg(any(
+    feature = "param",
+    feature = "runtime",
+    feature = "time",
+    target_arch = "x86",
+))]
+pub(crate) mod param;
 pub(crate) mod process;
 #[cfg(feature = "rand")]
 pub(crate) mod rand;

--- a/src/backend/linux_raw/runtime/syscalls.rs
+++ b/src/backend/linux_raw/runtime/syscalls.rs
@@ -10,8 +10,10 @@ use super::super::c;
 #[cfg(target_arch = "x86")]
 use super::super::conv::by_mut;
 use super::super::conv::{c_int, c_uint, ret, ret_c_uint, ret_error, ret_usize_infallible, zero};
+#[cfg(feature = "fs")]
 use crate::fd::BorrowedFd;
 use crate::ffi::CStr;
+#[cfg(feature = "fs")]
 use crate::fs::AtFlags;
 use crate::io;
 use crate::process::{Pid, RawNonZeroPid};
@@ -32,6 +34,7 @@ pub(crate) unsafe fn fork() -> io::Result<Option<Pid>> {
     Ok(Pid::from_raw(pid))
 }
 
+#[cfg(feature = "fs")]
 pub(crate) unsafe fn execveat(
     dirfd: BorrowedFd<'_>,
     path: &CStr,

--- a/src/io/is_read_write.rs
+++ b/src/io/is_read_write.rs
@@ -1,6 +1,8 @@
 //! The [`is_read_write`] function.
 
+#[cfg(all(feature = "fs", feature = "net"))]
 use crate::{backend, io};
+#[cfg(all(feature = "fs", feature = "net"))]
 use backend::fd::AsFd;
 
 /// Returns a pair of booleans indicating whether the file descriptor is
@@ -11,6 +13,8 @@ use backend::fd::AsFd;
 ///
 /// [`is_file_read_write`]: crate::fs::is_file_read_write
 #[inline]
+#[cfg(all(feature = "fs", feature = "net"))]
+#[cfg_attr(doc_cfg, doc(cfg(all(feature = "fs", feature = "net"))))]
 pub fn is_read_write<Fd: AsFd>(fd: Fd) -> io::Result<(bool, bool)> {
     backend::io::syscalls::is_read_write(fd.as_fd())
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -10,7 +10,6 @@ mod eventfd;
 pub(crate) mod fd;
 mod ioctl;
 #[cfg(not(any(windows, target_os = "redox")))]
-#[cfg(feature = "net")]
 mod is_read_write;
 #[cfg(not(any(windows, target_os = "wasi")))]
 mod pipe;
@@ -42,7 +41,7 @@ pub use ioctl::{ioctl_blkpbszget, ioctl_blksszget};
 #[cfg(not(any(windows, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 pub use ioctl::{ioctl_tiocexcl, ioctl_tiocnxcl};
 #[cfg(not(any(windows, target_os = "redox")))]
-#[cfg(feature = "net")]
+#[cfg(all(feature = "fs", feature = "net"))]
 pub use is_read_write::is_read_write;
 #[cfg(not(any(windows, target_os = "wasi")))]
 pub use pipe::pipe;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,9 +207,6 @@ pub mod runtime;
 // that they're not public, but still available for internal use.
 
 #[cfg(not(windows))]
-#[cfg(not(feature = "fs"))]
-pub(crate) mod fs;
-#[cfg(not(windows))]
 #[cfg(all(
     not(feature = "param"),
     any(feature = "runtime", feature = "time", target_arch = "x86"),

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -81,4 +81,5 @@ pub use uname::{uname, Uname};
 pub use wait::{wait, waitpid, WaitOptions, WaitStatus};
 
 #[cfg(not(target_os = "wasi"))]
+#[cfg(feature = "fs")]
 pub(crate) use id::translate_fchown_args;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -23,12 +23,14 @@ use crate::backend;
 #[cfg(linux_raw)]
 use crate::ffi::CStr;
 #[cfg(linux_raw)]
+#[cfg(feature = "fs")]
 use crate::fs::AtFlags;
 #[cfg(linux_raw)]
 use crate::io;
 #[cfg(linux_raw)]
 use crate::process::Pid;
 #[cfg(linux_raw)]
+#[cfg(feature = "fs")]
 use backend::fd::AsFd;
 #[cfg(linux_raw)]
 use core::ffi::c_void;
@@ -236,6 +238,8 @@ pub unsafe fn fork() -> io::Result<Option<Pid>> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/execveat.2.html
 #[cfg(linux_raw)]
 #[inline]
+#[cfg(feature = "fs")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
 pub unsafe fn execveat<Fd: AsFd>(
     dirfd: Fd,
     path: &CStr,

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -91,7 +91,7 @@ fn test_file() {
         assert!(statvfs.f_frsize > 0);
     }
 
-    #[cfg(feature = "net")]
+    #[cfg(all(feature = "fs", feature = "net"))]
     assert_eq!(rustix::io::is_read_write(&file).unwrap(), (true, false));
 
     assert_ne!(rustix::io::ioctl_fionread(&file).unwrap(), 0);

--- a/tests/io/ioctl.rs
+++ b/tests/io/ioctl.rs
@@ -5,7 +5,7 @@
 fn test_ioctls() {
     let file = std::fs::File::open("Cargo.toml").unwrap();
 
-    #[cfg(feature = "net")]
+    #[cfg(all(feature = "fs", feature = "net"))]
     assert_eq!(rustix::io::is_read_write(&file).unwrap(), (true, false));
 
     assert_eq!(


### PR DESCRIPTION
Rustix no longer has anything in the tree that needs the `fs` module when the public "fs" feature isn't enabled, so make the `fd` module conditional on `cfg(feature = "fs")`.