### PR TITLE
Sync with io-lifetimes' build.rs changes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -180,26 +180,46 @@ fn has_feature(feature: &str) -> bool {
 }
 
 /// Test whether the rustc at `var("RUSTC")` can compile the given code.
-fn can_compile(code: &str) -> bool {
+fn can_compile<T: AsRef<str>>(test: T) -> bool {
     use std::process::Stdio;
+
     let out_dir = var("OUT_DIR").unwrap();
     let rustc = var("RUSTC").unwrap();
     let target = var("TARGET").unwrap();
 
-    let mut child = std::process::Command::new(rustc)
-        .arg("--crate-type=rlib") // Don't require `main`.
+    let mut cmd = if let Ok(wrapper) = var("CARGO_RUSTC_WRAPPER") {
+        let mut cmd = std::process::Command::new(wrapper);
+        // The wrapper's first argument is supposed to be the path to rustc.
+        cmd.arg(rustc);
+        cmd
+    } else {
+        std::process::Command::new(rustc)
+    };
+
+    cmd.arg("--crate-type=rlib") // Don't require `main`.
         .arg("--emit=metadata") // Do as little as possible but still parse.
         .arg("--target")
         .arg(target)
         .arg("--out-dir")
-        .arg(out_dir) // Put the output somewhere inconsequential.
+        .arg(out_dir); // Put the output somewhere inconsequential.
+
+    // If Cargo wants to set RUSTFLAGS, use that.
+    if let Ok(rustflags) = var("CARGO_ENCODED_RUSTFLAGS") {
+        if !rustflags.is_empty() {
+            for arg in rustflags.split('\x1f') {
+                cmd.arg(arg);
+            }
+        }
+    }
+
+    let mut child = cmd
         .arg("-") // Read from stdin.
         .stdin(Stdio::piped()) // Stdin is a pipe.
-        .stderr(Stdio::null())
+        .stderr(Stdio::null()) // Errors from feature detection aren't interesting and can be confusing.
         .spawn()
         .unwrap();
 
-    writeln!(child.stdin.take().unwrap(), "{}", code).unwrap();
+    writeln!(child.stdin.take().unwrap(), "{}", test.as_ref()).unwrap();
 
     child.wait().unwrap().success()
 }


### PR DESCRIPTION
As a counterpart to https://github.com/sunfishcode/io-lifetimes/pull/58, port the changes from io-lifetimes' build.rs to rustix.