### PR TITLE
Fix compilation on armv7-unknown-freebsd

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,6 +203,7 @@ jobs:
     - run: cargo check -Z build-std --target mips64-openwrt-linux-musl --all-targets --features=all-apis
     - run: cargo check -Z build-std --target x86_64-unknown-dragonfly --all-targets --features=all-apis
     - run: cargo check -Z build-std --target sparc-unknown-linux-gnu --all-targets --features=all-apis
+    - run: cargo check -Z build-std --target armv7-unknown-freebsd --all-targets --features=all-apis
     # Omit --all-targets on haiku because not all the tests build yet.
     - run: cargo check -Z build-std --target x86_64-unknown-haiku --features=all-apis
     # x86_64-uwp-windows-msvc isn't currently working.

--- a/src/backend/libc/net/syscalls.rs
+++ b/src/backend/libc/net/syscalls.rs
@@ -555,11 +555,7 @@ pub(crate) mod sockopt {
                     return Err(io::Errno::INVAL);
                 }
 
-                let tv_sec = timeout.as_secs().try_into();
-                #[cfg(not(all(target_arch = "x86_64", target_pointer_width = "32")))]
-                let tv_sec = tv_sec.unwrap_or(c::c_long::MAX);
-                #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
-                let tv_sec = tv_sec.unwrap_or(i64::MAX);
+                let tv_sec = timeout.as_secs().try_into().unwrap_or(c::time_t::MAX);
 
                 // `subsec_micros` rounds down, so we use `subsec_nanos` and
                 // manually round up.

--- a/src/backend/libc/net/syscalls.rs
+++ b/src/backend/libc/net/syscalls.rs
@@ -555,6 +555,11 @@ pub(crate) mod sockopt {
                     return Err(io::Errno::INVAL);
                 }
 
+                // Rust's musl libc bindings deprecated `time_t` while they
+                // transition to 64-bit `time_t`. What we want here is just
+                // "whatever type `timeval`'s `tv_sec` is", so we're ok using
+                // the deprecated type.
+                #[allow(deprecated)]
                 let tv_sec = timeout.as_secs().try_into().unwrap_or(c::time_t::MAX);
 
                 // `subsec_micros` rounds down, so we use `subsec_nanos` and


### PR DESCRIPTION
Use `time_t::MAX` to avoid depending on the relationship between `time_t` and `c_long`.