### PR TITLE
Remove FreeBSD 12 from CI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,17 +14,3 @@ task:
   test_script:
     - . $HOME/.cargo/env
     - cargo test --workspace --features=all-apis
-
-task:
-  name: stable x86_64-unknown-freebsd-12
-  freebsd_instance:
-    image_family: freebsd-12-1
-  setup_script:
-    - pkg install -y curl
-    - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh --default-toolchain stable -y --profile=minimal
-    - . $HOME/.cargo/env
-    - rustup default stable
-  test_script:
-    - . $HOME/.cargo/env
-    - cargo test --workspace --features=all-apis


### PR DESCRIPTION
FreeBSD 12 has been failing in CI like this:

```
...
[5/5] Extracting curl-7.87.0: .......... done
curl https://sh.rustup.rs -sSf --output rustup.sh
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.

Exit status: 60
```

The FreeBSD 13 run still works, so switch to just testing on FreeBSD 13.