### PR TITLE
Add unmount syscall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ once_cell = { version = "1.5.2", optional = true }
 # libc backend can be selected via adding `--cfg=rustix_use_libc` to
 # `RUSTFLAGS` or enabling the `use-libc` cargo feature.
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
-linux-raw-sys = { version = "0.2.0", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
+linux-raw-sys = { version = "0.2.1", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 libc_errno = { package = "errno", version = "0.2.8", default-features = false, optional = true }
 libc = { version = "0.2.133", features = ["extra_traits"], optional = true }
 
@@ -56,7 +56,7 @@ libc = { version = "0.2.133", features = ["extra_traits"] }
 # Some syscalls do not have libc wrappers, such as in `io_uring`. For these,
 # the libc backend uses the linux-raw-sys ABI and `libc::syscall`.
 [target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64"))))))))'.dependencies]
-linux-raw-sys = { version = "0.2.0", default-features = false, features = ["general", "no_std"] }
+linux-raw-sys = { version = "0.2.1", default-features = false, features = ["general", "no_std"] }
 
 # For the libc backend on Windows, use the Winsock2 API in windows-sys.
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -1818,3 +1818,8 @@ pub(crate) fn mount(
         ))
     }
 }
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub(crate) fn unmount(target: &CStr, flags: super::types::UnmountFlags) -> io::Result<()> {
+    unsafe { ret(c::umount2(target.as_ptr(), flags.bits())) }
+}

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -1194,3 +1194,18 @@ bitflags! {
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub(crate) struct MountFlagsArg(pub(crate) c::c_ulong);
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+bitflags! {
+    /// `MNT_*` constants for use with [`unmount`][crate::fs::mount::unmount].
+    pub struct UnmountFlags: c::c_int {
+        /// `MNT_FORCE`
+        const FORCE = c::MNT_FORCE;
+        /// `MNT_DETACH`
+        const DETACH = c::MNT_DETACH;
+        /// `MNT_EXPIRE`
+        const EXPIRE = c::MNT_EXPIRE;
+        /// `UMOUNT_NOFOLLOW`
+        const NOFOLLOW = c::UMOUNT_NOFOLLOW;
+    }
+}

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -674,6 +674,15 @@ impl<'a, Num: ArgNumber> From<crate::backend::fs::types::MountFlagsArg> for ArgR
     }
 }
 
+#[cfg(feature = "fs")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
+impl<'a, Num: ArgNumber> From<crate::backend::fs::types::UnmountFlags> for ArgReg<'a, Num> {
+    #[inline]
+    fn from(flags: crate::backend::fs::types::UnmountFlags) -> Self {
+        c_uint(flags.bits())
+    }
+}
+
 /// Convert a `usize` returned from a syscall that effectively returns `()` on
 /// success.
 ///

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -1416,3 +1416,9 @@ pub(crate) fn mount(
         ))
     }
 }
+
+#[inline]
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub(crate) fn unmount(target: &CStr, flags: super::types::UnmountFlags) -> io::Result<()> {
+    unsafe { ret(syscall_readonly!(__NR_umount2, target, flags)) }
+}

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -727,3 +727,18 @@ bitflags! {
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub(crate) struct MountFlagsArg(pub(crate) c::c_uint);
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+bitflags! {
+    /// `MNT_*` constants for use with [`unmount`][crate::fs::mount::unmount].
+    pub struct UnmountFlags: c::c_uint {
+        /// `MNT_FORCE`
+        const FORCE = linux_raw_sys::general::MNT_FORCE;
+        /// `MNT_DETACH`
+        const DETACH = linux_raw_sys::general::MNT_DETACH;
+        /// `MNT_EXPIRE`
+        const EXPIRE = linux_raw_sys::general::MNT_EXPIRE;
+        /// `UMOUNT_NOFOLLOW`
+        const NOFOLLOW = linux_raw_sys::general::UMOUNT_NOFOLLOW;
+    }
+}

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -12,7 +12,9 @@ pub use backend::fs::types::AtFlags;
 pub use backend::fs::types::{CloneFlags, CopyfileFlags};
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-pub use backend::fs::types::{MountFlags, MountPropagationFlags, RenameFlags, ResolveFlags};
+pub use backend::fs::types::{
+    MountFlags, MountPropagationFlags, RenameFlags, ResolveFlags, UnmountFlags,
+};
 
 #[cfg(not(target_os = "redox"))]
 pub use backend::fs::types::Dev;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -104,7 +104,7 @@ pub use constants::{Access, FdFlags, Mode, Nsecs, OFlags, Secs, Timespec};
 #[cfg(not(target_os = "redox"))]
 pub use constants::{AtFlags, Dev};
 #[cfg(any(target_os = "android", target_os = "linux"))]
-pub use constants::{MountFlags, MountPropagationFlags, RenameFlags, ResolveFlags};
+pub use constants::{MountFlags, MountPropagationFlags, RenameFlags, ResolveFlags, UnmountFlags};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use copy_file_range::copy_file_range;
 #[cfg(not(target_os = "redox"))]
@@ -202,7 +202,9 @@ pub use makedev::{major, makedev, minor};
 #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 pub use memfd_create::{memfd_create, MemfdFlags};
 #[cfg(any(target_os = "android", target_os = "linux"))]
-pub use mount::{bind_mount, change_mount, mount, move_mount, recursive_bind_mount, remount};
+pub use mount::{
+    bind_mount, change_mount, mount, move_mount, recursive_bind_mount, remount, unmount,
+};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use openat2::openat2;
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/fs/mount.rs
+++ b/src/fs/mount.rs
@@ -1,7 +1,7 @@
 //! Linux `mount`.
 
 use crate::backend::fs::types::{
-    InternalMountFlags, MountFlags, MountFlagsArg, MountPropagationFlags,
+    InternalMountFlags, MountFlags, MountFlagsArg, MountPropagationFlags, UnmountFlags,
 };
 use crate::{backend, io, path};
 
@@ -43,6 +43,7 @@ pub fn mount<Source: path::Arg, Target: path::Arg, Fs: path::Arg, Data: path::Ar
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/mount.2.html
 #[inline]
+#[doc(alias = "mount")]
 pub fn remount<Target: path::Arg, Data: path::Arg>(
     target: Target,
     flags: MountFlags,
@@ -68,6 +69,7 @@ pub fn remount<Target: path::Arg, Data: path::Arg>(
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/mount.2.html
 #[inline]
+#[doc(alias = "mount")]
 pub fn bind_mount<Source: path::Arg, Target: path::Arg>(
     source: Source,
     target: Target,
@@ -92,6 +94,7 @@ pub fn bind_mount<Source: path::Arg, Target: path::Arg>(
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/mount.2.html
 #[inline]
+#[doc(alias = "mount")]
 pub fn recursive_bind_mount<Source: path::Arg, Target: path::Arg>(
     source: Source,
     target: Target,
@@ -116,6 +119,7 @@ pub fn recursive_bind_mount<Source: path::Arg, Target: path::Arg>(
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/mount.2.html
 #[inline]
+#[doc(alias = "mount")]
 pub fn change_mount<Target: path::Arg>(
     target: Target,
     flags: MountPropagationFlags,
@@ -132,6 +136,7 @@ pub fn change_mount<Target: path::Arg>(
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/mount.2.html
 #[inline]
+#[doc(alias = "mount")]
 pub fn move_mount<Source: path::Arg, Target: path::Arg>(
     source: Source,
     target: Target,
@@ -147,4 +152,15 @@ pub fn move_mount<Source: path::Arg, Target: path::Arg>(
             )
         })
     })
+}
+
+/// `umount2(target, flags)`
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/umount.2.html
+#[doc(alias = "umount", alias = "umount2")]
+pub fn unmount<Target: path::Arg>(target: Target, flags: UnmountFlags) -> io::Result<()> {
+    target.into_with_c_str(|target| backend::fs::syscalls::unmount(target, flags))
 }


### PR DESCRIPTION
Broken due to https://github.com/sunfishcode/linux-raw-sys/issues/40.

Design decisions: instead of providing both `umount` and `umount2`, I stuck with just `umount2` and called it `unmount`. Is that fine or should it be called `unmount2`?