### PR TITLE
Add NO_AUTOMOUNT AtFlags,  STATX_DIOALIGN mask and reorder bitflag to follow numbering

### DIFF
--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -648,6 +648,9 @@ bitflags! {
         /// `STATX_MNT_ID` (since Linux 5.8)
         const MNT_ID = c::STATX_MNT_ID;
 
+        /// `STATX_DIOALIGN` (since Linux 6.1)
+        const DIOALIGN = c::STATX_DIOALIGN;
+
         /// `STATX_ALL`
         const ALL = c::STATX_ALL;
     }

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -44,7 +44,7 @@ bitflags! {
         const SYMLINK_FOLLOW = c::AT_SYMLINK_FOLLOW;
 
         /// `AT_NO_AUTOMOUNT`
-        #[cfg(all(target_os = "linux", target_env = "gnu"))]
+        #[cfg(any(linux_like, target_os = "fuchsia"))]
         const NO_AUTOMOUNT = c::AT_NO_AUTOMOUNT;
 
         /// `AT_EMPTY_PATH`

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -30,14 +30,22 @@ bitflags! {
     /// [`statat`]: crate::fs::statat
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct AtFlags: c::c_int {
+        /// `AT_SYMLINK_NOFOLLOW`
+        const SYMLINK_NOFOLLOW = c::AT_SYMLINK_NOFOLLOW;
+
+        /// `AT_EACCESS`
+        #[cfg(not(any(target_os = "emscripten", target_os = "android")))]
+        const EACCESS = c::AT_EACCESS;
+
         /// `AT_REMOVEDIR`
         const REMOVEDIR = c::AT_REMOVEDIR;
 
         /// `AT_SYMLINK_FOLLOW`
         const SYMLINK_FOLLOW = c::AT_SYMLINK_FOLLOW;
 
-        /// `AT_SYMLINK_NOFOLLOW`
-        const SYMLINK_NOFOLLOW = c::AT_SYMLINK_NOFOLLOW;
+        /// `AT_NO_AUTOMOUNT`
+        #[cfg(all(target_os = "linux", target_env = "gnu"))]
+        const NO_AUTOMOUNT = c::AT_NO_AUTOMOUNT;
 
         /// `AT_EMPTY_PATH`
         #[cfg(any(
@@ -50,10 +58,6 @@ bitflags! {
         /// `AT_RESOLVE_BENEATH`
         #[cfg(target_os = "freebsd")]
         const RESOLVE_BENEATH = c::AT_RESOLVE_BENEATH;
-
-        /// `AT_EACCESS`
-        #[cfg(not(any(target_os = "emscripten", target_os = "android")))]
-        const EACCESS = c::AT_EACCESS;
 
         /// `AT_STATX_SYNC_AS_STAT`
         #[cfg(all(target_os = "linux", target_env = "gnu"))]

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -29,20 +29,23 @@ bitflags! {
     /// [`statat`]: crate::fs::statat
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct AtFlags: c::c_uint {
+        /// `AT_SYMLINK_NOFOLLOW`
+        const SYMLINK_NOFOLLOW = linux_raw_sys::general::AT_SYMLINK_NOFOLLOW;
+
+        /// `AT_EACCESS`
+        const EACCESS = linux_raw_sys::general::AT_EACCESS;
+
         /// `AT_REMOVEDIR`
         const REMOVEDIR = linux_raw_sys::general::AT_REMOVEDIR;
 
         /// `AT_SYMLINK_FOLLOW`
         const SYMLINK_FOLLOW = linux_raw_sys::general::AT_SYMLINK_FOLLOW;
 
-        /// `AT_SYMLINK_NOFOLLOW`
-        const SYMLINK_NOFOLLOW = linux_raw_sys::general::AT_SYMLINK_NOFOLLOW;
+        /// `AT_NO_AUTOMOUNT`
+        const NO_AUTOMOUNT = linux_raw_sys::general::AT_NO_AUTOMOUNT;
 
         /// `AT_EMPTY_PATH`
         const EMPTY_PATH = linux_raw_sys::general::AT_EMPTY_PATH;
-
-        /// `AT_EACCESS`
-        const EACCESS = linux_raw_sys::general::AT_EACCESS;
 
         /// `AT_STATX_SYNC_AS_STAT`
         const STATX_SYNC_AS_STAT = linux_raw_sys::general::AT_STATX_SYNC_AS_STAT;

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -497,6 +497,9 @@ bitflags! {
         /// `STATX_MNT_ID` (since Linux 5.8)
         const MNT_ID = linux_raw_sys::general::STATX_MNT_ID;
 
+        /// `STATX_DIOALIGN` (since Linux 6.1)
+        const DIOALIGN = linux_raw_sys::general::STATX_DIOALIGN;
+
         /// `STATX_ALL`
         const ALL = linux_raw_sys::general::STATX_ALL;
     }


### PR DESCRIPTION
The statx syscall accept the [AT_NO_AUTOMOUNT flag ](https://man.archlinux.org/man/statx.2#AT_NO_AUTOMOUNT), however this one was not listed inside the AtFlags bitflag. 
This PR add such flag from the underlying raw types, it also re-orders the bitflag to be in correlation with the underlying values.

The statx syscall accept the [STATX_DIOALIGN](https://elixir.bootlin.com/linux/v6.1/A/ident/STATX_DIOALIGN) mask since Linux 6.1 however this one was not listed inside the StatxFlags bitflag.
This PR add such flag from the underlying raw types.

Note, `can_compile` signature in build.rs was changed on the 13th of January and you can remove the reference to format (thx clippy)