### PR TITLE
Make the "param" module depend on the "fs" module.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ process = []
 time = []
 
 # Enable `rustix::param::*`.
-param = []
+param = ["fs"]
 
 # Enable this to enable `rustix::io::proc_self_*` (on Linux) and `ttyname`.
 procfs = ["once_cell", "itoa", "fs"]

--- a/src/backend/linux_raw/param/auxv.rs
+++ b/src/backend/linux_raw/param/auxv.rs
@@ -10,6 +10,7 @@ use super::super::elf::*;
 use crate::fd::OwnedFd;
 #[cfg(feature = "param")]
 use crate::ffi::CStr;
+#[cfg(not(target_vendor = "mustang"))]
 use crate::fs::{Mode, OFlags};
 use crate::utils::{as_ptr, check_raw_pointer};
 use alloc::vec::Vec;
@@ -130,6 +131,7 @@ static PHNUM: AtomicUsize = AtomicUsize::new(0);
 static EXECFN: AtomicPtr<c::c_char> = AtomicPtr::new(null_mut());
 
 /// On non-Mustang platforms, we read the aux vector from /proc/self/auxv.
+#[cfg(not(target_vendor = "mustang"))]
 fn init_from_proc_self_auxv() {
     // Open "/proc/self/auxv", either because we trust "/proc", or because
     // we're running inside QEMU and `proc_self_auxv`'s extra checking foils
@@ -144,6 +146,11 @@ fn init_from_proc_self_auxv() {
     .unwrap();
 
     let _ = init_from_auxv_file(file);
+}
+
+#[cfg(target_vendor = "mustang")]
+fn init_from_proc_self_auxv() {
+    panic!("mustang should have initialized the auxv values");
 }
 
 /// Process auxv entries from the open file `auxv`.


### PR DESCRIPTION
In some configurations, the param module needs to open /proc/self/auxv, and it needs the fs API to do that, so make the param module depend on the fs module.

Also, disable the init_from_proc_self_auxv code on mustang, which doesn't need it.