### PR TITLE
Enable `rustix::termios::isatty` on wasm32-wasi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ serial_test = "0.6"
 memoffset = "0.7.1"
 flate2 = "1.0"
 
-[target.'cfg(not(target_os = "emscripten"))'.dev-dependencies]
+[target.'cfg(not(any(target_os = "emscripten", target_os = "wasi")))'.dev-dependencies]
 criterion = "0.4"
 
 [target.'cfg(windows)'.dev-dependencies]

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -38,9 +38,17 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     if isatty(fd) {
         #[cfg(feature = "procfs")]
         println!(" - ttyname: {}", ttyname(fd, Vec::new())?.to_string_lossy());
+
+        #[cfg(target_os = "wasi")]
+        println!(" - is a tty");
+
+        #[cfg(not(target_os = "wasi"))]
         println!(" - process group: {:?}", rustix::termios::tcgetpgrp(fd)?);
+
+        #[cfg(not(target_os = "wasi"))]
         println!(" - winsize: {:?}", rustix::termios::tcgetwinsize(fd)?);
 
+        #[cfg(not(target_os = "wasi"))]
         {
             use rustix::termios::*;
             let term = tcgetattr(fd)?;

--- a/src/backend/libc/io/errno.rs
+++ b/src/backend/libc/io/errno.rs
@@ -158,7 +158,7 @@ impl Errno {
     /// `ECANCELED`
     pub const CANCELED: Self = Self(c::ECANCELED);
     /// `ECAPMODE`
-    #[cfg(any(target_os = "freebsd"))]
+    #[cfg(target_os = "freebsd")]
     pub const CAPMODE: Self = Self(c::ECAPMODE);
     /// `ECHILD`
     #[cfg(not(windows))]

--- a/src/backend/libc/mod.rs
+++ b/src/backend/libc/mod.rs
@@ -81,7 +81,7 @@ pub(crate) mod process;
 #[cfg(not(windows))]
 #[cfg(feature = "rand")]
 pub(crate) mod rand;
-#[cfg(not(any(windows, target_os = "wasi")))]
+#[cfg(not(windows))]
 #[cfg(feature = "termios")]
 pub(crate) mod termios;
 #[cfg(not(windows))]

--- a/src/backend/libc/mod.rs
+++ b/src/backend/libc/mod.rs
@@ -61,7 +61,6 @@ pub(crate) mod fs;
 pub(crate) mod io;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[cfg(feature = "io_uring")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "io_uring")))]
 pub(crate) mod io_uring;
 #[cfg(not(any(windows, target_os = "wasi")))]
 #[cfg(feature = "mm")]

--- a/src/backend/libc/offset.rs
+++ b/src/backend/libc/offset.rs
@@ -360,7 +360,7 @@ pub(super) use readwrite_pv::{preadv as libc_preadv, pwritev as libc_pwritev};
 )))]
 #[cfg(feature = "fs")]
 pub(super) use c::posix_fallocate as libc_posix_fallocate;
-#[cfg(any(target_os = "l4re"))]
+#[cfg(target_os = "l4re")]
 #[cfg(feature = "fs")]
 pub(super) use c::posix_fallocate64 as libc_posix_fallocate;
 #[cfg(not(any(

--- a/src/backend/libc/termios/mod.rs
+++ b/src/backend/libc/termios/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod syscalls;
+#[cfg(not(target_os = "wasi"))]
 pub(crate) mod types;

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -11,11 +11,14 @@ use crate::fd::BorrowedFd;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 use crate::ffi::CStr;
 use crate::io;
+#[cfg(not(target_os = "wasi"))]
 use crate::process::{Pid, RawNonZeroPid};
+#[cfg(not(target_os = "wasi"))]
 use crate::termios::{Action, OptionalActions, QueueSelector, Speed, Termios, Winsize};
 use core::mem::MaybeUninit;
 use libc_errno::errno;
 
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn tcgetattr(fd: BorrowedFd<'_>) -> io::Result<Termios> {
     let mut result = MaybeUninit::<Termios>::uninit();
     unsafe {
@@ -24,6 +27,7 @@ pub(crate) fn tcgetattr(fd: BorrowedFd<'_>) -> io::Result<Termios> {
     }
 }
 
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn tcgetpgrp(fd: BorrowedFd<'_>) -> io::Result<Pid> {
     unsafe {
         let pid = ret_pid_t(c::tcgetpgrp(borrowed_fd(fd)))?;
@@ -32,10 +36,12 @@ pub(crate) fn tcgetpgrp(fd: BorrowedFd<'_>) -> io::Result<Pid> {
     }
 }
 
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn tcsetpgrp(fd: BorrowedFd<'_>, pid: Pid) -> io::Result<()> {
     unsafe { ret(c::tcsetpgrp(borrowed_fd(fd), pid.as_raw_nonzero().get())) }
 }
 
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn tcsetattr(
     fd: BorrowedFd,
     optional_actions: OptionalActions,
@@ -50,22 +56,27 @@ pub(crate) fn tcsetattr(
     }
 }
 
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn tcsendbreak(fd: BorrowedFd) -> io::Result<()> {
     unsafe { ret(c::tcsendbreak(borrowed_fd(fd), 0)) }
 }
 
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn tcdrain(fd: BorrowedFd) -> io::Result<()> {
     unsafe { ret(c::tcdrain(borrowed_fd(fd))) }
 }
 
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn tcflush(fd: BorrowedFd, queue_selector: QueueSelector) -> io::Result<()> {
     unsafe { ret(c::tcflush(borrowed_fd(fd), queue_selector as _)) }
 }
 
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn tcflow(fd: BorrowedFd, action: Action) -> io::Result<()> {
     unsafe { ret(c::tcflow(borrowed_fd(fd), action as _)) }
 }
 
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn tcgetsid(fd: BorrowedFd) -> io::Result<Pid> {
     unsafe {
         let pid = ret_pid_t(c::tcgetsid(borrowed_fd(fd)))?;
@@ -74,10 +85,12 @@ pub(crate) fn tcgetsid(fd: BorrowedFd) -> io::Result<Pid> {
     }
 }
 
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn tcsetwinsize(fd: BorrowedFd, winsize: Winsize) -> io::Result<()> {
     unsafe { ret(c::ioctl(borrowed_fd(fd), c::TIOCSWINSZ, &winsize)) }
 }
 
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn tcgetwinsize(fd: BorrowedFd) -> io::Result<Winsize> {
     unsafe {
         let mut buf = MaybeUninit::<Winsize>::uninit();
@@ -90,33 +103,39 @@ pub(crate) fn tcgetwinsize(fd: BorrowedFd) -> io::Result<Winsize> {
     }
 }
 
+#[cfg(not(target_os = "wasi"))]
 #[inline]
 #[must_use]
 pub(crate) fn cfgetospeed(termios: &Termios) -> Speed {
     unsafe { c::cfgetospeed(termios) }
 }
 
+#[cfg(not(target_os = "wasi"))]
 #[inline]
 #[must_use]
 pub(crate) fn cfgetispeed(termios: &Termios) -> Speed {
     unsafe { c::cfgetispeed(termios) }
 }
 
+#[cfg(not(target_os = "wasi"))]
 #[inline]
 pub(crate) fn cfmakeraw(termios: &mut Termios) {
     unsafe { c::cfmakeraw(termios) }
 }
 
+#[cfg(not(target_os = "wasi"))]
 #[inline]
 pub(crate) fn cfsetospeed(termios: &mut Termios, speed: Speed) -> io::Result<()> {
     unsafe { ret(c::cfsetospeed(termios, speed)) }
 }
 
+#[cfg(not(target_os = "wasi"))]
 #[inline]
 pub(crate) fn cfsetispeed(termios: &mut Termios, speed: Speed) -> io::Result<()> {
     unsafe { ret(c::cfsetispeed(termios, speed)) }
 }
 
+#[cfg(not(target_os = "wasi"))]
 #[inline]
 pub(crate) fn cfsetspeed(termios: &mut Termios, speed: Speed) -> io::Result<()> {
     unsafe { ret(c::cfsetspeed(termios, speed)) }

--- a/src/backend/linux_raw/mod.rs
+++ b/src/backend/linux_raw/mod.rs
@@ -28,7 +28,6 @@ mod vdso_wrappers;
 pub(crate) mod fs;
 pub(crate) mod io;
 #[cfg(feature = "io_uring")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "io_uring")))]
 pub(crate) mod io_uring;
 #[cfg(feature = "mm")]
 pub(crate) mod mm;

--- a/src/backend/linux_raw/termios/types.rs
+++ b/src/backend/linux_raw/termios/types.rs
@@ -338,19 +338,19 @@ pub const B1500000: Speed = linux_raw_sys::general::B1500000;
 pub const B2000000: Speed = linux_raw_sys::general::B2000000;
 
 /// `B2500000`
-#[cfg(not(any(target_arch = "sparc", target_arch = "sparc64",)))]
+#[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))]
 pub const B2500000: Speed = linux_raw_sys::general::B2500000;
 
 /// `B3000000`
-#[cfg(not(any(target_arch = "sparc", target_arch = "sparc64",)))]
+#[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))]
 pub const B3000000: Speed = linux_raw_sys::general::B3000000;
 
 /// `B3500000`
-#[cfg(not(any(target_arch = "sparc", target_arch = "sparc64",)))]
+#[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))]
 pub const B3500000: Speed = linux_raw_sys::general::B3500000;
 
 /// `B4000000`
-#[cfg(not(any(target_arch = "sparc", target_arch = "sparc64",)))]
+#[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))]
 pub const B4000000: Speed = linux_raw_sys::general::B4000000;
 
 /// `CSIZE`

--- a/src/backend/linux_raw/vdso_wrappers.rs
+++ b/src/backend/linux_raw/vdso_wrappers.rs
@@ -364,7 +364,7 @@ fn init() {
 
         // On all 64-bit platforms, the 64-bit `clock_gettime` symbols are
         // always available.
-        #[cfg(any(target_pointer_width = "64"))]
+        #[cfg(target_pointer_width = "64")]
         let ok = true;
 
         // On some 32-bit platforms, the 64-bit `clock_gettime` symbols are not

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -372,7 +372,7 @@ pub fn mknodat<P: path::Arg, Fd: AsFd>(
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/fchownat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/fchownat.2.html
-#[cfg(not(any(target_os = "wasi")))]
+#[cfg(not(target_os = "wasi"))]
 #[inline]
 pub fn chownat<P: path::Arg, Fd: AsFd>(
     dirfd: Fd,

--- a/src/io/fcntl.rs
+++ b/src/io/fcntl.rs
@@ -8,8 +8,7 @@
 //!
 //! [`io`]: crate::io
 
-use crate::backend;
-use crate::io;
+use crate::{backend, io};
 use backend::fd::{AsFd, OwnedFd, RawFd};
 
 pub use backend::io::types::FdFlags;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@ pub mod process;
 #[cfg(feature = "rand")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "rand")))]
 pub mod rand;
-#[cfg(not(any(windows, target_os = "wasi")))]
+#[cfg(not(windows))]
 #[cfg(feature = "termios")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "termios")))]
 pub mod termios;

--- a/src/termios/mod.rs
+++ b/src/termios/mod.rs
@@ -1,11 +1,15 @@
 //! Terminal I/O stream operations.
 
+#[cfg(not(target_os = "wasi"))]
 mod cf;
+#[cfg(not(target_os = "wasi"))]
 mod constants;
+#[cfg(not(target_os = "wasi"))]
 mod tc;
 #[cfg(not(windows))]
 mod tty;
 
+#[cfg(not(target_os = "wasi"))]
 pub use cf::{cfgetispeed, cfgetospeed, cfmakeraw, cfsetispeed, cfsetospeed, cfsetspeed};
 #[cfg(not(any(
     target_os = "dragonfly",
@@ -16,6 +20,7 @@ pub use cf::{cfgetispeed, cfgetospeed, cfmakeraw, cfsetispeed, cfsetospeed, cfse
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::B1000000;
 #[cfg(not(any(
@@ -27,6 +32,7 @@ pub use constants::B1000000;
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::B1152000;
 #[cfg(not(any(
@@ -38,6 +44,7 @@ pub use constants::B1152000;
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::B1500000;
 #[cfg(not(any(
@@ -49,6 +56,7 @@ pub use constants::B1500000;
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::B2000000;
 #[cfg(not(any(
@@ -62,6 +70,7 @@ pub use constants::B2000000;
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::B2500000;
 #[cfg(not(any(
@@ -75,6 +84,7 @@ pub use constants::B2500000;
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::B3000000;
 #[cfg(not(any(
@@ -88,6 +98,7 @@ pub use constants::B3000000;
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::B3500000;
 #[cfg(not(any(
@@ -101,6 +112,7 @@ pub use constants::B3500000;
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::B4000000;
 #[cfg(not(any(
@@ -108,7 +120,8 @@ pub use constants::B4000000;
     target_os = "haiku",
     target_os = "ios",
     target_os = "macos",
-    target_os = "openbsd"
+    target_os = "openbsd",
+    target_os = "wasi",
 )))]
 pub use constants::B460800;
 #[cfg(not(any(
@@ -121,6 +134,7 @@ pub use constants::B460800;
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::B500000;
 #[cfg(not(any(
@@ -133,6 +147,7 @@ pub use constants::B500000;
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::B576000;
 #[cfg(not(any(
@@ -140,10 +155,11 @@ pub use constants::B576000;
     target_os = "haiku",
     target_os = "ios",
     target_os = "macos",
-    target_os = "openbsd"
+    target_os = "openbsd",
+    target_os = "wasi",
 )))]
 pub use constants::B921600;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::BRKINT;
 #[cfg(not(any(
     target_os = "dragonfly",
@@ -156,6 +172,7 @@ pub use constants::BRKINT;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::BS0;
 #[cfg(not(any(
@@ -171,6 +188,7 @@ pub use constants::BS0;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::BS1;
 #[cfg(not(any(
@@ -183,6 +201,7 @@ pub use constants::BS1;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::BSDLY;
 #[cfg(not(any(
@@ -194,6 +213,7 @@ pub use constants::BSDLY;
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "redox",
+    target_os = "wasi",
 )))]
 pub use constants::CBAUD;
 #[cfg(not(any(
@@ -207,6 +227,7 @@ pub use constants::CBAUD;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::CBAUDEX;
 #[cfg(not(any(
@@ -219,9 +240,10 @@ pub use constants::CBAUDEX;
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "redox",
+    target_os = "wasi",
 )))]
 pub use constants::CIBAUD;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::CLOCAL;
 #[cfg(not(any(
     target_os = "dragonfly",
@@ -235,6 +257,7 @@ pub use constants::CLOCAL;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::CMSPAR;
 #[cfg(not(any(
@@ -248,6 +271,7 @@ pub use constants::CMSPAR;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::CR0;
 #[cfg(not(any(
@@ -263,6 +287,7 @@ pub use constants::CR0;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::CR1;
 #[cfg(not(any(
@@ -278,6 +303,7 @@ pub use constants::CR1;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::CR2;
 #[cfg(not(any(
@@ -293,6 +319,7 @@ pub use constants::CR2;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::CR3;
 #[cfg(not(any(
@@ -305,37 +332,58 @@ pub use constants::CR3;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::CRDLY;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::CREAD;
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 pub use constants::CRTSCTS;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::CS5;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::CS6;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::CS7;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::CS8;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::CSIZE;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::CSTOPB;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::ECHO;
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 pub use constants::ECHOCTL;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::ECHOE;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::ECHOK;
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 pub use constants::ECHOKE;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::ECHONL;
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 pub use constants::ECHOPRT;
 #[cfg(not(any(
     target_os = "emscripten",
@@ -345,6 +393,7 @@ pub use constants::ECHOPRT;
     target_os = "macos",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::EXTA;
 #[cfg(not(any(
@@ -355,13 +404,15 @@ pub use constants::EXTA;
     target_os = "macos",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::EXTB;
 #[cfg(not(any(
     target_os = "haiku",
     target_os = "ios",
     target_os = "macos",
-    target_os = "redox"
+    target_os = "redox",
+    target_os = "wasi",
 )))]
 pub use constants::EXTPROC;
 #[cfg(not(any(
@@ -375,6 +426,7 @@ pub use constants::EXTPROC;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::FF0;
 #[cfg(not(any(
@@ -390,6 +442,7 @@ pub use constants::FF0;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::FF1;
 #[cfg(not(any(
@@ -403,36 +456,43 @@ pub use constants::FF1;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::FFDLY;
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 pub use constants::FLUSHO;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::HUPCL;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::ICRNL;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::IEXTEN;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::IGNBRK;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::IGNCR;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::IGNPAR;
 #[cfg(not(any(
     target_os = "haiku",
     target_os = "ios",
     target_os = "macos",
-    target_os = "redox"
+    target_os = "redox",
+    target_os = "wasi",
 )))]
 pub use constants::IMAXBEL;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::INLCR;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::INPCK;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::ISIG;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::ISTRIP;
 #[cfg(any(
     linux_raw,
@@ -454,13 +514,19 @@ pub use constants::IUCLC;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::IUTF8;
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 pub use constants::IXANY;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::IXOFF;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::IXON;
 #[cfg(not(any(
     target_os = "dragonfly",
@@ -473,6 +539,7 @@ pub use constants::IXON;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::NL0;
 #[cfg(not(any(
@@ -486,6 +553,7 @@ pub use constants::NL0;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::NL1;
 #[cfg(not(any(
@@ -498,11 +566,12 @@ pub use constants::NL1;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::NLDLY;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::NOFLSH;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::OCRNL;
 #[cfg(not(any(
     target_os = "dragonfly",
@@ -511,6 +580,7 @@ pub use constants::OCRNL;
     target_os = "macos",
     target_os = "netbsd",
     target_os = "openbsd",
+    target_os = "wasi",
 )))]
 pub use constants::OFDEL;
 #[cfg(not(any(
@@ -520,6 +590,7 @@ pub use constants::OFDEL;
     target_os = "macos",
     target_os = "netbsd",
     target_os = "openbsd",
+    target_os = "wasi",
 )))]
 pub use constants::OFILL;
 #[cfg(not(any(
@@ -529,23 +600,29 @@ pub use constants::OFILL;
     target_os = "macos",
     target_os = "netbsd",
     target_os = "redox",
+    target_os = "wasi",
 )))]
 pub use constants::OLCUC;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::ONLCR;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::ONLRET;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::ONOCR;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::OPOST;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::PARENB;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::PARMRK;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::PARODD;
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 pub use constants::PENDIN;
 #[cfg(not(any(
     target_os = "dragonfly",
@@ -557,6 +634,7 @@ pub use constants::PENDIN;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::TAB0;
 #[cfg(not(any(
@@ -572,6 +650,7 @@ pub use constants::TAB0;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::TAB1;
 #[cfg(not(any(
@@ -587,6 +666,7 @@ pub use constants::TAB1;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::TAB2;
 #[cfg(not(any(
@@ -601,6 +681,7 @@ pub use constants::TAB2;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::TAB3;
 #[cfg(not(any(
@@ -612,9 +693,10 @@ pub use constants::TAB3;
     target_os = "illumos",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::TABDLY;
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use constants::TOSTOP;
 #[cfg(not(any(
     target_os = "dragonfly",
@@ -626,6 +708,7 @@ pub use constants::TOSTOP;
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::VSWTC;
 #[cfg(not(any(
@@ -639,6 +722,7 @@ pub use constants::VSWTC;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::VT0;
 #[cfg(not(any(
@@ -654,6 +738,7 @@ pub use constants::VT0;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::VT1;
 #[cfg(not(any(
@@ -667,6 +752,7 @@ pub use constants::VT1;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::VTDLY;
 #[cfg(any(linux_raw, all(libc, any(target_arch = "s390x", target_os = "haiku"))))]
@@ -682,15 +768,18 @@ pub use constants::XCASE;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "wasi",
 )))]
 pub use constants::XTABS;
+#[cfg(not(target_os = "wasi"))]
 pub use constants::{
     speed_value, B0, B110, B115200, B1200, B134, B150, B1800, B19200, B200, B230400, B2400, B300,
     B38400, B4800, B50, B57600, B600, B75, B9600, ICANON, VEOF, VEOL, VEOL2, VERASE, VINTR, VKILL,
     VMIN, VQUIT, VSTART, VSTOP, VSUSP, VTIME,
 };
-#[cfg(not(target_os = "haiku"))]
+#[cfg(not(any(target_os = "haiku", target_os = "wasi")))]
 pub use constants::{VDISCARD, VLNEXT, VREPRINT, VWERASE};
+#[cfg(not(target_os = "wasi"))]
 pub use tc::{
     tcdrain, tcflow, tcflush, tcgetattr, tcgetpgrp, tcgetsid, tcgetwinsize, tcsendbreak, tcsetattr,
     tcsetpgrp, tcsetwinsize, Action, OptionalActions, QueueSelector, Speed, Tcflag, Termios,

--- a/src/termios/tty.rs
+++ b/src/termios/tty.rs
@@ -5,7 +5,6 @@ use crate::backend;
     all(linux_raw, feature = "procfs"),
     all(libc, not(any(target_os = "fuchsia", target_os = "wasi"))),
 ))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
 use crate::io;
 use backend::fd::AsFd;
 #[cfg(any(

--- a/src/time/clock.rs
+++ b/src/time/clock.rs
@@ -3,7 +3,7 @@ use crate::{backend, io};
 pub use backend::time::types::{Nsecs, Secs, Timespec};
 
 /// `clockid_t`
-#[cfg(any(not(target_os = "wasi")))]
+#[cfg(not(target_os = "wasi"))]
 pub use backend::time::types::{ClockId, DynamicClockId};
 
 /// `clock_getres(id)`—Returns the resolution of a clock.

--- a/tests/process/prctl.rs
+++ b/tests/process/prctl.rs
@@ -26,37 +26,37 @@ fn test_machine_check_memory_corruption_kill_policy() {
     dbg!(machine_check_memory_corruption_kill_policy().unwrap());
 }
 
-#[cfg(any(target_arch = "x86"))]
+#[cfg(target_arch = "x86")]
 #[test]
 fn test_time_stamp_counter_readability() {
     dbg!(time_stamp_counter_readability().unwrap());
 }
 
-#[cfg(any(target_arch = "powerpc"))]
+#[cfg(target_arch = "powerpc")]
 #[test]
 fn test_unaligned_access_control() {
     dbg!(unaligned_access_control().unwrap());
 }
 
-#[cfg(any(target_arch = "powerpc"))]
+#[cfg(target_arch = "powerpc")]
 #[test]
 fn test_floating_point_exception_mode() {
     dbg!(floating_point_exception_mode().unwrap());
 }
 
-#[cfg(any(target_arch = "powerpc"))]
+#[cfg(target_arch = "powerpc")]
 #[test]
 fn test_endian_mode() {
     dbg!(endian_mode().unwrap());
 }
 
-#[cfg(any(target_arch = "mips"))]
+#[cfg(target_arch = "mips")]
 #[test]
 fn test_floating_point_mode() {
     dbg!(floating_point_mode().unwrap());
 }
 
-#[cfg(any(target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 #[test]
 #[ignore = "Only on ARMv8.3 and later"]
 fn test_enabled_pointer_authentication_keys() {

--- a/tests/thread/main.rs
+++ b/tests/thread/main.rs
@@ -3,7 +3,7 @@
 #![cfg(feature = "thread")]
 #![cfg(not(windows))]
 
-#[cfg(not(any(target_os = "redox")))]
+#[cfg(not(target_os = "redox"))]
 mod clocks;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod id;

--- a/tests/thread/prctl.rs
+++ b/tests/thread/prctl.rs
@@ -38,13 +38,13 @@ fn test_capability_is_in_ambient_capability_set() {
     dbg!(capability_is_in_ambient_capability_set(Capability::ChangeOwnership).unwrap());
 }
 
-#[cfg(any(target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 #[test]
 fn test_sve_vector_length_configuration() {
     dbg!(sve_vector_length_configuration().unwrap());
 }
 
-#[cfg(any(target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 #[test]
 fn test_current_tagged_address_mode() {
     dbg!(current_tagged_address_mode().unwrap());


### PR DESCRIPTION
Enable `rustix::termios::isatty` on wasm32-wasi, which doesn't yet have full termios support, but can support isatty.