### PR TITLE
Fix copy_file_range to use ABI specified len types

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -779,8 +779,8 @@ pub(crate) fn copy_file_range(
     off_in: Option<&mut u64>,
     fd_out: BorrowedFd<'_>,
     off_out: Option<&mut u64>,
-    len: u64,
-) -> io::Result<u64> {
+    len: usize,
+) -> io::Result<usize> {
     assert_eq!(size_of::<c::loff_t>(), size_of::<u64>());
 
     let mut off_in_val: c::loff_t = 0;
@@ -798,7 +798,6 @@ pub(crate) fn copy_file_range(
     } else {
         null_mut()
     };
-    let len: usize = len.try_into().unwrap_or(usize::MAX);
     let copied = unsafe {
         syscall_ret_ssize_t(c::syscall(
             c::SYS_copy_file_range,
@@ -816,7 +815,7 @@ pub(crate) fn copy_file_range(
     if let Some(off_out) = off_out {
         *off_out = off_out_val as u64;
     }
-    Ok(copied as u64)
+    Ok(copied as usize)
 }
 
 #[cfg(not(any(

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -30,6 +30,7 @@ use crate::fs::{
 };
 use crate::io::{self, SeekFrom};
 use crate::process::{Gid, Uid};
+#[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
 use core::convert::TryInto;
 use core::mem::MaybeUninit;
 #[cfg(target_arch = "mips64")]
@@ -1346,20 +1347,7 @@ pub(crate) fn copy_file_range(
     off_in: Option<&mut u64>,
     fd_out: BorrowedFd<'_>,
     off_out: Option<&mut u64>,
-    len: u64,
-) -> io::Result<u64> {
-    let len: usize = len.try_into().unwrap_or(usize::MAX);
-    _copy_file_range(fd_in, off_in, fd_out, off_out, len, 0).map(|result| result as u64)
-}
-
-#[inline]
-fn _copy_file_range(
-    fd_in: BorrowedFd<'_>,
-    off_in: Option<&mut u64>,
-    fd_out: BorrowedFd<'_>,
-    off_out: Option<&mut u64>,
     len: usize,
-    flags: c::c_uint,
 ) -> io::Result<usize> {
     unsafe {
         ret_usize(syscall!(
@@ -1369,7 +1357,7 @@ fn _copy_file_range(
             fd_out,
             opt_mut(off_out),
             pass_usize(len),
-            c_uint(flags)
+            c_uint(0)
         ))
     }
 }

--- a/src/fs/copy_file_range.rs
+++ b/src/fs/copy_file_range.rs
@@ -14,7 +14,7 @@ pub fn copy_file_range<InFd: AsFd, OutFd: AsFd>(
     off_in: Option<&mut u64>,
     fd_out: OutFd,
     off_out: Option<&mut u64>,
-    len: u64,
-) -> io::Result<u64> {
+    len: usize,
+) -> io::Result<usize> {
     backend::fs::syscalls::copy_file_range(fd_in.as_fd(), off_in, fd_out.as_fd(), off_out, len)
 }


### PR DESCRIPTION
This is an 0.37 breaking change. The lengths are specified as `size_t`s which means everything will break if we ever get 128 bit machines. I think this is trying to emulate the stdlib copy APIs, but they have different requirements: their APIs always copy the full buffer and just return the number of bytes copied as a convenience. I'm pretty sure you can easily overflow the returned length by doing an `io::copy` between pipes for example. In rustix land, people need to do the looping themselves. On that note, I believe using a u64 also breaks 32 bit implementations:
```rust
        let mut total_copied = 0;
        loop {
            let byte_copied = copy_file_range(&from, None, &to, None,
                // This will stay usize::MAX which will cause an EOVERFLOW
                u64::MAX - total_copied)?;
            if byte_copied == 0 {
                return Ok(());
            }
            total_copied += byte_copied;
        }
```

Using usize also makes this API consistent with splice.