### PR TITLE
Support `preadv2` and `pwritev2` on all non-glibc Linux ABIs.

### DIFF
--- a/src/backend/libc/io/types.rs
+++ b/src/backend/libc/io/types.rs
@@ -22,20 +22,15 @@ bitflags! {
     /// [`pwritev2`]: crate::io::pwritev
     pub struct ReadWriteFlags: c::c_int {
         /// `RWF_DSYNC` (since Linux 4.7)
-        #[cfg(all(target_os = "linux", target_env = "gnu"))]
-        const DSYNC = c::RWF_DSYNC;
+        const DSYNC = linux_raw_sys::general::RWF_DSYNC as c::c_int;
         /// `RWF_HIPRI` (since Linux 4.6)
-        #[cfg(all(target_os = "linux", target_env = "gnu"))]
-        const HIPRI = c::RWF_HIPRI;
+        const HIPRI = linux_raw_sys::general::RWF_HIPRI as c::c_int;
         /// `RWF_SYNC` (since Linux 4.7)
-        #[cfg(all(target_os = "linux", target_env = "gnu"))]
-        const SYNC = c::RWF_SYNC;
+        const SYNC = linux_raw_sys::general::RWF_SYNC as c::c_int;
         /// `RWF_NOWAIT` (since Linux 4.14)
-        #[cfg(all(target_os = "linux", target_env = "gnu"))]
-        const NOWAIT = c::RWF_NOWAIT;
+        const NOWAIT = linux_raw_sys::general::RWF_NOWAIT as c::c_int;
         /// `RWF_APPEND` (since Linux 4.16)
-        #[cfg(all(target_os = "linux", target_env = "gnu"))]
-        const APPEND = c::RWF_APPEND;
+        const APPEND = linux_raw_sys::general::RWF_APPEND as c::c_int;
     }
 }
 

--- a/src/io/read_write.rs
+++ b/src/io/read_write.rs
@@ -62,6 +62,10 @@ pub fn pread<Fd: AsFd>(fd: Fd, buf: &mut [u8], offset: u64) -> io::Result<usize>
 
 /// `pwrite(fd, bufs)`—Writes to a file at a given position.
 ///
+/// Contrary to POSIX, on many popular platforms including Linux and FreeBSD,
+/// if the file is opened in append mode, this ignores the offset appends the
+/// data to the end of the file.
+///
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
@@ -120,6 +124,10 @@ pub fn preadv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io:
 
 /// `pwritev(fd, bufs, offset)`—Writes to a file at a given position from
 /// multiple buffers.
+///
+/// Contrary to POSIX, on many popular platforms including Linux and FreeBSD,
+/// if the file is opened in append mode, this ignores the offset appends the
+/// data to the end of the file.
 ///
 /// # References
 ///  - [Linux]


### PR DESCRIPTION
Use `libc::syscall` on ABIs where libc doesn't have bindings for `preadv2` and `pwritev2`.