### PR TITLE
Some io_uring additions

### DIFF
--- a/src/backend/libc/io_uring/syscalls.rs
+++ b/src/backend/libc/io_uring/syscalls.rs
@@ -1,7 +1,7 @@
 //! libc syscalls supporting `rustix::io_uring`.
 
 use super::super::c;
-use super::super::conv::{borrowed_fd, syscall_ret, syscall_ret_owned_fd, syscall_ret_u32};
+use super::super::conv::{borrowed_fd, syscall_ret_owned_fd, syscall_ret_u32};
 use crate::fd::{BorrowedFd, OwnedFd};
 use crate::io;
 use crate::io_uring::{io_uring_params, IoringEnterFlags, IoringRegisterOp};
@@ -24,8 +24,8 @@ pub(crate) unsafe fn io_uring_register(
     opcode: IoringRegisterOp,
     arg: *const c::c_void,
     nr_args: u32,
-) -> io::Result<()> {
-    syscall_ret(c::syscall(
+) -> io::Result<u32> {
+    syscall_ret_u32(c::syscall(
         __NR_io_uring_register as _,
         borrowed_fd(fd),
         opcode as u32 as usize,

--- a/src/backend/linux_raw/io_uring/syscalls.rs
+++ b/src/backend/linux_raw/io_uring/syscalls.rs
@@ -6,7 +6,7 @@
 #![allow(unsafe_code)]
 #![allow(clippy::undocumented_unsafe_blocks)]
 
-use super::super::conv::{by_mut, c_uint, pass_usize, ret, ret_c_uint, ret_owned_fd};
+use super::super::conv::{by_mut, c_uint, pass_usize, ret_c_uint, ret_owned_fd};
 use crate::fd::{BorrowedFd, OwnedFd};
 use crate::io;
 use crate::io_uring::{io_uring_params, IoringEnterFlags, IoringRegisterOp};
@@ -29,8 +29,8 @@ pub(crate) unsafe fn io_uring_register(
     opcode: IoringRegisterOp,
     arg: *const c_void,
     nr_args: u32,
-) -> io::Result<()> {
-    ret(syscall_readonly!(
+) -> io::Result<u32> {
+    ret_c_uint(syscall_readonly!(
         __NR_io_uring_register,
         fd,
         c_uint(opcode as u32),


### PR DESCRIPTION
A couple io_uring additions and an adjustment to `io_uring_register`.

`io_uring_register` can return positive values:

> On success, [io_uring_register(2)](https://man7.org/linux/man-pages//man2/io_uring_register.2.html) returns either 0 or a positive
> value, depending on the opcode used.  On error, a negative error
> value is returned. The caller should not rely on the [errno](https://man7.org/linux/man-pages//man3/errno.3.html)
> variable.

`sqe.ioprio` takes in flags for certain operations so added a union for those ([accept](https://github.com/torvalds/linux/blob/master/include/uapi/linux/io_uring.h#L293) and [send/recv](https://github.com/torvalds/linux/blob/ae3419fbac845b4d3f3a9fae4cc80c68d82cdf6e/include/uapi/linux/io_uring.h#L330))

Adds `io_uring_recvmsg_out` which outs recvmsg flags (see [here](https://man7.org/linux/man-pages/man3/io_uring_recvmsg_out.3.html))

> __u32 flags;      /* Flags result as would have been populated by recvmsg(2) */