### PR TITLE
Use OS groups and star imports to reduce `cfg` boilerplate.

### DIFF
--- a/examples/process.rs
+++ b/examples/process.rs
@@ -59,77 +59,28 @@ fn main() -> io::Result<()> {
         #[cfg(not(target_os = "openbsd"))]
         println!("As Limit: {:?}", getrlimit(Resource::As));
         #[cfg(not(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
+            apple,
+            freebsdlike,
+            solarish,
             target_os = "haiku",
-            target_os = "illumos",
-            target_os = "ios",
-            target_os = "macos",
             target_os = "netbsd",
             target_os = "openbsd",
-            target_os = "solaris",
         )))]
         println!("Locks Limit: {:?}", getrlimit(Resource::Locks));
-        #[cfg(not(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "haiku",
-            target_os = "illumos",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "solaris",
-        )))]
+        #[cfg(not(any(bsd, solarish, target_os = "haiku")))]
         println!("Sigpending Limit: {:?}", getrlimit(Resource::Sigpending));
-        #[cfg(not(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "haiku",
-            target_os = "illumos",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "solaris",
-        )))]
+        #[cfg(not(any(bsd, solarish, target_os = "haiku")))]
         println!("Msgqueue Limit: {:?}", getrlimit(Resource::Msgqueue));
-        #[cfg(not(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "haiku",
-            target_os = "illumos",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "solaris",
-        )))]
+        #[cfg(not(any(bsd, solarish, target_os = "haiku")))]
         println!("Nice Limit: {:?}", getrlimit(Resource::Nice));
-        #[cfg(not(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "haiku",
-            target_os = "illumos",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "solaris",
-        )))]
+        #[cfg(not(any(bsd, solarish, target_os = "haiku")))]
         println!("Rtprio Limit: {:?}", getrlimit(Resource::Rtprio));
         #[cfg(not(any(
+            bsd,
+            solarish,
             target_os = "android",
-            target_os = "dragonfly",
             target_os = "emscripten",
-            target_os = "freebsd",
             target_os = "haiku",
-            target_os = "illumos",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "solaris",
         )))]
         println!("Rttime Limit: {:?}", getrlimit(Resource::Rttime));
     }

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -129,9 +129,8 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
                 print!(" IMAXBEL");
             }
             #[cfg(not(any(
-                target_os = "dragonfly",
+                freebsdlike,
                 target_os = "emscripten",
-                target_os = "freebsd",
                 target_os = "haiku",
                 target_os = "illumos",
                 target_os = "ios",
@@ -151,14 +150,7 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
             if (term.c_oflag & OPOST) != 0 {
                 print!(" OPOST");
             }
-            #[cfg(not(any(
-                target_os = "dragonfly",
-                target_os = "freebsd",
-                target_os = "ios",
-                target_os = "macos",
-                target_os = "netbsd",
-                target_os = "redox",
-            )))]
+            #[cfg(not(any(apple, freebsdlike, target_os = "netbsd", target_os = "redox")))]
             if (term.c_oflag & OLCUC) != 0 {
                 print!(" OLCUC");
             }
@@ -178,14 +170,7 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
             if (term.c_oflag & ONLRET) != 0 {
                 print!(" ONLRET");
             }
-            #[cfg(not(any(
-                target_os = "dragonfly",
-                target_os = "freebsd",
-                target_os = "ios",
-                target_os = "macos",
-                target_os = "netbsd",
-                target_os = "openbsd",
-            )))]
+            #[cfg(not(bsd))]
             if (term.c_oflag & OFILL) != 0 {
                 print!(" OFILL");
             }
@@ -200,57 +185,33 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
             if (term.c_oflag & OFDEL) != 0 {
                 print!(" OFDEL");
             }
-            #[cfg(not(any(
-                target_os = "dragonfly",
-                target_os = "freebsd",
-                target_os = "illumos",
-                target_os = "ios",
-                target_os = "macos",
-                target_os = "netbsd",
-                target_os = "openbsd",
-                target_os = "redox",
-                target_os = "solaris",
-            )))]
+            #[cfg(not(any(bsd, solarish, target_os = "redox")))]
             if (term.c_oflag & NLDLY) != 0 {
                 print!(" NLDLY");
             }
-            #[cfg(not(any(
-                target_os = "dragonfly",
-                target_os = "freebsd",
-                target_os = "illumos",
-                target_os = "ios",
-                target_os = "macos",
-                target_os = "netbsd",
-                target_os = "openbsd",
-                target_os = "redox",
-                target_os = "solaris",
-            )))]
+            #[cfg(not(any(bsd, solarish, target_os = "redox")))]
             if (term.c_oflag & CRDLY) != 0 {
                 print!(" CRDLY");
             }
             #[cfg(not(any(
+                apple,
+                netbsdlike,
+                solarish,
                 target_os = "dragonfly",
-                target_os = "ios",
-                target_os = "macos",
-                target_os = "netbsd",
-                target_os = "openbsd",
-                target_os = "illumos",
                 target_os = "redox",
-                target_os = "solaris",
             )))]
             if (term.c_oflag & TABDLY) != 0 {
                 print!(" TABDLY");
             }
             #[cfg(not(any(
+                solarish,
                 target_os = "dragonfly",
                 target_os = "freebsd",
-                target_os = "illumos",
                 target_os = "ios",
                 target_os = "macos",
                 target_os = "netbsd",
                 target_os = "openbsd",
                 target_os = "redox",
-                target_os = "solaris",
             )))]
             if (term.c_oflag & BSDLY) != 0 {
                 print!(" BSDLY");

--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -1,0 +1,9 @@
+pub(crate) use libc::*;
+
+/// `PROC_SUPER_MAGIC`—The magic number for the procfs filesystem.
+#[cfg(all(any(target_os = "android", target_os = "linux"), target_env = "musl"))]
+pub(crate) const PROC_SUPER_MAGIC: u32 = 0x0000_9fa0;
+
+/// `NFS_SUPER_MAGIC`—The magic number for the NFS filesystem.
+#[cfg(all(any(target_os = "android", target_os = "linux"), target_env = "musl"))]
+pub(crate) const NFS_SUPER_MAGIC: u32 = 0x0000_6969;

--- a/src/backend/libc/fs/dir.rs
+++ b/src/backend/libc/fs/dir.rs
@@ -16,40 +16,18 @@ use crate::fs::{fcntl_getfl, fstat, openat, Mode, OFlags, Stat};
     target_os = "wasi",
 )))]
 use crate::fs::{fstatfs, StatFs};
-#[cfg(not(any(
-    target_os = "haiku",
-    target_os = "illumos",
-    target_os = "redox",
-    target_os = "solaris",
-    target_os = "wasi",
-)))]
+#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 use crate::fs::{fstatvfs, StatVfs};
 use crate::io;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 use crate::process::fchdir;
 #[cfg(target_os = "wasi")]
 use alloc::borrow::ToOwned;
-#[cfg(not(any(
-    target_os = "android",
-    target_os = "emscripten",
-    target_os = "l4re",
-    target_os = "linux",
-    target_os = "openbsd",
-)))]
+#[cfg(not(any(linux_like, target_os = "openbsd")))]
 use c::dirent as libc_dirent;
-#[cfg(not(any(
-    target_os = "android",
-    target_os = "emscripten",
-    target_os = "l4re",
-    target_os = "linux",
-)))]
+#[cfg(not(linux_like))]
 use c::readdir as libc_readdir;
-#[cfg(any(
-    target_os = "android",
-    target_os = "emscripten",
-    target_os = "l4re",
-    target_os = "linux",
-))]
+#[cfg(linux_like)]
 use c::{dirent64 as libc_dirent, readdir64 as libc_readdir};
 use core::fmt;
 use core::mem::zeroed;

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -62,7 +62,7 @@ use crate::fd::{BorrowedFd, OwnedFd};
 use crate::ffi::CStr;
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 use crate::ffi::CString;
-#[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
+#[cfg(not(solarish))]
 use crate::fs::Access;
 #[cfg(not(any(
     target_os = "dragonfly",

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -1072,31 +1072,6 @@ pub type FsWord = u64;
 #[cfg(all(target_os = "linux", target_arch = "s390x"))]
 pub type FsWord = u32;
 
-#[cfg(not(target_os = "redox"))]
-pub use c::{UTIME_NOW, UTIME_OMIT};
-
-/// `PROC_SUPER_MAGIC`—The magic number for the procfs filesystem.
-#[cfg(all(
-    any(target_os = "android", target_os = "linux"),
-    not(target_env = "musl"),
-))]
-pub const PROC_SUPER_MAGIC: FsWord = c::PROC_SUPER_MAGIC as FsWord;
-
-/// `NFS_SUPER_MAGIC`—The magic number for the NFS filesystem.
-#[cfg(all(
-    any(target_os = "android", target_os = "linux"),
-    not(target_env = "musl"),
-))]
-pub const NFS_SUPER_MAGIC: FsWord = c::NFS_SUPER_MAGIC as FsWord;
-
-/// `PROC_SUPER_MAGIC`—The magic number for the procfs filesystem.
-#[cfg(all(any(target_os = "android", target_os = "linux"), target_env = "musl"))]
-pub const PROC_SUPER_MAGIC: FsWord = 0x0000_9fa0;
-
-/// `NFS_SUPER_MAGIC`—The magic number for the NFS filesystem.
-#[cfg(all(any(target_os = "android", target_os = "linux"), target_env = "musl"))]
-pub const NFS_SUPER_MAGIC: FsWord = 0x0000_6969;
-
 /// `copyfile_state_t`—State for use with [`fcopyfile`].
 ///
 /// [`fcopyfile`]: crate::fs::fcopyfile

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -872,12 +872,7 @@ pub enum FlockOperation {
 ///
 /// [`statat`]: crate::fs::statat
 /// [`fstat`]: crate::fs::fstat
-#[cfg(not(any(
-    target_os = "android",
-    target_os = "linux",
-    target_os = "emscripten",
-    target_os = "l4re",
-)))]
+#[cfg(not(linux_like))]
 pub type Stat = c::stat;
 
 /// `struct stat` for use with [`statat`] and [`fstat`].
@@ -932,15 +927,11 @@ pub struct Stat {
 /// [`statfs`]: crate::fs::statfs
 /// [`fstatfs`]: crate::fs::fstatfs
 #[cfg(not(any(
-    target_os = "android",
-    target_os = "emscripten",
+    linux_like,
+    solarish,
     target_os = "haiku",
-    target_os = "illumos",
-    target_os = "linux",
-    target_os = "l4re",
     target_os = "netbsd",
     target_os = "redox",
-    target_os = "solaris",
     target_os = "wasi",
 )))]
 #[allow(clippy::module_name_repetitions)]
@@ -950,25 +941,14 @@ pub type StatFs = c::statfs;
 ///
 /// [`statfs`]: crate::fs::statfs
 /// [`fstatfs`]: crate::fs::fstatfs
-#[cfg(any(
-    target_os = "android",
-    target_os = "linux",
-    target_os = "emscripten",
-    target_os = "l4re",
-))]
+#[cfg(linux_like)]
 pub type StatFs = c::statfs64;
 
 /// `struct statvfs` for use with [`statvfs`] and [`fstatvfs`].
 ///
 /// [`statvfs`]: crate::fs::statvfs
 /// [`fstatvfs`]: crate::fs::fstatvfs
-#[cfg(not(any(
-    target_os = "haiku",
-    target_os = "illumos",
-    target_os = "redox",
-    target_os = "solaris",
-    target_os = "wasi",
-)))]
+#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 #[allow(missing_docs)]
 pub struct StatVfs {
     pub f_bsize: u64,

--- a/src/backend/libc/io/errno.rs
+++ b/src/backend/libc/io/errno.rs
@@ -25,13 +25,12 @@ impl Errno {
     pub const ADDRNOTAVAIL: Self = Self(c::EADDRNOTAVAIL);
     /// `EADV`
     #[cfg(not(any(
+        apple,
         windows,
         target_os = "aix",
         target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "haiku",
-        target_os = "ios",
-        target_os = "macos",
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "wasi",
@@ -44,26 +43,17 @@ impl Errno {
     /// `EALREADY`
     pub const ALREADY: Self = Self(c::EALREADY);
     /// `EAUTH`
-    #[cfg(any(
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd",
-    ))]
+    #[cfg(any(apple, netbsdlike, target_os = "dragonfly", target_os = "freebsd"))]
     pub const AUTH: Self = Self(c::EAUTH);
     /// `EBADE`
     #[cfg(not(any(
+        apple,
+        netbsdlike,
         windows,
         target_os = "aix",
         target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "haiku",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd",
         target_os = "wasi",
     )))]
     pub const BADE: Self = Self(c::EBADE);
@@ -71,15 +61,13 @@ impl Errno {
     pub const BADF: Self = Self(c::EBADF);
     /// `EBADFD`
     #[cfg(not(any(
+        apple,
+        netbsdlike,
         windows,
         target_os = "aix",
         target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "haiku",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd",
         target_os = "wasi",
     )))]
     pub const BADFD: Self = Self(c::EBADFD);
@@ -88,15 +76,13 @@ impl Errno {
     pub const BADMSG: Self = Self(c::EBADMSG);
     /// `EBADR`
     #[cfg(not(any(
+        apple,
+        netbsdlike,
         windows,
         target_os = "aix",
         target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "haiku",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd",
         target_os = "wasi",
     )))]
     pub const BADR: Self = Self(c::EBADR);

--- a/src/backend/libc/io/types.rs
+++ b/src/backend/libc/io/types.rs
@@ -57,16 +57,15 @@ bitflags! {
     pub struct DupFlags: c::c_int {
         /// `O_CLOEXEC`
         #[cfg(not(any(
+            apple,
             target_os = "android",
-            target_os = "ios",
-            target_os = "macos",
             target_os = "redox",
         )))] // Android 5.0 has dup3, but libc doesn't have bindings
         const CLOEXEC = c::O_CLOEXEC;
     }
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
+#[cfg(not(any(apple, target_os = "wasi")))]
 bitflags! {
     /// `O_*` constants for use with [`pipe_with`].
     ///
@@ -76,11 +75,10 @@ bitflags! {
         const CLOEXEC = c::O_CLOEXEC;
         /// `O_DIRECT`
         #[cfg(not(any(
+            solarish,
             target_os = "haiku",
-            target_os = "illumos",
             target_os = "openbsd",
             target_os = "redox",
-            target_os = "solaris",
         )))]
         const DIRECT = c::O_DIRECT;
         /// `O_NONBLOCK`

--- a/src/backend/libc/mod.rs
+++ b/src/backend/libc/mod.rs
@@ -49,11 +49,8 @@ pub(crate) mod fd {
 
 // On Windows we emulate selected libc-compatible interfaces. On non-Windows,
 // we just use libc here, since this is the libc backend.
-#[cfg(windows)]
-#[path = "winsock_c.rs"]
+#[cfg_attr(windows, path = "winsock_c.rs")]
 pub(crate) mod c;
-#[cfg(not(windows))]
-pub(crate) use libc as c;
 
 #[cfg(not(windows))]
 #[cfg(feature = "fs")]

--- a/src/backend/libc/net/ext.rs
+++ b/src/backend/libc/net/ext.rs
@@ -162,7 +162,7 @@ pub(crate) const fn sockaddr_in6_new(
         sin6_flowinfo,
         sin6_addr,
         sin6_scope_id,
-        #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg(solarish)]
         __sin6_src_id: 0,
     }
 }

--- a/src/backend/libc/net/syscalls.rs
+++ b/src/backend/libc/net/syscalls.rs
@@ -636,25 +636,13 @@ pub(crate) mod sockopt {
         }
     }
 
-    #[cfg(any(
-        target_os = "freebsd",
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "tvos",
-        target_os = "watchos"
-    ))]
+    #[cfg(any(apple, target_os = "freebsd"))]
     #[inline]
     pub(crate) fn getsockopt_nosigpipe(fd: BorrowedFd<'_>) -> io::Result<bool> {
         getsockopt(fd, c::SOL_SOCKET, c::SO_NOSIGPIPE).map(to_bool)
     }
 
-    #[cfg(any(
-        target_os = "freebsd",
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "tvos",
-        target_os = "watchos"
-    ))]
+    #[cfg(any(apple, target_os = "freebsd"))]
     #[inline]
     pub(crate) fn setsockopt_nosigpipe(fd: BorrowedFd<'_>, val: bool) -> io::Result<()> {
         setsockopt(fd, c::SOL_SOCKET, c::SO_NOSIGPIPE, from_bool(val))
@@ -761,26 +749,24 @@ pub(crate) mod sockopt {
         interface: u32,
     ) -> io::Result<()> {
         #[cfg(not(any(
+            apple,
             target_os = "dragonfly",
             target_os = "freebsd",
             target_os = "haiku",
             target_os = "illumos",
-            target_os = "ios",
             target_os = "l4re",
-            target_os = "macos",
             target_os = "netbsd",
             target_os = "openbsd",
             target_os = "solaris",
         )))]
         use c::IPV6_ADD_MEMBERSHIP;
         #[cfg(any(
+            apple,
             target_os = "dragonfly",
             target_os = "freebsd",
             target_os = "haiku",
             target_os = "illumos",
-            target_os = "ios",
             target_os = "l4re",
-            target_os = "macos",
             target_os = "netbsd",
             target_os = "openbsd",
             target_os = "solaris",
@@ -808,26 +794,24 @@ pub(crate) mod sockopt {
         interface: u32,
     ) -> io::Result<()> {
         #[cfg(not(any(
+            apple,
             target_os = "dragonfly",
             target_os = "freebsd",
             target_os = "haiku",
             target_os = "illumos",
-            target_os = "ios",
             target_os = "l4re",
-            target_os = "macos",
             target_os = "netbsd",
             target_os = "openbsd",
             target_os = "solaris",
         )))]
         use c::IPV6_DROP_MEMBERSHIP;
         #[cfg(any(
+            apple,
             target_os = "dragonfly",
             target_os = "freebsd",
             target_os = "haiku",
             target_os = "illumos",
-            target_os = "ios",
             target_os = "l4re",
-            target_os = "macos",
             target_os = "netbsd",
             target_os = "openbsd",
             target_os = "solaris",

--- a/src/backend/libc/net/types.rs
+++ b/src/backend/libc/net/types.rs
@@ -62,16 +62,10 @@ impl AddressFamily {
     pub const INET6: Self = Self(c::AF_INET6 as _);
     /// `AF_NETLINK`
     #[cfg(not(any(
+        bsd,
+        solarish,
         windows,
-        target_os = "dragonfly",
-        target_os = "freebsd",
         target_os = "haiku",
-        target_os = "illumos",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "solaris",
     )))]
     pub const NETLINK: Self = Self(c::AF_NETLINK as _);
     /// `AF_UNIX`, aka `AF_LOCAL`
@@ -79,16 +73,10 @@ impl AddressFamily {
     pub const UNIX: Self = Self(c::AF_UNIX as _);
     /// `AF_AX25`
     #[cfg(not(any(
+        bsd,
+        solarish,
         windows,
-        target_os = "dragonfly",
-        target_os = "freebsd",
         target_os = "haiku",
-        target_os = "illumos",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "solaris",
     )))]
     pub const AX25: Self = Self(c::AF_AX25 as _);
     /// `AF_IPX`

--- a/src/backend/libc/offset.rs
+++ b/src/backend/libc/offset.rs
@@ -3,96 +3,47 @@
 #[cfg(not(windows))]
 use super::c;
 
-#[cfg(not(any(
-    windows,
-    target_os = "android",
-    target_os = "emscripten",
-    target_os = "l4re",
-    target_os = "linux",
-)))]
+#[cfg(not(any(linux_like, windows)))]
 #[cfg(feature = "fs")]
 pub(super) use c::{
     fstat as libc_fstat, fstatat as libc_fstatat, ftruncate as libc_ftruncate, lseek as libc_lseek,
     off_t as libc_off_t,
 };
 
-#[cfg(any(
-    target_os = "android",
-    target_os = "emscripten",
-    target_os = "l4re",
-    target_os = "linux",
-))]
+#[cfg(linux_like)]
 #[cfg(feature = "fs")]
 pub(super) use c::{
     fstat64 as libc_fstat, fstatat64 as libc_fstatat, ftruncate64 as libc_ftruncate,
     lseek64 as libc_lseek, off64_t as libc_off_t,
 };
 
-#[cfg(any(
-    target_os = "android",
-    target_os = "emscripten",
-    target_os = "l4re",
-    target_os = "linux",
-))]
+#[cfg(linux_like)]
 pub(super) use c::rlimit64 as libc_rlimit;
 
-#[cfg(not(any(
-    windows,
-    target_os = "android",
-    target_os = "emscripten",
-    target_os = "l4re",
-    target_os = "linux",
-    target_os = "wasi",
-)))]
+#[cfg(not(any(linux_like, windows, target_os = "wasi")))]
 #[cfg(feature = "mm")]
 pub(super) use c::mmap as libc_mmap;
 
 #[cfg(not(any(
+    linux_like,
     windows,
-    target_os = "android",
-    target_os = "emscripten",
     target_os = "fuchsia",
-    target_os = "l4re",
-    target_os = "linux",
     target_os = "redox",
     target_os = "wasi",
 )))]
 pub(super) use c::{rlimit as libc_rlimit, RLIM_INFINITY as LIBC_RLIM_INFINITY};
 
-#[cfg(not(any(
-    windows,
-    target_os = "android",
-    target_os = "fuchsia",
-    target_os = "emscripten",
-    target_os = "l4re",
-    target_os = "linux",
-    target_os = "wasi",
-)))]
+#[cfg(not(any(linux_like, windows, target_os = "fuchsia", target_os = "wasi")))]
 pub(super) use c::{getrlimit as libc_getrlimit, setrlimit as libc_setrlimit};
 
 // TODO: Add `RLIM64_INFINITY` to upstream libc.
-#[cfg(any(
-    target_os = "android",
-    target_os = "linux",
-    target_os = "emscripten",
-    target_os = "l4re",
-))]
+#[cfg(linux_like)]
 pub(super) const LIBC_RLIM_INFINITY: u64 = !0_u64;
 
-#[cfg(any(
-    target_os = "android",
-    target_os = "linux",
-    target_os = "emscripten",
-    target_os = "l4re",
-))]
+#[cfg(linux_like)]
 pub(super) use c::{getrlimit64 as libc_getrlimit, setrlimit64 as libc_setrlimit};
 
-#[cfg(any(
-    target_os = "android",
-    target_os = "linux",
-    target_os = "emscripten",
-    target_os = "l4re",
-))]
+#[cfg(linux_like)]
 #[cfg(feature = "mm")]
 pub(super) use c::mmap64 as libc_mmap;
 
@@ -152,22 +103,10 @@ pub(super) unsafe fn libc_prlimit(
     prlimit64(pid, resource, new_limit, old_limit)
 }
 
-#[cfg(not(any(
-    windows,
-    target_os = "android",
-    target_os = "linux",
-    target_os = "emscripten",
-    target_os = "l4re",
-    target_os = "redox",
-)))]
+#[cfg(not(any(linux_like, windows, target_os = "redox")))]
 #[cfg(feature = "fs")]
 pub(super) use c::openat as libc_openat;
-#[cfg(any(
-    target_os = "android",
-    target_os = "linux",
-    target_os = "emscripten",
-    target_os = "l4re",
-))]
+#[cfg(linux_like)]
 #[cfg(feature = "fs")]
 pub(super) use c::openat64 as libc_openat;
 
@@ -178,29 +117,18 @@ pub(super) use c::fallocate as libc_fallocate;
 #[cfg(feature = "fs")]
 pub(super) use c::fallocate64 as libc_fallocate;
 #[cfg(not(any(
+    apple,
+    linux_like,
+    netbsdlike,
+    solarish,
     windows,
-    target_os = "android",
     target_os = "dragonfly",
-    target_os = "emscripten",
     target_os = "haiku",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "linux",
-    target_os = "l4re",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 #[cfg(feature = "fs")]
 pub(super) use c::posix_fadvise as libc_posix_fadvise;
-#[cfg(any(
-    target_os = "android",
-    target_os = "emscripten",
-    target_os = "linux",
-    target_os = "l4re",
-))]
+#[cfg(linux_like)]
 #[cfg(feature = "fs")]
 pub(super) use c::posix_fadvise64 as libc_posix_fadvise;
 
@@ -303,13 +231,12 @@ mod readwrite_pv64 {
     }
 }
 #[cfg(not(any(
+    apple,
     windows,
     target_os = "android",
     target_os = "emscripten",
     target_os = "haiku",
-    target_os = "ios",
     target_os = "linux",
-    target_os = "macos",
     target_os = "redox",
     target_os = "solaris",
 )))]
@@ -344,6 +271,7 @@ pub(super) use readwrite_pv::{preadv as libc_preadv, pwritev as libc_pwritev};
 
 #[cfg(not(any(
     windows,
+    netbsdlike,
     target_os = "aix",
     target_os = "android",
     target_os = "dragonfly",
@@ -353,8 +281,6 @@ pub(super) use readwrite_pv::{preadv as libc_preadv, pwritev as libc_pwritev};
     target_os = "linux",
     target_os = "l4re",
     target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
 )))]
@@ -364,13 +290,10 @@ pub(super) use c::posix_fallocate as libc_posix_fallocate;
 #[cfg(feature = "fs")]
 pub(super) use c::posix_fallocate64 as libc_posix_fallocate;
 #[cfg(not(any(
+    linux_like,
     windows,
-    target_os = "android",
-    target_os = "emscripten",
     target_os = "haiku",
     target_os = "illumos",
-    target_os = "linux",
-    target_os = "l4re",
     target_os = "netbsd",
     target_os = "redox",
     target_os = "solaris",
@@ -379,26 +302,17 @@ pub(super) use c::posix_fallocate64 as libc_posix_fallocate;
 #[cfg(feature = "fs")]
 pub(super) use {c::fstatfs as libc_fstatfs, c::statfs as libc_statfs};
 #[cfg(not(any(
+    linux_like,
+    solarish,
     windows,
-    target_os = "android",
-    target_os = "emscripten",
     target_os = "haiku",
-    target_os = "illumos",
-    target_os = "linux",
-    target_os = "l4re",
     target_os = "redox",
-    target_os = "solaris",
     target_os = "wasi",
 )))]
 #[cfg(feature = "fs")]
 pub(super) use {c::fstatvfs as libc_fstatvfs, c::statvfs as libc_statvfs};
 
-#[cfg(any(
-    target_os = "android",
-    target_os = "linux",
-    target_os = "emscripten",
-    target_os = "l4re",
-))]
+#[cfg(linux_like)]
 #[cfg(feature = "fs")]
 pub(super) use {
     c::fstatfs64 as libc_fstatfs, c::fstatvfs64 as libc_fstatvfs, c::statfs64 as libc_statfs,

--- a/src/backend/libc/process/wait.rs
+++ b/src/backend/libc/process/wait.rs
@@ -5,5 +5,5 @@ pub(crate) use c::{
     WTERMSIG, WUNTRACED,
 };
 
-#[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "wasi",)))]
+#[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "wasi")))]
 pub(crate) use c::{WEXITED, WNOWAIT, WSTOPPED};

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -14,12 +14,11 @@ use crate::process::{Pid, RawNonZeroPid};
 use crate::thread::{NanosleepRelativeResult, Timespec};
 use core::mem::MaybeUninit;
 #[cfg(not(any(
+    apple,
     target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "freebsd",
     target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "wasi",
@@ -38,12 +37,11 @@ weak!(fn __clock_nanosleep_time64(c::clockid_t, c::c_int, *const LibcTimespec, *
 weak!(fn __nanosleep64(*const LibcTimespec, *mut LibcTimespec) -> c::c_int);
 
 #[cfg(not(any(
+    apple,
     target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "freebsd", // FreeBSD 12 has clock_nanosleep, but libc targets FreeBSD 11.
     target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "wasi",

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -28,3 +28,4 @@ pub(crate) use linux_raw_sys::general::{
     SO_PASSCRED, SO_RCVTIMEO_NEW, SO_RCVTIMEO_OLD, SO_REUSEADDR, SO_SNDTIMEO_NEW, SO_SNDTIMEO_OLD,
     SO_TYPE, TCP_NODELAY,
 };
+pub(crate) use linux_raw_sys::general::{NFS_SUPER_MAGIC, PROC_SUPER_MAGIC, UTIME_NOW, UTIME_OMIT};

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -640,14 +640,6 @@ pub type FsWord = linux_raw_sys::general::__fsword_t;
 #[cfg(target_arch = "mips64")]
 pub type FsWord = i64;
 
-pub use linux_raw_sys::general::{UTIME_NOW, UTIME_OMIT};
-
-/// `PROC_SUPER_MAGIC`—The magic number for the procfs filesystem.
-pub const PROC_SUPER_MAGIC: FsWord = linux_raw_sys::general::PROC_SUPER_MAGIC as FsWord;
-
-/// `NFS_SUPER_MAGIC`—The magic number for the NFS filesystem.
-pub const NFS_SUPER_MAGIC: FsWord = linux_raw_sys::general::NFS_SUPER_MAGIC as FsWord;
-
 #[cfg(any(target_os = "android", target_os = "linux"))]
 bitflags! {
     /// `MS_*` constants for use with [`mount`][crate::fs::mount].

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -30,13 +30,13 @@ pub use backend::fs::types::{Dev, RawMode};
 ///
 /// [`utimensat`]: crate::fs::utimensat
 #[cfg(not(target_os = "redox"))]
-pub const UTIME_NOW: Nsecs = backend::fs::types::UTIME_NOW as Nsecs;
+pub const UTIME_NOW: Nsecs = backend::c::UTIME_NOW as Nsecs;
 
 /// `UTIME_OMIT` for use with [`utimensat`].
 ///
 /// [`utimensat`]: crate::fs::utimensat
 #[cfg(not(target_os = "redox"))]
-pub const UTIME_OMIT: Nsecs = backend::fs::types::UTIME_OMIT as Nsecs;
+pub const UTIME_OMIT: Nsecs = backend::c::UTIME_OMIT as Nsecs;
 
 /// `openat(dirfd, path, oflags, mode)`—Opens a file.
 ///

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -7,11 +7,11 @@
 
 use crate::fd::OwnedFd;
 use crate::ffi::{CStr, CString};
-#[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
+#[cfg(not(solarish))]
 use crate::fs::Access;
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(apple)]
 use crate::fs::CloneFlags;
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
+#[cfg(not(any(apple, target_os = "wasi")))]
 use crate::fs::FileType;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use crate::fs::RenameFlags;
@@ -271,7 +271,7 @@ pub fn statat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, flags: AtFlags) -> io:
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/faccessat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/faccessat.2.html
-#[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
+#[cfg(not(solarish))]
 #[inline]
 #[doc(alias = "faccessat")]
 pub fn accessat<P: path::Arg, Fd: AsFd>(
@@ -328,7 +328,7 @@ pub fn chmodat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, mode: Mode) -> io::Re
 ///  - [Apple]
 ///
 /// [Apple]: https://opensource.apple.com/source/xnu/xnu-3789.21.4/bsd/man/man2/clonefile.2.auto.html
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(apple)]
 #[inline]
 pub fn fclonefileat<Fd: AsFd, DstFd: AsFd, P: path::Arg>(
     src: Fd,
@@ -349,7 +349,7 @@ pub fn fclonefileat<Fd: AsFd, DstFd: AsFd, P: path::Arg>(
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/mknodat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/mknodat.2.html
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
+#[cfg(not(any(apple, target_os = "wasi")))]
 #[inline]
 pub fn mknodat<P: path::Arg, Fd: AsFd>(
     dirfd: Fd,

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -8,13 +8,11 @@ pub use backend::fs::types::{Access, Mode, OFlags};
 #[cfg(not(target_os = "redox"))]
 pub use backend::fs::types::AtFlags;
 
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(apple)]
 pub use backend::fs::types::{CloneFlags, CopyfileFlags};
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-pub use backend::fs::types::{
-    MountFlags, MountPropagationFlags, RenameFlags, ResolveFlags, UnmountFlags,
-};
+pub use backend::fs::types::*;
 
 #[cfg(not(target_os = "redox"))]
 pub use backend::fs::types::Dev;

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -67,7 +67,7 @@ pub struct Timestamps {
 ///
 /// [the `fstatfs` man page]: https://man7.org/linux/man-pages/man2/fstatfs.2.html#DESCRIPTION
 #[cfg(any(target_os = "android", target_os = "linux"))]
-pub const PROC_SUPER_MAGIC: FsWord = backend::fs::types::PROC_SUPER_MAGIC;
+pub const PROC_SUPER_MAGIC: FsWord = backend::c::PROC_SUPER_MAGIC as FsWord;
 
 /// The filesystem magic number for NFS.
 ///
@@ -75,7 +75,7 @@ pub const PROC_SUPER_MAGIC: FsWord = backend::fs::types::PROC_SUPER_MAGIC;
 ///
 /// [the `fstatfs` man page]: https://man7.org/linux/man-pages/man2/fstatfs.2.html#DESCRIPTION
 #[cfg(any(target_os = "android", target_os = "linux"))]
-pub const NFS_SUPER_MAGIC: FsWord = backend::fs::types::NFS_SUPER_MAGIC;
+pub const NFS_SUPER_MAGIC: FsWord = backend::c::NFS_SUPER_MAGIC as FsWord;
 
 /// `lseek(fd, offset, whence)`—Repositions a file descriptor within a file.
 ///

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -12,13 +12,12 @@ use backend::fd::{AsFd, BorrowedFd};
 pub use backend::fs::types::FlockOperation;
 
 #[cfg(not(any(
+    solarish,
     target_os = "aix",
     target_os = "dragonfly",
-    target_os = "illumos",
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub use backend::fs::types::FallocateFlags;
 
@@ -313,10 +312,9 @@ pub fn fsync<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/fdatasync.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/fdatasync.2.html
 #[cfg(not(any(
+    apple,
     target_os = "dragonfly",
     target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
     target_os = "redox",
 )))]
 #[inline]

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -11,37 +11,30 @@ mod cwd;
 #[cfg(not(target_os = "redox"))]
 mod dir;
 #[cfg(not(any(
+    apple,
+    netbsdlike,
+    solarish,
     target_os = "dragonfly",
     target_os = "haiku",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 mod fadvise;
 pub(crate) mod fcntl;
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(apple)]
 mod fcntl_darwin;
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(apple)]
 mod fcopyfile;
 pub(crate) mod fd;
 mod file_type;
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(apple)]
 mod getpath;
 #[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
+    apple,
+    freebsdlike,
+    netbsdlike,
+    solarish,
     target_os = "haiku",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
     target_os = "wasi",
 )))]
 mod makedev;
@@ -77,36 +70,9 @@ pub use abs::statfs;
     target_os = "wasi",
 )))]
 pub use abs::statvfs;
-#[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "solaris")))]
-pub use at::accessat;
-#[cfg(any(target_os = "ios", target_os = "macos"))]
-pub use at::fclonefileat;
-#[cfg(not(any(
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "redox",
-    target_os = "wasi",
-)))]
-pub use at::mknodat;
-#[cfg(any(target_os = "android", target_os = "linux"))]
-pub use at::renameat_with;
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
-pub use at::{chmodat, chownat};
 #[cfg(not(target_os = "redox"))]
-pub use at::{
-    linkat, mkdirat, openat, readlinkat, renameat, statat, symlinkat, unlinkat, utimensat, RawMode,
-    UTIME_NOW, UTIME_OMIT,
-};
-#[cfg(any(target_os = "ios", target_os = "macos"))]
-pub use constants::CloneFlags;
-/// `copyfile_flags_t`
-#[cfg(any(target_os = "ios", target_os = "macos"))]
-pub use constants::CopyfileFlags;
-pub use constants::{Access, FdFlags, Mode, Nsecs, OFlags, Secs, Timespec};
-#[cfg(not(target_os = "redox"))]
-pub use constants::{AtFlags, Dev};
-#[cfg(any(target_os = "android", target_os = "linux"))]
-pub use constants::{MountFlags, MountPropagationFlags, RenameFlags, ResolveFlags, UnmountFlags};
+pub use at::*;
+pub use constants::*;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use copy_file_range::copy_file_range;
 #[cfg(not(target_os = "redox"))]
@@ -114,99 +80,37 @@ pub use cwd::cwd;
 #[cfg(not(target_os = "redox"))]
 pub use dir::{Dir, DirEntry};
 #[cfg(not(any(
+    apple,
+    solarish,
+    netbsdlike,
     target_os = "dragonfly",
     target_os = "haiku",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub use fadvise::{fadvise, Advice};
-#[cfg(not(target_os = "wasi"))]
-pub use fcntl::fcntl_dupfd_cloexec;
-#[cfg(any(
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "linux",
-))]
-pub use fcntl::{fcntl_add_seals, fcntl_get_seals, SealFlags};
-pub use fcntl::{fcntl_getfd, fcntl_getfl, fcntl_setfd, fcntl_setfl};
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+pub use fcntl::*;
+#[cfg(apple)]
 pub use fcntl_darwin::{fcntl_fullfsync, fcntl_rdadvise};
-#[cfg(any(target_os = "ios", target_os = "macos"))]
-pub use fcopyfile::{
-    copyfile_state_alloc, copyfile_state_free, copyfile_state_get, copyfile_state_get_copied,
-    copyfile_state_t, fcopyfile,
-};
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "redox",
-)))]
-pub use fd::fdatasync;
-#[cfg(not(any(
-    target_os = "aix",
-    target_os = "dragonfly",
-    target_os = "illumos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "solaris",
-)))]
-pub use fd::{fallocate, FallocateFlags};
-#[cfg(not(target_os = "wasi"))]
-pub use fd::{fchmod, fchown};
-#[cfg(not(any(target_os = "solaris", target_os = "wasi")))]
-pub use fd::{flock, FlockOperation};
-pub use fd::{fstat, fsync, ftruncate, futimens, is_file_read_write, seek, tell, Stat, Timestamps};
-#[cfg(not(any(
-    target_os = "haiku",
-    target_os = "illumos",
-    target_os = "netbsd",
-    target_os = "redox",
-    target_os = "solaris",
-    target_os = "wasi",
-)))]
-pub use fd::{fstatfs, StatFs};
-#[cfg(not(any(
-    target_os = "haiku",
-    target_os = "illumos",
-    target_os = "redox",
-    target_os = "solaris",
-    target_os = "wasi",
-)))]
-pub use fd::{fstatvfs, StatVfs, StatVfsMountFlags};
-#[cfg(any(target_os = "android", target_os = "linux"))]
-pub use fd::{FsWord, NFS_SUPER_MAGIC, PROC_SUPER_MAGIC};
+#[cfg(apple)]
+pub use fcopyfile::*;
+pub use fd::*;
 pub use file_type::FileType;
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(apple)]
 pub use getpath::getpath;
 #[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
+    apple,
+    freebsdlike,
+    netbsdlike,
+    solarish,
     target_os = "haiku",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
     target_os = "wasi",
 )))]
 pub use makedev::{major, makedev, minor};
 #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 pub use memfd_create::{memfd_create, MemfdFlags};
 #[cfg(any(target_os = "android", target_os = "linux"))]
-pub use mount::{
-    bind_mount, change_mount, mount, move_mount, recursive_bind_mount, remount, unmount,
-};
+pub use mount::*;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use openat2::openat2;
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/io/ioctl.rs
+++ b/src/io/ioctl.rs
@@ -42,7 +42,7 @@ pub fn ioctl_tiocnxcl<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/ioctl.2.html
 /// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-ioctlsocket
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(apple)]
 #[inline]
 #[doc(alias = "FIOCLEX")]
 #[doc(alias = "FD_CLOEXEC")]

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -36,15 +36,7 @@ pub use eventfd::{eventfd, EventfdFlags};
 pub use fcntl::fcntl_dupfd_cloexec;
 #[cfg(not(windows))]
 pub use fcntl::{fcntl_getfd, fcntl_setfd, FdFlags};
-#[cfg(any(target_os = "ios", target_os = "macos"))]
-pub use ioctl::ioctl_fioclex;
-pub use ioctl::ioctl_fionbio;
-#[cfg(not(target_os = "redox"))]
-pub use ioctl::ioctl_fionread;
-#[cfg(any(target_os = "android", target_os = "linux"))]
-pub use ioctl::{ioctl_blkpbszget, ioctl_blksszget};
-#[cfg(not(any(windows, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
-pub use ioctl::{ioctl_tiocexcl, ioctl_tiocnxcl};
+pub use ioctl::*;
 #[cfg(not(any(windows, target_os = "redox")))]
 #[cfg(all(feature = "fs", feature = "net"))]
 pub use is_read_write::is_read_write;
@@ -60,11 +52,10 @@ pub use pipe::pipe;
 )))]
 pub use pipe::PIPE_BUF;
 #[cfg(not(any(
+    apple,
     windows,
     target_os = "aix",
     target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
     target_os = "wasi"
 )))]
 pub use pipe::{pipe_with, PipeFlags};
@@ -72,11 +63,9 @@ pub use pipe::{pipe_with, PipeFlags};
 pub use pipe::{splice, vmsplice, IoSliceRaw, SpliceFlags};
 pub use poll::{poll, PollFd, PollFlags};
 #[cfg(all(feature = "procfs", any(target_os = "android", target_os = "linux")))]
-pub use procfs::{
-    proc_self_fd, proc_self_fdinfo_fd, proc_self_maps, proc_self_pagemap, proc_self_status,
-};
+pub use procfs::*;
 #[cfg(not(windows))]
-pub use read_write::{pread, pwrite, read, readv, write, writev, IoSlice, IoSliceMut};
+pub use read_write::*;
 #[cfg(not(any(
     windows,
     target_os = "haiku",
@@ -88,6 +77,4 @@ pub use read_write::{preadv, pwritev};
 pub use read_write::{preadv2, pwritev2, ReadWriteFlags};
 pub use seek_from::SeekFrom;
 #[cfg(not(windows))]
-pub use stdio::{
-    raw_stderr, raw_stdin, raw_stdout, stderr, stdin, stdout, take_stderr, take_stdin, take_stdout,
-};
+pub use stdio::*;

--- a/src/io/pipe.rs
+++ b/src/io/pipe.rs
@@ -5,7 +5,7 @@ use crate::{backend, io};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use backend::fd::AsFd;
 
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub use backend::io::types::PipeFlags;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -54,12 +54,7 @@ pub fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/pipe2.2.html
-#[cfg(not(any(
-    target_os = "aix",
-    target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos"
-)))]
+#[cfg(not(any(apple, target_os = "aix", target_os = "haiku")))]
 #[inline]
 #[doc(alias = "pipe2")]
 pub fn pipe_with(flags: PipeFlags) -> io::Result<(OwnedFd, OwnedFd)> {

--- a/src/io/seek_from.rs
+++ b/src/io/seek_from.rs
@@ -33,12 +33,7 @@ pub enum SeekFrom {
     ///
     /// If the offset is in a hole at the end of the file, the seek will produce
     /// an `NXIO` error.
-    #[cfg(any(
-        target_os = "linux",
-        target_os = "solaris",
-        target_os = "freebsd",
-        target_os = "dragonfly",
-    ))]
+    #[cfg(any(freebsdlike, target_os = "linux", target_os = "solaris"))]
     Data(i64),
 
     /// Sets the offset to the current position plus the specified number of bytes,

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -9,9 +9,7 @@ mod userfaultfd;
 
 #[cfg(not(target_os = "redox"))]
 pub use madvise::{madvise, Advice};
-pub use mmap::{
-    mlock, mmap, mmap_anonymous, mprotect, munlock, munmap, MapFlags, MprotectFlags, ProtFlags,
-};
+pub use mmap::*;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use mmap::{mlock_with, MlockFlags};
 #[cfg(any(linux_raw, all(libc, target_os = "linux")))]

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -659,13 +659,7 @@ pub fn get_tcp_nodelay<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
 /// [Linux `tcp`]: https://man7.org/linux/man-pages/man7/tcp.7.html
 /// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
 /// [Winsock2 `IPPROTO_TCP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-tcp-socket-options
-#[cfg(any(
-    target_os = "freebsd",
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "tvos",
-    target_os = "watchos"
-))]
+#[cfg(any(apple, target_os = "freebsd"))]
 #[doc(alias = "SO_NOSIGPIPE")]
 #[inline]
 pub fn getsockopt_nosigpipe<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
@@ -688,13 +682,7 @@ pub fn getsockopt_nosigpipe<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
 /// [Linux `tcp`]: https://man7.org/linux/man-pages/man7/tcp.7.html
 /// [Winsock2 `setsockopt`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt
 /// [Winsock2 `IPPROTO_TCP` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-tcp-socket-options
-#[cfg(any(
-    target_os = "freebsd",
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "tvos",
-    target_os = "watchos"
-))]
+#[cfg(any(apple, target_os = "freebsd"))]
 #[doc(alias = "SO_NOSIGPIPE")]
 #[inline]
 pub fn setsockopt_nosigpipe<Fd: AsFd>(fd: Fd, val: bool) -> io::Result<()> {

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -33,58 +33,36 @@ mod uname;
 mod wait;
 
 #[cfg(not(target_os = "wasi"))]
-pub use chdir::chdir;
-#[cfg(not(any(target_os = "wasi", target_os = "fuchsia")))]
-pub use chdir::fchdir;
+pub use chdir::*;
+pub use exit::*;
 #[cfg(not(target_os = "wasi"))]
-pub use chdir::getcwd;
+pub use id::*;
 #[cfg(not(target_os = "wasi"))]
-pub use exit::EXIT_SIGNALED_SIGABRT;
-pub use exit::{EXIT_FAILURE, EXIT_SUCCESS};
+pub use kill::*;
 #[cfg(any(target_os = "android", target_os = "linux"))]
-pub use id::Cpuid;
-#[cfg(not(target_os = "wasi"))]
-pub use id::{
-    getegid, geteuid, getgid, getpgid, getpgrp, getpid, getppid, getuid, setsid, Gid, Pid, RawGid,
-    RawNonZeroPid, RawPid, RawUid, Uid,
-};
-#[cfg(not(target_os = "wasi"))]
-pub use kill::{kill_current_process_group, kill_process, kill_process_group, Signal};
-#[cfg(any(target_os = "android", target_os = "linux"))]
-pub use membarrier::{
-    membarrier, membarrier_cpu, membarrier_query, MembarrierCommand, MembarrierQuery,
-};
+pub use membarrier::*;
 #[cfg(target_os = "linux")]
-pub use pidfd::{pidfd_open, PidfdFlags};
+pub use pidfd::*;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use prctl::*;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
-pub use priority::nice;
-#[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
-pub use priority::{
-    getpriority_pgrp, getpriority_process, getpriority_user, setpriority_pgrp, setpriority_process,
-    setpriority_user,
-};
+pub use priority::*;
 #[cfg(target_os = "freebsd")]
 pub use procctl::*;
-#[cfg(any(target_os = "android", target_os = "linux"))]
-pub use rlimit::prlimit;
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
-pub use rlimit::{getrlimit, setrlimit, Resource, Rlimit};
+pub use rlimit::*;
 #[cfg(any(
     target_os = "android",
     target_os = "dragonfly",
     target_os = "fuchsia",
     target_os = "linux",
 ))]
-pub use sched::{sched_getaffinity, sched_setaffinity, CpuSet};
+pub use sched::*;
 pub use sched_yield::sched_yield;
 #[cfg(not(target_os = "wasi"))]
 pub use uname::{uname, Uname};
 #[cfg(not(target_os = "wasi"))]
-pub use wait::{wait, waitpid, WaitOptions, WaitStatus};
-#[cfg(not(any(target_os = "wasi", target_os = "redox", target_os = "openbsd")))]
-pub use wait::{waitid, WaitId, WaitidOptions, WaitidStatus};
+pub use wait::*;
 
 #[cfg(not(target_os = "wasi"))]
 #[cfg(feature = "fs")]

--- a/src/thread/clock.rs
+++ b/src/thread/clock.rs
@@ -3,11 +3,10 @@ use crate::{backend, io};
 pub use backend::time::types::Timespec;
 
 #[cfg(not(any(
+    apple,
     target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "freebsd", // FreeBSD 12 has clock_nanosleep, but libc targets FreeBSD 11.
-    target_os = "ios",
-    target_os = "macos",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "wasi",
@@ -27,12 +26,11 @@ pub use backend::time::types::ClockId;
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/clock_nanosleep.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/clock_nanosleep.2.html
 #[cfg(not(any(
+    apple,
     target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "freebsd", // FreeBSD 12 has clock_nanosleep, but libc targets FreeBSD 11.
     target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "wasi",
@@ -55,12 +53,11 @@ pub fn clock_nanosleep_relative(id: ClockId, request: &Timespec) -> NanosleepRel
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/clock_nanosleep.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/clock_nanosleep.2.html
 #[cfg(not(any(
+    apple,
     target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "freebsd", // FreeBSD 12 has clock_nanosleep, but libc targets FreeBSD 11.
     target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "wasi",

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -13,20 +13,8 @@ mod prctl;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod setns;
 
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "emscripten",
-    target_os = "freebsd",
-    target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "wasi",
-)))]
-pub use clock::{clock_nanosleep_absolute, clock_nanosleep_relative, ClockId};
 #[cfg(not(target_os = "redox"))]
-pub use clock::{nanosleep, NanosleepRelativeResult, Timespec};
+pub use clock::*;
 #[cfg(linux_raw)]
 pub use futex::{futex, FutexFlags, FutexOperation};
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -7,14 +7,7 @@ mod timerfd;
 
 // TODO: Convert WASI'S clock APIs to use handles rather than ambient clock
 // identifiers, update `wasi-libc`, and then add support in `rustix`.
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
-pub use clock::clock_getres;
-#[cfg(not(target_os = "wasi"))]
-pub use clock::{clock_gettime, clock_gettime_dynamic, ClockId, DynamicClockId};
-pub use clock::{Nsecs, Secs, Timespec};
+pub use clock::*;
 #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
 #[cfg(feature = "time")]
-pub use timerfd::{
-    timerfd_create, timerfd_gettime, timerfd_settime, Itimerspec, TimerfdClockId, TimerfdFlags,
-    TimerfdTimerFlags,
-};
+pub use timerfd::*;

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -1,7 +1,7 @@
 #[cfg(not(target_os = "redox"))]
 #[test]
 fn test_file() {
-    #[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
+    #[cfg(not(solarish))]
     rustix::fs::accessat(
         rustix::fs::cwd(),
         "Cargo.toml",


### PR DESCRIPTION
Define cfg flags following the OS groups from the libc crate, linux_like, freebsdlike, netbsdlike, apple, and solarish, to factor out common cfg groups.

And use `pub use foo::*;` instead of explicitly naming all the contents of `foo` in several places, reducing the need for `cfg` boilerplate.

There's more that can be done here, but this is a start.