### PR TITLE
FreeBSD RESOLVE_BENEATH support and more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,15 @@ targets = [
     "i686-unknown-linux-gnu",
     "x86_64-apple-darwin",
     "x86_64-pc-windows-msvc",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-openbsd",
+    "x86_64-unknown-netbsd",
+    "x86_64-unknown-dragonfly",
+    "x86_64-unknown-illumos",
+    "x86_64-unknown-redox",
+    "x86_64-unknown-haiku",
+    "wasm32-unknown-emscripten",
+    "wasm32-wasi",
 ]
 
 [features]

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -40,10 +40,15 @@ bitflags! {
         /// `AT_EMPTY_PATH`
         #[cfg(any(
             target_os = "android",
+            target_os = "freebsd",
             target_os = "fuchsia",
             target_os = "linux",
         ))]
         const EMPTY_PATH = c::AT_EMPTY_PATH;
+
+        /// `AT_RESOLVE_BENEATH`
+        #[cfg(target_os = "freebsd")]
+        const RESOLVE_BENEATH = c::AT_RESOLVE_BENEATH;
 
         /// `AT_EACCESS`
         #[cfg(not(any(target_os = "emscripten", target_os = "android")))]
@@ -175,7 +180,7 @@ bitflags! {
         const DIRECTORY = c::O_DIRECTORY;
 
         /// `O_DSYNC`
-        #[cfg(not(any(freebsdlike, target_os = "redox")))]
+        #[cfg(not(any(target_os = "dragonfly", target_os = "redox")))]
         const DSYNC = c::O_DSYNC;
 
         /// `O_EXCL`
@@ -228,6 +233,7 @@ bitflags! {
         #[cfg(any(
             target_os = "android",
             target_os = "emscripten",
+            target_os = "freebsd",
             target_os = "fuchsia",
             target_os = "linux",
             target_os = "redox",
@@ -264,6 +270,14 @@ bitflags! {
             target_os = "netbsd",
         ))]
         const DIRECT = c::O_DIRECT;
+
+        /// `O_RESOLVE_BENEATH`
+        #[cfg(target_os = "freebsd")]
+        const RESOLVE_BENEATH = c::O_RESOLVE_BENEATH;
+
+        /// `O_EMPTY_PATH`
+        #[cfg(target_os = "freebsd")]
+        const EMPTY_PATH = c::O_EMPTY_PATH;
     }
 }
 
@@ -499,40 +513,28 @@ bitflags! {
         const HUGETLB = c::MFD_HUGETLB;
 
         /// `MFD_HUGE_64KB`
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_64KB = c::MFD_HUGE_64KB;
         /// `MFD_HUGE_512JB`
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_512KB = c::MFD_HUGE_512KB;
         /// `MFD_HUGE_1MB`
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_1MB = c::MFD_HUGE_1MB;
         /// `MFD_HUGE_2MB`
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_2MB = c::MFD_HUGE_2MB;
         /// `MFD_HUGE_8MB`
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_8MB = c::MFD_HUGE_8MB;
         /// `MFD_HUGE_16MB`
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_16MB = c::MFD_HUGE_16MB;
         /// `MFD_HUGE_32MB`
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_32MB = c::MFD_HUGE_32MB;
         /// `MFD_HUGE_256MB`
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_256MB = c::MFD_HUGE_256MB;
         /// `MFD_HUGE_512MB`
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_512MB = c::MFD_HUGE_512MB;
         /// `MFD_HUGE_1GB`
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_1GB = c::MFD_HUGE_1GB;
         /// `MFD_HUGE_2GB`
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_2GB = c::MFD_HUGE_2GB;
         /// `MFD_HUGE_16GB`
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         const HUGE_16GB = c::MFD_HUGE_16GB;
     }
 }

--- a/src/backend/libc/time/types.rs
+++ b/src/backend/libc/time/types.rs
@@ -126,6 +126,10 @@ pub enum ClockId {
     /// `CLOCK_MONOTONIC`
     Monotonic = c::CLOCK_MONOTONIC,
 
+    /// `CLOCK_UPTIME`
+    #[cfg(any(freebsdlike))]
+    Uptime = c::CLOCK_UPTIME,
+
     /// `CLOCK_PROCESS_CPUTIME_ID`
     #[cfg(not(any(netbsdlike, solarish, target_os = "redox")))]
     ProcessCPUTime = c::CLOCK_PROCESS_CPUTIME_ID,
@@ -135,11 +139,11 @@ pub enum ClockId {
     ThreadCPUTime = c::CLOCK_THREAD_CPUTIME_ID,
 
     /// `CLOCK_REALTIME_COARSE`
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "freebsd"))]
     RealtimeCoarse = c::CLOCK_REALTIME_COARSE,
 
     /// `CLOCK_MONOTONIC_COARSE`
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "freebsd"))]
     MonotonicCoarse = c::CLOCK_MONOTONIC_COARSE,
 
     /// `CLOCK_MONOTONIC_RAW`

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -138,7 +138,18 @@ pub(crate) fn chmod(filename: &CStr, mode: Mode) -> io::Result<()> {
 }
 
 #[inline]
-pub(crate) fn chmodat(dirfd: BorrowedFd<'_>, filename: &CStr, mode: Mode) -> io::Result<()> {
+pub(crate) fn chmodat(
+    dirfd: BorrowedFd<'_>,
+    filename: &CStr,
+    mode: Mode,
+    flags: AtFlags,
+) -> io::Result<()> {
+    if flags == AtFlags::SYMLINK_NOFOLLOW {
+        return Err(io::Errno::OPNOTSUPP);
+    }
+    if !flags.is_empty() {
+        return Err(io::Errno::INVAL);
+    }
     unsafe { ret(syscall_readonly!(__NR_fchmodat, dirfd, filename, mode)) }
 }
 


### PR DESCRIPTION
This is everything required to implement support for FreeBSD's `(O|AT)_RESOLVE_BENEATH` based lookup sandboxing in cap-std :) While here, also expose more Linux-compatible stuff that FreeBSD's libc exposes, also improve kqueue a bit.

The `chmodat` signature change is an API break :/ but the omission of `flags` feels like a mistake to me and I think it's better to fix it earlier rather than later. What do you think?

~~Waiting for: a libc release with https://github.com/rust-lang/libc/pull/3114 https://github.com/rust-lang/libc/pull/3122 https://github.com/rust-lang/libc/pull/3124~~ wheeee  
~~Includes: #540~~
