### PR TITLE
Fix compilation with --no-default-features.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,6 +139,7 @@ jobs:
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
+    - run: cargo check --workspace --release --no-default-features -vv
     - run: cargo check --workspace --release --no-default-features --features all-apis -vv
 
   check_nightly:

--- a/src/backend/libc/fs/mod.rs
+++ b/src/backend/libc/fs/mod.rs
@@ -1,5 +1,4 @@
 #[cfg(not(target_os = "redox"))]
-#[cfg(any(feature = "fs", feature = "procfs"))]
 pub(crate) mod dir;
 #[cfg(not(any(
     target_os = "dragonfly",

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -2,17 +2,6 @@ use super::super::c;
 use bitflags::bitflags;
 
 bitflags! {
-    /// `FD_*` constants for use with [`fcntl_getfd`] and [`fcntl_setfd`].
-    ///
-    /// [`fcntl_getfd`]: crate::fs::fcntl_getfd
-    /// [`fcntl_setfd`]: crate::fs::fcntl_setfd
-    pub struct FdFlags: c::c_int {
-        /// `FD_CLOEXEC`
-        const CLOEXEC = c::FD_CLOEXEC;
-    }
-}
-
-bitflags! {
     /// `*_OK` constants for use with [`accessat`].
     ///
     /// [`accessat`]: fn.accessat.html

--- a/src/backend/libc/io/types.rs
+++ b/src/backend/libc/io/types.rs
@@ -1,8 +1,18 @@
 use super::super::c;
-#[cfg(not(target_os = "wasi"))]
 use bitflags::bitflags;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use core::marker::PhantomData;
+
+bitflags! {
+    /// `FD_*` constants for use with [`fcntl_getfd`] and [`fcntl_setfd`].
+    ///
+    /// [`fcntl_getfd`]: crate::io::fcntl_getfd
+    /// [`fcntl_setfd`]: crate::io::fcntl_setfd
+    pub struct FdFlags: c::c_int {
+        /// `FD_CLOEXEC`
+        const CLOEXEC = c::FD_CLOEXEC;
+    }
+}
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 bitflags! {

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -337,10 +337,9 @@ impl<'a, Num: ArgNumber> From<crate::fs::StatxFlags> for ArgReg<'a, Num> {
     }
 }
 
-#[cfg(feature = "fs")]
-impl<'a, Num: ArgNumber> From<crate::fs::FdFlags> for ArgReg<'a, Num> {
+impl<'a, Num: ArgNumber> From<crate::io::FdFlags> for ArgReg<'a, Num> {
     #[inline]
-    fn from(flags: crate::fs::FdFlags) -> Self {
+    fn from(flags: crate::io::FdFlags) -> Self {
         c_uint(flags.bits())
     }
 }

--- a/src/backend/linux_raw/fs/mod.rs
+++ b/src/backend/linux_raw/fs/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(any(feature = "fs", feature = "procfs"))]
 pub(crate) mod dir;
 pub(crate) mod makedev;
 pub(crate) mod syscalls;

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -21,12 +21,12 @@ use super::super::conv::{loff_t, loff_t_from_u64, ret_u64};
     target_pointer_width = "32",
 ))]
 use crate::fd::AsFd;
-use crate::fd::{BorrowedFd, OwnedFd, RawFd};
+use crate::fd::{BorrowedFd, OwnedFd};
 use crate::ffi::CStr;
 use crate::fs::{
-    Access, Advice, AtFlags, FallocateFlags, FdFlags, FileType, FlockOperation, MemfdFlags, Mode,
-    OFlags, RenameFlags, ResolveFlags, SealFlags, Stat, StatFs, StatVfs, StatVfsMountFlags,
-    StatxFlags, Timestamps,
+    Access, Advice, AtFlags, FallocateFlags, FileType, FlockOperation, MemfdFlags, Mode, OFlags,
+    RenameFlags, ResolveFlags, SealFlags, Stat, StatFs, StatVfs, StatVfsMountFlags, StatxFlags,
+    Timestamps,
 };
 use crate::io::{self, SeekFrom};
 use crate::process::{Gid, Uid};
@@ -36,9 +36,8 @@ use core::mem::MaybeUninit;
 use linux_raw_sys::general::stat as linux_stat64;
 use linux_raw_sys::general::{
     __kernel_fsid_t, __kernel_timespec, open_how, statx, AT_EACCESS, AT_FDCWD, AT_REMOVEDIR,
-    AT_SYMLINK_NOFOLLOW, F_ADD_SEALS, F_DUPFD, F_DUPFD_CLOEXEC, F_GETFD, F_GETFL, F_GETLEASE,
-    F_GETOWN, F_GETPIPE_SZ, F_GETSIG, F_GET_SEALS, F_SETFD, F_SETFL, F_SETPIPE_SZ, SEEK_CUR,
-    SEEK_END, SEEK_SET, STATX__RESERVED,
+    AT_SYMLINK_NOFOLLOW, F_ADD_SEALS, F_GETFL, F_GETLEASE, F_GETOWN, F_GETPIPE_SZ, F_GETSIG,
+    F_GET_SEALS, F_SETFL, F_SETPIPE_SZ, SEEK_CUR, SEEK_END, SEEK_SET, STATX__RESERVED,
 };
 #[cfg(target_pointer_width = "32")]
 use {
@@ -882,76 +881,6 @@ pub(crate) fn readlinkat(dirfd: BorrowedFd<'_>, path: &CStr, buf: &mut [u8]) -> 
             buf_addr_mut,
             buf_len
         ))
-    }
-}
-
-#[inline]
-pub(crate) fn fcntl_dupfd(fd: BorrowedFd<'_>, min: RawFd) -> io::Result<OwnedFd> {
-    #[cfg(target_pointer_width = "32")]
-    unsafe {
-        ret_owned_fd(syscall_readonly!(
-            __NR_fcntl64,
-            fd,
-            c_uint(F_DUPFD),
-            raw_fd(min)
-        ))
-    }
-    #[cfg(target_pointer_width = "64")]
-    unsafe {
-        ret_owned_fd(syscall_readonly!(
-            __NR_fcntl,
-            fd,
-            c_uint(F_DUPFD),
-            raw_fd(min)
-        ))
-    }
-}
-
-#[inline]
-pub(crate) fn fcntl_dupfd_cloexec(fd: BorrowedFd<'_>, min: RawFd) -> io::Result<OwnedFd> {
-    #[cfg(target_pointer_width = "32")]
-    unsafe {
-        ret_owned_fd(syscall_readonly!(
-            __NR_fcntl64,
-            fd,
-            c_uint(F_DUPFD_CLOEXEC),
-            raw_fd(min)
-        ))
-    }
-    #[cfg(target_pointer_width = "64")]
-    unsafe {
-        ret_owned_fd(syscall_readonly!(
-            __NR_fcntl,
-            fd,
-            c_uint(F_DUPFD_CLOEXEC),
-            raw_fd(min)
-        ))
-    }
-}
-
-#[inline]
-pub(crate) fn fcntl_getfd(fd: BorrowedFd<'_>) -> io::Result<FdFlags> {
-    #[cfg(target_pointer_width = "32")]
-    unsafe {
-        ret_c_uint(syscall_readonly!(__NR_fcntl64, fd, c_uint(F_GETFD)))
-            .map(FdFlags::from_bits_truncate)
-    }
-    #[cfg(target_pointer_width = "64")]
-    unsafe {
-        ret_c_uint(syscall_readonly!(__NR_fcntl, fd, c_uint(F_GETFD)))
-            .map(FdFlags::from_bits_truncate)
-    }
-}
-
-#[inline]
-pub(crate) fn fcntl_setfd(fd: BorrowedFd<'_>, flags: FdFlags) -> io::Result<()> {
-    #[cfg(target_pointer_width = "32")]
-    unsafe {
-        ret(syscall_readonly!(__NR_fcntl64, fd, c_uint(F_SETFD), flags))
-    }
-    #[cfg(target_pointer_width = "64")]
-    unsafe {
-        ret(syscall_readonly!(__NR_fcntl, fd, c_uint(F_SETFD), flags))
     }
 }
 

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -2,17 +2,6 @@ use super::super::c;
 use bitflags::bitflags;
 
 bitflags! {
-    /// `FD_*` constants for use with [`fcntl_getfd`] and [`fcntl_setfd`].
-    ///
-    /// [`fcntl_getfd`]: crate::fs::fcntl_getfd
-    /// [`fcntl_setfd`]: crate::fs::fcntl_setfd
-    pub struct FdFlags: c::c_uint {
-        /// `FD_CLOEXEC`
-        const CLOEXEC = linux_raw_sys::general::FD_CLOEXEC;
-    }
-}
-
-bitflags! {
     /// `*_OK` constants for use with [`accessat`].
     ///
     /// [`accessat`]: fn.accessat.html

--- a/src/backend/linux_raw/io/types.rs
+++ b/src/backend/linux_raw/io/types.rs
@@ -3,6 +3,17 @@ use bitflags::bitflags;
 use core::marker::PhantomData;
 
 bitflags! {
+    /// `FD_*` constants for use with [`fcntl_getfd`] and [`fcntl_setfd`].
+    ///
+    /// [`fcntl_getfd`]: crate::io::fcntl_getfd
+    /// [`fcntl_setfd`]: crate::io::fcntl_setfd
+    pub struct FdFlags: c::c_uint {
+        /// `FD_CLOEXEC`
+        const CLOEXEC = linux_raw_sys::general::FD_CLOEXEC;
+    }
+}
+
+bitflags! {
     /// `RWF_*` constants for use with [`preadv2`] and [`pwritev2`].
     ///
     /// [`preadv2`]: crate::io::preadv2

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -2,7 +2,8 @@
 
 use crate::backend;
 
-pub use backend::fs::types::{Access, FdFlags, Mode, OFlags};
+pub use crate::io::FdFlags;
+pub use backend::fs::types::{Access, Mode, OFlags};
 
 #[cfg(not(target_os = "redox"))]
 pub use backend::fs::types::AtFlags;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -1,16 +1,7 @@
 //! Filesystem operations.
 
-#[cfg(feature = "fs")]
 mod abs;
 #[cfg(not(target_os = "redox"))]
-#[cfg(any(
-    feature = "fs",
-    feature = "param",
-    feature = "procfs",
-    feature = "runtime",
-    feature = "time",
-    target_arch = "x86"
-))]
 mod at;
 mod constants;
 #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -18,7 +9,6 @@ mod copy_file_range;
 #[cfg(not(target_os = "redox"))]
 mod cwd;
 #[cfg(not(target_os = "redox"))]
-#[cfg(any(feature = "fs", feature = "procfs"))]
 mod dir;
 #[cfg(not(any(
     target_os = "dragonfly",
@@ -58,7 +48,6 @@ mod makedev;
 #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 mod memfd_create;
 #[cfg(any(target_os = "android", target_os = "linux"))]
-#[cfg(feature = "fs")]
 mod openat2;
 #[cfg(target_os = "linux")]
 mod sendfile;
@@ -73,7 +62,6 @@ mod statx;
     target_os = "solaris",
     target_os = "wasi",
 )))]
-#[cfg(feature = "fs")]
 pub use abs::statfs;
 #[cfg(not(any(
     target_os = "haiku",
@@ -82,13 +70,10 @@ pub use abs::statfs;
     target_os = "solaris",
     target_os = "wasi",
 )))]
-#[cfg(feature = "fs")]
 pub use abs::statvfs;
 #[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "solaris")))]
-#[cfg(feature = "fs")]
 pub use at::accessat;
 #[cfg(any(target_os = "ios", target_os = "macos"))]
-#[cfg(feature = "fs")]
 pub use at::fclonefileat;
 #[cfg(not(any(
     target_os = "ios",
@@ -96,23 +81,12 @@ pub use at::fclonefileat;
     target_os = "redox",
     target_os = "wasi",
 )))]
-#[cfg(feature = "fs")]
 pub use at::mknodat;
 #[cfg(any(target_os = "android", target_os = "linux"))]
-#[cfg(feature = "fs")]
 pub use at::renameat_with;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
-#[cfg(feature = "fs")]
 pub use at::{chmodat, chownat};
 #[cfg(not(target_os = "redox"))]
-#[cfg(any(
-    feature = "fs",
-    feature = "param",
-    feature = "procfs",
-    feature = "runtime",
-    feature = "time",
-    target_arch = "x86"
-))]
 pub use at::{
     linkat, mkdirat, openat, readlinkat, renameat, statat, symlinkat, unlinkat, utimensat, RawMode,
     UTIME_NOW, UTIME_OMIT,
@@ -134,7 +108,6 @@ pub use copy_file_range::copy_file_range;
 #[cfg(not(target_os = "redox"))]
 pub use cwd::cwd;
 #[cfg(not(target_os = "redox"))]
-#[cfg(any(feature = "fs", feature = "procfs"))]
 pub use dir::{Dir, DirEntry};
 #[cfg(not(any(
     target_os = "dragonfly",
@@ -227,7 +200,6 @@ pub use makedev::{major, makedev, minor};
 #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 pub use memfd_create::{memfd_create, MemfdFlags};
 #[cfg(any(target_os = "android", target_os = "linux"))]
-#[cfg(feature = "fs")]
 pub use openat2::openat2;
 #[cfg(target_os = "linux")]
 pub use sendfile::sendfile;

--- a/src/io/dup.rs
+++ b/src/io/dup.rs
@@ -24,7 +24,7 @@ pub use backend::io::types::DupFlags;
 ///  - [Apple]
 ///
 /// [file description]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_258
-/// [`fcntl_dupfd_cloexec`]: crate::fs::fcntl_dupfd_cloexec
+/// [`fcntl_dupfd_cloexec`]: crate::io::fcntl_dupfd_cloexec
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/dup.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/dup.2.html
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/dup.2.html
@@ -51,7 +51,7 @@ pub fn dup<Fd: AsFd>(fd: Fd) -> io::Result<OwnedFd> {
 ///  - [Apple]
 ///
 /// [file description]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_258
-/// [`fcntl_dupfd_cloexec`]: crate::fs::fcntl_dupfd_cloexec
+/// [`fcntl_dupfd_cloexec`]: crate::io::fcntl_dupfd_cloexec
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/dup2.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/dup2.2.html
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/dup2.2.html

--- a/src/io/fcntl.rs
+++ b/src/io/fcntl.rs
@@ -1,0 +1,86 @@
+//! The Unix `fcntl` function is effectively lots of different functions
+//! hidden behind a single dynamic dispatch interface. In order to provide
+//! a type-safe API, rustix makes them all separate functions so that they
+//! can have dedicated static type signatures.
+//!
+//! `fcntl` functions which are not specific to files or directories live
+//! in the [`io`] module instead.
+//!
+//! [`io`]: crate::io
+
+use crate::backend;
+use crate::io;
+use backend::fd::{AsFd, OwnedFd, RawFd};
+
+pub use backend::io::types::FdFlags;
+
+/// `fcntl(fd, F_GETFD)`—Returns a file descriptor's flags.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/fcntl.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/fcntl.2.html
+#[inline]
+#[doc(alias = "F_GETFD")]
+pub fn fcntl_getfd<Fd: AsFd>(fd: Fd) -> io::Result<FdFlags> {
+    backend::io::syscalls::fcntl_getfd(fd.as_fd())
+}
+
+/// `fcntl(fd, F_SETFD, flags)`—Sets a file descriptor's flags.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/fcntl.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/fcntl.2.html
+#[inline]
+#[doc(alias = "F_SETFD")]
+pub fn fcntl_setfd<Fd: AsFd>(fd: Fd, flags: FdFlags) -> io::Result<()> {
+    backend::io::syscalls::fcntl_setfd(fd.as_fd(), flags)
+}
+
+/// `fcntl(fd, F_DUPFD_CLOEXEC)`—Creates a new `OwnedFd` instance, with value
+/// at least `min`, that has `O_CLOEXEC` set and that shares the same
+/// underlying [file description] as `fd`.
+///
+/// POSIX guarantees that `F_DUPFD_CLOEXEC` will use the lowest unused file
+/// descriptor which is at least `min`, however it is not safe in general to
+/// rely on this, as file descriptors may be unexpectedly allocated on other
+/// threads or in libraries.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/fcntl.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/fcntl.2.html
+#[cfg(not(any(target_os = "wasi", target_os = "espidf")))]
+#[inline]
+#[doc(alias = "F_DUPFD_CLOEXEC")]
+pub fn fcntl_dupfd_cloexec<Fd: AsFd>(fd: Fd, min: RawFd) -> io::Result<OwnedFd> {
+    backend::io::syscalls::fcntl_dupfd_cloexec(fd.as_fd(), min)
+}
+
+/// `fcntl(fd, F_DUPFD)`—Creates a new `OwnedFd` instance, with value at least
+/// `min`, that shares the same underlying [file description] as `fd`.
+///
+/// POSIX guarantees that `F_DUPFD` will use the lowest unused file descriptor
+/// which is at least `min`, however it is not safe in general to rely on this,
+/// as file descriptors may be unexpectedly allocated on other threads or in
+/// libraries.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/fcntl.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/fcntl.2.html
+#[cfg(target_os = "espidf")]
+#[inline]
+#[doc(alias = "F_DUPFD")]
+pub fn fcntl_dupfd<Fd: AsFd>(fd: Fd, min: RawFd) -> io::Result<OwnedFd> {
+    backend::io::syscalls::fcntl_dupfd(fd.as_fd(), min)
+}

--- a/src/io/fd/owned.rs
+++ b/src/io/fd/owned.rs
@@ -92,14 +92,14 @@ impl OwnedFd {
         // CLOEXEC flag, and currently that's done via F_DUPFD_CLOEXEC. This
         // is a POSIX flag that was added to Linux in 2.6.24.
         #[cfg(not(target_os = "espidf"))]
-        let fd = crate::fs::fcntl_dupfd_cloexec(self, 0)?;
+        let fd = crate::io::fcntl_dupfd_cloexec(self, 0)?;
 
         // For ESP-IDF, F_DUPFD is used instead, because the CLOEXEC semantics
         // will never be supported, as this is a bare metal framework with
         // no capabilities for multi-process execution. While F_DUPFD is also
         // not supported yet, it might be (currently it returns ENOSYS).
         #[cfg(target_os = "espidf")]
-        let fd = crate::fs::fcntl_dupfd(self)?;
+        let fd = crate::io::fcntl_dupfd(self)?;
 
         Ok(fd.into())
     }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -6,6 +6,8 @@ mod dup;
 mod errno;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod eventfd;
+#[cfg(not(windows))]
+mod fcntl;
 #[cfg(not(feature = "std"))]
 pub(crate) mod fd;
 mod ioctl;
@@ -31,6 +33,10 @@ pub use dup::{dup, dup2, dup3, DupFlags};
 pub use errno::{retry_on_intr, Errno, Result};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use eventfd::{eventfd, EventfdFlags};
+#[cfg(not(any(windows, target_os = "wasi")))]
+pub use fcntl::fcntl_dupfd_cloexec;
+#[cfg(not(windows))]
+pub use fcntl::{fcntl_getfd, fcntl_setfd, FdFlags};
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 pub use ioctl::ioctl_fioclex;
 pub use ioctl::ioctl_fionbio;

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -54,8 +54,8 @@ fn test_file() {
     rustix::fs::fadvise(&file, 0, 10, rustix::fs::Advice::Normal).unwrap();
 
     assert_eq!(
-        rustix::fs::fcntl_getfd(&file).unwrap(),
-        rustix::fs::FdFlags::empty()
+        rustix::io::fcntl_getfd(&file).unwrap(),
+        rustix::io::FdFlags::empty()
     );
     assert_eq!(
         rustix::fs::fcntl_getfl(&file).unwrap(),


### PR DESCRIPTION
Move `fcntl_getfd`, `fcntl_setfd`, and `fcntl_dupfd_cloexec` out of the `fs` module and into the `io` module, since they're not specific to files, directories or memfd. This allows them to be used with the "fs" feature is not enabled.

Also, add public aliases for then in `fs`, for compatibility, and to have a place where all `fcntl` function are present.

And add a CI check for --no-default-features with no API features.

Fixes #453.