### PR TITLE
Add `From` impls for `SocketAddrAny`.

### DIFF
--- a/src/net/socket_addr_any.rs
+++ b/src/net/socket_addr_any.rs
@@ -32,6 +32,28 @@ pub enum SocketAddrAny {
     Unix(SocketAddrUnix),
 }
 
+impl From<SocketAddrV4> for SocketAddrAny {
+    #[inline]
+    fn from(from: SocketAddrV4) -> Self {
+        Self::V4(from)
+    }
+}
+
+impl From<SocketAddrV6> for SocketAddrAny {
+    #[inline]
+    fn from(from: SocketAddrV6) -> Self {
+        Self::V6(from)
+    }
+}
+
+#[cfg(unix)]
+impl From<SocketAddrUnix> for SocketAddrAny {
+    #[inline]
+    fn from(from: SocketAddrUnix) -> Self {
+        Self::Unix(from)
+    }
+}
+
 impl SocketAddrAny {
     /// Return the address family of this socket address.
     #[inline]

--- a/tests/net/connect_bind_send.rs
+++ b/tests/net/connect_bind_send.rs
@@ -158,7 +158,7 @@ fn net_v6_connect() -> std::io::Result<()> {
 #[test]
 fn net_v4_bind_any() -> std::io::Result<()> {
     let localhost = Ipv4Addr::LOCALHOST;
-    let addr = SocketAddrAny::V4(SocketAddrV4::new(localhost, 0));
+    let addr = SocketAddrV4::new(localhost, 0).into();
     let listener =
         rustix::net::socket(AddressFamily::INET, SocketType::STREAM, Protocol::default())?;
     rustix::net::bind_any(&listener, &addr).expect("bind");


### PR DESCRIPTION
This allows more convenient construction of `SocketAddrAny` values.