### PR TITLE
Miscellaneous cleanups.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustix"
-version = "0.37.0-alpha.0"
+version = "0.37.0-alpha.1"
 authors = [
     "Dan Gohman <dev@sunfishcode.online>",
     "Jakub Konka <kubkon@jakubkonka.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ once_cell = { version = "1.5.2", optional = true }
 # libc backend can be selected via adding `--cfg=rustix_use_libc` to
 # `RUSTFLAGS` or enabling the `use-libc` cargo feature.
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
-linux-raw-sys = { version = "0.2.1", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
+linux-raw-sys = { version = "0.3.0", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 libc_errno = { package = "errno", version = "0.3.0", default-features = false, optional = true }
 libc = { version = "0.2.133", features = ["extra_traits"], optional = true }
 
@@ -56,7 +56,7 @@ libc = { version = "0.2.133", features = ["extra_traits"] }
 # Some syscalls do not have libc wrappers, such as in `io_uring`. For these,
 # the libc backend uses the linux-raw-sys ABI and `libc::syscall`.
 [target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64"))))))))'.dependencies]
-linux-raw-sys = { version = "0.2.1", default-features = false, features = ["general", "no_std"] }
+linux-raw-sys = { version = "0.3.0", default-features = false, features = ["general", "no_std"] }
 
 # For the libc backend on Windows, use the Winsock2 API in windows-sys.
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/build.rs
+++ b/build.rs
@@ -218,7 +218,7 @@ fn use_feature(feature: &str) {
 
 /// Test whether the rustc at `var("RUSTC")` supports the given feature.
 fn has_feature(feature: &str) -> bool {
-    can_compile(&format!(
+    can_compile(format!(
         "#![allow(stable_features)]\n#![feature({})]",
         feature
     ))

--- a/src/backend/libc/fs/inotify.rs
+++ b/src/backend/libc/fs/inotify.rs
@@ -110,9 +110,9 @@ pub fn inotify_add_watch<P: crate::path::Arg>(
 /// `inotify_rm_watch(self, wd)`-Removes a watch from this inotify
 ///
 /// The watch descriptor provided should have previously been returned
-/// by [`Self::add_watch()`] and not previously have been removed.
+/// by [`inotify_add_watch`] and not previously have been removed.
 #[doc(alias = "inotify_rm_watch")]
-pub fn inotify_remove_watch<P: crate::path::Arg>(inot: BorrowedFd<'_>, wd: i32) -> io::Result<()> {
+pub fn inotify_remove_watch(inot: BorrowedFd<'_>, wd: i32) -> io::Result<()> {
     // Android's `inotify_rm_watch` takes u32 despite `inotify_add_watch` is i32.
     #[cfg(target_os = "android")]
     let wd = wd as u32;

--- a/src/backend/libc/fs/inotify.rs
+++ b/src/backend/libc/fs/inotify.rs
@@ -96,7 +96,8 @@ pub fn inotify_add_watch<P: crate::path::Arg>(
     flags: WatchFlags,
 ) -> io::Result<i32> {
     let path = path.as_cow_c_str().unwrap();
-    // Safety: The fd and path we are passing is guranteed valid by the type system.
+    // Safety: The fd and path we are passing is guranteed valid by the type
+    // system.
     unsafe {
         ret_c_int(c::inotify_add_watch(
             borrowed_fd(inot),

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -1137,6 +1137,7 @@ pub(crate) fn fallocate(
     };
     unsafe {
         if c::fcntl(borrowed_fd(fd), c::F_PREALLOCATE, &store) == -1 {
+            // Unable to allocate contiguous disk space; attempt to allocate non-contiguously.
             store.fst_flags = c::F_ALLOCATEALL;
             let _ = ret_c_int(c::fcntl(borrowed_fd(fd), c::F_PREALLOCATE, &store))?;
         }

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -1137,7 +1137,8 @@ pub(crate) fn fallocate(
     };
     unsafe {
         if c::fcntl(borrowed_fd(fd), c::F_PREALLOCATE, &store) == -1 {
-            // Unable to allocate contiguous disk space; attempt to allocate non-contiguously.
+            // Unable to allocate contiguous disk space; attempt to allocate
+            // non-contiguously.
             store.fst_flags = c::F_ALLOCATEALL;
             let _ = ret_c_int(c::fcntl(borrowed_fd(fd), c::F_PREALLOCATE, &store))?;
         }

--- a/src/backend/libc/io/epoll.rs
+++ b/src/backend/libc/io/epoll.rs
@@ -47,7 +47,7 @@
 //!             let conn_sock = accept(&listen_sock)?;
 //!             ioctl_fionbio(&conn_sock, true)?;
 //!             epoll::epoll_add(&epoll, &conn_sock, next_id, epoll::EventFlags::OUT | epoll::EventFlags::ET)?;
-//!             
+//!
 //!             // Keep track of the socket.
 //!             sockets.insert(next_id, conn_sock);
 //!             next_id += 1;

--- a/src/backend/libc/io/epoll.rs
+++ b/src/backend/libc/io/epoll.rs
@@ -11,8 +11,7 @@
 //! # #[cfg(feature = "net")]
 //! # fn main() -> std::io::Result<()> {
 //! use io_lifetimes::AsFd;
-//! use rustix::io::epoll;
-//! use rustix::io::{ioctl_fionbio, read, write};
+//! use rustix::io::{epoll, ioctl_fionbio, read, write};
 //! use rustix::net::{
 //!     accept, bind_v4, listen, socket, AddressFamily, Ipv4Addr, Protocol, SocketAddrV4,
 //!     SocketType,
@@ -46,7 +45,12 @@
 //!             // register to be notified when it's ready to write to.
 //!             let conn_sock = accept(&listen_sock)?;
 //!             ioctl_fionbio(&conn_sock, true)?;
-//!             epoll::epoll_add(&epoll, &conn_sock, next_id, epoll::EventFlags::OUT | epoll::EventFlags::ET)?;
+//!             epoll::epoll_add(
+//!                 &epoll,
+//!                 &conn_sock,
+//!                 next_id,
+//!                 epoll::EventFlags::OUT | epoll::EventFlags::ET,
+//!             )?;
 //!
 //!             // Keep track of the socket.
 //!             sockets.insert(next_id, conn_sock);

--- a/src/backend/libc/io/types.rs
+++ b/src/backend/libc/io/types.rs
@@ -116,9 +116,10 @@ pub(crate) const STDOUT_FILENO: c::c_int = c::STDOUT_FILENO;
 pub(crate) const STDERR_FILENO: c::c_int = c::STDERR_FILENO;
 
 /// A buffer type used with `vmsplice`.
-/// It is guaranteed to be ABI compatible with the iovec type on Unix platforms and WSABUF on Windows.
-/// Unlike `IoSlice` and `IoSliceMut` it is semantically like a raw pointer,
-/// and therefore can be shared or mutated as needed.
+/// It is guaranteed to be ABI compatible with the iovec type on Unix platforms
+/// and `WSABUF` on Windows. Unlike `IoSlice` and `IoSliceMut` it is
+/// semantically like a raw pointer, and therefore can be shared or mutated as
+/// needed.
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[repr(transparent)]
 pub struct IoSliceRaw<'a> {

--- a/src/backend/libc/io_lifetimes.rs
+++ b/src/backend/libc/io_lifetimes.rs
@@ -13,11 +13,11 @@ pub use io_lifetimes::AsSocket;
 
 /// A version of [`AsRawFd`] for use with Winsock2 API.
 ///
-/// [`AsRawFd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.AsRawFd.html
+/// [`AsRawFd`]: https://doc.rust-lang.org/stable/std/os/fd/trait.AsRawFd.html
 pub trait AsRawFd {
     /// A version of [`as_raw_fd`] for use with Winsock2 API.
     ///
-    /// [`as_raw_fd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.FromRawFd.html#tymethod.as_raw_fd
+    /// [`as_raw_fd`]: https://doc.rust-lang.org/stable/std/os/fd/trait.FromRawFd.html#tymethod.as_raw_fd
     fn as_raw_fd(&self) -> RawFd;
 }
 #[cfg(feature = "std")]
@@ -30,11 +30,11 @@ impl<T: std::os::windows::io::AsRawSocket> AsRawFd for T {
 
 /// A version of [`IntoRawFd`] for use with Winsock2 API.
 ///
-/// [`IntoRawFd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.IntoRawFd.html
+/// [`IntoRawFd`]: https://doc.rust-lang.org/stable/std/os/fd/trait.IntoRawFd.html
 pub trait IntoRawFd {
     /// A version of [`into_raw_fd`] for use with Winsock2 API.
     ///
-    /// [`into_raw_fd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.FromRawFd.html#tymethod.into_raw_fd
+    /// [`into_raw_fd`]: https://doc.rust-lang.org/stable/std/os/fd/trait.FromRawFd.html#tymethod.into_raw_fd
     fn into_raw_fd(self) -> RawFd;
 }
 #[cfg(feature = "std")]
@@ -47,11 +47,16 @@ impl<T: std::os::windows::io::IntoRawSocket> IntoRawFd for T {
 
 /// A version of [`FromRawFd`] for use with Winsock2 API.
 ///
-/// [`FromRawFd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.FromRawFd.html
+/// [`FromRawFd`]: https://doc.rust-lang.org/stable/std/os/fd/trait.FromRawFd.html
 pub trait FromRawFd {
     /// A version of [`from_raw_fd`] for use with Winsock2 API.
     ///
-    /// [`from_raw_fd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.FromRawFd.html#tymethod.from_raw_fd
+    /// # Safety
+    ///
+    /// See the [safety requirements] for [`from_raw_fd`].
+    ///
+    /// [`from_raw_fd`]: https://doc.rust-lang.org/stable/std/os/fd/trait.FromRawFd.html#tymethod.from_raw_fd
+    /// [safety requirements]: https://doc.rust-lang.org/stable/std/os/fd/trait.FromRawFd.html#safety
     unsafe fn from_raw_fd(raw_fd: RawFd) -> Self;
 }
 #[cfg(feature = "std")]
@@ -64,7 +69,7 @@ impl<T: std::os::windows::io::FromRawSocket> FromRawFd for T {
 
 /// A version of [`AsFd`] for use with Winsock2 API.
 ///
-/// [`AsFd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.AsFd.html
+/// [`AsFd`]: https://doc.rust-lang.org/stable/std/os/fd/trait.AsFd.html
 pub trait AsFd {
     /// An `as_fd` function for Winsock2, where a `Fd` is a `Socket`.
     fn as_fd(&self) -> BorrowedFd;

--- a/src/backend/libc/mm/syscalls.rs
+++ b/src/backend/libc/mm/syscalls.rs
@@ -7,7 +7,7 @@ use super::super::conv::{borrowed_fd, no_fd, ret};
 use super::super::offset::libc_mmap;
 #[cfg(not(target_os = "redox"))]
 use super::types::Advice;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "emscripten", target_os = "linux"))]
 use super::types::MremapFlags;
 use super::types::{MapFlags, MprotectFlags, MsyncFlags, ProtFlags};
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/backend/libc/mm/syscalls.rs
+++ b/src/backend/libc/mm/syscalls.rs
@@ -130,7 +130,7 @@ pub(crate) unsafe fn munmap(ptr: *mut c::c_void, len: usize) -> io::Result<()> {
 ///
 /// `mremap` is primarily unsafe due to the `old_address` parameter, as
 /// anything working with memory pointed to by raw pointers is unsafe.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "emscripten", target_os = "linux"))]
 pub(crate) unsafe fn mremap(
     old_address: *mut c::c_void,
     old_size: usize,
@@ -150,7 +150,7 @@ pub(crate) unsafe fn mremap(
 /// `mremap_fixed` is primarily unsafe due to the `old_address` and
 /// `new_address` parameters, as anything working with memory pointed to by raw
 /// pointers is unsafe.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "emscripten", target_os = "linux"))]
 pub(crate) unsafe fn mremap_fixed(
     old_address: *mut c::c_void,
     old_size: usize,

--- a/src/backend/libc/mm/types.rs
+++ b/src/backend/libc/mm/types.rs
@@ -180,7 +180,7 @@ bitflags! {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "emscripten", target_os = "linux"))]
 bitflags! {
     /// `MREMAP_*` flags for use with [`mremap`].
     ///

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -466,8 +466,8 @@ fn _waitid_pidfd(fd: BorrowedFd<'_>, options: WaitidOptions) -> io::Result<Optio
 ///
 /// # Safety
 ///
-/// The caller must ensure that `status` is initialized and that `waitid` returned
-/// successfully.
+/// The caller must ensure that `status` is initialized and that `waitid`
+/// returned successfully.
 #[cfg(not(any(target_os = "wasi", target_os = "redox", target_os = "openbsd")))]
 #[inline]
 unsafe fn cvt_waitid_status(status: MaybeUninit<c::siginfo_t>) -> Option<WaitidStatus> {

--- a/src/backend/libc/rand/syscalls.rs
+++ b/src/backend/libc/rand/syscalls.rs
@@ -1,9 +1,9 @@
 //! libc syscalls supporting `rustix::rand`.
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 use {super::super::c, super::super::conv::ret_ssize_t, crate::io, crate::rand::GetRandomFlags};
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 pub(crate) fn getrandom(buf: &mut [u8], flags: GetRandomFlags) -> io::Result<usize> {
     // `getrandom` wasn't supported in glibc until 2.25.
     weak_or_syscall! {

--- a/src/backend/libc/rand/types.rs
+++ b/src/backend/libc/rand/types.rs
@@ -1,9 +1,9 @@
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 use super::super::c;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 use bitflags::bitflags;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 bitflags! {
     /// `GRND_*` flags for use with [`getrandom`].
     ///

--- a/src/backend/libc/termios/types.rs
+++ b/src/backend/libc/termios/types.rs
@@ -367,6 +367,7 @@ pub const TAB2: c::c_uint = c::TAB2;
     bsd,
     solarish,
     target_os = "emscripten",
+    target_os = "fuchsia",
     target_os = "redox",
 )))]
 pub const TAB3: c::c_uint = c::TAB3;

--- a/src/backend/libc/termios/types.rs
+++ b/src/backend/libc/termios/types.rs
@@ -113,16 +113,14 @@ pub const VMIN: usize = c::VMIN as usize;
 
 /// `VSWTC`
 #[cfg(not(any(
+    apple,
+    solarish,
     target_os = "aix",
     target_os = "dragonfly",
     target_os = "freebsd",
     target_os = "haiku",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
     target_os = "netbsd",
     target_os = "openbsd",
-    target_os = "solaris",
 )))]
 pub const VSWTC: usize = c::VSWTC as usize;
 
@@ -158,475 +156,275 @@ pub const VLNEXT: usize = c::VLNEXT as usize;
 pub const VEOL2: usize = c::VEOL2 as usize;
 
 /// `IGNBRK`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const IGNBRK: c::c_uint = c::IGNBRK;
 
 /// `BRKINT`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const BRKINT: c::c_uint = c::BRKINT;
 
 /// `IGNPAR`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const IGNPAR: c::c_uint = c::IGNPAR;
 
 /// `PARMRK`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const PARMRK: c::c_uint = c::PARMRK;
 
 /// `INPCK`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const INPCK: c::c_uint = c::INPCK;
 
 /// `ISTRIP`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const ISTRIP: c::c_uint = c::ISTRIP;
 
 /// `INLCR`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const INLCR: c::c_uint = c::INLCR;
 
 /// `IGNCR`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const IGNCR: c::c_uint = c::IGNCR;
 
 /// `ICRNL`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const ICRNL: c::c_uint = c::ICRNL;
 
 /// `IUCLC`
-#[cfg(any(target_os = "haiku", target_os = "illumos", target_os = "solaris"))]
+#[cfg(any(solarish, target_os = "haiku"))]
 pub const IUCLC: c::c_uint = c::IUCLC;
 
 /// `IXON`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const IXON: c::c_uint = c::IXON;
 
 /// `IXANY`
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(apple, target_os = "redox")))]
 pub const IXANY: c::c_uint = c::IXANY;
 
 /// `IXOFF`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const IXOFF: c::c_uint = c::IXOFF;
 
 /// `IMAXBEL`
-#[cfg(not(any(
-    target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "redox"
-)))]
+#[cfg(not(any(apple, target_os = "haiku", target_os = "redox")))]
 pub const IMAXBEL: c::c_uint = c::IMAXBEL;
 
 /// `IUTF8`
 #[cfg(not(any(
+    apple,
+    solarish,
     target_os = "aix",
     target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "freebsd",
     target_os = "haiku",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const IUTF8: c::c_uint = c::IUTF8;
 
 /// `OPOST`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const OPOST: c::c_uint = c::OPOST;
 
 /// `OLCUC`
 #[cfg(not(any(
+    apple,
     target_os = "aix",
     target_os = "dragonfly",
     target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
     target_os = "netbsd",
     target_os = "redox",
 )))]
 pub const OLCUC: c::c_uint = c::OLCUC;
 
 /// `ONLCR`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const ONLCR: c::c_uint = c::ONLCR;
 
 /// `OCRNL`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const OCRNL: c::c_uint = c::OCRNL;
 
 /// `ONOCR`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const ONOCR: c::c_uint = c::ONOCR;
 
 /// `ONLRET`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const ONLRET: c::c_uint = c::ONLRET;
 
 /// `OFILL`
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-)))]
+#[cfg(not(bsd))]
 pub const OFILL: c::c_uint = c::OFILL;
 
 /// `OFDEL`
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-)))]
+#[cfg(not(bsd))]
 pub const OFDEL: c::c_uint = c::OFDEL;
 
 /// `NLDLY`
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "solaris",
-)))]
+#[cfg(not(any(bsd, solarish, target_os = "redox")))]
 pub const NLDLY: c::c_uint = c::NLDLY;
 
 /// `NL0`
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "solaris",
-)))]
+#[cfg(not(any(bsd, solarish, target_os = "fuchsia", target_os = "redox")))]
 pub const NL0: c::c_uint = c::NL0;
 
 /// `NL1`
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "solaris",
-)))]
+#[cfg(not(any(bsd, solarish, target_os = "fuchsia", target_os = "redox")))]
 pub const NL1: c::c_uint = c::NL1;
 
 /// `CRDLY`
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "solaris",
-)))]
+#[cfg(not(any(bsd, solarish, target_os = "redox")))]
 pub const CRDLY: c::c_uint = c::CRDLY;
 
 /// `CR0`
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "solaris",
-)))]
+#[cfg(not(any(bsd, solarish, target_os = "fuchsia", target_os = "redox")))]
 pub const CR0: c::c_uint = c::CR0;
 
 /// `CR1`
 #[cfg(not(any(
     target_env = "musl",
-    target_os = "dragonfly",
+    bsd,
+    solarish,
     target_os = "emscripten",
-    target_os = "freebsd",
     target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const CR1: c::c_uint = c::CR1;
 
 /// `CR2`
 #[cfg(not(any(
     target_env = "musl",
-    target_os = "dragonfly",
+    bsd,
+    solarish,
     target_os = "emscripten",
-    target_os = "freebsd",
     target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const CR2: c::c_uint = c::CR2;
 
 /// `CR3`
 #[cfg(not(any(
     target_env = "musl",
-    target_os = "dragonfly",
+    bsd,
+    solarish,
     target_os = "emscripten",
-    target_os = "freebsd",
     target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const CR3: c::c_uint = c::CR3;
 
 /// `TABDLY`
 #[cfg(not(any(
+    apple,
+    netbsdlike,
+    solarish,
     target_os = "dragonfly",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "illumos",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const TABDLY: c::c_uint = c::TABDLY;
 
 /// `TAB0`
 #[cfg(not(any(
+    apple,
+    netbsdlike,
+    solarish,
     target_os = "dragonfly",
     target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const TAB0: c::c_uint = c::TAB0;
 
 /// `TAB1`
 #[cfg(not(any(
     target_env = "musl",
-    target_os = "dragonfly",
+    bsd,
+    solarish,
     target_os = "emscripten",
-    target_os = "freebsd",
     target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const TAB1: c::c_uint = c::TAB1;
 
 /// `TAB2`
 #[cfg(not(any(
     target_env = "musl",
-    target_os = "dragonfly",
+    bsd,
+    solarish,
     target_os = "emscripten",
-    target_os = "freebsd",
     target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const TAB2: c::c_uint = c::TAB2;
 
 /// `TAB3`
 #[cfg(not(any(
     target_env = "musl",
-    target_os = "dragonfly",
+    bsd,
+    solarish,
     target_os = "emscripten",
-    target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const TAB3: c::c_uint = c::TAB3;
 
 /// `BSDLY`
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "solaris",
-)))]
+#[cfg(not(any(bsd, solarish, target_os = "redox")))]
 pub const BSDLY: c::c_uint = c::BSDLY;
 
 /// `BS0`
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "solaris",
-)))]
+#[cfg(not(any(bsd, solarish, target_os = "fuchsia", target_os = "redox")))]
 pub const BS0: c::c_uint = c::BS0;
 
 /// `BS1`
 #[cfg(not(any(
     target_env = "musl",
+    bsd,
+    solarish,
     target_os = "emscripten",
-    target_os = "dragonfly",
-    target_os = "freebsd",
     target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const BS1: c::c_uint = c::BS1;
 
 /// `FFDLY`
-#[cfg(not(any(
-    target_env = "musl",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "solaris",
-)))]
+#[cfg(not(any(target_env = "musl", bsd, solarish, target_os = "redox")))]
 pub const FFDLY: c::c_uint = c::FFDLY;
 
 /// `FF0`
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "solaris",
-)))]
+#[cfg(not(any(bsd, solarish, target_os = "fuchsia", target_os = "redox")))]
 pub const FF0: c::c_uint = c::FF0;
 
 /// `FF1`
 #[cfg(not(any(
     target_env = "musl",
-    target_os = "dragonfly",
+    bsd,
+    solarish,
     target_os = "emscripten",
-    target_os = "freebsd",
     target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const FF1: c::c_uint = c::FF1;
 
 /// `VTDLY`
-#[cfg(not(any(
-    target_env = "musl",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "solaris",
-)))]
+#[cfg(not(any(target_env = "musl", bsd, solarish, target_os = "redox")))]
 pub const VTDLY: c::c_uint = c::VTDLY;
 
 /// `VT0`
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "solaris",
-)))]
+#[cfg(not(any(bsd, solarish, target_os = "fuchsia", target_os = "redox")))]
 pub const VT0: c::c_uint = c::VT0;
 
 /// `VT1`
 #[cfg(not(any(
     target_env = "musl",
-    target_os = "dragonfly",
+    bsd,
+    solarish,
     target_os = "emscripten",
-    target_os = "freebsd",
     target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const VT1: c::c_uint = c::VT1;
 
@@ -692,124 +490,55 @@ pub const B230400: Speed = c::B230400;
 
 /// `B460800`
 #[cfg(not(any(
+    apple,
     target_os = "aix",
     target_os = "dragonfly",
     target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
     target_os = "openbsd"
 )))]
 pub const B460800: Speed = c::B460800;
 
 /// `B500000`
-#[cfg(not(any(
-    target_os = "aix",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "haiku",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "solaris",
-)))]
+#[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
 pub const B500000: Speed = c::B500000;
 
 /// `B576000`
-#[cfg(not(any(
-    target_os = "aix",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "haiku",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "solaris",
-)))]
+#[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
 pub const B576000: Speed = c::B576000;
 
 /// `B921600`
 #[cfg(not(any(
+    apple,
     target_os = "aix",
     target_os = "dragonfly",
     target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
     target_os = "openbsd"
 )))]
 pub const B921600: Speed = c::B921600;
 
 /// `B1000000`
-#[cfg(not(any(
-    target_os = "aix",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "solaris"
-)))]
+#[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "solaris")))]
 pub const B1000000: Speed = c::B1000000;
 
 /// `B1152000`
-#[cfg(not(any(
-    target_os = "aix",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "solaris",
-)))]
+#[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "solaris")))]
 pub const B1152000: Speed = c::B1152000;
 
 /// `B1500000`
-#[cfg(not(any(
-    target_os = "aix",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "solaris",
-)))]
+#[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "solaris")))]
 pub const B1500000: Speed = c::B1500000;
 
 /// `B2000000`
-#[cfg(not(any(
-    target_os = "aix",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "solaris",
-)))]
+#[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "solaris")))]
 pub const B2000000: Speed = c::B2000000;
 
 /// `B2500000`
 #[cfg(not(any(
     target_arch = "sparc",
     target_arch = "sparc64",
+    bsd,
     target_os = "aix",
-    target_os = "dragonfly",
-    target_os = "freebsd",
     target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "solaris",
 )))]
 pub const B2500000: Speed = c::B2500000;
@@ -818,14 +547,9 @@ pub const B2500000: Speed = c::B2500000;
 #[cfg(not(any(
     target_arch = "sparc",
     target_arch = "sparc64",
+    bsd,
     target_os = "aix",
-    target_os = "dragonfly",
-    target_os = "freebsd",
     target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "solaris",
 )))]
 pub const B3000000: Speed = c::B3000000;
@@ -834,14 +558,9 @@ pub const B3000000: Speed = c::B3000000;
 #[cfg(not(any(
     target_arch = "sparc",
     target_arch = "sparc64",
+    bsd,
     target_os = "aix",
-    target_os = "dragonfly",
-    target_os = "freebsd",
     target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "solaris",
 )))]
 pub const B3500000: Speed = c::B3500000;
@@ -850,14 +569,9 @@ pub const B3500000: Speed = c::B3500000;
 #[cfg(not(any(
     target_arch = "sparc",
     target_arch = "sparc64",
+    bsd,
     target_os = "aix",
-    target_os = "dragonfly",
-    target_os = "freebsd",
     target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "solaris",
 )))]
 pub const B4000000: Speed = c::B4000000;
@@ -867,51 +581,51 @@ pub const B4000000: Speed = c::B4000000;
 pub const BOTHER: c::c_uint = c::BOTHER;
 
 /// `CSIZE`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const CSIZE: c::c_uint = c::CSIZE;
 
 /// `CS5`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const CS5: c::c_uint = c::CS5;
 
 /// `CS6`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const CS6: c::c_uint = c::CS6;
 
 /// `CS7`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const CS7: c::c_uint = c::CS7;
 
 /// `CS8`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const CS8: c::c_uint = c::CS8;
 
 /// `CSTOPB`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const CSTOPB: c::c_uint = c::CSTOPB;
 
 /// `CREAD`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const CREAD: c::c_uint = c::CREAD;
 
 /// `PARENB`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const PARENB: c::c_uint = c::PARENB;
 
 /// `PARODD`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const PARODD: c::c_uint = c::PARODD;
 
 /// `HUPCL`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const HUPCL: c::c_uint = c::HUPCL;
 
 /// `CLOCAL`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const CLOCAL: c::c_uint = c::CLOCAL;
 
 /// `ISIG`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const ISIG: c::c_uint = c::ISIG;
 
 /// `ICANON`—A flag for the `c_lflag` field of [`Termios`] indicating
@@ -919,99 +633,75 @@ pub const ISIG: c::c_uint = c::ISIG;
 pub const ICANON: Tcflag = c::ICANON;
 
 /// `ECHO`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const ECHO: c::c_uint = c::ECHO;
 
 /// `ECHOE`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const ECHOE: c::c_uint = c::ECHOE;
 
 /// `ECHOK`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const ECHOK: c::c_uint = c::ECHOK;
 
 /// `ECHONL`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const ECHONL: c::c_uint = c::ECHONL;
 
 /// `NOFLSH`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const NOFLSH: c::c_uint = c::NOFLSH;
 
 /// `TOSTOP`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const TOSTOP: c::c_uint = c::TOSTOP;
 
 /// `IEXTEN`
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(apple))]
 pub const IEXTEN: c::c_uint = c::IEXTEN;
 
 /// `EXTA`
 #[cfg(not(any(
+    apple,
+    solarish,
     target_os = "emscripten",
     target_os = "haiku",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const EXTA: c::c_uint = c::EXTA;
 
 /// `EXTB`
 #[cfg(not(any(
+    apple,
+    solarish,
     target_os = "emscripten",
     target_os = "haiku",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const EXTB: c::c_uint = c::EXTB;
 
 /// `CBAUD`
-#[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-)))]
+#[cfg(not(any(bsd, target_os = "haiku", target_os = "redox")))]
 pub const CBAUD: c::c_uint = c::CBAUD;
 
 /// `CBAUDEX`
 #[cfg(not(any(
+    bsd,
+    solarish,
     target_os = "aix",
-    target_os = "dragonfly",
-    target_os = "freebsd",
     target_os = "haiku",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const CBAUDEX: c::c_uint = c::CBAUDEX;
 
 /// `CIBAUD`
 #[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "emscripten",
-    target_os = "freebsd",
-    target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
     target_arch = "powerpc",
     target_arch = "powerpc64",
+    bsd,
+    target_os = "emscripten",
+    target_os = "haiku",
+    target_os = "redox",
 )))]
 pub const CIBAUD: c::tcflag_t = c::CIBAUD;
 
@@ -1022,28 +712,17 @@ pub const CIBAUD: c::tcflag_t = 0o77600000;
 
 /// `CMSPAR`
 #[cfg(not(any(
+    bsd,
+    solarish,
     target_os = "aix",
-    target_os = "dragonfly",
     target_os = "emscripten",
-    target_os = "freebsd",
     target_os = "haiku",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const CMSPAR: c::c_uint = c::CMSPAR;
 
 /// `CRTSCTS`
-#[cfg(not(any(
-    target_os = "aix",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "redox",
-)))]
+#[cfg(not(any(apple, target_os = "aix", target_os = "redox")))]
 pub const CRTSCTS: c::c_uint = c::CRTSCTS;
 
 /// `XCASE`
@@ -1051,47 +730,35 @@ pub const CRTSCTS: c::c_uint = c::CRTSCTS;
 pub const XCASE: c::c_uint = c::XCASE;
 
 /// `ECHOCTL`
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(apple, target_os = "redox")))]
 pub const ECHOCTL: c::c_uint = c::ECHOCTL;
 
 /// `ECHOPRT`
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(apple, target_os = "redox")))]
 pub const ECHOPRT: c::c_uint = c::ECHOPRT;
 
 /// `ECHOKE`
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(apple, target_os = "redox")))]
 pub const ECHOKE: c::c_uint = c::ECHOKE;
 
 /// `FLUSHO`
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(apple, target_os = "redox")))]
 pub const FLUSHO: c::c_uint = c::FLUSHO;
 
 /// `PENDIN`
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(apple, target_os = "redox")))]
 pub const PENDIN: c::c_uint = c::PENDIN;
 
 /// `EXTPROC`
-#[cfg(not(any(
-    target_os = "aix",
-    target_os = "haiku",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "redox"
-)))]
+#[cfg(not(any(apple, target_os = "aix", target_os = "haiku", target_os = "redox")))]
 pub const EXTPROC: c::c_uint = c::EXTPROC;
 
 /// `XTABS`
 #[cfg(not(any(
+    bsd,
+    solarish,
     target_os = "aix",
-    target_os = "dragonfly",
-    target_os = "freebsd",
     target_os = "haiku",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
     target_os = "redox",
-    target_os = "solaris",
 )))]
 pub const XTABS: c::c_uint = c::XTABS;

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -318,14 +318,12 @@ pub(crate) fn capset(
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
-#[must_use]
 pub(crate) fn setuid_thread(uid: crate::process::Uid) -> io::Result<()> {
     unsafe { syscall_ret(c::syscall(c::SYS_setuid, uid.as_raw())) }
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
-#[must_use]
 pub(crate) fn setgid_thread(gid: crate::process::Gid) -> io::Result<()> {
     unsafe { syscall_ret(c::syscall(c::SYS_setgid, gid.as_raw())) }
 }

--- a/src/backend/linux_raw/fs/inotify.rs
+++ b/src/backend/linux_raw/fs/inotify.rs
@@ -103,6 +103,6 @@ pub fn inotify_add_watch<P: crate::path::Arg>(
 /// The watch descriptor provided should have previously been returned
 /// by [`Self::add_watch()`] and not previously have been removed.
 #[doc(alias = "inotify_rm_watch")]
-pub fn inotify_remove_watch<P: crate::path::Arg>(inot: BorrowedFd<'_>, wd: i32) -> io::Result<()> {
+pub fn inotify_remove_watch(inot: BorrowedFd<'_>, wd: i32) -> io::Result<()> {
     syscalls::inotify_rm_watch(inot, wd)
 }

--- a/src/backend/linux_raw/fs/inotify.rs
+++ b/src/backend/linux_raw/fs/inotify.rs
@@ -101,7 +101,7 @@ pub fn inotify_add_watch<P: crate::path::Arg>(
 /// `inotify_rm_watch(self, wd)`-Removes a watch from this inotify
 ///
 /// The watch descriptor provided should have previously been returned
-/// by [`Self::add_watch()`] and not previously have been removed.
+/// by [`inotify_add_watch`] and not previously have been removed.
 #[doc(alias = "inotify_rm_watch")]
 pub fn inotify_remove_watch(inot: BorrowedFd<'_>, wd: i32) -> io::Result<()> {
     syscalls::inotify_rm_watch(inot, wd)

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -23,11 +23,10 @@ use super::super::conv::{loff_t, loff_t_from_u64, ret_u64};
 use crate::fd::AsFd;
 use crate::fd::{BorrowedFd, OwnedFd};
 use crate::ffi::CStr;
-use crate::fs::inotify;
 use crate::fs::{
-    Access, Advice, AtFlags, FallocateFlags, FileType, FlockOperation, MemfdFlags, Mode, OFlags,
-    RenameFlags, ResolveFlags, SealFlags, Stat, StatFs, StatVfs, StatVfsMountFlags, StatxFlags,
-    Timestamps,
+    inotify, Access, Advice, AtFlags, FallocateFlags, FileType, FlockOperation, MemfdFlags, Mode,
+    OFlags, RenameFlags, ResolveFlags, SealFlags, Stat, StatFs, StatVfs, StatVfsMountFlags,
+    StatxFlags, Timestamps,
 };
 use crate::io::{self, SeekFrom};
 use crate::process::{Gid, Uid};

--- a/src/backend/linux_raw/io/epoll.rs
+++ b/src/backend/linux_raw/io/epoll.rs
@@ -47,7 +47,7 @@
 //!             let conn_sock = accept(&listen_sock)?;
 //!             ioctl_fionbio(&conn_sock, true)?;
 //!             epoll::epoll_add(&epoll, &conn_sock, next_id, epoll::EventFlags::OUT | epoll::EventFlags::ET)?;
-//!             
+//!
 //!             // Keep track of the socket.
 //!             sockets.insert(next_id, conn_sock);
 //!             next_id += 1;

--- a/src/backend/linux_raw/io/epoll.rs
+++ b/src/backend/linux_raw/io/epoll.rs
@@ -11,8 +11,7 @@
 //! # #[cfg(feature = "net")]
 //! # fn main() -> std::io::Result<()> {
 //! use io_lifetimes::AsFd;
-//! use rustix::io::epoll;
-//! use rustix::io::{ioctl_fionbio, read, write};
+//! use rustix::io::{epoll, ioctl_fionbio, read, write};
 //! use rustix::net::{
 //!     accept, bind_v4, listen, socket, AddressFamily, Ipv4Addr, Protocol, SocketAddrV4,
 //!     SocketType,
@@ -46,7 +45,12 @@
 //!             // register to be notified when it's ready to write to.
 //!             let conn_sock = accept(&listen_sock)?;
 //!             ioctl_fionbio(&conn_sock, true)?;
-//!             epoll::epoll_add(&epoll, &conn_sock, next_id, epoll::EventFlags::OUT | epoll::EventFlags::ET)?;
+//!             epoll::epoll_add(
+//!                 &epoll,
+//!                 &conn_sock,
+//!                 next_id,
+//!                 epoll::EventFlags::OUT | epoll::EventFlags::ET,
+//!             )?;
 //!
 //!             // Keep track of the socket.
 //!             sockets.insert(next_id, conn_sock);

--- a/src/backend/linux_raw/io/types.rs
+++ b/src/backend/linux_raw/io/types.rs
@@ -104,7 +104,7 @@ pub struct IoSliceRaw<'a> {
 }
 
 impl<'a> IoSliceRaw<'a> {
-    /// Creates a new IoSlice wrapping a byte slice.
+    /// Creates a new `IoSlice` wrapping a byte slice.
     pub fn from_slice(buf: &'a [u8]) -> Self {
         IoSliceRaw {
             _buf: c::iovec {
@@ -115,7 +115,7 @@ impl<'a> IoSliceRaw<'a> {
         }
     }
 
-    /// Creates a new IoSlice wrapping a mutable byte slice.
+    /// Creates a new `IoSlice` wrapping a mutable byte slice.
     pub fn from_slice_mut(buf: &'a mut [u8]) -> Self {
         IoSliceRaw {
             _buf: c::iovec {

--- a/src/backend/linux_raw/io/types.rs
+++ b/src/backend/linux_raw/io/types.rs
@@ -94,9 +94,10 @@ pub(crate) const STDOUT_FILENO: c::c_uint = linux_raw_sys::general::STDOUT_FILEN
 pub(crate) const STDERR_FILENO: c::c_uint = linux_raw_sys::general::STDERR_FILENO;
 
 /// A buffer type used with `vmsplice`.
-/// It is guaranteed to be ABI compatible with the iovec type on Unix platforms and WSABUF on Windows.
-/// Unlike `IoSlice` and `IoSliceMut` it is semantically like a raw pointer,
-/// and therefore can be shared or mutated as needed.
+/// It is guaranteed to be ABI compatible with the iovec type on Unix platforms
+/// and `WSABUF` on Windows. Unlike `IoSlice` and `IoSliceMut` it is
+/// semantically like a raw pointer, and therefore can be shared or mutated as
+/// needed.
 #[repr(transparent)]
 pub struct IoSliceRaw<'a> {
     _buf: c::iovec,

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -582,8 +582,8 @@ fn _waitid_pidfd(fd: BorrowedFd<'_>, options: WaitidOptions) -> io::Result<Optio
 ///
 /// # Safety
 ///
-/// The caller must ensure that `status` is initialized and that `waitid` returned
-/// successfully.
+/// The caller must ensure that `status` is initialized and that `waitid`
+/// returned successfully.
 #[inline]
 unsafe fn cvt_waitid_status(status: MaybeUninit<c::siginfo_t>) -> Option<WaitidStatus> {
     let status = status.assume_init();

--- a/src/fs/mount.rs
+++ b/src/fs/mount.rs
@@ -36,7 +36,7 @@ pub fn mount<Source: path::Arg, Target: path::Arg, Fs: path::Arg, Data: path::Ar
     })
 }
 
-/// `mount(null, target, null, MS_REMOUNT | mountflags, data)`
+/// `mount(NULL, target, NULL, MS_REMOUNT | mountflags, data)`
 ///
 /// # References
 ///  - [Linux]
@@ -62,7 +62,7 @@ pub fn remount<Target: path::Arg, Data: path::Arg>(
     })
 }
 
-/// `mount(source, target, null, MS_BIND, null)`
+/// `mount(source, target, NULL, MS_BIND, NULL)`
 ///
 /// # References
 ///  - [Linux]
@@ -87,7 +87,7 @@ pub fn bind_mount<Source: path::Arg, Target: path::Arg>(
     })
 }
 
-/// `mount(source, target, null, MS_BIND | MS_REC, null)`
+/// `mount(source, target, NULL, MS_BIND | MS_REC, NULL)`
 ///
 /// # References
 ///  - [Linux]
@@ -112,7 +112,7 @@ pub fn recursive_bind_mount<Source: path::Arg, Target: path::Arg>(
     })
 }
 
-/// `mount(null, target, null, mountflags, null)`
+/// `mount(NULL, target, NULL, mountflags, NULL)`
 ///
 /// # References
 ///  - [Linux]
@@ -129,7 +129,7 @@ pub fn change_mount<Target: path::Arg>(
     })
 }
 
-/// `mount(source, target, null, MS_MOVE, null)`
+/// `mount(source, target, NULL, MS_MOVE, NULL)`
 ///
 /// # References
 ///  - [Linux]

--- a/src/fs/raw_dir.rs
+++ b/src/fs/raw_dir.rs
@@ -171,6 +171,7 @@ impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
     /// Note: this interface will be broken to implement a stdlib iterator API with
     /// GAT support once one becomes available.
     #[allow(unsafe_code)]
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Option<io::Result<RawDirEntry>> {
         if self.is_buffer_empty() {
             match getdents_uninit(self.fd.as_fd(), self.buf) {

--- a/src/fs/raw_dir.rs
+++ b/src/fs/raw_dir.rs
@@ -12,10 +12,11 @@ use crate::io;
 
 /// A directory iterator implemented with getdents.
 ///
-/// Note: This implementation does not handle growing the buffer. If this functionality is
-/// necessary, you'll need to drop the current iterator, resize the buffer, and then
-/// re-create the iterator. The iterator is guaranteed to continue where it left off provided
-/// the file descriptor isn't changed. See the example in [`RawDir::new`].
+/// Note: This implementation does not handle growing the buffer. If this
+/// functionality is necessary, you'll need to drop the current iterator,
+/// resize the buffer, and then re-create the iterator. The iterator is
+/// guaranteed to continue where it left off provided the file descriptor isn't
+/// changed. See the example in [`RawDir::new`].
 pub struct RawDir<'buf, Fd: AsFd> {
     fd: Fd,
     buf: &'buf mut [MaybeUninit<u8>],
@@ -26,14 +27,16 @@ pub struct RawDir<'buf, Fd: AsFd> {
 impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
     /// Create a new iterator from the given file descriptor and buffer.
     ///
-    /// Note: the buffer size may be trimmed to accommodate alignment requirements.
+    /// Note: the buffer size may be trimmed to accommodate alignment
+    /// requirements.
     ///
     /// # Examples
     ///
     /// ## Simple but non-portable
     ///
-    /// These examples are non-portable, because file systems may not have a maximum file name
-    /// length. If you can make assumptions that bound this length, then these examples may suffice.
+    /// These examples are non-portable, because file systems may not have a
+    /// maximum file name length. If you can make assumptions that bound
+    /// this length, then these examples may suffice.
     ///
     /// Using the heap:
     ///
@@ -58,7 +61,13 @@ impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
     /// # use std::mem::MaybeUninit;
     /// # use rustix::fs::{cwd, Mode, OFlags, openat, RawDir};
     ///
-    /// let fd = openat(cwd(), ".", OFlags::RDONLY | OFlags::DIRECTORY, Mode::empty()).unwrap();
+    /// let fd = openat(
+    ///     cwd(),
+    ///     ".",
+    ///     OFlags::RDONLY | OFlags::DIRECTORY,
+    ///     Mode::empty(),
+    /// )
+    /// .unwrap();
     ///
     /// let mut buf = [MaybeUninit::uninit(); 2048];
     /// let mut iter = RawDir::new(fd, &mut buf);
@@ -70,8 +79,8 @@ impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
     ///
     /// ## Portable
     ///
-    /// Heap allocated growing buffer for supporting directory entries with arbitrarily
-    /// large file names:
+    /// Heap allocated growing buffer for supporting directory entries with
+    /// arbitrarily large file names:
     ///
     /// ```notrust
     /// # // The `notrust` above can be removed when we can depend on Rust 1.60.
@@ -118,7 +127,8 @@ impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
 
 /// A raw directory entry, similar to `std::fs::DirEntry`.
 ///
-/// Note that unlike the std version, this may represent the `.` or `..` entries.
+/// Note that unlike the std version, this may represent the `.` or `..`
+/// entries.
 pub struct RawDirEntry<'a> {
     file_name: &'a CStr,
     file_type: u8,
@@ -166,10 +176,11 @@ impl<'a> RawDirEntry<'a> {
 }
 
 impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
-    /// Identical to [Iterator::next] except that [Iterator::Item] borrows from self.
+    /// Identical to [Iterator::next] except that [Iterator::Item] borrows from
+    /// self.
     ///
-    /// Note: this interface will be broken to implement a stdlib iterator API with
-    /// GAT support once one becomes available.
+    /// Note: this interface will be broken to implement a stdlib iterator API
+    /// with GAT support once one becomes available.
     #[allow(unsafe_code)]
     #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Option<io::Result<RawDirEntry>> {
@@ -203,8 +214,8 @@ impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
         }))
     }
 
-    /// Returns true if the internal buffer is empty and will be refilled when calling
-    /// [`next`][Self::next].
+    /// Returns true if the internal buffer is empty and will be refilled when
+    /// calling [`next`][Self::next].
     pub fn is_buffer_empty(&self) -> bool {
         self.offset >= self.initialized
     }

--- a/src/io/fd/owned.rs
+++ b/src/io/fd/owned.rs
@@ -168,7 +168,7 @@ impl Drop for OwnedFd {
             // the file descriptor was closed or not, and if we retried (for
             // something like EINTR), we might close another valid file
             // descriptor opened after we closed ours.
-            let _ = close(self.fd as _);
+            close(self.fd as _);
         }
     }
 }

--- a/src/io/kqueue.rs
+++ b/src/io/kqueue.rs
@@ -7,13 +7,7 @@ use crate::io;
 use backend::c::{self, kevent as kevent_t, uintptr_t};
 use backend::io::syscalls;
 
-#[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "watchos",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-))]
+#[cfg(any(apple, freebsdlike))]
 use backend::c::intptr_t;
 
 use alloc::vec::Vec;
@@ -44,13 +38,7 @@ impl Event {
                 c::EVFILT_PROC,
                 flags.bits(),
             ),
-            #[cfg(any(
-                target_os = "macos",
-                target_os = "ios",
-                target_os = "tvos",
-                target_os = "watchos",
-                target_os = "freebsd",
-            ))]
+            #[cfg(any(apple, target_os = "freebsd"))]
             EventFilter::Timer(timer) => {
                 let (data, fflags) = match timer {
                     Some(timer) => {
@@ -67,13 +55,7 @@ impl Event {
 
                 (data, c::EVFILT_TIMER, fflags)
             }
-            #[cfg(any(
-                target_os = "macos",
-                target_os = "ios",
-                target_os = "watchos",
-                target_os = "dragonfly",
-                target_os = "freebsd",
-            ))]
+            #[cfg(any(apple, freebsdlike))]
             EventFilter::User {
                 ident,
                 flags,
@@ -126,13 +108,7 @@ impl Event {
                 pid: unsafe { crate::process::Pid::from_raw(self.inner.ident as _) }.unwrap(),
                 flags: ProcessEvents::from_bits_truncate(self.inner.fflags),
             },
-            #[cfg(any(
-                target_os = "macos",
-                target_os = "ios",
-                target_os = "tvos",
-                target_os = "watchos",
-                target_os = "freebsd",
-            ))]
+            #[cfg(any(apple, target_os = "freebsd"))]
             c::EVFILT_TIMER => EventFilter::Timer({
                 let (data, fflags) = (self.inner.data, self.inner.fflags);
                 match fflags as _ {
@@ -145,13 +121,7 @@ impl Event {
                     }
                 }
             }),
-            #[cfg(any(
-                target_os = "macos",
-                target_os = "ios",
-                target_os = "watchos",
-                target_os = "dragonfly",
-                target_os = "freebsd",
-            ))]
+            #[cfg(any(apple, freebsdlike))]
             c::EVFILT_USER => EventFilter::User {
                 ident: self.inner.ident as _,
                 flags: UserFlags::from_bits_truncate(self.inner.fflags),
@@ -163,13 +133,7 @@ impl Event {
 }
 
 /// Bottom 24 bits of a u32.
-#[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "watchos",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-))]
+#[cfg(any(apple, freebsdlike))]
 const EVFILT_USER_FLAGS: u32 = 0x00ff_ffff;
 
 /// The possible filters for a `kqueue`.
@@ -202,23 +166,11 @@ pub enum EventFilter {
     },
 
     /// A timer filter.
-    #[cfg(any(
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "tvos",
-        target_os = "watchos",
-        target_os = "freebsd",
-    ))]
+    #[cfg(any(apple, target_os = "freebsd"))]
     Timer(Option<Duration>),
 
     /// A user filter.
-    #[cfg(any(
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "watchos",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-    ))]
+    #[cfg(any(apple, freebsdlike))]
     User {
         /// The identifier for this event.
         ident: intptr_t,
@@ -311,13 +263,7 @@ bitflags::bitflags! {
     }
 }
 
-#[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "watchos",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-))]
+#[cfg(any(apple, freebsdlike))]
 bitflags::bitflags! {
     /// The flags for a user event.
     pub struct UserFlags : u32 {
@@ -348,23 +294,11 @@ bitflags::bitflags! {
 ///
 /// Only the lower 24 bits are used in this struct.
 #[repr(transparent)]
-#[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "watchos",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-))]
+#[cfg(any(apple, freebsdlike))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct UserDefinedFlags(u32);
 
-#[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "watchos",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-))]
+#[cfg(any(apple, freebsdlike))]
 impl UserDefinedFlags {
     /// Create a new `UserDefinedFlags` from a `u32`.
     pub fn new(flags: u32) -> Self {

--- a/src/io/kqueue.rs
+++ b/src/io/kqueue.rs
@@ -1,8 +1,7 @@
 //! An API for interfacing with `kqueue`.
 
-use crate::backend;
 use crate::fd::{AsFd, AsRawFd, OwnedFd, RawFd};
-use crate::io;
+use crate::{backend, io};
 
 use backend::c::{self, kevent as kevent_t, uintptr_t};
 use backend::io::syscalls;
@@ -334,8 +333,8 @@ pub fn kqueue() -> io::Result<OwnedFd> {
 ///
 /// # Safety
 ///
-/// The file descriptors referred to by the `Event` structs must be valid for the lifetime
-/// of the `kqueue` file descriptor.
+/// The file descriptors referred to by the `Event` structs must be valid for
+/// the lifetime of the `kqueue` file descriptor.
 ///
 /// # References
 ///

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -31,10 +31,8 @@ mod stdio;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use crate::backend::io::epoll;
 pub use close::close;
-#[cfg(not(any(windows, target_os = "wasi")))]
-pub use dup::{dup, dup2};
-#[cfg(not(any(windows, target_os = "aix", target_os = "wasi")))]
-pub use dup::{dup3, DupFlags};
+#[cfg(not(windows))]
+pub use dup::*;
 pub use errno::{retry_on_intr, Errno, Result};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use eventfd::{eventfd, EventfdFlags};

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -13,21 +13,12 @@ pub(crate) mod fd;
 mod ioctl;
 #[cfg(not(any(windows, target_os = "redox")))]
 mod is_read_write;
-#[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "tvos",
-    target_os = "watchos",
-    target_os = "freebsd",
-    target_os = "dragonfly",
-    target_os = "openbsd",
-    target_os = "netbsd"
-))]
+#[cfg(bsd)]
 pub mod kqueue;
 #[cfg(not(any(windows, target_os = "wasi")))]
 mod pipe;
 mod poll;
-#[cfg(any(target_os = "illumos", target_os = "solaris"))]
+#[cfg(solarish)]
 pub mod port;
 #[cfg(all(feature = "procfs", any(target_os = "android", target_os = "linux")))]
 mod procfs;

--- a/src/io/pipe.rs
+++ b/src/io/pipe.rs
@@ -60,10 +60,11 @@ pub fn pipe_with(flags: PipeFlags) -> io::Result<(OwnedFd, OwnedFd)> {
     backend::io::syscalls::pipe_with(flags)
 }
 
-/// `splice(fd_in, off_in, fd_out, off_out, len, flags)`—Transfer data between a file and a pipe.
+/// `splice(fd_in, off_in, fd_out, off_out, len, flags)`—Transfer data between
+/// a file and a pipe.
 ///
-/// This function transfers up to `len` bytes of data from the file descriptor `fd_in`
-/// to the file descriptor `fd_out`, where one of the file descriptors
+/// This function transfers up to `len` bytes of data from the file descriptor
+/// `fd_in` to the file descriptor `fd_out`, where one of the file descriptors
 /// must refer to a pipe.
 ///
 /// `off_*` must be `None` if the corresponding fd refers to a pipe.
@@ -101,8 +102,9 @@ pub fn splice<FdIn: AsFd, FdOut: AsFd>(
 ///
 /// # Safety
 ///
-/// If the memory must not be mutated (such as when `bufs` were originally immutable slices),
-/// it is up to the caller to ensure that the write end of the pipe is placed in `fd`.
+/// If the memory must not be mutated (such as when `bufs` were originally
+/// immutable slices), it is up to the caller to ensure that the write end of
+/// the pipe is placed in `fd`.
 ///
 /// Additionally if `SpliceFlags::GIFT` is set, the caller must also ensure
 /// that the contents of `bufs` in never modified following the call,

--- a/src/io/port.rs
+++ b/src/io/port.rs
@@ -93,7 +93,7 @@ pub unsafe fn port_dissociate_fd(port: impl AsFd, object: impl AsRawFd) -> io::R
     syscalls::port_dissociate(port.as_fd(), c::PORT_SOURCE_FD, object.as_raw_fd() as _)
 }
 
-/// `port_get()`- Gets an event from a port.
+/// `port_get(port, timeout)`- Gets an event from a port.
 ///
 /// # References
 ///
@@ -111,7 +111,7 @@ pub fn port_get(port: impl AsFd, timeout: Option<Duration>) -> io::Result<Event>
     syscalls::port_get(port.as_fd(), timeout.as_mut())
 }
 
-/// `port_getn()`- Gets multiple events from a port.
+/// `port_getn(port, events, min_events, timeout)`- Gets multiple events from a port.
 ///
 /// # References
 ///
@@ -141,7 +141,7 @@ pub fn port_getn(
     )
 }
 
-/// `port_send()`- Sends an event to a port.
+/// `port_send(port, events, userdata)`- Sends an event to a port.
 ///
 /// # References
 ///

--- a/src/io/port.rs
+++ b/src/io/port.rs
@@ -1,6 +1,7 @@
 //! Solaris/Illumos event ports.
 
-use crate::backend::{c, io::syscalls};
+use crate::backend::c;
+use crate::backend::io::syscalls;
 use crate::fd::{AsFd, AsRawFd, OwnedFd};
 use crate::io;
 
@@ -48,9 +49,9 @@ pub fn port_create() -> io::Result<OwnedFd> {
 ///
 /// # Safety
 ///
-/// Any `object`s passed into the `port` must be valid for the lifetime of the `port`.
-/// Logically, `port` keeps a borrowed reference to the `object` until it is
-/// removed via `port_dissociate_fd`.
+/// Any `object`s passed into the `port` must be valid for the lifetime of the
+/// `port`. Logically, `port` keeps a borrowed reference to the `object` until
+/// it is removed via `port_dissociate_fd`.
 ///
 /// # References
 ///
@@ -111,7 +112,8 @@ pub fn port_get(port: impl AsFd, timeout: Option<Duration>) -> io::Result<Event>
     syscalls::port_get(port.as_fd(), timeout.as_mut())
 }
 
-/// `port_getn(port, events, min_events, timeout)`- Gets multiple events from a port.
+/// `port_getn(port, events, min_events, timeout)`- Gets multiple events from a
+/// port.
 ///
 /// # References
 ///

--- a/src/io/seek_from.rs
+++ b/src/io/seek_from.rs
@@ -5,6 +5,8 @@
 /// Enumeration of possible methods to seek within an I/O object.
 ///
 /// It is used by the [`Seek`] trait.
+///
+/// [`Seek`]: std::io::Seek
 #[derive(Copy, PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))]
 pub enum SeekFrom {

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -1168,7 +1168,7 @@ pub struct io_uring_buf_reg {
     pub ring_entries: u32,
     pub bgid: u16,
     pub pad: u16,
-    pub resv: [u64; 3usize],
+    pub resv: [u64; 3_usize],
 }
 
 #[allow(missing_docs)]

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -385,7 +385,8 @@ impl Default for IoringRestrictionOp {
     }
 }
 
-/// `IORING_MSG_*` constants which represent commands for use with [`IoringOp::Msgring`], (`seq.addr`)
+/// `IORING_MSG_*` constants which represent commands for use with
+/// [`IoringOp::Msgring`], (`seq.addr`)
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(u64)]
 #[non_exhaustive]

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -386,7 +386,7 @@ impl Default for IoringRestrictionOp {
 }
 
 /// `IORING_MSG_*` constants which represent commands for use with
-/// [`IoringOp::Msgring`], (`seq.addr`)
+/// [`IoringOp::MsgRing`], (`seq.addr`)
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(u64)]
 #[non_exhaustive]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,11 +86,10 @@
 //! [`io-streams`]: https://crates.io/crates/io-streams
 //! [`getrandom`]: https://crates.io/crates/getrandom
 //! [`bitflags`]: https://crates.io/crates/bitflags
-//! [`AsFd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.AsFd.html
-//! [`OwnedFd`]: https://docs.rs/io-lifetimes/latest/io_lifetimes/struct.OwnedFd.html
-//! [io-lifetimes crate]: https://crates.io/crates/io-lifetimes
+//! [`AsFd`]: https://doc.rust-lang.org/stable/std/os/fd/trait.AsFd.html
+//! [`OwnedFd`]: https://doc.rust-lang.org/stable/std/os/fd/struct.OwnedFd.html
 //! [I/O-safe]: https://github.com/rust-lang/rfcs/blob/master/text/3128-io-safety.md
-//! [`Result`]: https://docs.rs/rustix/latest/rustix/io/type.Result.html
+//! [`Result`]: https://doc.rust-lang.org/stable/std/result/enum.Result.html
 //! [`Arg`]: https://docs.rs/rustix/latest/rustix/path/trait.Arg.html
 
 #![deny(missing_docs)]

--- a/src/mm/mmap.rs
+++ b/src/mm/mmap.rs
@@ -12,7 +12,7 @@ use core::ffi::c_void;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use backend::mm::types::MlockFlags;
-#[cfg(any(linux_raw, all(libc, target_os = "linux")))]
+#[cfg(any(target_os = "emscripten", target_os = "linux"))]
 pub use backend::mm::types::MremapFlags;
 pub use backend::mm::types::{MapFlags, MprotectFlags, ProtFlags};
 
@@ -101,7 +101,7 @@ pub unsafe fn munmap(ptr: *mut c_void, len: usize) -> io::Result<()> {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/mremap.2.html
-#[cfg(any(linux_raw, all(libc, target_os = "linux")))]
+#[cfg(any(target_os = "emscripten", target_os = "linux"))]
 #[inline]
 pub unsafe fn mremap(
     old_address: *mut c_void,
@@ -126,7 +126,7 @@ pub unsafe fn mremap(
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/mremap.2.html
-#[cfg(any(linux_raw, all(libc, target_os = "linux")))]
+#[cfg(any(target_os = "emscripten", target_os = "linux"))]
 #[inline]
 #[doc(alias = "mremap")]
 pub unsafe fn mremap_fixed(

--- a/src/net/ip.rs
+++ b/src/net/ip.rs
@@ -1200,6 +1200,7 @@ impl Ipv6Addr {
         rustc_const_stable(feature = "const_ip_32", since = "1.32.0")
     )]
     #[cfg_attr(staged_api, stable(feature = "rust1", since = "1.0.0"))]
+    #[allow(clippy::too_many_arguments)]
     #[must_use]
     #[inline]
     pub const fn new(a: u16, b: u16, c: u16, d: u16, e: u16, f: u16, g: u16, h: u16) -> Ipv6Addr {

--- a/src/param/mod.rs
+++ b/src/param/mod.rs
@@ -11,21 +11,6 @@ mod auxv;
 mod init;
 
 #[cfg(feature = "param")]
-#[cfg(not(target_os = "wasi"))]
-pub use auxv::clock_ticks_per_second;
-#[cfg(feature = "param")]
-pub use auxv::page_size;
-#[cfg(feature = "param")]
-#[cfg(any(
-    linux_raw,
-    all(
-        libc,
-        any(
-            all(target_os = "android", target_pointer_width = "64"),
-            target_os = "linux",
-        )
-    )
-))]
-pub use auxv::{linux_execfn, linux_hwcap};
+pub use auxv::*;
 #[cfg(target_vendor = "mustang")]
 pub use init::init;

--- a/src/process/prctl.rs
+++ b/src/process/prctl.rs
@@ -1,7 +1,7 @@
 //! Bindings for the Linux `prctl` system call.
 //!
-//! There are similarities (but also differences) with FreeBSD's `procctl` system call, whose
-//! interface is located in the `procctl.rs` file.
+//! There are similarities (but also differences) with FreeBSD's `procctl`
+//! system call, whose interface is located in the `procctl.rs` file.
 
 #![allow(unsafe_code)]
 
@@ -146,13 +146,14 @@ pub fn dumpable_behavior() -> io::Result<DumpableBehavior> {
 
 const PR_SET_DUMPABLE: c_int = 4;
 
-/// Set the state of the `dumpable` attribute, which determines whether the process can be traced
-/// and whether core dumps are produced for the calling process upon delivery of a signal whose
-/// default behavior is to produce a core dump.
+/// Set the state of the `dumpable` attribute, which determines whether the
+/// process can be traced and whether core dumps are produced for the calling
+/// process upon delivery of a signal whose default behavior is to produce a
+/// core dump.
 ///
-/// A similar function with the same name is available on FreeBSD (as part of the `procctl`
-/// interface), but it has an extra argument which allows to select a process other then the
-/// current process.
+/// A similar function with the same name is available on FreeBSD (as part of
+/// the `procctl` interface), but it has an extra argument which allows to
+/// select a process other then the current process.
 ///
 /// # References
 /// - [`prctl(PR_SET_DUMPABLE,...)`]
@@ -350,8 +351,8 @@ pub fn timing_method() -> io::Result<TimingMethod> {
 
 const PR_SET_TIMING: c_int = 14;
 
-/// Set whether to use (normal, traditional) statistical process timing or accurate
-/// timestamp-based process timing.
+/// Set whether to use (normal, traditional) statistical process timing or
+/// accurate timestamp-based process timing.
 ///
 /// # References
 /// - [`prctl(PR_SET_TIMING,...)`]
@@ -470,7 +471,8 @@ pub fn time_stamp_counter_readability() -> io::Result<TimeStampCounterReadabilit
 
 const PR_SET_TSC: c_int = 26;
 
-/// Set the state of the flag determining if the timestamp counter can be read by the process.
+/// Set the state of the flag determining if the timestamp counter can be read
+/// by the process.
 ///
 /// # References
 /// - [`prctl(PR_SET_TSC,...)`]
@@ -611,13 +613,16 @@ pub enum VirtualMemoryMapAddress {
     CodeStart = PR_SET_MM_START_CODE,
     /// Set the address below which the program text can run.
     CodeEnd = PR_SET_MM_END_CODE,
-    /// Set the address above which initialized and uninitialized (bss) data are placed.
+    /// Set the address above which initialized and uninitialized (bss) data
+    /// are placed.
     DataStart = PR_SET_MM_START_DATA,
-    /// Set the address below which initialized and uninitialized (bss) data are placed.
+    /// Set the address below which initialized and uninitialized (bss) data
+    /// are placed.
     DataEnd = PR_SET_MM_END_DATA,
     /// Set the start address of the stack.
     StackStart = PR_SET_MM_START_STACK,
-    /// Set the address above which the program heap can be expanded with `brk` call.
+    /// Set the address above which the program heap can be expanded with `brk`
+    /// call.
     BrkStart = PR_SET_MM_START_BRK,
     /// Set the current `brk` value.
     BrkCurrent = PR_SET_MM_BRK,
@@ -631,7 +636,8 @@ pub enum VirtualMemoryMapAddress {
     EnvironmentEnd = PR_SET_MM_ENV_END,
 }
 
-/// Modify certain kernel memory map descriptor addresses of the calling process.
+/// Modify certain kernel memory map descriptor addresses of the calling
+/// process.
 ///
 /// # References
 /// - [`prctl(PR_SET_MM,...)`]
@@ -651,7 +657,8 @@ pub unsafe fn set_virtual_memory_map_address(
     prctl_3args(PR_SET_MM, option as usize as *mut _, address).map(|_r| ())
 }
 
-/// Supersede the `/proc/pid/exe` symbolic link with a new one pointing to a new executable file.
+/// Supersede the `/proc/pid/exe` symbolic link with a new one pointing to a
+/// new executable file.
 ///
 /// # References
 /// - [`prctl(PR_SET_MM,PR_SET_MM_EXE_FILE,...)`]
@@ -700,8 +707,8 @@ pub fn virtual_memory_map_config_struct_size() -> io::Result<usize> {
     Ok(value as usize)
 }
 
-/// This structure provides new memory descriptor map which mostly modifies `/proc/pid/stat[m]`
-/// output for a task.
+/// This structure provides new memory descriptor map which mostly modifies
+/// `/proc/pid/stat[m]` output for a task.
 /// This mostly done in a sake of checkpoint/restore functionality.
 #[repr(C)]
 #[derive(Debug, Clone)]
@@ -732,11 +739,13 @@ pub struct PrctlMmMap {
     pub auxv: *mut u64,
     /// Auxiliary vector size.
     pub auxv_size: u32,
-    /// File descriptor of executable file that was used to create this process.
+    /// File descriptor of executable file that was used to create this
+    /// process.
     pub exe_fd: u32,
 }
 
-/// Provides one-shot access to all the addresses by passing in a [`PrctlMmMap`].
+/// Provides one-shot access to all the addresses by passing in a
+/// [`PrctlMmMap`].
 ///
 /// # References
 /// - [`prctl(PR_SET_MM,PR_SET_MM_MAP,...)`]
@@ -778,8 +787,8 @@ pub enum PTracer {
     ProcessID(Pid),
 }
 
-/// Declare that the ptracer process can `ptrace` the calling process as if it were a direct
-/// process ancestor.
+/// Declare that the ptracer process can `ptrace` the calling process as if it
+/// were a direct process ancestor.
 ///
 /// # References
 /// - [`prctl(PR_SET_PTRACER,...)`]
@@ -1002,8 +1011,8 @@ pub fn is_io_flusher() -> io::Result<bool> {
 
 const PR_SET_IO_FLUSHER: c_int = 57;
 
-/// Put the process in the `IO_FLUSHER` state, allowing it to make progress when
-/// allocating memory.
+/// Put the process in the `IO_FLUSHER` state, allowing it to make progress
+/// when allocating memory.
 ///
 /// # References
 /// - [`prctl(PR_SET_IO_FLUSHER,...)`]

--- a/src/process/priority.rs
+++ b/src/process/priority.rs
@@ -1,7 +1,7 @@
 use crate::process::{Pid, Uid};
 use crate::{backend, io};
 
-/// `nice()`—Adjust the scheduling priority of the current process.
+/// `nice(inc)`—Adjust the scheduling priority of the current process.
 ///
 /// # References
 ///  - [POSIX]

--- a/src/process/procctl.rs
+++ b/src/process/procctl.rs
@@ -1,7 +1,7 @@
 //! Bindings for the FreeBSD `procctl` system call.
 //!
-//! There are similarities (but also differences) with Linux's `prctl` system call, whose interface
-//! is located in the `prctl.rs` file.
+//! There are similarities (but also differences) with Linux's `prctl` system
+//! call, whose interface is located in the `prctl.rs` file.
 
 #![allow(unsafe_code)]
 
@@ -28,9 +28,10 @@ pub enum IdType {
 
 /// A process selector for use with the `procctl` interface.
 ///
-/// `None` represents the current process. `Some((IdType::Pid, pid))` represents the process
-/// with pid `pid`. `Some((IdType::Pgid, pgid))` represents the control processes belonging to
-/// the process group with id `pgid`.
+/// `None` represents the current process. `Some((IdType::Pid, pid))`
+/// represents the process with pid `pid`. `Some((IdType::Pgid, pgid))`
+/// represents the control processes belonging to the process group with id
+/// `pgid`.
 pub type ProcSelector = Option<(IdType, Pid)>;
 fn proc_selector_to_raw(selector: ProcSelector) -> (IdType, RawPid) {
     match selector {
@@ -125,13 +126,15 @@ pub enum DumpableBehavior {
     NotDumpableExecPreserved = PROC_TRACE_CTL_DISABLE_EXEC,
 }
 
-/// Set the state of the `dumpable` attribute for the process indicated by `idtype` and `id`.
-/// This determines whether the process can be traced and whether core dumps are produced for
-/// the process upon delivery of a signal whose default behavior is to produce a core dump.
+/// Set the state of the `dumpable` attribute for the process indicated by
+/// `idtype` and `id`. This determines whether the process can be traced and
+/// whether core dumps are produced for the process upon delivery of a signal
+/// whose default behavior is to produce a core dump.
 ///
-/// This is similar to `set_dumpable_behavior` on Linux, with the exception that on FreeBSD
-/// there is an extra argument `process`. When `process` is set to `None`, the operation is
-/// performed for the current process, like on Linux.
+/// This is similar to `set_dumpable_behavior` on Linux, with the exception
+/// that on FreeBSD there is an extra argument `process`. When `process` is set
+/// to `None`, the operation is performed for the current process, like on
+/// Linux.
 ///
 /// # References
 /// - [`procctl(PROC_TRACE_CTL,...)`]
@@ -153,10 +156,11 @@ const PROC_TRACE_STATUS: c_int = 8;
 pub enum TracingStatus {
     /// Tracing is disabled for the process.
     NotTraceble,
-    /// Tracing is not disabled for the process, but not debugger/tracer is attached.
+    /// Tracing is not disabled for the process, but not debugger/tracer is
+    /// attached.
     Tracable,
-    /// The process is being traced by the process whose pid is stored in the first
-    /// component of this variant.
+    /// The process is being traced by the process whose pid is stored in the
+    /// first component of this variant.
     BeingTraced(Pid),
 }
 

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -175,7 +175,8 @@ pub fn wait(waitopts: WaitOptions) -> io::Result<Option<(Pid, WaitStatus)>> {
     backend::process::syscalls::wait(waitopts)
 }
 
-/// `waitid(_, _, _, opts)`-Wait for the specified child process to change state.
+/// `waitid(_, _, _, opts)`-Wait for the specified child process to change
+/// state.
 #[cfg(not(any(target_os = "wasi", target_os = "redox", target_os = "openbsd")))]
 #[inline]
 pub fn waitid<'a>(

--- a/src/rand/mod.rs
+++ b/src/rand/mod.rs
@@ -1,7 +1,7 @@
 //! Random-related operations.
 
-#[cfg(any(linux_raw, all(libc, target_os = "linux")))]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 mod getrandom;
 
-#[cfg(any(linux_raw, all(libc, target_os = "linux")))]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 pub use getrandom::{getrandom, GetRandomFlags};

--- a/src/termios/constants.rs
+++ b/src/termios/constants.rs
@@ -33,150 +33,66 @@ pub fn speed_value(speed: backend::termios::types::Speed) -> Option<u32> {
         #[cfg(not(target_os = "aix"))]
         backend::termios::types::B230400 => Some(230_400),
         #[cfg(not(any(
+            apple,
             target_os = "aix",
             target_os = "dragonfly",
             target_os = "haiku",
-            target_os = "ios",
-            target_os = "macos",
             target_os = "openbsd"
         )))]
         backend::termios::types::B460800 => Some(460_800),
-        #[cfg(not(any(
-            target_os = "aix",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "haiku",
-            target_os = "illumos",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "solaris",
-        )))]
+        #[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
         backend::termios::types::B500000 => Some(500_000),
-        #[cfg(not(any(
-            target_os = "aix",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "haiku",
-            target_os = "illumos",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "solaris",
-        )))]
+        #[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
         backend::termios::types::B576000 => Some(576_000),
         #[cfg(not(any(
+            apple,
             target_os = "aix",
             target_os = "dragonfly",
             target_os = "haiku",
-            target_os = "ios",
-            target_os = "macos",
             target_os = "openbsd"
         )))]
         backend::termios::types::B921600 => Some(921_600),
-        #[cfg(not(any(
-            target_os = "aix",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "haiku",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "solaris",
-        )))]
+        #[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "solaris")))]
         backend::termios::types::B1000000 => Some(1_000_000),
-        #[cfg(not(any(
-            target_os = "aix",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "haiku",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "solaris",
-        )))]
+        #[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "solaris")))]
         backend::termios::types::B1152000 => Some(1_152_000),
-        #[cfg(not(any(
-            target_os = "aix",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "haiku",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "solaris",
-        )))]
+        #[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "solaris")))]
         backend::termios::types::B1500000 => Some(1_500_000),
-        #[cfg(not(any(
-            target_os = "aix",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "haiku",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "solaris",
-        )))]
+        #[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "solaris")))]
         backend::termios::types::B2000000 => Some(2_000_000),
         #[cfg(not(any(
             target_arch = "sparc",
             target_arch = "sparc64",
+            bsd,
             target_os = "aix",
-            target_os = "dragonfly",
-            target_os = "freebsd",
             target_os = "haiku",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd",
             target_os = "solaris",
         )))]
         backend::termios::types::B2500000 => Some(2_500_000),
         #[cfg(not(any(
             target_arch = "sparc",
             target_arch = "sparc64",
+            bsd,
             target_os = "aix",
-            target_os = "dragonfly",
-            target_os = "freebsd",
             target_os = "haiku",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd",
             target_os = "solaris",
         )))]
         backend::termios::types::B3000000 => Some(3_000_000),
         #[cfg(not(any(
             target_arch = "sparc",
             target_arch = "sparc64",
+            bsd,
             target_os = "aix",
-            target_os = "dragonfly",
-            target_os = "freebsd",
             target_os = "haiku",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd",
             target_os = "solaris",
         )))]
         backend::termios::types::B3500000 => Some(3_500_000),
         #[cfg(not(any(
             target_arch = "sparc",
             target_arch = "sparc64",
+            bsd,
             target_os = "aix",
-            target_os = "dragonfly",
-            target_os = "freebsd",
             target_os = "haiku",
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd",
             target_os = "solaris",
         )))]
         backend::termios::types::B4000000 => Some(4_000_000),

--- a/src/termios/mod.rs
+++ b/src/termios/mod.rs
@@ -13,7 +13,6 @@ mod tty;
 pub use cf::{cfgetispeed, cfgetospeed, cfmakeraw, cfsetispeed, cfsetospeed, cfsetspeed};
 
 #[cfg(not(target_os = "wasi"))]
-#[allow(unused_imports)]
 pub use constants::*;
 
 #[cfg(not(target_os = "wasi"))]

--- a/src/termios/mod.rs
+++ b/src/termios/mod.rs
@@ -10,33 +10,10 @@ mod tc;
 mod tty;
 
 #[cfg(not(target_os = "wasi"))]
-pub use cf::{cfgetispeed, cfgetospeed, cfmakeraw, cfsetispeed, cfsetospeed, cfsetspeed};
-
+pub use cf::*;
 #[cfg(not(target_os = "wasi"))]
 pub use constants::*;
-
 #[cfg(not(target_os = "wasi"))]
-pub use tc::{
-    tcdrain, tcflow, tcflush, tcgetattr, tcgetpgrp, tcgetsid, tcgetwinsize, tcsendbreak, tcsetattr,
-    tcsetpgrp, tcsetwinsize, Action, OptionalActions, QueueSelector, Speed, Tcflag, Termios,
-    Winsize,
-};
-#[cfg(all(
-    any(target_os = "android", target_os = "linux"),
-    any(
-        target_arch = "x86",
-        target_arch = "x86_64",
-        target_arch = "x32",
-        target_arch = "riscv64",
-        target_arch = "aarch64",
-        target_arch = "arm",
-        target_arch = "mips",
-        target_arch = "mips64",
-    )
-))]
-pub use tc::{tcgetattr2, tcsetattr2, Termios2};
+pub use tc::*;
 #[cfg(not(windows))]
-pub use tty::isatty;
-#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
-#[cfg(feature = "procfs")]
-pub use tty::ttyname;
+pub use tty::*;

--- a/src/thread/id.rs
+++ b/src/thread/id.rs
@@ -22,11 +22,11 @@ pub fn gettid() -> Pid {
 ///
 /// This is not the setxid you are looking for... POSIX requires xids to be
 /// process granular, but on Linux they are per-thread. Thus, this call only
-/// changes the xid for the current *thread*, not the entire process even though
-/// that is in violation of the POSIX standard.
+/// changes the xid for the current *thread*, not the entire process even
+/// though that is in violation of the POSIX standard.
 ///
-/// For details on this distinction, see the C library vs. kernel differences in
-/// the [man page][linux_notes]. This call implements the kernel behavior.
+/// For details on this distinction, see the C library vs. kernel differences
+/// in the [man page][linux_notes]. This call implements the kernel behavior.
 ///
 /// # References
 ///  - [POSIX]
@@ -46,11 +46,11 @@ pub fn set_thread_uid(uid: Uid) -> io::Result<()> {
 ///
 /// This is not the setxid you are looking for... POSIX requires xids to be
 /// process granular, but on Linux they are per-thread. Thus, this call only
-/// changes the xid for the current *thread*, not the entire process even though
-/// that is in violation of the POSIX standard.
+/// changes the xid for the current *thread*, not the entire process even
+/// though that is in violation of the POSIX standard.
 ///
-/// For details on this distinction, see the C library vs. kernel differences in
-/// the [man page][linux_notes]. This call implements the kernel behavior.
+/// For details on this distinction, see the C library vs. kernel differences
+/// in the [man page][linux_notes]. This call implements the kernel behavior.
 ///
 /// # References
 ///  - [POSIX]

--- a/src/thread/id.rs
+++ b/src/thread/id.rs
@@ -36,7 +36,6 @@ pub fn gettid() -> Pid {
 /// [Linux]: https://man7.org/linux/man-pages/man2/setuid.2.html
 /// [linux_notes]: https://man7.org/linux/man-pages/man2/setuid.2.html#NOTES
 #[inline]
-#[must_use]
 pub fn set_thread_uid(uid: Uid) -> io::Result<()> {
     backend::thread::syscalls::setuid_thread(uid)
 }
@@ -61,7 +60,6 @@ pub fn set_thread_uid(uid: Uid) -> io::Result<()> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/setgid.2.html
 /// [linux_notes]: https://man7.org/linux/man-pages/man2/setgid.2.html#NOTES
 #[inline]
-#[must_use]
 pub fn set_thread_gid(gid: Gid) -> io::Result<()> {
     backend::thread::syscalls::setgid_thread(gid)
 }

--- a/src/thread/libcap.rs
+++ b/src/thread/libcap.rs
@@ -115,7 +115,8 @@ pub fn capabilities(pid: Option<Pid>) -> io::Result<CapabilitySets> {
     capget(pid)
 }
 
-/// `capset(_LINUX_CAPABILITY_VERSION_3, pid, effective, permitted, inheritable)`
+/// `capset(_LINUX_CAPABILITY_VERSION_3, pid, effective, permitted,
+/// inheritable)`
 ///
 /// # References
 ///  - [Linux]
@@ -139,7 +140,8 @@ fn capget(pid: Option<Pid>) -> io::Result<CapabilitySets> {
         };
 
         backend::thread::syscalls::capget(&mut header, &mut data)?;
-        // SAFETY: v3 is a 64-bit implementation, so the kernel filled in both data structs.
+        // SAFETY: v3 is a 64-bit implementation, so the kernel filled in both data
+        // structs.
         unsafe { (data[0].assume_init(), data[1].assume_init()) }
     };
 

--- a/src/thread/prctl.rs
+++ b/src/thread/prctl.rs
@@ -142,7 +142,8 @@ pub fn secure_computing_mode() -> io::Result<SecureComputingMode> {
 
 const PR_SET_SECCOMP: c_int = 22;
 
-/// Set the secure computing mode for the calling thread, to limit the available system calls.
+/// Set the secure computing mode for the calling thread, to limit the
+/// available system calls.
 ///
 /// # References
 /// - [`prctl(PR_SET_SECCOMP,...)`]
@@ -163,69 +164,79 @@ const PR_CAPBSET_READ: c_int = 23;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum Capability {
-    /// In a system with the `_POSIX_CHOWN_RESTRICTED` option defined, this overrides
-    /// the restriction of changing file ownership and group ownership.
+    /// In a system with the `_POSIX_CHOWN_RESTRICTED` option defined, this
+    /// overrides the restriction of changing file ownership and group
+    /// ownership.
     ChangeOwnership = linux_raw_sys::general::CAP_CHOWN,
-    /// Override all DAC access, including ACL execute access if `_POSIX_ACL` is defined.
-    /// Excluding DAC access covered by [`Capability::LinuxImmutable`].
+    /// Override all DAC access, including ACL execute access if `_POSIX_ACL`
+    /// is defined. Excluding DAC access covered by
+    /// [`Capability::LinuxImmutable`].
     DACOverride = linux_raw_sys::general::CAP_DAC_OVERRIDE,
-    /// Overrides all DAC restrictions regarding read and search on files and directories,
-    /// including ACL restrictions if `_POSIX_ACL` is defined. Excluding DAC access covered
-    /// by [`Capability::LinuxImmutable`].
+    /// Overrides all DAC restrictions regarding read and search on files and
+    /// directories, including ACL restrictions if `_POSIX_ACL` is defined.
+    /// Excluding DAC access covered by [`Capability::LinuxImmutable`].
     DACReadSearch = linux_raw_sys::general::CAP_DAC_READ_SEARCH,
-    /// Overrides all restrictions about allowed operations on files, where file owner ID must be
-    /// equal to the user ID, except where [`Capability::FileSetID`] is applicable.
-    /// It doesn't override MAC and DAC restrictions.
+    /// Overrides all restrictions about allowed operations on files, where
+    /// file owner ID must be equal to the user ID, except where
+    /// [`Capability::FileSetID`] is applicable. It doesn't override MAC
+    /// and DAC restrictions.
     FileOwner = linux_raw_sys::general::CAP_FOWNER,
-    /// Overrides the following restrictions that the effective user ID shall match the file owner
-    /// ID when setting the `S_ISUID` and `S_ISGID` bits on that file; that the effective group ID
-    /// (or one of the supplementary group IDs) shall match the file owner ID when setting the
-    /// `S_ISGID` bit on that file; that the `S_ISUID` and `S_ISGID` bits are cleared on successful
-    /// return from `chown` (not implemented).
+    /// Overrides the following restrictions that the effective user ID shall
+    /// match the file owner ID when setting the `S_ISUID` and `S_ISGID`
+    /// bits on that file; that the effective group ID (or one of the
+    /// supplementary group IDs) shall match the file owner ID when setting the
+    /// `S_ISGID` bit on that file; that the `S_ISUID` and `S_ISGID` bits are
+    /// cleared on successful return from `chown` (not implemented).
     FileSetID = linux_raw_sys::general::CAP_FSETID,
-    /// Overrides the restriction that the real or effective user ID of a process sending a signal
-    /// must match the real or effective user ID of the process receiving the signal.
+    /// Overrides the restriction that the real or effective user ID of a
+    /// process sending a signal must match the real or effective user ID
+    /// of the process receiving the signal.
     Kill = linux_raw_sys::general::CAP_KILL,
-    /// Allows `setgid` manipulation. Allows `setgroups`. Allows forged gids on socket
-    /// credentials passing.
+    /// Allows `setgid` manipulation. Allows `setgroups`. Allows forged gids on
+    /// socket credentials passing.
     SetGroupID = linux_raw_sys::general::CAP_SETGID,
-    /// Allows `set*uid` manipulation (including fsuid). Allows forged pids on socket
-    /// credentials passing.
+    /// Allows `set*uid` manipulation (including fsuid). Allows forged pids on
+    /// socket credentials passing.
     SetUserID = linux_raw_sys::general::CAP_SETUID,
     /// Without VFS support for capabilities:
     /// - Transfer any capability in your permitted set to any pid.
-    /// - remove any capability in your permitted set from any pid.
-    ///   With VFS support for capabilities (neither of above, but)
-    /// - Add any capability from current's capability bounding set to the current process'
-    ///   inheritable set.
+    /// - remove any capability in your permitted set from any pid. With VFS
+    ///   support for capabilities (neither of above, but)
+    /// - Add any capability from current's capability bounding set to the
+    ///   current process' inheritable set.
     /// - Allow taking bits out of capability bounding set.
     /// - Allow modification of the securebits for a process.
     SetPermittedCapabilities = linux_raw_sys::general::CAP_SETPCAP,
     /// Allow modification of `S_IMMUTABLE` and `S_APPEND` file attributes.
     LinuxImmutable = linux_raw_sys::general::CAP_LINUX_IMMUTABLE,
-    /// Allows binding to TCP/UDP sockets below 1024. Allows binding to ATM VCIs below 32.
+    /// Allows binding to TCP/UDP sockets below 1024. Allows binding to ATM
+    /// VCIs below 32.
     NetBindService = linux_raw_sys::general::CAP_NET_BIND_SERVICE,
     /// Allow broadcasting, listen to multicast.
     NetBroadcast = linux_raw_sys::general::CAP_NET_BROADCAST,
-    /// Allow interface configuration. Allow administration of IP firewall, masquerading and
-    /// accounting. Allow setting debug option on sockets. Allow modification of routing tables.
-    /// Allow setting arbitrary process / process group ownership on sockets. Allow binding to any
-    /// address for transparent proxying (also via [`Capability::NetRaw`]). Allow setting TOS
-    /// (type of service). Allow setting promiscuous mode. Allow clearing driver statistics.
-    /// Allow multicasting. Allow read/write of device-specific registers. Allow activation of ATM
+    /// Allow interface configuration. Allow administration of IP firewall,
+    /// masquerading and accounting. Allow setting debug option on sockets.
+    /// Allow modification of routing tables. Allow setting arbitrary
+    /// process / process group ownership on sockets. Allow binding to any
+    /// address for transparent proxying (also via [`Capability::NetRaw`]).
+    /// Allow setting TOS (type of service). Allow setting promiscuous
+    /// mode. Allow clearing driver statistics. Allow multicasting. Allow
+    /// read/write of device-specific registers. Allow activation of ATM
     /// control sockets.
     NetAdmin = linux_raw_sys::general::CAP_NET_ADMIN,
-    /// Allow use of `RAW` sockets. Allow use of `PACKET` sockets. Allow binding to any address for
-    /// transparent proxying (also via [`Capability::NetAdmin`]).
+    /// Allow use of `RAW` sockets. Allow use of `PACKET` sockets. Allow
+    /// binding to any address for transparent proxying (also via
+    /// [`Capability::NetAdmin`]).
     NetRaw = linux_raw_sys::general::CAP_NET_RAW,
-    /// Allow locking of shared memory segments. Allow mlock and mlockall (which doesn't really have
-    /// anything to do with IPC).
+    /// Allow locking of shared memory segments. Allow mlock and mlockall
+    /// (which doesn't really have anything to do with IPC).
     IPCLock = linux_raw_sys::general::CAP_IPC_LOCK,
     /// Override IPC ownership checks.
     IPCOwner = linux_raw_sys::general::CAP_IPC_OWNER,
     /// Insert and remove kernel modules - modify kernel without limit.
     SystemModule = linux_raw_sys::general::CAP_SYS_MODULE,
-    /// Allow ioperm/iopl access. Allow sending USB messages to any device via `/dev/bus/usb`.
+    /// Allow ioperm/iopl access. Allow sending USB messages to any device via
+    /// `/dev/bus/usb`.
     SystemRawIO = linux_raw_sys::general::CAP_SYS_RAWIO,
     /// Allow use of `chroot`.
     SystemChangeRoot = linux_raw_sys::general::CAP_SYS_CHROOT,
@@ -233,43 +244,53 @@ pub enum Capability {
     SystemProcessTrace = linux_raw_sys::general::CAP_SYS_PTRACE,
     /// Allow configuration of process accounting.
     SystemProcessAccounting = linux_raw_sys::general::CAP_SYS_PACCT,
-    /// Allow configuration of the secure attention key. Allow administration of the random device.
-    /// Allow examination and configuration of disk quotas. Allow setting the domainname.
-    /// Allow setting the hostname. Allow `mount` and `umount`, setting up new smb connection.
-    /// Allow some autofs root ioctls. Allow nfsservctl. Allow `VM86_REQUEST_IRQ`.
-    /// Allow to read/write pci config on alpha. Allow `irix_prctl` on mips (setstacksize).
-    /// Allow flushing all cache on m68k (`sys_cacheflush`). Allow removing semaphores.
-    /// Used instead of [`Capability::ChangeOwnership`] to "chown" IPC message queues, semaphores
-    /// and shared memory. Allow locking/unlocking of shared memory segment. Allow turning swap
-    /// on/off. Allow forged pids on socket credentials passing. Allow setting readahead and
-    /// flushing buffers on block devices. Allow setting geometry in floppy driver. Allow turning
-    /// DMA on/off in `xd` driver. Allow administration of md devices (mostly the above, but some
-    /// extra ioctls). Allow tuning the ide driver. Allow access to the nvram device. Allow
-    /// administration of `apm_bios`, serial and bttv (TV) device. Allow manufacturer commands in
-    /// isdn CAPI support driver. Allow reading non-standardized portions of pci configuration
-    /// space. Allow DDI debug ioctl on sbpcd driver. Allow setting up serial ports. Allow sending
-    /// raw qic-117 commands. Allow enabling/disabling tagged queuing on SCSI controllers and
-    /// sending arbitrary SCSI commands. Allow setting encryption key on loopback filesystem.
-    /// Allow setting zone reclaim policy. Allow everything under
-    /// [`Capability::BerkeleyPacketFilters`] and [`Capability::PerformanceMonitoring`] for backward
-    /// compatibility.
+    /// Allow configuration of the secure attention key. Allow administration
+    /// of the random device. Allow examination and configuration of disk
+    /// quotas. Allow setting the domainname. Allow setting the hostname.
+    /// Allow `mount` and `umount`, setting up new smb connection.
+    /// Allow some autofs root ioctls. Allow nfsservctl. Allow
+    /// `VM86_REQUEST_IRQ`. Allow to read/write pci config on alpha. Allow
+    /// `irix_prctl` on mips (setstacksize). Allow flushing all cache on
+    /// m68k (`sys_cacheflush`). Allow removing semaphores. Used instead of
+    /// [`Capability::ChangeOwnership`] to "chown" IPC message queues,
+    /// semaphores and shared memory. Allow locking/unlocking of shared
+    /// memory segment. Allow turning swap on/off. Allow forged pids on
+    /// socket credentials passing. Allow setting readahead and
+    /// flushing buffers on block devices. Allow setting geometry in floppy
+    /// driver. Allow turning DMA on/off in `xd` driver. Allow
+    /// administration of md devices (mostly the above, but some
+    /// extra ioctls). Allow tuning the ide driver. Allow access to the nvram
+    /// device. Allow administration of `apm_bios`, serial and bttv (TV)
+    /// device. Allow manufacturer commands in isdn CAPI support driver.
+    /// Allow reading non-standardized portions of pci configuration space.
+    /// Allow DDI debug ioctl on sbpcd driver. Allow setting up serial ports.
+    /// Allow sending raw qic-117 commands. Allow enabling/disabling tagged
+    /// queuing on SCSI controllers and sending arbitrary SCSI commands.
+    /// Allow setting encryption key on loopback filesystem. Allow setting
+    /// zone reclaim policy. Allow everything under
+    /// [`Capability::BerkeleyPacketFilters`] and
+    /// [`Capability::PerformanceMonitoring`] for backward compatibility.
     SystemAdmin = linux_raw_sys::general::CAP_SYS_ADMIN,
     /// Allow use of `reboot`.
     SystemBoot = linux_raw_sys::general::CAP_SYS_BOOT,
-    /// Allow raising priority and setting priority on other (different UID) processes. Allow use of
-    /// FIFO and round-robin (realtime) scheduling on own processes and setting the scheduling
-    /// algorithm used by another process. Allow setting cpu affinity on other processes.
-    /// Allow setting realtime ioprio class. Allow setting ioprio class on other processes.
+    /// Allow raising priority and setting priority on other (different UID)
+    /// processes. Allow use of FIFO and round-robin (realtime) scheduling
+    /// on own processes and setting the scheduling algorithm used by
+    /// another process. Allow setting cpu affinity on other processes.
+    /// Allow setting realtime ioprio class. Allow setting ioprio class on
+    /// other processes.
     SystemNice = linux_raw_sys::general::CAP_SYS_NICE,
-    /// Override resource limits. Set resource limits. Override quota limits. Override reserved
-    /// space on ext2 filesystem. Modify data journaling mode on ext3 filesystem (uses journaling
-    /// resources). NOTE: ext2 honors fsuid when checking for resource overrides, so you can
-    /// override using fsuid too. Override size restrictions on IPC message queues. Allow more than
-    /// 64hz interrupts from the real-time clock. Override max number of consoles on console
-    /// allocation. Override max number of keymaps. Control memory reclaim behavior.
+    /// Override resource limits. Set resource limits. Override quota limits.
+    /// Override reserved space on ext2 filesystem. Modify data journaling
+    /// mode on ext3 filesystem (uses journaling resources). NOTE: ext2
+    /// honors fsuid when checking for resource overrides, so you can
+    /// override using fsuid too. Override size restrictions on IPC message
+    /// queues. Allow more than 64hz interrupts from the real-time clock.
+    /// Override max number of consoles on console allocation. Override max
+    /// number of keymaps. Control memory reclaim behavior.
     SystemResource = linux_raw_sys::general::CAP_SYS_RESOURCE,
-    /// Allow manipulation of system clock. Allow `irix_stime` on mips. Allow setting the real-time
-    /// clock.
+    /// Allow manipulation of system clock. Allow `irix_stime` on mips. Allow
+    /// setting the real-time clock.
     SystemTime = linux_raw_sys::general::CAP_SYS_TIME,
     /// Allow configuration of tty devices. Allow `vhangup` of tty.
     SystemTTYConfig = linux_raw_sys::general::CAP_SYS_TTY_CONFIG,
@@ -281,16 +302,19 @@ pub enum Capability {
     AuditWrite = linux_raw_sys::general::CAP_AUDIT_WRITE,
     /// Allow configuration of audit via unicast netlink socket.
     AuditControl = linux_raw_sys::general::CAP_AUDIT_CONTROL,
-    /// Set or remove capabilities on files. Map `uid=0` into a child user namespace.
+    /// Set or remove capabilities on files. Map `uid=0` into a child user
+    /// namespace.
     SetFileCapabilities = linux_raw_sys::general::CAP_SETFCAP,
-    /// Override MAC access. The base kernel enforces no MAC policy. An LSM may enforce a MAC
-    /// policy, and if it does and it chooses to implement capability based overrides of that
-    /// policy, this is the capability it should use to do so.
+    /// Override MAC access. The base kernel enforces no MAC policy. An LSM may
+    /// enforce a MAC policy, and if it does and it chooses to implement
+    /// capability based overrides of that policy, this is the capability
+    /// it should use to do so.
     MACOverride = linux_raw_sys::general::CAP_MAC_OVERRIDE,
-    /// Allow MAC configuration or state changes. The base kernel requires no MAC configuration.
-    /// An LSM may enforce a MAC policy, and if it does and it chooses to implement capability based
-    /// checks on modifications to that policy or the data required to maintain it, this is the
-    /// capability it should use to do so.
+    /// Allow MAC configuration or state changes. The base kernel requires no
+    /// MAC configuration. An LSM may enforce a MAC policy, and if it does
+    /// and it chooses to implement capability based
+    /// checks on modifications to that policy or the data required to maintain
+    /// it, this is the capability it should use to do so.
     MACAdmin = linux_raw_sys::general::CAP_MAC_ADMIN,
     /// Allow configuring the kernel's `syslog` (`printk` behaviour).
     SystemLog = linux_raw_sys::general::CAP_SYSLOG,
@@ -300,8 +324,8 @@ pub enum Capability {
     BlockSuspend = linux_raw_sys::general::CAP_BLOCK_SUSPEND,
     /// Allow reading the audit log via multicast netlink socket.
     AuditRead = linux_raw_sys::general::CAP_AUDIT_READ,
-    /// Allow system performance and observability privileged operations using `perf_events`,
-    /// `i915_perf` and other kernel subsystems.
+    /// Allow system performance and observability privileged operations using
+    /// `perf_events`, `i915_perf` and other kernel subsystems.
     PerformanceMonitoring = linux_raw_sys::general::CAP_PERFMON,
     /// This capability allows the following BPF operations:
     /// - Creating all types of BPF maps
@@ -317,7 +341,8 @@ pub enum Capability {
     /// - Retrieve `xlated` and JITed code of BPF programs
     /// - Use `bpf_spin_lock` helper
     ///
-    /// [`Capability::PerformanceMonitoring`] relaxes the verifier checks further:
+    /// [`Capability::PerformanceMonitoring`] relaxes the verifier checks
+    /// further:
     /// - BPF progs can use of pointer-to-integer conversions
     /// - speculation attack hardening measures are bypassed
     /// - `bpf_probe_read` to read arbitrary kernel memory is allowed
@@ -328,17 +353,19 @@ pub enum Capability {
     /// [`Capability::SystemAdmin`] is required to iterate system wide loaded
     /// programs, maps, links, BTFs and convert their IDs to file descriptors.
     ///
-    /// [`Capability::PerformanceMonitoring`] and [`Capability::BerkeleyPacketFilters`] are required
-    /// to load tracing programs.
-    /// [`Capability::NetAdmin`] and [`Capability::BerkeleyPacketFilters`] are required to load
+    /// [`Capability::PerformanceMonitoring`] and
+    /// [`Capability::BerkeleyPacketFilters`] are required to load tracing
+    /// programs. [`Capability::NetAdmin`] and
+    /// [`Capability::BerkeleyPacketFilters`] are required to load
     /// networking programs.
     BerkeleyPacketFilters = linux_raw_sys::general::CAP_BPF,
-    /// Allow checkpoint/restore related operations. Allow PID selection during `clone3`.
-    /// Allow writing to `ns_last_pid`.
+    /// Allow checkpoint/restore related operations. Allow PID selection during
+    /// `clone3`. Allow writing to `ns_last_pid`.
     CheckpointRestore = linux_raw_sys::general::CAP_CHECKPOINT_RESTORE,
 }
 
-/// Check if the specified capability is in the calling thread's capability bounding set.
+/// Check if the specified capability is in the calling thread's capability
+/// bounding set.
 ///
 /// # References
 /// - [`prctl(PR_CAPBSET_READ,...)`]
@@ -351,8 +378,9 @@ pub fn capability_is_in_bounding_set(capability: Capability) -> io::Result<bool>
 
 const PR_CAPBSET_DROP: c_int = 24;
 
-/// If the calling thread has the [`Capability::SetPermittedCapabilities`] capability within its
-/// user namespace, then drop the specified capability from the thread's capability bounding set.
+/// If the calling thread has the [`Capability::SetPermittedCapabilities`]
+/// capability within its user namespace, then drop the specified capability
+/// from the thread's capability bounding set.
 ///
 /// # References
 /// - [`prctl(PR_CAPBSET_DROP,...)`]
@@ -661,8 +689,8 @@ pub unsafe fn set_sve_vector_length_configuration(
 
 const PR_PAC_RESET_KEYS: c_int = 54;
 
-/// Securely reset the thread's pointer authentication keys to fresh random values generated
-/// by the kernel.
+/// Securely reset the thread's pointer authentication keys to fresh random
+/// values generated by the kernel.
 ///
 /// # References
 /// - [`prctl(PR_PAC_RESET_KEYS,...)`]
@@ -770,8 +798,8 @@ const SYSCALL_DISPATCH_FILTER_ALLOW: u8 = 0;
 /// Block system calls from executing.
 const SYSCALL_DISPATCH_FILTER_BLOCK: u8 = 1;
 
-/// Value of the fast switch flag controlling system calls user dispatch mechanism without the need
-/// to issue a syscall.
+/// Value of the fast switch flag controlling system calls user dispatch
+/// mechanism without the need to issue a syscall.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum SysCallUserDispatchFastSwitch {
@@ -837,7 +865,8 @@ const PR_SCHED_CORE_SCOPE_PROCESS_GROUP: u32 = 2;
 pub enum CoreSchedulingScope {
     /// Operation will be performed for the thread.
     Thread = PR_SCHED_CORE_SCOPE_THREAD,
-    /// Operation will be performed for all tasks in the task group of the process.
+    /// Operation will be performed for all tasks in the task group of the
+    /// process.
     ThreadGroup = PR_SCHED_CORE_SCOPE_THREAD_GROUP,
     /// Operation will be performed for all processes in the process group.
     ProcessGroup = PR_SCHED_CORE_SCOPE_PROCESS_GROUP,

--- a/src/thread/setns.rs
+++ b/src/thread/setns.rs
@@ -81,10 +81,11 @@ bitflags! {
     }
 }
 
-/// Reassociate the calling thread with the namespace associated with link referred to by `fd`.
+/// Reassociate the calling thread with the namespace associated with link
+/// referred to by `fd`.
 ///
-/// `fd` must refer to one of the magic links in a `/proc/[pid]/ns/` directory, or a bind mount
-/// to such a link.
+/// `fd` must refer to one of the magic links in a `/proc/[pid]/ns/` directory,
+/// or a bind mount to such a link.
 ///
 /// # References
 /// - [`setns`]
@@ -98,8 +99,8 @@ pub fn move_into_link_name_space(
     syscalls::setns(fd, allowed_type).map(|_r| ())
 }
 
-/// Atomically move the calling thread into one or more of the same namespaces as the thread
-/// referred to by `fd`.
+/// Atomically move the calling thread into one or more of the same namespaces
+/// as the thread referred to by `fd`.
 ///
 /// `fd` must refer to a thread ID. See: `pidfd_open` and `clone`.
 ///

--- a/tests/fs/readdir.rs
+++ b/tests/fs/readdir.rs
@@ -115,7 +115,8 @@ fn test_raw_dir(buf: &mut [MaybeUninit<u8>]) {
 #[test]
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn raw_dir_entries_heap() {
-    // When we can depend on Rust 1.60, we can use the spare_capacity_mut version instead.
+    // When we can depend on Rust 1.60, we can use the spare_capacity_mut version
+    // instead.
     /*
     let mut buf = Vec::with_capacity(8192);
     test_raw_dir(buf.spare_capacity_mut());

--- a/tests/io/epoll.rs
+++ b/tests/io/epoll.rs
@@ -1,7 +1,6 @@
 #![cfg(any(target_os = "android", target_os = "linux"))]
 
-use rustix::io::epoll;
-use rustix::io::{ioctl_fionbio, read, write};
+use rustix::io::{epoll, ioctl_fionbio, read, write};
 use rustix::net::{
     accept, bind_v4, connect_v4, getsockname, listen, socket, AddressFamily, Ipv4Addr, Protocol,
     SocketAddrAny, SocketAddrV4, SocketType,

--- a/tests/io/read_write.rs
+++ b/tests/io/read_write.rs
@@ -96,8 +96,7 @@ fn test_readwrite_v() {
 #[test]
 fn test_readwrite() {
     use rustix::fs::{cwd, openat, seek, Mode, OFlags};
-    use rustix::io::SeekFrom;
-    use rustix::io::{read, write};
+    use rustix::io::{read, write, SeekFrom};
 
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();

--- a/tests/mm/mmap.rs
+++ b/tests/mm/mmap.rs
@@ -114,7 +114,10 @@ fn test_mlock() {
             }
 
             match mlock_with(addr, 8192, MlockFlags::ONFAULT) {
+                // Linux versions that lack `mlock` return this.
                 Err(rustix::io::Errno::NOSYS) => (),
+                // Linux versions that don't recognize `ONFAULT` return this.
+                Err(rustix::io::Errno::INVAL) => (),
                 Err(err) => Err(err).unwrap(),
                 Ok(()) => munlock(addr, 8192).unwrap(),
             }

--- a/tests/mm/mmap.rs
+++ b/tests/mm/mmap.rs
@@ -113,15 +113,13 @@ fn test_mlock() {
                 Ok(()) => munlock(addr, 8192).unwrap(),
             }
 
-            #[cfg(linux_raw)] // libc doesn't expose `MLOCK_UNFAULT` yet.
-            {
-                match mlock_with(addr, 8192, MlockFlags::ONFAULT) {
-                    Err(rustix::io::Errno::NOSYS) => (),
-                    Err(err) => Err(err).unwrap(),
-                    Ok(()) => munlock(addr, 8192).unwrap(),
-                }
-                munlock(addr, 8192).unwrap();
+            match mlock_with(addr, 8192, MlockFlags::ONFAULT) {
+                Err(rustix::io::Errno::NOSYS) => (),
+                Err(err) => Err(err).unwrap(),
+                Ok(()) => munlock(addr, 8192).unwrap(),
             }
+
+            munlock(addr, 8192).unwrap();
         }
 
         munmap(addr, 8192).unwrap();

--- a/tests/process/pidfd.rs
+++ b/tests/process/pidfd.rs
@@ -1,7 +1,8 @@
 //! Tests for the `pidfd` type.
 
 use libc::{kill, SIGSTOP};
-use rustix::{fd::AsFd, io, process};
+use rustix::fd::AsFd;
+use rustix::{io, process};
 use serial_test::serial;
 use std::process::Command;
 

--- a/tests/rand/main.rs
+++ b/tests/rand/main.rs
@@ -5,5 +5,5 @@
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 
-#[cfg(any(linux_raw, all(libc, target_os = "linux")))]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 mod getrandom;


### PR DESCRIPTION
Avoid using the `linux_raw` flag to determine public APIs, make `mremap` available on emscripten, make `getrandom` available on android, and other minor cleanups.