### PR TITLE
Add ioctl_getflags and ioctl_setflags

### DIFF
--- a/src/backend/libc/io/types.rs
+++ b/src/backend/libc/io/types.rs
@@ -157,3 +157,36 @@ impl<'a> IoSliceRaw<'a> {
         }
     }
 }
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+bitflags! {
+    /// `FS_*` constants for use with [`ioctl_getflags`][crate::io::ioctl::ioctl_getflags].
+    pub struct IFlags: c::c_uint {
+        /// `FS_APPEND_FL`
+        const APPEND = c::FS_APPEND_FL;
+        /// `FS_COMPR_FL`
+        const COMPRESSED = c::FS_COMPR_FL;
+        /// `FS_DIRSYNC_FL`
+        const DIRSYNC = c::FS_DIRSYNC_FL;
+        /// `FS_IMMUTABLE_FL`
+        const IMMUTABLE = c::FS_IMMUTABLE_FL;
+        /// `FS_JOURNAL_DATA_FL`
+        const JOURNALING = c::FS_JOURNAL_DATA_FL;
+        /// `FS_NOATIME_FL`
+        const NOATIME = c::FS_NOATIME_FL;
+        /// `FS_NODUMP_FL`
+        const NODUMP = c::FS_NODUMP_FL;
+        /// `FS_NOTAIL_FL`
+        const NOTAIL = c::FS_NOTAIL_FL;
+        /// `FS_PROJINHERIT_FL`
+        const PROJECT_INHERIT = c::FS_PROJINHERIT_FL;
+        /// `FS_SECRM_FL`
+        const SECURE_REMOVAL = c::FS_SECRM_FL;
+        /// `FS_SYNC_FL`
+        const SYNC = c::FS_SYNC_FL;
+        /// `FS_TOPDIR_FL`
+        const TOPDIR = c::FS_TOPDIR_FL;
+        /// `FS_UNRM_FL`
+        const UNRM = c::FS_UNRM_FL;
+    }
+}

--- a/src/backend/libc/io/types.rs
+++ b/src/backend/libc/io/types.rs
@@ -174,6 +174,8 @@ bitflags! {
         const JOURNALING = c::FS_JOURNAL_DATA_FL;
         /// `FS_NOATIME_FL`
         const NOATIME = c::FS_NOATIME_FL;
+        /// `FS_NOCOW_FL`
+        const NOCOW = c::FS_NOCOW_FL;
         /// `FS_NODUMP_FL`
         const NODUMP = c::FS_NODUMP_FL;
         /// `FS_NOTAIL_FL`

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -683,6 +683,14 @@ impl<'a, Num: ArgNumber> From<crate::backend::fs::types::UnmountFlags> for ArgRe
     }
 }
 
+#[cfg(any(target_os = "android", target_os = "linux"))]
+impl<'a, Num: ArgNumber> From<crate::backend::io::types::IFlags> for ArgReg<'a, Num> {
+    #[inline]
+    fn from(flags: crate::backend::io::types::IFlags) -> Self {
+        c_uint(flags.bits())
+    }
+}
+
 /// Convert a `usize` returned from a syscall that effectively returns `()` on
 /// success.
 ///

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -683,14 +683,6 @@ impl<'a, Num: ArgNumber> From<crate::backend::fs::types::UnmountFlags> for ArgRe
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
-impl<'a, Num: ArgNumber> From<crate::backend::io::types::IFlags> for ArgReg<'a, Num> {
-    #[inline]
-    fn from(flags: crate::backend::io::types::IFlags) -> Self {
-        c_uint(flags.bits())
-    }
-}
-
 /// Convert a `usize` returned from a syscall that effectively returns `()` on
 /// success.
 ///

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -385,13 +385,15 @@ pub(crate) fn ioctl_get_flags(fd: BorrowedFd) -> io::Result<IFlags> {
 
 #[inline]
 pub(crate) fn ioctl_set_flags(fd: BorrowedFd, flags: IFlags) -> io::Result<()> {
+    // ioctl expect a *const c_uint, we thus need to convert it and pass it by reference
+    let attr = flags.bits();
     #[cfg(target_pointer_width = "32")]
     unsafe {
         ret(syscall_readonly!(
             __NR_ioctl,
             fd,
             c_uint(FS_IOC32_SETFLAGS),
-            flags
+            by_ref(&attr)
         ))
     }
     #[cfg(target_pointer_width = "64")]
@@ -400,7 +402,7 @@ pub(crate) fn ioctl_set_flags(fd: BorrowedFd, flags: IFlags) -> io::Result<()> {
             __NR_ioctl,
             fd,
             c_uint(FS_IOC_SETFLAGS),
-            flags
+            by_ref(&attr)
         ))
     }
 }

--- a/src/backend/linux_raw/io/types.rs
+++ b/src/backend/linux_raw/io/types.rs
@@ -126,3 +126,35 @@ impl<'a> IoSliceRaw<'a> {
         }
     }
 }
+
+bitflags! {
+    /// `FS_*` constants for use with [`ioctl_getflags`][crate::io::ioctl::ioctl_getflags].
+    pub struct IFlags: c::c_uint {
+        /// `FS_APPEND_FL`
+        const APPEND = linux_raw_sys::general::FS_APPEND_FL;
+        /// `FS_COMPR_FL`
+        const COMPRESSED = linux_raw_sys::general::FS_COMPR_FL;
+        /// `FS_DIRSYNC_FL`
+        const DIRSYNC = linux_raw_sys::general::FS_DIRSYNC_FL;
+        /// `FS_IMMUTABLE_FL`
+        const IMMUTABLE = linux_raw_sys::general::FS_IMMUTABLE_FL;
+        /// `FS_JOURNAL_DATA_FL`
+        const JOURNALING = linux_raw_sys::general::FS_JOURNAL_DATA_FL;
+        /// `FS_NOATIME_FL`
+        const NOATIME = linux_raw_sys::general::FS_NOATIME_FL;
+        /// `FS_NODUMP_FL`
+        const NODUMP = linux_raw_sys::general::FS_NODUMP_FL;
+        /// `FS_NOTAIL_FL`
+        const NOTAIL = linux_raw_sys::general::FS_NOTAIL_FL;
+        /// `FS_PROJINHERIT_FL`
+        const PROJECT_INHERIT = linux_raw_sys::general::FS_PROJINHERIT_FL;
+        /// `FS_SECRM_FL`
+        const SECURE_REMOVAL = linux_raw_sys::general::FS_SECRM_FL;
+        /// `FS_SYNC_FL`
+        const SYNC = linux_raw_sys::general::FS_SYNC_FL;
+        /// `FS_TOPDIR_FL`
+        const TOPDIR = linux_raw_sys::general::FS_TOPDIR_FL;
+        /// `FS_UNRM_FL`
+        const UNRM = linux_raw_sys::general::FS_UNRM_FL;
+    }
+}

--- a/src/backend/linux_raw/io/types.rs
+++ b/src/backend/linux_raw/io/types.rs
@@ -142,6 +142,8 @@ bitflags! {
         const JOURNALING = linux_raw_sys::general::FS_JOURNAL_DATA_FL;
         /// `FS_NOATIME_FL`
         const NOATIME = linux_raw_sys::general::FS_NOATIME_FL;
+        /// `FS_NOCOW_FL`
+        const NOCOW = linux_raw_sys::general::FS_NOCOW_FL;
         /// `FS_NODUMP_FL`
         const NODUMP = linux_raw_sys::general::FS_NODUMP_FL;
         /// `FS_NOTAIL_FL`

--- a/src/io/ioctl.rs
+++ b/src/io/ioctl.rs
@@ -5,6 +5,8 @@
 
 use crate::{backend, io};
 use backend::fd::AsFd;
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub use backend::io::types::IFlags;
 
 /// `ioctl(fd, TIOCEXCL)`—Enables exclusive mode on a terminal.
 ///
@@ -104,7 +106,7 @@ pub fn ioctl_blkpbszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 #[doc(alias = "FS_IOC_GETFLAGS")]
-pub fn ioctl_getflags<Fd: AsFd>(fd: Fd) -> io::Result<backend::io::types::IFlags> {
+pub fn ioctl_getflags<Fd: AsFd>(fd: Fd) -> io::Result<IFlags> {
     backend::io::syscalls::ioctl_get_flags(fd.as_fd())
 }
 
@@ -114,6 +116,6 @@ pub fn ioctl_getflags<Fd: AsFd>(fd: Fd) -> io::Result<backend::io::types::IFlags
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 #[doc(alias = "FS_IOC_GETFLAGS")]
-pub fn ioctl_setflags<Fd: AsFd>(fd: Fd, flags: backend::io::types::IFlags) -> io::Result<()> {
+pub fn ioctl_setflags<Fd: AsFd>(fd: Fd, flags: IFlags) -> io::Result<()> {
     backend::io::syscalls::ioctl_set_flags(fd.as_fd(), flags)
 }

--- a/src/io/ioctl.rs
+++ b/src/io/ioctl.rs
@@ -97,3 +97,23 @@ pub fn ioctl_blksszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
 pub fn ioctl_blkpbszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
     backend::io::syscalls::ioctl_blkpbszget(fd.as_fd())
 }
+
+/// `ioctl(fd, FS_IOC_GETFLAGS)`—Returns the [inode flags] attributes
+///
+/// [inode flags]: https://man7.org/linux/man-pages/man2/ioctl_iflags.2.html
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[inline]
+#[doc(alias = "FS_IOC_GETFLAGS")]
+pub fn ioctl_getflags<Fd: AsFd>(fd: Fd) -> io::Result<backend::io::types::IFlags> {
+    backend::io::syscalls::ioctl_get_flags(fd.as_fd())
+}
+
+/// `ioctl(fd, FS_IOC_SETFLAGS)`—Modify the [inode flags] attributes
+///
+/// [inode flags]: https://man7.org/linux/man-pages/man2/ioctl_iflags.2.html
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[inline]
+#[doc(alias = "FS_IOC_GETFLAGS")]
+pub fn ioctl_setflags<Fd: AsFd>(fd: Fd, flags: backend::io::types::IFlags) -> io::Result<()> {
+    backend::io::syscalls::ioctl_set_flags(fd.as_fd(), flags)
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -42,7 +42,7 @@ pub use ioctl::ioctl_fionbio;
 #[cfg(not(target_os = "redox"))]
 pub use ioctl::ioctl_fionread;
 #[cfg(any(target_os = "android", target_os = "linux"))]
-pub use ioctl::{ioctl_blkpbszget, ioctl_blksszget};
+pub use ioctl::{ioctl_blkpbszget, ioctl_blksszget, ioctl_getflags, ioctl_setflags};
 #[cfg(not(any(windows, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 pub use ioctl::{ioctl_tiocexcl, ioctl_tiocnxcl};
 #[cfg(not(any(windows, target_os = "redox")))]

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -42,6 +42,8 @@ pub use ioctl::ioctl_fionbio;
 #[cfg(not(target_os = "redox"))]
 pub use ioctl::ioctl_fionread;
 #[cfg(any(target_os = "android", target_os = "linux"))]
+pub use ioctl::IFlags;
+#[cfg(any(target_os = "android", target_os = "linux"))]
 pub use ioctl::{ioctl_blkpbszget, ioctl_blksszget, ioctl_getflags, ioctl_setflags};
 #[cfg(not(any(windows, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 pub use ioctl::{ioctl_tiocexcl, ioctl_tiocnxcl};


### PR DESCRIPTION
Add the IOCTL get/setflags with the underlyng IFlags bitflag.

Resources: https://man7.org/linux/man-pages/man2/ioctl_iflags.2.html

To be supported, this need that libc merge this https://github.com/rust-lang/libc/pull/3089