### PR TITLE
Add --features=all-apis to the Cirrus CI config.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ task:
     - rustup default stable
   test_script:
     - . $HOME/.cargo/env
-    - cargo test --workspace
+    - cargo test --workspace --features=all-apis
 
 task:
   name: stable x86_64-unknown-freebsd-12
@@ -27,4 +27,4 @@ task:
     - rustup default stable
   test_script:
     - . $HOME/.cargo/env
-    - cargo test --workspace
+    - cargo test --workspace --features=all-apis


### PR DESCRIPTION
This enables testing for all the API modules, such as fs, net, process, and all the rest.