### PR TITLE
Bump errno 0.3.0 and memoffset 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ once_cell = { version = "1.5.2", optional = true }
 # `RUSTFLAGS` or enabling the `use-libc` cargo feature.
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
 linux-raw-sys = { version = "0.2.1", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
-libc_errno = { package = "errno", version = "0.2.8", default-features = false, optional = true }
+libc_errno = { package = "errno", version = "0.3.0", default-features = false, optional = true }
 libc = { version = "0.2.133", features = ["extra_traits"], optional = true }
 
 # Dependencies for platforms where only libc is supported:
@@ -48,7 +48,7 @@ libc = { version = "0.2.133", features = ["extra_traits"], optional = true }
 # On all other Unix-family platforms, and under Miri, we always use the libc
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))))'.dependencies]
-libc_errno = { package = "errno", version = "0.2.8", default-features = false }
+libc_errno = { package = "errno", version = "0.3.0", default-features = false }
 libc = { version = "0.2.133", features = ["extra_traits"] }
 
 # Additional dependencies for Linux with the libc backend:
@@ -71,12 +71,12 @@ features = [
 [dev-dependencies]
 tempfile = "3.2.0"
 libc = "0.2.133"
-libc_errno = { package = "errno", version = "0.2.8", default-features = false }
+libc_errno = { package = "errno", version = "0.3.0", default-features = false }
 io-lifetimes = { version = "1.0.0", default-features = false, features = ["close"] }
 # Don't upgrade to serial_test 0.7 for now because it depends on a
 # `parking_lot_core` version which is not compatible with our MSRV of 1.48.
 serial_test = "0.6"
-memoffset = "0.7.1"
+memoffset = "0.8.0"
 flate2 = "1.0"
 
 [target.'cfg(all(criterion, not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]


### PR DESCRIPTION
Gets rid of winapi as implicit dep (from [errno](https://github.com/lambda-fairy/rust-errno/blob/main/CHANGELOG.md#030---2023-02-12)).