### PR TITLE
Fix another UB in raw dir

### DIFF
--- a/tests/fs/readdir.rs
+++ b/tests/fs/readdir.rs
@@ -56,16 +56,15 @@ fn read_entries(dir: &mut Dir) -> HashMap<String, DirEntry> {
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn test_raw_dir(buf: &mut [MaybeUninit<u8>]) {
+    use std::collections::HashSet;
     use std::io::{Seek, SeekFrom};
 
     use rustix::fd::AsFd;
-    use rustix::fs::{RawDir, RawDirEntry};
+    use rustix::fs::RawDir;
 
-    fn read_raw_entries<'a, Fd: AsFd>(
-        dir: &'a mut RawDir<'_, Fd>,
-    ) -> HashMap<String, RawDirEntry<'a>> {
-        let mut out = HashMap::new();
-        for entry in dir {
+    fn read_raw_entries<Fd: AsFd>(dir: &mut RawDir<Fd>) -> HashSet<String> {
+        let mut out = HashSet::new();
+        while let Some(entry) = dir.next() {
             let entry = entry.expect("non-error entry");
             let name = entry
                 .file_name()
@@ -73,7 +72,7 @@ fn test_raw_dir(buf: &mut [MaybeUninit<u8>]) {
                 .expect("utf8 filename")
                 .to_owned();
             if name != "." && name != ".." {
-                out.insert(name, entry);
+                out.insert(name);
             }
         }
         out


### PR DESCRIPTION
This kind of sucks, but we can't use for loops until `LendingIterator` becomes a thing in the stdlib. For now, I elected to simply not implement the `Iterator` interface and make people manually call next.

Code that compiled before:
```rust
let mut buf = Vec::with_capacity(1000);
let mut other = Vec::new();
for x in RawDir::new(cwd(), buf.spare_capacity_mut()) {
    other.push(x.unwrap());
}
```

Code that no longer compiles:
```rust
let mut buf = Vec::with_capacity(1000);
let mut other = Vec::new();
let mut iter = RawDir::new(crate::fs::cwd(), buf.spare_capacity_mut());
while let Some(entry) = iter.next() {
    other.push(entry.unwrap());
}
```

Closes https://github.com/bytecodealliance/rustix/issues/472