### PR TITLE
Improve perf of all buffer consuming APIs

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -220,7 +220,11 @@ pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
 
 #[cfg(not(target_os = "redox"))]
 #[inline]
-pub(crate) fn readlinkat(dirfd: BorrowedFd<'_>, path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
+pub(crate) fn readlinkat(
+    dirfd: BorrowedFd<'_>,
+    path: &CStr,
+    buf: &mut [MaybeUninit<u8>],
+) -> io::Result<usize> {
     unsafe {
         ret_usize(c::readlinkat(
             borrowed_fd(dirfd),

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -54,7 +54,7 @@ pub(crate) fn chroot(path: &CStr) -> io::Result<()> {
 
 #[cfg(feature = "fs")]
 #[cfg(not(target_os = "wasi"))]
-pub(crate) fn getcwd(buf: &mut [u8]) -> io::Result<()> {
+pub(crate) fn getcwd(buf: &mut [MaybeUninit<u8>]) -> io::Result<()> {
     unsafe { ret_discarded_char_ptr(c::getcwd(buf.as_mut_ptr().cast(), buf.len())) }
 }
 

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -210,7 +210,7 @@ pub(crate) fn isatty(fd: BorrowedFd<'_>) -> bool {
 
 #[cfg(feature = "procfs")]
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
-pub(crate) fn ttyname(dirfd: BorrowedFd<'_>, buf: &mut [u8]) -> io::Result<usize> {
+pub(crate) fn ttyname(dirfd: BorrowedFd<'_>, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
     unsafe {
         // `ttyname_r` returns its error status rather than using `errno`.
         match c::ttyname_r(borrowed_fd(dirfd), buf.as_mut_ptr().cast(), buf.len()) {

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -861,7 +861,11 @@ pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
 }
 
 #[inline]
-pub(crate) fn readlinkat(dirfd: BorrowedFd<'_>, path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
+pub(crate) fn readlinkat(
+    dirfd: BorrowedFd<'_>,
+    path: &CStr,
+    buf: &mut [MaybeUninit<u8>],
+) -> io::Result<usize> {
     let (buf_addr_mut, buf_len) = slice_mut(buf);
     unsafe {
         ret_usize(syscall!(

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -56,7 +56,7 @@ pub(crate) fn chroot(filename: &CStr) -> io::Result<()> {
 
 #[cfg(feature = "fs")]
 #[inline]
-pub(crate) fn getcwd(buf: &mut [u8]) -> io::Result<usize> {
+pub(crate) fn getcwd(buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
     let (buf_addr_mut, buf_len) = slice_mut(buf);
     unsafe { ret_usize(syscall!(__NR_getcwd, buf_addr_mut, buf_len)) }
 }

--- a/src/process/chdir.rs
+++ b/src/process/chdir.rs
@@ -4,7 +4,7 @@ use crate::backend::fd::AsFd;
 use crate::{backend, io};
 #[cfg(feature = "fs")]
 use {
-    crate::ffi::CString,
+    crate::ffi::{CStr, CString},
     crate::path::{self, SMALL_PATH_BUFFER_SIZE},
     alloc::vec::Vec,
 };
@@ -40,7 +40,7 @@ pub fn fchdir<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 
 /// `getCWD`—Return the current working directory.
 ///
-/// If `reuse` is non-empty, reuse its buffer to store the result if possible.
+/// If `reuse` already has available capacity, reuse it if possible.
 ///
 /// # References
 ///  - [POSIX]
@@ -57,23 +57,32 @@ pub fn getcwd<B: Into<Vec<u8>>>(reuse: B) -> io::Result<CString> {
 }
 
 #[cfg(feature = "fs")]
+#[allow(unsafe_code)]
 fn _getcwd(mut buffer: Vec<u8>) -> io::Result<CString> {
-    // This code would benefit from having a better way to read into
-    // uninitialized memory, but that requires `unsafe`.
     buffer.clear();
     buffer.reserve(SMALL_PATH_BUFFER_SIZE);
-    buffer.resize(buffer.capacity(), 0_u8);
 
     loop {
-        match backend::process::syscalls::getcwd(&mut buffer) {
+        match backend::process::syscalls::getcwd(buffer.spare_capacity_mut()) {
             Err(io::Errno::RANGE) => {
-                buffer.reserve(1); // use `Vec` reallocation strategy to grow capacity exponentially
-                buffer.resize(buffer.capacity(), 0_u8);
+                buffer.reserve(buffer.capacity() + 1); // use `Vec` reallocation strategy to grow capacity exponentially
             }
             Ok(_) => {
-                let len = buffer.iter().position(|x| *x == b'\0').unwrap();
-                buffer.resize(len, 0_u8);
-                return Ok(CString::new(buffer).unwrap());
+                // SAFETY:
+                // - "These functions return a null-terminated string"
+                // - POSIX definition 3.375: String (https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_375)
+                //   "A contiguous sequence of bytes terminated by and including the first null byte."
+                //
+                // Thus, there will be a single NUL byte at the end of the string.
+                unsafe {
+                    buffer.set_len(
+                        CStr::from_ptr(buffer.as_ptr().cast())
+                            .to_bytes_with_nul()
+                            .len(),
+                    );
+
+                    return Ok(CString::from_vec_with_nul_unchecked(buffer));
+                }
             }
             Err(errno) => return Err(errno),
         }


### PR DESCRIPTION
Rustix being a low-level library, it should not have worse perf than the stdlib: https://github.com/rust-lang/rust/blob/0fb8b72ce49997d60a631e921d2cf5be9ca229e6/library/std/src/sys/unix/fs.rs#L1396-L1423