### PR TITLE
Detect overflow on `nchanges` and `nevents` in `kevent`.

### DIFF
--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -469,9 +469,15 @@ pub(crate) unsafe fn kevent(
     ret_c_int(c::kevent(
         borrowed_fd(kq),
         changelist.as_ptr() as *const _,
-        changelist.len() as _,
+        changelist
+            .len()
+            .try_into()
+            .map_err(|_| io::Errno::OVERFLOW)?,
         eventlist.as_mut_ptr() as *mut _,
-        eventlist.len() as _,
+        eventlist
+            .len()
+            .try_into()
+            .map_err(|_| io::Errno::OVERFLOW)?,
         timeout.map_or(core::ptr::null(), |t| t as *const _),
     ))
 }


### PR DESCRIPTION
The `nchanges` and `nevents` arguments on at least FreeBSD have type `c_int`, so detect and report overflow when converting from `usize`.