### PR TITLE
Fix a few clippy lints.

### DIFF
--- a/src/backend/libc/fs/dir.rs
+++ b/src/backend/libc/fs/dir.rs
@@ -75,8 +75,8 @@ impl Dir {
         // file description state, which would cause Undefined Behavior after
         // our call to `fdopendir`. To prevent this, we obtain an independent
         // `OwnedFd`.
-        let flags = fcntl_getfl(&fd)?;
-        let fd_for_dir = openat(&fd, cstr!("."), flags | OFlags::CLOEXEC, Mode::empty())?;
+        let flags = fcntl_getfl(fd)?;
+        let fd_for_dir = openat(fd, cstr!("."), flags | OFlags::CLOEXEC, Mode::empty())?;
 
         let raw = owned_fd(fd_for_dir);
         unsafe {

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -394,9 +394,9 @@ pub(crate) fn statat(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io::
     ))]
     {
         match statx(dirfd, path, flags, StatxFlags::BASIC_STATS) {
-            Ok(x) => return statx_to_stat(x),
+            Ok(x) => statx_to_stat(x),
             Err(io::Errno::NOSYS) => statat_old(dirfd, path, flags),
-            Err(err) => return Err(err),
+            Err(err) => Err(err),
         }
     }
 
@@ -963,9 +963,9 @@ pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
     ))]
     {
         match statx(fd, cstr!(""), AtFlags::EMPTY_PATH, StatxFlags::BASIC_STATS) {
-            Ok(x) => return statx_to_stat(x),
+            Ok(x) => statx_to_stat(x),
             Err(io::Errno::NOSYS) => fstat_old(fd),
-            Err(err) => return Err(err),
+            Err(err) => Err(err),
         }
     }
 
@@ -1201,7 +1201,7 @@ pub(crate) fn fallocate(
 
     assert!(mode.is_empty());
 
-    let new_len = offset.checked_add(len).ok_or_else(|| io::Errno::FBIG)?;
+    let new_len = offset.checked_add(len).ok_or(io::Errno::FBIG)?;
     let mut store = c::fstore_t {
         fst_flags: c::F_ALLOCATECONTIG,
         fst_posmode: c::F_PEOFPOSMODE,

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -149,7 +149,6 @@ pub(crate) fn getppid() -> Option<Pid> {
 
 #[cfg(not(target_os = "wasi"))]
 #[inline]
-#[must_use]
 pub(crate) fn getpgid(pid: Option<Pid>) -> io::Result<Pid> {
     unsafe {
         let pgid = ret_pid_t(c::getpgid(Pid::as_raw(pid) as _))?;

--- a/src/backend/linux_raw/arch/mod.rs
+++ b/src/backend/linux_raw/arch/mod.rs
@@ -15,6 +15,8 @@
 
 #![allow(unsafe_code)]
 #![cfg_attr(not(feature = "all-apis"), allow(unused_imports))]
+// We'll use as many arguments as syscalls need.
+#![allow(clippy::too_many_arguments)]
 
 // When inline asm is available, use it. Otherwise, use out-of-line asm. These
 // functions always use the machine's syscall instruction, even when it isn't

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -230,7 +230,7 @@ pub(super) fn opt_mut<T: Sized, Num: ArgNumber>(t: Option<&mut T>) -> ArgReg<Num
 /// syscall.
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 #[inline]
-pub(super) fn opt_ref<'a, T: Sized, Num: ArgNumber>(t: Option<&'a T>) -> ArgReg<'a, Num> {
+pub(super) fn opt_ref<T: Sized, Num: ArgNumber>(t: Option<&T>) -> ArgReg<Num> {
     // This optimizes into the equivalent of `transmute(t)`, and has the
     // advantage of not requiring `unsafe`.
     match t {

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -454,9 +454,9 @@ pub(crate) fn stat(filename: &CStr) -> io::Result<Stat> {
             AtFlags::empty(),
             StatxFlags::BASIC_STATS,
         ) {
-            Ok(x) => return statx_to_stat(x),
+            Ok(x) => statx_to_stat(x),
             Err(io::Errno::NOSYS) => stat_old(filename),
-            Err(err) => return Err(err),
+            Err(err) => Err(err),
         }
     }
 
@@ -508,9 +508,9 @@ pub(crate) fn statat(dirfd: BorrowedFd<'_>, filename: &CStr, flags: AtFlags) -> 
     #[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
     {
         match statx(dirfd, filename, flags, StatxFlags::BASIC_STATS) {
-            Ok(x) => return statx_to_stat(x),
+            Ok(x) => statx_to_stat(x),
             Err(io::Errno::NOSYS) => statat_old(dirfd, filename, flags),
-            Err(err) => return Err(err),
+            Err(err) => Err(err),
         }
     }
 
@@ -567,9 +567,9 @@ pub(crate) fn lstat(filename: &CStr) -> io::Result<Stat> {
             AtFlags::SYMLINK_NOFOLLOW,
             StatxFlags::BASIC_STATS,
         ) {
-            Ok(x) => return statx_to_stat(x),
+            Ok(x) => statx_to_stat(x),
             Err(io::Errno::NOSYS) => lstat_old(filename),
-            Err(err) => return Err(err),
+            Err(err) => Err(err),
         }
     }
 

--- a/src/backend/linux_raw/mm/syscalls.rs
+++ b/src/backend/linux_raw/mm/syscalls.rs
@@ -61,7 +61,7 @@ pub(crate) unsafe fn mmap(
             fd,
             (offset / 4096)
                 .try_into()
-                .map(|scaled_offset| pass_usize(scaled_offset))
+                .map(pass_usize)
                 .map_err(|_| io::Errno::INVAL)?
         ))
     }

--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -230,7 +230,7 @@ pub(crate) fn ttyname(fd: BorrowedFd<'_>, buf: &mut [u8]) -> io::Result<usize> {
 
     // Gather the ttyname by reading the 'fd' file inside 'proc_self_fd'.
     let r =
-        super::super::fs::syscalls::readlinkat(proc_self_fd, DecInt::from_fd(&fd).as_c_str(), buf)?;
+        super::super::fs::syscalls::readlinkat(proc_self_fd, DecInt::from_fd(fd).as_c_str(), buf)?;
 
     // If the number of bytes is equal to the buffer length, truncation may
     // have occurred. This check also ensures that we have enough space for

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -338,7 +338,7 @@ pub fn fclonefileat<Fd: AsFd, DstFd: AsFd, P: path::Arg>(
     flags: CloneFlags,
 ) -> io::Result<()> {
     dst.into_with_c_str(|dst| {
-        backend::fs::syscalls::fclonefileat(src.as_fd(), dst_dir.as_fd(), &dst, flags)
+        backend::fs::syscalls::fclonefileat(src.as_fd(), dst_dir.as_fd(), dst, flags)
     })
 }
 

--- a/src/io/procfs.rs
+++ b/src/io/procfs.rs
@@ -410,7 +410,7 @@ fn open_and_check_file(dir: BorrowedFd, dir_stat: &Stat, name: &CStr) -> io::Res
     // [requires us to own the file]: https://man7.org/linux/man-pages/man2/openat.2.html
     // [to root:root]: https://man7.org/linux/man-pages/man5/proc.5.html
     let oflags = OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW | OFlags::NOCTTY;
-    let file = openat(&dir, name, oflags, Mode::empty()).map_err(|_err| io::Errno::NOTSUP)?;
+    let file = openat(dir, name, oflags, Mode::empty()).map_err(|_err| io::Errno::NOTSUP)?;
     let file_stat = fstat(&file)?;
 
     // `is_mountpoint` only works on directory mount points, not file mount

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,12 @@
 )]
 #![cfg_attr(asm_experimental_arch, feature(asm_experimental_arch))]
 #![cfg_attr(not(feature = "all-apis"), allow(dead_code))]
+// Clamp depends on Rust 1.50 which is newer than our MSRV.
+#![allow(clippy::manual_clamp)]
+// It is common in linux and libc APIs for types to vary between platforms.
+#![allow(clippy::unnecessary_cast)]
+// It is common in linux and libc APIs for types to vary between platforms.
+#![allow(clippy::useless_conversion)]
 
 #[cfg(not(feature = "rustc-dep-of-std"))]
 extern crate alloc;

--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -276,7 +276,6 @@ pub fn getppid() -> Option<Pid> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpgid.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getpgid.2.html
 #[inline]
-#[must_use]
 pub fn getpgid(pid: Option<Pid>) -> io::Result<Pid> {
     backend::process::syscalls::getpgid(pid)
 }


### PR DESCRIPTION
Fix a few minor clippy lints, and add clippy overrides for warnings that we can't easily fix due to our MSRV, or due to our support of multiple targets.