### PR TITLE
Support `SEEK_DATA` and `SEEK_HOLE` for `lseek`

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -900,9 +900,19 @@ pub(crate) fn seek(fd: BorrowedFd<'_>, pos: SeekFrom) -> io::Result<u64> {
         }
         SeekFrom::End(offset) => (c::SEEK_END, offset),
         SeekFrom::Current(offset) => (c::SEEK_CUR, offset),
-        #[cfg(target_os = "linux")]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "solaris",
+            target_os = "freebsd",
+            target_os = "dragonfly",
+        ))]
         SeekFrom::Data(offset) => (c::SEEK_DATA, offset),
-        #[cfg(target_os = "linux")]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "solaris",
+            target_os = "freebsd",
+            target_os = "dragonfly",
+        ))]
         SeekFrom::Hole(offset) => (c::SEEK_HOLE, offset),
     };
     let offset = unsafe { ret_off_t(libc_lseek(borrowed_fd(fd), offset, whence))? };

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -900,7 +900,9 @@ pub(crate) fn seek(fd: BorrowedFd<'_>, pos: SeekFrom) -> io::Result<u64> {
         }
         SeekFrom::End(offset) => (c::SEEK_END, offset),
         SeekFrom::Current(offset) => (c::SEEK_CUR, offset),
+        #[cfg(target_os = "linux")]
         SeekFrom::Data(offset) => (c::SEEK_DATA, offset),
+        #[cfg(target_os = "linux")]
         SeekFrom::Hole(offset) => (c::SEEK_HOLE, offset),
     };
     let offset = unsafe { ret_off_t(libc_lseek(borrowed_fd(fd), offset, whence))? };

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -900,6 +900,8 @@ pub(crate) fn seek(fd: BorrowedFd<'_>, pos: SeekFrom) -> io::Result<u64> {
         }
         SeekFrom::End(offset) => (c::SEEK_END, offset),
         SeekFrom::Current(offset) => (c::SEEK_CUR, offset),
+        SeekFrom::Data(offset) => (c::SEEK_DATA, offset),
+        SeekFrom::Hole(offset) => (c::SEEK_HOLE, offset),
     };
     let offset = unsafe { ret_off_t(libc_lseek(borrowed_fd(fd), offset, whence))? };
     Ok(offset as u64)

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -215,7 +215,9 @@ pub(crate) fn seek(fd: BorrowedFd<'_>, pos: SeekFrom) -> io::Result<u64> {
         }
         SeekFrom::End(offset) => (SEEK_END, offset),
         SeekFrom::Current(offset) => (SEEK_CUR, offset),
+        #[cfg(target_os = "linux")]
         SeekFrom::Data(offset) => (SEEK_DATA, offset),
+        #[cfg(target_os = "linux")]
         SeekFrom::Hole(offset) => (SEEK_HOLE, offset),
     };
     _seek(fd, offset, whence)

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -37,7 +37,8 @@ use linux_raw_sys::general::stat as linux_stat64;
 use linux_raw_sys::general::{
     __kernel_fsid_t, __kernel_timespec, open_how, statx, AT_EACCESS, AT_FDCWD, AT_REMOVEDIR,
     AT_SYMLINK_NOFOLLOW, F_ADD_SEALS, F_GETFL, F_GETLEASE, F_GETOWN, F_GETPIPE_SZ, F_GETSIG,
-    F_GET_SEALS, F_SETFL, F_SETPIPE_SZ, SEEK_CUR, SEEK_END, SEEK_SET, STATX__RESERVED,
+    F_GET_SEALS, F_SETFL, F_SETPIPE_SZ, SEEK_CUR, SEEK_DATA, SEEK_END, SEEK_HOLE, SEEK_SET,
+    STATX__RESERVED,
 };
 #[cfg(target_pointer_width = "32")]
 use {
@@ -214,6 +215,8 @@ pub(crate) fn seek(fd: BorrowedFd<'_>, pos: SeekFrom) -> io::Result<u64> {
         }
         SeekFrom::End(offset) => (SEEK_END, offset),
         SeekFrom::Current(offset) => (SEEK_CUR, offset),
+        SeekFrom::Data(offset) => (SEEK_DATA, offset),
+        SeekFrom::Hole(offset) => (SEEK_HOLE, offset),
     };
     _seek(fd, offset, whence)
 }

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -215,9 +215,19 @@ pub(crate) fn seek(fd: BorrowedFd<'_>, pos: SeekFrom) -> io::Result<u64> {
         }
         SeekFrom::End(offset) => (SEEK_END, offset),
         SeekFrom::Current(offset) => (SEEK_CUR, offset),
-        #[cfg(target_os = "linux")]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "solaris",
+            target_os = "freebsd",
+            target_os = "dragonfly",
+        ))]
         SeekFrom::Data(offset) => (SEEK_DATA, offset),
-        #[cfg(target_os = "linux")]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "solaris",
+            target_os = "freebsd",
+            target_os = "dragonfly",
+        ))]
         SeekFrom::Hole(offset) => (SEEK_HOLE, offset),
     };
     _seek(fd, offset, whence)

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -22,7 +22,7 @@ mod poll;
 mod procfs;
 #[cfg(not(windows))]
 mod read_write;
-#[cfg(not(feature = "std"))]
+#[cfg(not(windows))]
 mod seek_from;
 #[cfg(not(windows))]
 mod stdio;
@@ -89,10 +89,7 @@ pub use read_write::{pread, pwrite, read, readv, write, writev, IoSlice, IoSlice
 pub use read_write::{preadv, pwritev};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use read_write::{preadv2, pwritev2, ReadWriteFlags};
-#[cfg(not(feature = "std"))]
 pub use seek_from::SeekFrom;
-#[cfg(feature = "std")]
-pub use std::io::SeekFrom;
 #[cfg(not(windows))]
 pub use stdio::{
     raw_stderr, raw_stdin, raw_stdout, stderr, stdin, stdout, take_stderr, take_stdin, take_stdout,

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -22,7 +22,6 @@ mod poll;
 mod procfs;
 #[cfg(not(windows))]
 mod read_write;
-#[cfg(not(windows))]
 mod seek_from;
 #[cfg(not(windows))]
 mod stdio;

--- a/src/io/seek_from.rs
+++ b/src/io/seek_from.rs
@@ -32,8 +32,7 @@ pub enum SeekFrom {
     /// specified number of bytes that contains data.
     ///
     /// If the offset points to data, the file offset is set to it.
-    #[cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))]
-    Data(#[cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))] i64),
+    Data(i64),
 
     /// Sets the offset to the next hole in the file greater than or equal to the
     /// specified number of bytes.
@@ -43,6 +42,5 @@ pub enum SeekFrom {
     ///
     /// If there is no hole past offset, then the file offset is adjusted to the end
     /// of the file (i.e., there is an implicit hole at the end of any file).
-    #[cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))]
-    Hole(#[cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))] i64),
+    Hole(i64),
 }

--- a/src/io/seek_from.rs
+++ b/src/io/seek_from.rs
@@ -27,4 +27,22 @@ pub enum SeekFrom {
     /// to seek before byte 0.
     #[cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))]
     Current(#[cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))] i64),
+
+    /// Sets the offset to next location in the file greater than or equal to the
+    /// specified number of bytes that contains data.
+    ///
+    /// If the offset points to data, the file offset is set to it.
+    #[cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))]
+    Data(#[cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))] i64),
+
+    /// Sets the offset to the next hole in the file greater than or equal to the
+    /// specified number of bytes.
+    ///
+    /// If offset points into the middle of a hole, then the file offset is set to
+    /// offset.
+    ///
+    /// If there is no hole past offset, then the file offset is adjusted to the end
+    /// of the file (i.e., there is an implicit hole at the end of any file).
+    #[cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))]
+    Hole(#[cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))] i64),
 }

--- a/src/io/seek_from.rs
+++ b/src/io/seek_from.rs
@@ -32,7 +32,12 @@ pub enum SeekFrom {
     /// specified number of bytes that contains data.
     ///
     /// If the offset points to data, the file offset is set to it.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "solaris",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+    ))]
     Data(i64),
 
     /// Sets the offset to the next hole in the file greater than or equal to the
@@ -43,6 +48,11 @@ pub enum SeekFrom {
     ///
     /// If there is no hole past offset, then the file offset is adjusted to the end
     /// of the file (i.e., there is an implicit hole at the end of any file).
-    #[cfg(target_os = "linux")]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "solaris",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+    ))]
     Hole(i64),
 }

--- a/src/io/seek_from.rs
+++ b/src/io/seek_from.rs
@@ -32,6 +32,7 @@ pub enum SeekFrom {
     /// specified number of bytes that contains data.
     ///
     /// If the offset points to data, the file offset is set to it.
+    #[cfg(target_os = "linux")]
     Data(i64),
 
     /// Sets the offset to the next hole in the file greater than or equal to the
@@ -42,5 +43,6 @@ pub enum SeekFrom {
     ///
     /// If there is no hole past offset, then the file offset is adjusted to the end
     /// of the file (i.e., there is an implicit hole at the end of any file).
+    #[cfg(target_os = "linux")]
     Hole(i64),
 }

--- a/src/io/seek_from.rs
+++ b/src/io/seek_from.rs
@@ -28,10 +28,11 @@ pub enum SeekFrom {
     #[cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))]
     Current(#[cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))] i64),
 
-    /// Sets the offset to next location in the file greater than or equal to the
-    /// specified number of bytes that contains data.
-    ///
-    /// If the offset points to data, the file offset is set to it.
+    /// Sets the offset to the current position plus the specified number of bytes,
+    /// plus the distance to the next byte which is not in a hole.
+    /// 
+    /// If the offset is in a hole at the end of the file, the seek will produce
+    /// an `NXIO` error.
     #[cfg(any(
         target_os = "linux",
         target_os = "solaris",
@@ -40,14 +41,11 @@ pub enum SeekFrom {
     ))]
     Data(i64),
 
-    /// Sets the offset to the next hole in the file greater than or equal to the
-    /// specified number of bytes.
-    ///
-    /// If offset points into the middle of a hole, then the file offset is set to
-    /// offset.
-    ///
-    /// If there is no hole past offset, then the file offset is adjusted to the end
-    /// of the file (i.e., there is an implicit hole at the end of any file).
+    /// Sets the offset to the current position plus the specified number of bytes,
+    /// plus the distance to the next byte which is in a hole.
+    /// 
+    /// If there is no hole past the offset, it will be set to the end of the file
+    /// i.e. there is an implicit hole at the end of any file.
     #[cfg(any(
         target_os = "linux",
         target_os = "solaris",

--- a/src/io/seek_from.rs
+++ b/src/io/seek_from.rs
@@ -30,7 +30,7 @@ pub enum SeekFrom {
 
     /// Sets the offset to the current position plus the specified number of bytes,
     /// plus the distance to the next byte which is not in a hole.
-    /// 
+    ///
     /// If the offset is in a hole at the end of the file, the seek will produce
     /// an `NXIO` error.
     #[cfg(any(
@@ -43,7 +43,7 @@ pub enum SeekFrom {
 
     /// Sets the offset to the current position plus the specified number of bytes,
     /// plus the distance to the next byte which is in a hole.
-    /// 
+    ///
     /// If there is no hole past the offset, it will be set to the end of the file
     /// i.e. there is an implicit hole at the end of any file.
     #[cfg(any(

--- a/tests/io/read_write.rs
+++ b/tests/io/read_write.rs
@@ -96,8 +96,8 @@ fn test_readwrite_v() {
 #[test]
 fn test_readwrite() {
     use rustix::fs::{cwd, openat, seek, Mode, OFlags};
-    use rustix::io::{read, write};
     use rustix::io::SeekFrom;
+    use rustix::io::{read, write};
 
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();

--- a/tests/io/read_write.rs
+++ b/tests/io/read_write.rs
@@ -97,7 +97,7 @@ fn test_readwrite_v() {
 fn test_readwrite() {
     use rustix::fs::{cwd, openat, seek, Mode, OFlags};
     use rustix::io::{read, write};
-    use std::io::SeekFrom;
+    use rustix::io::SeekFrom;
 
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();


### PR DESCRIPTION
Fixes #480 

Adds two new variants to the `SeekFrom` API, `Data` and `Hole`.

Some questions:
- Are the docs fine? They're basically copied from [the man page](https://man7.org/linux/man-pages/man2/lseek.2.html).
- Should the `staged_api` attribute and other aspects be used? I'm not sure what their purpose is but I included it just in case.