### PR TITLE
Enable makedev on more platforms.

### DIFF
--- a/src/backend/libc/fs/makedev.rs
+++ b/src/backend/libc/fs/makedev.rs
@@ -2,7 +2,12 @@
 use super::super::c;
 use crate::fs::Dev;
 
-#[cfg(not(any(target_os = "android", target_os = "emscripten")))]
+#[cfg(not(any(
+    apple,
+    target_os = "aix",
+    target_os = "android",
+    target_os = "emscripten",
+)))]
 #[inline]
 pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
     c::makedev(maj, min)
@@ -11,7 +16,6 @@ pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
 #[cfg(all(target_os = "android", not(target_pointer_width = "32")))]
 #[inline]
 pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
-    // Android's `makedev` oddly has signed argument types.
     c::makedev(maj, min)
 }
 
@@ -33,7 +37,27 @@ pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
     Dev::from(c::makedev(maj, min))
 }
 
-#[cfg(not(any(target_os = "android", target_os = "emscripten")))]
+#[cfg(apple)]
+#[inline]
+pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
+    // Apple's `makedev` oddly has signed argument types and is `unsafe`.
+    unsafe { c::makedev(maj as i32, min as i32) }
+}
+
+#[cfg(target_os = "aix")]
+#[inline]
+pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
+    // AIX's `makedev` oddly is `unsafe`.
+    unsafe { c::makedev(maj, min) }
+}
+
+#[cfg(not(any(
+    apple,
+    freebsdlike,
+    netbsdlike,
+    target_os = "android",
+    target_os = "emscripten",
+)))]
 #[inline]
 pub(crate) fn major(dev: Dev) -> u32 {
     unsafe { c::major(dev) }
@@ -61,7 +85,13 @@ pub(crate) fn major(dev: Dev) -> u32 {
     unsafe { c::major(dev as u32) }
 }
 
-#[cfg(not(any(target_os = "android", target_os = "emscripten")))]
+#[cfg(not(any(
+    apple,
+    freebsdlike,
+    netbsdlike,
+    target_os = "android",
+    target_os = "emscripten",
+)))]
 #[inline]
 pub(crate) fn minor(dev: Dev) -> u32 {
     unsafe { c::minor(dev) }

--- a/src/backend/libc/fs/mod.rs
+++ b/src/backend/libc/fs/mod.rs
@@ -3,14 +3,8 @@ pub(crate) mod dir;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub mod inotify;
 #[cfg(not(any(
-    target_os = "dragonfly",
     target_os = "haiku",
-    target_os = "freebsd",
     target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
     target_os = "wasi",

--- a/src/fs/makedev.rs
+++ b/src/fs/makedev.rs
@@ -18,6 +18,7 @@ pub fn makedev(maj: u32, min: u32) -> Dev {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man3/minor.3.html
+#[cfg(not(bsd))]
 #[inline]
 pub fn minor(dev: Dev) -> u32 {
     backend::fs::makedev::minor(dev)
@@ -29,6 +30,7 @@ pub fn minor(dev: Dev) -> u32 {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man3/major.3.html
+#[cfg(not(bsd))]
 #[inline]
 pub fn major(dev: Dev) -> u32 {
     backend::fs::makedev::major(dev)

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -28,12 +28,7 @@ pub(crate) mod fd;
 mod file_type;
 #[cfg(apple)]
 mod getpath;
-#[cfg(not(any(
-    solarish,
-    target_os = "haiku",
-    target_os = "redox",
-    target_os = "wasi",
-)))]
+#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 mod makedev;
 #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 mod memfd_create;
@@ -94,12 +89,7 @@ pub use fd::*;
 pub use file_type::FileType;
 #[cfg(apple)]
 pub use getpath::getpath;
-#[cfg(not(any(
-    solarish,
-    target_os = "haiku",
-    target_os = "redox",
-    target_os = "wasi",
-)))]
+#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 pub use makedev::*;
 #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 pub use memfd_create::{memfd_create, MemfdFlags};

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -106,7 +106,7 @@ pub use getpath::getpath;
     target_os = "redox",
     target_os = "wasi",
 )))]
-pub use makedev::{major, makedev, minor};
+pub use makedev::*;
 #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 pub use memfd_create::{memfd_create, MemfdFlags};
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -29,9 +29,6 @@ mod file_type;
 #[cfg(apple)]
 mod getpath;
 #[cfg(not(any(
-    apple,
-    freebsdlike,
-    netbsdlike,
     solarish,
     target_os = "haiku",
     target_os = "redox",
@@ -98,9 +95,6 @@ pub use file_type::FileType;
 #[cfg(apple)]
 pub use getpath::getpath;
 #[cfg(not(any(
-    apple,
-    freebsdlike,
-    netbsdlike,
     solarish,
     target_os = "haiku",
     target_os = "redox",

--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -16,14 +16,8 @@ mod futimens;
 mod invalid_offset;
 mod long_paths;
 #[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
     target_os = "haiku",
     target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
     target_os = "wasi",

--- a/tests/fs/makedev.rs
+++ b/tests/fs/makedev.rs
@@ -1,10 +1,17 @@
-use rustix::fs::{major, makedev, minor};
+use rustix::fs::makedev;
+#[cfg(not(bsd))]
+use rustix::fs::{major, minor};
 
 #[test]
 fn makedev_roundtrip() {
     let maj = 0x2324_2526;
     let min = 0x6564_6361;
     let dev = makedev(maj, min);
-    assert_eq!(maj, major(dev));
-    assert_eq!(min, minor(dev));
+    #[cfg(not(bsd))]
+    {
+        assert_eq!(maj, major(dev));
+        assert_eq!(min, minor(dev));
+    }
+    #[cfg(bsd)]
+    let _ = dev;
 }


### PR DESCRIPTION
Enable the `makedev` function on freebsd, netbsd, opensd, dragonfly, ios, and macos. And handle `makedev` being `unsafe` on AIX.