### PR TITLE
0.36 updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
 
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.
+      # In theory we should add --cfg criterion here, but criterion doesn't compile under Rust 1.48.
       RUSTFLAGS: -D warnings
     steps:
     - uses: actions/checkout@v3
@@ -85,38 +86,38 @@ jobs:
       if: matrix.rust == '1.48'
       run: cargo update --package=once_cell --precise 1.14.0
 
-    - run: cargo check --workspace --release -vv
-    - run: cargo check --workspace --release -vv --features=all-apis
-    - run: cargo check --workspace --release -vv --features=use-libc,all-apis
-    - run: cargo check --workspace --release -vv --target=aarch64-linux-android
-    - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-musl --features=all-apis
-    - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-musl --features=use-libc,all-apis
-    - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-gnux32 --features=all-apis
-    - run: cargo check --workspace --release -vv --target=x86_64-linux-android --features=all-apis
-    - run: cargo check --workspace --release -vv --target=i686-linux-android --features=all-apis
-    - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin --features=all-apis
-    - run: cargo check --workspace --release -vv --target=x86_64-unknown-freebsd --features=all-apis
-    - run: cargo check --workspace --release -vv --target=x86_64-unknown-netbsd --features=all-apis
-    - run: cargo check --workspace --release -vv --target=x86_64-fuchsia --features=all-apis
-    - run: cargo check --workspace --release -vv --target=x86_64-unknown-illumos --features=all-apis
-    - run: cargo check --workspace --release -vv --target=i686-unknown-linux-gnu --features=all-apis
-    - run: cargo check --workspace --release -vv --target=i686-unknown-linux-musl --features=all-apis
-    - run: cargo check --workspace --release -vv --target=i686-unknown-linux-musl --features=use-libc,all-apis
-    - run: cargo check --workspace --release -vv --target=wasm32-unknown-emscripten --features=all-apis
-    - run: cargo check --workspace --release -vv --target=riscv64gc-unknown-linux-gnu --features=all-apis
-    - run: cargo check --workspace --release -vv --target=aarch64-unknown-linux-gnu --features=all-apis
-    - run: cargo check --workspace --release -vv --target=aarch64-unknown-linux-musl --features=all-apis
-    - run: cargo check --workspace --release -vv --target=aarch64-unknown-linux-musl --features=use-libc,all-apis
-    - run: cargo check --workspace --release -vv --target=powerpc64le-unknown-linux-gnu --features=all-apis
-    - run: cargo check --workspace --release -vv --target=mipsel-unknown-linux-gnu --features=all-apis
-    - run: cargo check --workspace --release -vv --target=mips64el-unknown-linux-gnuabi64 --features=all-apis
-    - run: cargo check --workspace --release -vv --target=armv5te-unknown-linux-gnueabi --features=all-apis
-    - run: cargo check --workspace --release -vv --target=s390x-unknown-linux-gnu --features=all-apis
-    - run: cargo check --workspace --release -vv --target=arm-linux-androideabi --features=all-apis
-    - run: cargo check --workspace --release -vv --target=sparc64-unknown-linux-gnu --features=all-apis
-    - run: cargo check --workspace --release -vv --target=sparcv9-sun-solaris --features=all-apis
-    - run: cargo check --workspace --release -vv --target=aarch64-apple-ios --features=all-apis
-    - run: cargo check --workspace --release -vv --target=aarch64-linux-android --features=all-apis
+    - run: cargo check --workspace --release -vv --all-targets
+    - run: cargo check --workspace --release -vv --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --features=use-libc,all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=aarch64-linux-android --all-targets
+    - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-musl --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-musl --features=use-libc,all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=x86_64-unknown-linux-gnux32 --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=x86_64-linux-android --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=i686-linux-android --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=x86_64-unknown-freebsd --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=x86_64-unknown-netbsd --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=x86_64-fuchsia --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=x86_64-unknown-illumos --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=i686-unknown-linux-gnu --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=i686-unknown-linux-musl --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=i686-unknown-linux-musl --features=use-libc,all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=wasm32-unknown-emscripten --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=riscv64gc-unknown-linux-gnu --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=aarch64-unknown-linux-gnu --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=aarch64-unknown-linux-musl --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=aarch64-unknown-linux-musl --features=use-libc,all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=powerpc64le-unknown-linux-gnu --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=mipsel-unknown-linux-gnu --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=mips64el-unknown-linux-gnuabi64 --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=armv5te-unknown-linux-gnueabi --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=s390x-unknown-linux-gnu --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=arm-linux-androideabi --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=sparc64-unknown-linux-gnu --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=sparcv9-sun-solaris --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=aarch64-apple-ios --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=aarch64-linux-android --features=all-apis --all-targets
 
   check_no_default_features:
     name: Check --no-default-features
@@ -189,7 +190,7 @@ jobs:
         toolchain: ${{ matrix.rust }}
       env:
         # See the comments in the libc crate
-        RUSTFLAGS: -A improper_ctypes_definitions
+        RUSTFLAGS: -A improper_ctypes_definitions --cfg criterion
     - run: rustup component add rust-src
     - run: cargo check -Z build-std --target x86_64-unknown-openbsd --all-targets --features=all-apis
     - run: cargo check -Z build-std --target mips64-openwrt-linux-musl --all-targets --features=all-apis
@@ -207,7 +208,7 @@ jobs:
       QEMU_BUILD_VERSION: 7.0.0
     strategy:
       matrix:
-        build: [ubuntu, ubuntu-18.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, mipsel-linux-stable, mips64el-linux-stable, powerpc64le-linux-stable, arm-linux-stable, macos-latest, macos-10.15, windows, windows-2019]
+        build: [ubuntu, ubuntu-18.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, ubuntu-1.48, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, mipsel-linux-stable, mips64el-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.48, i686-linux-1.48, aarch64-linux-1.48, riscv64-linux-1.48, s390x-linux-1.48, mipsel-linux-1.48, mips64el-linux-1.48, powerpc64le-linux-1.48, arm-linux-1.48, macos-latest, macos-10.15, windows, windows-2019]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -358,6 +359,79 @@ jobs:
             qemu: qemu-arm
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
+          - build: ubuntu-1.48
+            os: ubuntu-latest
+            rust: 1.48
+          - build: i686-linux-1.48
+            os: ubuntu-latest
+            rust: 1.48
+            target: i686-unknown-linux-gnu
+            gcc_package: gcc-i686-linux-gnu
+            gcc: i686-linux-gnu-gcc
+            libc_package: libc-dev-i386-cross
+          - build: aarch64-linux-1.48
+            os: ubuntu-latest
+            rust: 1.48
+            target: aarch64-unknown-linux-gnu
+            gcc_package: gcc-aarch64-linux-gnu
+            gcc: aarch64-linux-gnu-gcc
+            qemu: qemu-aarch64
+            qemu_args: -L /usr/aarch64-linux-gnu
+            qemu_target: aarch64-linux-user
+          - build: riscv64-linux-1.48
+            os: ubuntu-latest
+            rust: 1.48
+            target: riscv64gc-unknown-linux-gnu
+            gcc_package: gcc-riscv64-linux-gnu
+            gcc: riscv64-linux-gnu-gcc
+            qemu: qemu-riscv64
+            qemu_args: -L /usr/riscv64-linux-gnu
+            qemu_target: riscv64-linux-user
+          - build: s390x-linux-1.48
+            os: ubuntu-latest
+            rust: 1.48
+            target: s390x-unknown-linux-gnu
+            gcc_package: gcc-s390x-linux-gnu
+            gcc: s390x-linux-gnu-gcc
+            qemu: qemu-s390x
+            qemu_args: -L /usr/s390x-linux-gnu
+            qemu_target: s390x-linux-user
+          - build: powerpc64le-linux-1.48
+            os: ubuntu-latest
+            rust: 1.48
+            target: powerpc64le-unknown-linux-gnu
+            gcc_package: gcc-powerpc64le-linux-gnu
+            gcc: powerpc64le-linux-gnu-gcc
+            qemu: qemu-ppc64le
+            qemu_args: -L /usr/powerpc64le-linux-gnu
+            qemu_target: ppc64le-linux-user
+          - build: mips64el-linux-1.48
+            os: ubuntu-latest
+            rust: 1.48
+            target: mips64el-unknown-linux-gnuabi64
+            gcc_package: gcc-mips64el-linux-gnuabi64
+            gcc: mips64el-linux-gnuabi64-gcc
+            qemu: qemu-mips64el
+            qemu_args: -L /usr/mips64el-linux-gnuabi64
+            qemu_target: mips64el-linux-user
+          - build: mipsel-linux-1.48
+            os: ubuntu-latest
+            rust: 1.48
+            target: mipsel-unknown-linux-gnu
+            gcc_package: gcc-mipsel-linux-gnu
+            gcc: mipsel-linux-gnu-gcc
+            qemu: qemu-mipsel
+            qemu_args: -L /usr/mipsel-linux-gnu
+            qemu_target: mipsel-linux-user
+          - build: arm-linux-1.48
+            os: ubuntu-latest
+            rust: 1.48
+            target: armv5te-unknown-linux-gnueabi
+            gcc_package: gcc-arm-linux-gnueabi
+            gcc: arm-linux-gnueabi-gcc
+            qemu: qemu-arm
+            qemu_args: -L /usr/arm-linux-gnueabi
+            qemu_target: arm-linux-user
           - build: macos-latest
             os: macos-latest
             rust: stable
@@ -432,15 +506,41 @@ jobs:
         ninja -C build install
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
+    - name: Use specific dependency versions for Rust 1.48 compatibility.
+      if: matrix.rust == '1.48'
+      run: cargo update --package=once_cell --precise 1.14.0
+
     - run: |
         # Run the tests, and check the prebuilt release libraries.
         cargo test --verbose --features=all-impls,all-apis,cc --release --workspace -- --nocapture
       env:
         RUST_BACKTRACE: full
+      if: matrix.rust != '1.48'
+
+    - run: |
+        # Run the tests with Rust 1.48, and check the prebuilt release libraries.
+        # Don't use all-impls because some of the impls have dependencies that
+        # don't support Rust 1.48.
+        cargo test --verbose --features=fs-err,all-apis,cc --release --workspace -- --nocapture
+      env:
+        RUST_BACKTRACE: full
+      if: matrix.rust == '1.48'
 
     - run: |
         # Check the prebuilt debug libraries too.
         cargo check --features=all-impls,all-apis,cc
+      env:
+        RUST_BACKTRACE: full
+      if: matrix.rust != '1.48'
+
+    - run: |
+        # Check the prebuilt debug libraries with Rust 1.48 too.
+        # Don't use all-impls because some of the impls have dependencies that
+        # don't support Rust 1.48.
+        cargo check --features=fs-err,all-apis,cc
+      env:
+        RUST_BACKTRACE: full
+      if: matrix.rust == '1.48'
 
   test_use_libc:
     name: Test use-libc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 keywords = ["api", "file", "network", "safe", "syscall"]
 categories = ["os::unix-apis", "date-and-time", "filesystem", "network-programming"]
 include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md", "benches"]
+rust-version = "1.48"
 
 [build-dependencies]
 cc = { version = "1.0.68", optional = true }
@@ -78,7 +79,7 @@ serial_test = "0.6"
 memoffset = "0.7.1"
 flate2 = "1.0"
 
-[target.'cfg(not(any(target_os = "emscripten", target_os = "wasi")))'.dev-dependencies]
+[target.'cfg(all(criterion, not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]
 criterion = "0.4"
 
 [target.'cfg(windows)'.dev-dependencies]

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -1,4 +1,13 @@
+/// Benchmarks for rustix.
+///
+/// To enable these benchmarks, add `--cfg=criterion` to RUSTFLAGS and enable
+/// the "fs", "time", and "process" cargo features.
+
 #[cfg(any(
+    not(criterion),
+    not(feature = "fs"),
+    not(feature = "process"),
+    not(feature = "time"),
     windows,
     target_os = "emscripten",
     target_os = "redox",
@@ -9,6 +18,10 @@ fn main() {
 }
 
 #[cfg(not(any(
+    not(criterion),
+    not(feature = "fs"),
+    not(feature = "process"),
+    not(feature = "time"),
     windows,
     target_os = "emscripten",
     target_os = "redox",
@@ -17,6 +30,10 @@ fn main() {
 use criterion::{criterion_group, criterion_main};
 
 #[cfg(not(any(
+    not(criterion),
+    not(feature = "fs"),
+    not(feature = "process"),
+    not(feature = "time"),
     windows,
     target_os = "emscripten",
     target_os = "redox",
@@ -132,6 +149,10 @@ mod suite {
 }
 
 #[cfg(not(any(
+    not(criterion),
+    not(feature = "fs"),
+    not(feature = "process"),
+    not(feature = "time"),
     windows,
     target_os = "emscripten",
     target_os = "redox",
@@ -149,6 +170,10 @@ criterion_group!(
     suite::simple_getpid_libc
 );
 #[cfg(not(any(
+    not(criterion),
+    not(feature = "fs"),
+    not(feature = "process"),
+    not(feature = "time"),
     windows,
     target_os = "emscripten",
     target_os = "redox",

--- a/examples/process.rs
+++ b/examples/process.rs
@@ -30,97 +30,109 @@ fn main() -> io::Result<()> {
     println!("Page size: {}", page_size());
     println!("Clock ticks/sec: {}", clock_ticks_per_second());
     println!("Uname: {:?}", uname());
-    println!("Process group priority: {}", getpriority_pgrp(None)?);
-    println!("Process priority: {}", getpriority_process(None)?);
-    println!("User priority: {}", getpriority_user(Uid::ROOT)?);
+    #[cfg(not(target_os = "fuchsia"))]
+    {
+        println!("Process group priority: {}", getpriority_pgrp(None)?);
+        println!("Process priority: {}", getpriority_process(None)?);
+        println!("User priority: {}", getpriority_user(Uid::ROOT)?);
+    }
     println!(
         "Current working directory: {}",
         getcwd(Vec::new())?.to_string_lossy()
     );
-    println!("Cpu Limit: {:?}", getrlimit(Resource::Cpu));
-    println!("Fsize Limit: {:?}", getrlimit(Resource::Fsize));
-    println!("Data Limit: {:?}", getrlimit(Resource::Data));
-    println!("Stack Limit: {:?}", getrlimit(Resource::Stack));
-    #[cfg(not(target_os = "haiku"))]
-    println!("Core Limit: {:?}", getrlimit(Resource::Core));
-    #[cfg(not(any(target_os = "haiku", target_os = "solaris")))]
-    println!("Rss Limit: {:?}", getrlimit(Resource::Rss));
-    #[cfg(not(any(target_os = "haiku", target_os = "solaris")))]
-    println!("Nproc Limit: {:?}", getrlimit(Resource::Nproc));
-    #[cfg(not(target_os = "solaris"))]
-    println!("Nofile Limit: {:?}", getrlimit(Resource::Nofile));
-    #[cfg(not(any(target_os = "haiku", target_os = "solaris")))]
-    println!("Memlock Limit: {:?}", getrlimit(Resource::Memlock));
-    #[cfg(not(target_os = "openbsd"))]
-    println!("As Limit: {:?}", getrlimit(Resource::As));
-    #[cfg(not(any(
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "haiku",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "solaris",
-    )))]
-    println!("Locks Limit: {:?}", getrlimit(Resource::Locks));
-    #[cfg(not(any(
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "haiku",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "solaris",
-    )))]
-    println!("Sigpending Limit: {:?}", getrlimit(Resource::Sigpending));
-    #[cfg(not(any(
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "haiku",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "solaris",
-    )))]
-    println!("Msgqueue Limit: {:?}", getrlimit(Resource::Msgqueue));
-    #[cfg(not(any(
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "haiku",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "solaris",
-    )))]
-    println!("Nice Limit: {:?}", getrlimit(Resource::Nice));
-    #[cfg(not(any(
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "haiku",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "solaris",
-    )))]
-    println!("Rtprio Limit: {:?}", getrlimit(Resource::Rtprio));
-    #[cfg(not(any(
-        target_os = "android",
-        target_os = "dragonfly",
-        target_os = "emscripten",
-        target_os = "freebsd",
-        target_os = "haiku",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "solaris",
-    )))]
-    println!("Rttime Limit: {:?}", getrlimit(Resource::Rttime));
+    #[cfg(not(target_os = "fuchsia"))]
+    {
+        println!("Cpu Limit: {:?}", getrlimit(Resource::Cpu));
+        println!("Fsize Limit: {:?}", getrlimit(Resource::Fsize));
+        println!("Data Limit: {:?}", getrlimit(Resource::Data));
+        println!("Stack Limit: {:?}", getrlimit(Resource::Stack));
+        #[cfg(not(target_os = "haiku"))]
+        println!("Core Limit: {:?}", getrlimit(Resource::Core));
+        #[cfg(not(any(target_os = "haiku", target_os = "illumos", target_os = "solaris")))]
+        println!("Rss Limit: {:?}", getrlimit(Resource::Rss));
+        #[cfg(not(any(target_os = "haiku", target_os = "illumos", target_os = "solaris")))]
+        println!("Nproc Limit: {:?}", getrlimit(Resource::Nproc));
+        #[cfg(not(target_os = "solaris"))]
+        println!("Nofile Limit: {:?}", getrlimit(Resource::Nofile));
+        #[cfg(not(any(target_os = "haiku", target_os = "illumos", target_os = "solaris")))]
+        println!("Memlock Limit: {:?}", getrlimit(Resource::Memlock));
+        #[cfg(not(target_os = "openbsd"))]
+        println!("As Limit: {:?}", getrlimit(Resource::As));
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "haiku",
+            target_os = "illumos",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "solaris",
+        )))]
+        println!("Locks Limit: {:?}", getrlimit(Resource::Locks));
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "haiku",
+            target_os = "illumos",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "solaris",
+        )))]
+        println!("Sigpending Limit: {:?}", getrlimit(Resource::Sigpending));
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "haiku",
+            target_os = "illumos",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "solaris",
+        )))]
+        println!("Msgqueue Limit: {:?}", getrlimit(Resource::Msgqueue));
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "haiku",
+            target_os = "illumos",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "solaris",
+        )))]
+        println!("Nice Limit: {:?}", getrlimit(Resource::Nice));
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "haiku",
+            target_os = "illumos",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "solaris",
+        )))]
+        println!("Rtprio Limit: {:?}", getrlimit(Resource::Rtprio));
+        #[cfg(not(any(
+            target_os = "android",
+            target_os = "dragonfly",
+            target_os = "emscripten",
+            target_os = "freebsd",
+            target_os = "haiku",
+            target_os = "illumos",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "solaris",
+        )))]
+        println!("Rttime Limit: {:?}", getrlimit(Resource::Rttime));
+    }
     #[cfg(any(
         all(target_os = "android", target_pointer_width = "64"),
         target_os = "linux"

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -10,7 +10,11 @@ use rustix::io::{self, stderr, stdin, stdout};
 #[cfg(feature = "termios")]
 #[cfg(not(windows))]
 use rustix::termios::isatty;
-#[cfg(all(not(windows), feature = "termios", feature = "procfs"))]
+#[cfg(all(
+    not(any(windows, target_os = "fuchsia")),
+    feature = "termios",
+    feature = "procfs"
+))]
 use rustix::termios::ttyname;
 
 #[cfg(not(windows))]
@@ -37,6 +41,7 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     #[cfg(feature = "termios")]
     if isatty(fd) {
         #[cfg(feature = "procfs")]
+        #[cfg(not(target_os = "fuchsia"))]
         println!(" - ttyname: {}", ttyname(fd, Vec::new())?.to_string_lossy());
 
         #[cfg(target_os = "wasi")]
@@ -125,6 +130,7 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
             }
             #[cfg(not(any(
                 target_os = "dragonfly",
+                target_os = "emscripten",
                 target_os = "freebsd",
                 target_os = "haiku",
                 target_os = "illumos",
@@ -340,6 +346,7 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
             }
             #[cfg(not(any(
                 target_os = "dragonfly",
+                target_os = "emscripten",
                 target_os = "freebsd",
                 target_os = "haiku",
                 target_os = "ios",
@@ -353,6 +360,7 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
             }
             #[cfg(not(any(
                 target_os = "dragonfly",
+                target_os = "emscripten",
                 target_os = "freebsd",
                 target_os = "haiku",
                 target_os = "illumos",

--- a/tests/fs/statfs.rs
+++ b/tests/fs/statfs.rs
@@ -66,7 +66,11 @@ fn test_fstatfs() {
 fn test_statfs_procfs() {
     let statfs = rustix::fs::statfs("/proc/self/maps").unwrap();
 
-    assert_eq!(statfs.f_type, rustix::fs::PROC_SUPER_MAGIC);
+    // Do the field access outside the assert to work around Rust 1.48 thinking
+    // that this is otherwise a packed field borrow.
+    let f_type = statfs.f_type;
+
+    assert_eq!(f_type, rustix::fs::PROC_SUPER_MAGIC);
 }
 
 #[test]

--- a/tests/fs/y2038.rs
+++ b/tests/fs/y2038.rs
@@ -50,11 +50,23 @@ fn test_y2038_with_utimensat() {
         TryInto::<u64>::try_into(stat.st_mtime).unwrap() as u64,
         m_sec
     );
+
+    #[cfg(not(target_os = "netbsd"))]
     assert_eq!(stat.st_mtime_nsec as u32, m_nsec);
+    #[cfg(target_os = "netbsd")]
+    assert_eq!(stat.st_mtimensec as u32, m_nsec);
+
     assert!(TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 >= a_sec);
+
+    #[cfg(not(target_os = "netbsd"))]
     assert!(
         TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 > a_sec
             || stat.st_atime_nsec as u32 >= a_nsec
+    );
+    #[cfg(target_os = "netbsd")]
+    assert!(
+        TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 > a_sec
+            || stat.st_atimensec as u32 >= a_nsec
     );
 
     // Now test the same thing, but with `fstat`.
@@ -65,11 +77,23 @@ fn test_y2038_with_utimensat() {
         TryInto::<u64>::try_into(stat.st_mtime).unwrap() as u64,
         m_sec
     );
+
+    #[cfg(not(target_os = "netbsd"))]
     assert_eq!(stat.st_mtime_nsec as u32, m_nsec);
+    #[cfg(target_os = "netbsd")]
+    assert_eq!(stat.st_mtimensec as u32, m_nsec);
+
     assert!(TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 >= a_sec);
+
+    #[cfg(not(target_os = "netbsd"))]
     assert!(
         TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 > a_sec
             || stat.st_atime_nsec as u32 >= a_nsec
+    );
+    #[cfg(target_os = "netbsd")]
+    assert!(
+        TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 > a_sec
+            || stat.st_atimensec as u32 >= a_nsec
     );
 }
 
@@ -122,11 +146,23 @@ fn test_y2038_with_futimens() {
     let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();
 
     assert_eq!(TryInto::<u64>::try_into(stat.st_mtime).unwrap(), m_sec);
+
+    #[cfg(not(target_os = "netbsd"))]
     assert_eq!(stat.st_mtime_nsec as u32, m_nsec);
+    #[cfg(target_os = "netbsd")]
+    assert_eq!(stat.st_mtimensec as u32, m_nsec);
+
     assert!(TryInto::<u64>::try_into(stat.st_atime).unwrap() >= a_sec);
+
+    #[cfg(not(target_os = "netbsd"))]
     assert!(
         TryInto::<u64>::try_into(stat.st_atime).unwrap() > a_sec
             || stat.st_atime_nsec as u32 >= a_nsec
+    );
+    #[cfg(target_os = "netbsd")]
+    assert!(
+        TryInto::<u64>::try_into(stat.st_atime).unwrap() > a_sec
+            || stat.st_atimensec as u32 >= a_nsec
     );
 
     // Now test the same thing, but with `fstat`.
@@ -137,10 +173,22 @@ fn test_y2038_with_futimens() {
         TryInto::<u64>::try_into(stat.st_mtime).unwrap() as u64,
         m_sec
     );
+
+    #[cfg(not(target_os = "netbsd"))]
     assert_eq!(stat.st_mtime_nsec as u32, m_nsec);
+    #[cfg(target_os = "netbsd")]
+    assert_eq!(stat.st_mtimensec as u32, m_nsec);
+
     assert!(TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 >= a_sec);
+
+    #[cfg(not(target_os = "netbsd"))]
     assert!(
         TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 > a_sec
             || stat.st_atime_nsec as u32 >= a_nsec
+    );
+    #[cfg(target_os = "netbsd")]
+    assert!(
+        TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 > a_sec
+            || stat.st_atimensec as u32 >= a_nsec
     );
 }

--- a/tests/io/pipe.rs
+++ b/tests/io/pipe.rs
@@ -17,7 +17,8 @@ fn test_splice_cursor() {
     splice(&src, None, &write_p, None, 5, SpliceFlags::empty()).unwrap();
     splice(&read_p, None, &dest, None, 5, SpliceFlags::empty()).unwrap();
 
-    dest.rewind().unwrap();
+    // When we can depend on Rust 1.55, we can use `rewind` here.
+    dest.seek(SeekFrom::Start(0)).unwrap();
 
     dest.read_to_end(&mut buff).unwrap();
     assert_eq!(buff, b"world");

--- a/tests/process/procctl.rs
+++ b/tests/process/procctl.rs
@@ -7,5 +7,5 @@ fn test_parent_process_death_signal() {
 
 #[test]
 fn test_trace_status() {
-    dbg!(trace_status().unwrap());
+    dbg!(trace_status(None).unwrap());
 }

--- a/tests/thread/setns.rs
+++ b/tests/thread/setns.rs
@@ -1,6 +1,9 @@
 use std::fs::File;
 
-use rustix::fd::{AsFd, FromRawFd, OwnedFd, RawFd};
+use rustix::fd::AsFd;
+#[cfg(not(target_os = "android"))]
+use rustix::fd::{FromRawFd, OwnedFd, RawFd};
+#[cfg(not(target_os = "android"))]
 use rustix::thread::*;
 
 #[test]
@@ -17,6 +20,7 @@ fn test_move_into_link_name_space() {
 
 #[test]
 #[ignore = "Requires CAP_SYS_ADMIN capability"]
+#[cfg(not(target_os = "android"))] // Android libc bindings don't have `SYS_pidfd_open` yet.
 fn test_move_into_thread_name_spaces() {
     let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, std::process::id() as usize, 0_usize) };
     if fd == -1 {


### PR DESCRIPTION
Cherry-pick changes from main to 0.36.

This omits the `RawDir` API for now (see #472).