### PR TITLE
Rename capabilities functions to be consistent

### DIFF
--- a/src/thread/prctl.rs
+++ b/src/thread/prctl.rs
@@ -387,7 +387,7 @@ pub enum Capability {
 ///
 /// [`prctl(PR_CAPBSET_READ,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
-pub fn is_in_capability_bounding_set(capability: Capability) -> io::Result<bool> {
+pub fn capability_is_in_bounding_set(capability: Capability) -> io::Result<bool> {
     unsafe { prctl_2args(PR_CAPBSET_READ, capability as usize as *mut _) }.map(|r| r != 0)
 }
 
@@ -401,7 +401,7 @@ const PR_CAPBSET_DROP: c_int = 24;
 ///
 /// [`prctl(PR_CAPBSET_DROP,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
-pub fn remove_capability_from_capability_bounding_set(capability: Capability) -> io::Result<()> {
+pub fn remove_capability_from_bounding_set(capability: Capability) -> io::Result<()> {
     unsafe { prctl_2args(PR_CAPBSET_DROP, capability as usize as *mut _) }.map(|_r| ())
 }
 
@@ -588,7 +588,7 @@ const PR_CAP_AMBIENT_IS_SET: usize = 1;
 ///
 /// [`prctl(PR_CAP_AMBIENT,PR_CAP_AMBIENT_IS_SET,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
-pub fn capability_is_in_ambient_capability_set(capability: Capability) -> io::Result<bool> {
+pub fn capability_is_in_ambient_set(capability: Capability) -> io::Result<bool> {
     let cap = capability as usize as *mut _;
     unsafe { prctl_3args(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET as *mut _, cap) }.map(|r| r != 0)
 }
@@ -616,10 +616,7 @@ const PR_CAP_AMBIENT_LOWER: usize = 3;
 ///
 /// [`prctl(PR_CAP_AMBIENT,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
-pub fn configure_capability_in_ambient_capability_set(
-    capability: Capability,
-    enable: bool,
-) -> io::Result<()> {
+pub fn configure_capability_in_ambient_set(capability: Capability, enable: bool) -> io::Result<()> {
     let sub_operation = if enable {
         PR_CAP_AMBIENT_RAISE
     } else {

--- a/tests/thread/prctl.rs
+++ b/tests/thread/prctl.rs
@@ -14,8 +14,8 @@ fn test_name() {
 }
 
 #[test]
-fn test_is_in_capability_bounding_set() {
-    dbg!(is_in_capability_bounding_set(Capability::ChangeOwnership).unwrap());
+fn test_capability_is_in_bounding_set() {
+    dbg!(capability_is_in_bounding_set(Capability::ChangeOwnership).unwrap());
 }
 
 #[test]
@@ -34,8 +34,8 @@ fn test_no_new_privs() {
 }
 
 #[test]
-fn test_capability_is_in_ambient_capability_set() {
-    dbg!(capability_is_in_ambient_capability_set(Capability::ChangeOwnership).unwrap());
+fn test_capability_is_in_ambient_set() {
+    dbg!(capability_is_in_ambient_set(Capability::ChangeOwnership).unwrap());
 }
 
 #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
Partial https://github.com/bytecodealliance/rustix/issues/493

I didn't rename `capabilities_secure_bits` yet because that's the one we don't seem to have agreement on.

Also did we say we actually wanted to go through a round of deprecation or just pull the plug? I just renamed things, though I can easily add back the old names as deprecated functions.