### PR TITLE
Update the inotify docs to remove references to the `Inotify` type.

### DIFF
--- a/src/backend/libc/fs/inotify.rs
+++ b/src/backend/libc/fs/inotify.rs
@@ -7,7 +7,9 @@ use crate::io;
 use bitflags::bitflags;
 
 bitflags! {
-    /// `IN_*` for use with [`Inotify::new`].
+    /// `IN_*` for use with [`inotify_init`].
+    ///
+    /// [`inotify_init`]: crate::fs::inotify::inotify_init
     pub struct CreateFlags: c::c_int {
         /// `IN_CLOEXEC`
         const CLOEXEC = c::IN_CLOEXEC;
@@ -17,7 +19,9 @@ bitflags! {
 }
 
 bitflags! {
-    /// `IN*` for use with [`Inotify::add_watch`].
+    /// `IN*` for use with [`inotify_add_watch`].
+    ///
+    /// [`inotify_add_watch`]: crate::fs::inotify::inotify_add_watch
     #[derive(Default)]
     pub struct WatchFlags: u32 {
         /// `IN_ACCESS`
@@ -67,7 +71,7 @@ bitflags! {
     }
 }
 
-/// `inotify_init1(flags)`—Creates a new `Inotify`.
+/// `inotify_init1(flags)`—Creates a new inotify object.
 ///
 /// Use the [`CreateFlags::CLOEXEC`] flag to prevent the resulting file
 /// descriptor from being implicitly passed across `exec` boundaries.

--- a/src/backend/linux_raw/fs/inotify.rs
+++ b/src/backend/linux_raw/fs/inotify.rs
@@ -7,7 +7,9 @@ use crate::io;
 use bitflags::bitflags;
 
 bitflags! {
-    /// `IN_*` for use with [`Inotify::new`].
+    /// `IN_*` for use with [`inotify_init`].
+    ///
+    /// [`inotify_init`]: crate::fs::inotify::inotify_init
     pub struct CreateFlags: c::c_uint {
         /// `IN_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::IN_CLOEXEC;
@@ -17,7 +19,9 @@ bitflags! {
 }
 
 bitflags! {
-    /// `IN*` for use with [`Inotify::add_watch`].
+    /// `IN*` for use with [`inotify_add_watch`].
+    ///
+    /// [`inotify_add_watch`]: crate::fs::inotify::inotify_add_watch
     #[derive(Default)]
     pub struct WatchFlags: c::c_uint {
         /// `IN_ACCESS`
@@ -67,7 +71,7 @@ bitflags! {
     }
 }
 
-/// `inotify_init1(flags)`—Creates a new `Inotify`.
+/// `inotify_init1(flags)`—Creates a new inotify object.
 ///
 /// Use the [`CreateFlags::CLOEXEC`] flag to prevent the resulting file
 /// descriptor from being implicitly passed across `exec` boundaries.

--- a/src/io/read_write.rs
+++ b/src/io/read_write.rs
@@ -11,7 +11,6 @@ pub use backend::io::io_slice::{IoSlice, IoSliceMut};
 #[cfg(feature = "std")]
 pub use std::io::{IoSlice, IoSliceMut};
 
-/// `RWF_*` constants for use with [`preadv2`] and [`pwritev2`].
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use backend::io::types::ReadWriteFlags;
 


### PR DESCRIPTION
Update the inotify documentation to remove references to the `Inotify` type which is no longer present in the API.