### PR TITLE
Capitalize SAFETY in safety comments.

### DIFF
--- a/src/backend/libc/fs/inotify.rs
+++ b/src/backend/libc/fs/inotify.rs
@@ -77,7 +77,7 @@ bitflags! {
 /// descriptor from being implicitly passed across `exec` boundaries.
 #[doc(alias = "inotify_init1")]
 pub fn inotify_init(flags: CreateFlags) -> io::Result<OwnedFd> {
-    // Safety: `inotify_init1` has no safety preconditions.
+    // SAFETY: `inotify_init1` has no safety preconditions.
     unsafe { ret_owned_fd(c::inotify_init1(flags.bits())) }
 }
 
@@ -96,7 +96,7 @@ pub fn inotify_add_watch<P: crate::path::Arg>(
     flags: WatchFlags,
 ) -> io::Result<i32> {
     let path = path.as_cow_c_str().unwrap();
-    // Safety: The fd and path we are passing is guranteed valid by the type
+    // SAFETY: The fd and path we are passing is guranteed valid by the type
     // system.
     unsafe {
         ret_c_int(c::inotify_add_watch(
@@ -116,6 +116,6 @@ pub fn inotify_remove_watch(inot: BorrowedFd<'_>, wd: i32) -> io::Result<()> {
     // Android's `inotify_rm_watch` takes u32 despite `inotify_add_watch` is i32.
     #[cfg(target_os = "android")]
     let wd = wd as u32;
-    // Safety: The fd is valid and closing an arbitrary wd is valid.
+    // SAFETY: The fd is valid and closing an arbitrary wd is valid.
     unsafe { ret(c::inotify_rm_watch(borrowed_fd(inot), wd)) }
 }

--- a/src/backend/libc/io/epoll.rs
+++ b/src/backend/libc/io/epoll.rs
@@ -126,7 +126,7 @@ bitflags! {
 #[inline]
 #[doc(alias = "epoll_create1")]
 pub fn epoll_create(flags: CreateFlags) -> io::Result<OwnedFd> {
-    // Safety: We're calling `epoll_create1` via FFI and we know how it
+    // SAFETY: We're calling `epoll_create1` via FFI and we know how it
     // behaves.
     unsafe { ret_owned_fd(c::epoll_create1(flags.bits())) }
 }
@@ -147,7 +147,7 @@ pub fn epoll_add(
     data: u64,
     event_flags: EventFlags,
 ) -> io::Result<()> {
-    // Safety: We're calling `epoll_ctl` via FFI and we know how it
+    // SAFETY: We're calling `epoll_ctl` via FFI and we know how it
     // behaves.
     unsafe {
         let raw_fd = source.as_fd().as_raw_fd();
@@ -176,7 +176,7 @@ pub fn epoll_mod(
 ) -> io::Result<()> {
     let raw_fd = source.as_fd().as_raw_fd();
 
-    // Safety: We're calling `epoll_ctl` via FFI and we know how it
+    // SAFETY: We're calling `epoll_ctl` via FFI and we know how it
     // behaves.
     unsafe {
         ret(c::epoll_ctl(
@@ -195,7 +195,7 @@ pub fn epoll_mod(
 /// this `Epoll`.
 #[doc(alias = "epoll_ctl")]
 pub fn epoll_del(epoll: impl AsFd, source: impl AsFd) -> io::Result<()> {
-    // Safety: We're calling `epoll_ctl` via FFI and we know how it
+    // SAFETY: We're calling `epoll_ctl` via FFI and we know how it
     // behaves.
     unsafe {
         let raw_fd = source.as_fd().as_raw_fd();
@@ -218,7 +218,7 @@ pub fn epoll_wait(
     event_list: &mut EventVec,
     timeout: c::c_int,
 ) -> io::Result<()> {
-    // Safety: We're calling `epoll_wait` via FFI and we know how it
+    // SAFETY: We're calling `epoll_wait` via FFI and we know how it
     // behaves.
     unsafe {
         event_list.events.set_len(0);
@@ -243,7 +243,7 @@ impl<'a> Iterator for Iter<'a> {
     type Item = (EventFlags, u64);
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Safety: `self.context` is guaranteed to be valid because we hold
+        // SAFETY: `self.context` is guaranteed to be valid because we hold
         // `'context` for it. And we know this event is associated with this
         // context because `wait` sets both.
         self.iter

--- a/src/backend/libc/io/poll_fd.rs
+++ b/src/backend/libc/io/poll_fd.rs
@@ -119,7 +119,7 @@ impl<'fd> PollFd<'fd> {
 impl<'fd> AsFd for PollFd<'fd> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
-        // Safety: Our constructors and `set_fd` require `pollfd.fd` to be
+        // SAFETY: Our constructors and `set_fd` require `pollfd.fd` to be
         // valid for the `fd lifetime.
         unsafe { BorrowedFd::borrow_raw(self.pollfd.fd) }
     }
@@ -129,7 +129,7 @@ impl<'fd> AsFd for PollFd<'fd> {
 impl<'fd> io_lifetimes::AsSocket for PollFd<'fd> {
     #[inline]
     fn as_socket(&self) -> BorrowedFd<'_> {
-        // Safety: Our constructors and `set_fd` require `pollfd.fd` to be
+        // SAFETY: Our constructors and `set_fd` require `pollfd.fd` to be
         // valid for the `fd lifetime.
         unsafe { BorrowedFd::borrow_raw(self.pollfd.fd as RawFd) }
     }

--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -97,7 +97,7 @@ impl SocketAddrUnix {
         if len != 0 && self.unix.sun_path[0] != b'\0' as c::c_char {
             let end = len as usize - offsetof_sun_path();
             let bytes = &self.unix.sun_path[..end];
-            // Safety: `from_raw_parts` to convert from `&[c_char]` to `&[u8]`. And
+            // SAFETY: `from_raw_parts` to convert from `&[c_char]` to `&[u8]`. And
             // `from_bytes_with_nul_unchecked` since the string is NUL-terminated.
             unsafe {
                 Some(CStr::from_bytes_with_nul_unchecked(slice::from_raw_parts(
@@ -118,7 +118,7 @@ impl SocketAddrUnix {
         if len != 0 && self.unix.sun_path[0] == b'\0' as c::c_char {
             let end = len as usize - offsetof_sun_path();
             let bytes = &self.unix.sun_path[1..end];
-            // Safety: `from_raw_parts` to convert from `&[c_char]` to `&[u8]`.
+            // SAFETY: `from_raw_parts` to convert from `&[c_char]` to `&[u8]`.
             unsafe { Some(slice::from_raw_parts(bytes.as_ptr().cast(), bytes.len())) }
         } else {
             None

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -143,7 +143,7 @@ impl<'a, Num: ArgNumber> From<Option<&'a CStr>> for ArgReg<'a, Num> {
 impl<'a, Num: ArgNumber> From<BorrowedFd<'a>> for ArgReg<'a, Num> {
     #[inline]
     fn from(fd: BorrowedFd<'a>) -> Self {
-        // Safety: `BorrowedFd` ensures that the file descriptor is valid, and the
+        // SAFETY: `BorrowedFd` ensures that the file descriptor is valid, and the
         // lifetime parameter on the resulting `ArgReg` ensures that the result is
         // bounded by the `BorrowedFd`'s lifetime.
         unsafe { raw_fd(fd.as_raw_fd()) }

--- a/src/backend/linux_raw/io/epoll.rs
+++ b/src/backend/linux_raw/io/epoll.rs
@@ -147,7 +147,7 @@ pub fn epoll_add(
     data: u64,
     event_flags: EventFlags,
 ) -> io::Result<()> {
-    // Safety: We're calling `epoll_ctl` via FFI and we know how it
+    // SAFETY: We're calling `epoll_ctl` via FFI and we know how it
     // behaves.
     unsafe {
         syscalls::epoll_add(
@@ -172,7 +172,7 @@ pub fn epoll_mod(
     data: u64,
     event_flags: EventFlags,
 ) -> io::Result<()> {
-    // Safety: We're calling `epoll_ctl` via FFI and we know how it
+    // SAFETY: We're calling `epoll_ctl` via FFI and we know how it
     // behaves.
     unsafe {
         let raw_fd = source.as_fd().as_raw_fd();
@@ -193,7 +193,7 @@ pub fn epoll_mod(
 /// This also returns the owning `Data`.
 #[doc(alias = "epoll_ctl")]
 pub fn epoll_del(epoll: impl AsFd, source: impl AsFd) -> io::Result<()> {
-    // Safety: We're calling `epoll_ctl` via FFI and we know how it
+    // SAFETY: We're calling `epoll_ctl` via FFI and we know how it
     // behaves.
     unsafe {
         let raw_fd = source.as_fd().as_raw_fd();
@@ -211,7 +211,7 @@ pub fn epoll_wait(
     event_list: &mut EventVec,
     timeout: c::c_int,
 ) -> io::Result<()> {
-    // Safety: We're calling `epoll_wait` via FFI and we know how it
+    // SAFETY: We're calling `epoll_wait` via FFI and we know how it
     // behaves.
     unsafe {
         event_list.events.set_len(0);

--- a/src/backend/linux_raw/io/errno.rs
+++ b/src/backend/linux_raw/io/errno.rs
@@ -69,7 +69,7 @@ impl Errno {
         // TODO: Use Range::contains, once that's `const`.
         const_assert!(encoded >= 0xf001);
 
-        // Safety: Linux syscalls return negated error values in the range
+        // SAFETY: Linux syscalls return negated error values in the range
         // `-4095..0`, which we just asserted.
         unsafe { Self(encoded) }
     }
@@ -82,7 +82,7 @@ pub(in crate::backend) fn try_decode_c_int<Num: RetNumber>(
     raw: RetReg<Num>,
 ) -> io::Result<c::c_int> {
     if raw.is_in_range(-4095..0) {
-        // Safety: `raw` must be in `-4095..0`, and we just checked that raw is
+        // SAFETY: `raw` must be in `-4095..0`, and we just checked that raw is
         // in that range.
         return Err(unsafe { Errno(raw.decode_error_code()) });
     }
@@ -97,7 +97,7 @@ pub(in crate::backend) fn try_decode_c_uint<Num: RetNumber>(
     raw: RetReg<Num>,
 ) -> io::Result<c::c_uint> {
     if raw.is_in_range(-4095..0) {
-        // Safety: `raw` must be in `-4095..0`, and we just checked that raw is
+        // SAFETY: `raw` must be in `-4095..0`, and we just checked that raw is
         // in that range.
         return Err(unsafe { Errno(raw.decode_error_code()) });
     }
@@ -110,7 +110,7 @@ pub(in crate::backend) fn try_decode_c_uint<Num: RetNumber>(
 #[inline]
 pub(in crate::backend) fn try_decode_usize<Num: RetNumber>(raw: RetReg<Num>) -> io::Result<usize> {
     if raw.is_in_range(-4095..0) {
-        // Safety: `raw` must be in `-4095..0`, and we just checked that raw is
+        // SAFETY: `raw` must be in `-4095..0`, and we just checked that raw is
         // in that range.
         return Err(unsafe { Errno(raw.decode_error_code()) });
     }
@@ -125,7 +125,7 @@ pub(in crate::backend) fn try_decode_void_star<Num: RetNumber>(
     raw: RetReg<Num>,
 ) -> io::Result<*mut c::c_void> {
     if raw.is_in_range(-4095..0) {
-        // Safety: `raw` must be in `-4095..0`, and we just checked that raw is
+        // SAFETY: `raw` must be in `-4095..0`, and we just checked that raw is
         // in that range.
         return Err(unsafe { Errno(raw.decode_error_code()) });
     }
@@ -139,7 +139,7 @@ pub(in crate::backend) fn try_decode_void_star<Num: RetNumber>(
 #[inline]
 pub(in crate::backend) fn try_decode_u64<Num: RetNumber>(raw: RetReg<Num>) -> io::Result<u64> {
     if raw.is_in_range(-4095..0) {
-        // Safety: `raw` must be in `-4095..0`, and we just checked that raw is
+        // SAFETY: `raw` must be in `-4095..0`, and we just checked that raw is
         // in that range.
         return Err(unsafe { Errno(raw.decode_error_code()) });
     }

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -71,7 +71,7 @@ impl SocketAddrUnix {
         if len != 0 && self.unix.sun_path[0] != b'\0' as c::c_char {
             let end = len as usize - offsetof_sun_path();
             let bytes = &self.unix.sun_path[..end];
-            // Safety: `from_raw_parts` to convert from `&[c_char]` to `&[u8]`. And
+            // SAFETY: `from_raw_parts` to convert from `&[c_char]` to `&[u8]`. And
             // `from_bytes_with_nul_unchecked` since the string is NUL-terminated.
             unsafe {
                 Some(CStr::from_bytes_with_nul_unchecked(slice::from_raw_parts(
@@ -91,7 +91,7 @@ impl SocketAddrUnix {
         if len != 0 && self.unix.sun_path[0] == b'\0' as c::c_char {
             let end = len as usize - offsetof_sun_path();
             let bytes = &self.unix.sun_path[1..end];
-            // Safety: `from_raw_parts` to convert from `&[c_char]` to `&[u8]`.
+            // SAFETY: `from_raw_parts` to convert from `&[c_char]` to `&[u8]`.
             unsafe { Some(slice::from_raw_parts(bytes.as_ptr().cast(), bytes.len())) }
         } else {
             None

--- a/src/backend/linux_raw/param/auxv.rs
+++ b/src/backend/linux_raw/param/auxv.rs
@@ -77,7 +77,7 @@ pub(crate) fn linux_execfn() -> &'static CStr {
         execfn = EXECFN.load(Relaxed);
     }
 
-    // Safety: We assume the `AT_EXECFN` value provided by the kernel is a
+    // SAFETY: We assume the `AT_EXECFN` value provided by the kernel is a
     // valid pointer to a valid NUL-terminated array of bytes.
     unsafe { CStr::from_ptr(execfn.cast()) }
 }
@@ -102,7 +102,7 @@ pub(crate) fn exe_phdrs() -> (*const c::c_void, usize) {
 pub(in super::super) fn exe_phdrs_slice() -> &'static [Elf_Phdr] {
     let (phdr, phnum) = exe_phdrs();
 
-    // Safety: We assume the `AT_PHDR` and `AT_PHNUM` values provided by the
+    // SAFETY: We assume the `AT_PHDR` and `AT_PHNUM` values provided by the
     // kernel form a valid slice.
     unsafe { slice::from_raw_parts(phdr.cast(), phnum) }
 }
@@ -177,7 +177,7 @@ fn init_from_auxv_file(auxv: OwnedFd) -> Option<()> {
         buffer.resize(cur + n, 0_u8);
     }
 
-    // Safety: We loaded from an auxv file into the buffer.
+    // SAFETY: We loaded from an auxv file into the buffer.
     unsafe { init_from_auxp(buffer.as_ptr().cast()) }
 }
 

--- a/src/backend/linux_raw/param/libc_auxv.rs
+++ b/src/backend/linux_raw/param/libc_auxv.rs
@@ -66,7 +66,7 @@ pub(crate) fn exe_phdrs() -> (*const libc::c_void, usize) {
 pub(in super::super) fn exe_phdrs_slice() -> &'static [Elf_Phdr] {
     let (phdr, phnum) = exe_phdrs();
 
-    // Safety: We assume the `AT_PHDR` and `AT_PHNUM` values provided by the
+    // SAFETY: We assume the `AT_PHDR` and `AT_PHNUM` values provided by the
     // kernel form a valid slice.
     unsafe { slice::from_raw_parts(phdr.cast(), phnum) }
 }

--- a/src/backend/linux_raw/param/mustang_auxv.rs
+++ b/src/backend/linux_raw/param/mustang_auxv.rs
@@ -22,28 +22,28 @@ use linux_raw_sys::general::{
 #[cfg(feature = "param")]
 #[inline]
 pub(crate) fn page_size() -> usize {
-    // Safety: This is initialized during program startup.
+    // SAFETY: This is initialized during program startup.
     unsafe { PAGE_SIZE }
 }
 
 #[cfg(feature = "param")]
 #[inline]
 pub(crate) fn clock_ticks_per_second() -> u64 {
-    // Safety: This is initialized during program startup.
+    // SAFETY: This is initialized during program startup.
     unsafe { CLOCK_TICKS_PER_SECOND as u64 }
 }
 
 #[cfg(feature = "param")]
 #[inline]
 pub(crate) fn linux_hwcap() -> (usize, usize) {
-    // Safety: This is initialized during program startup.
+    // SAFETY: This is initialized during program startup.
     unsafe { (HWCAP, HWCAP2) }
 }
 
 #[cfg(feature = "param")]
 #[inline]
 pub(crate) fn linux_execfn() -> &'static CStr {
-    // Safety: This is initialized during program startup. And we
+    // SAFETY: This is initialized during program startup. And we
     // assume it's a valid pointer to a NUL-terminated string.
     unsafe { CStr::from_ptr(EXECFN.0.cast()) }
 }
@@ -51,7 +51,7 @@ pub(crate) fn linux_execfn() -> &'static CStr {
 #[cfg(feature = "runtime")]
 #[inline]
 pub(crate) fn exe_phdrs() -> (*const c_void, usize) {
-    // Safety: This is initialized during program startup.
+    // SAFETY: This is initialized during program startup.
     unsafe { (PHDR.0.cast(), PHNUM) }
 }
 
@@ -60,7 +60,7 @@ pub(crate) fn exe_phdrs() -> (*const c_void, usize) {
 pub(in super::super) fn exe_phdrs_slice() -> &'static [Elf_Phdr] {
     let (phdr, phnum) = exe_phdrs();
 
-    // Safety: We assume the `AT_PHDR` and `AT_PHNUM` values provided by the
+    // SAFETY: We assume the `AT_PHDR` and `AT_PHNUM` values provided by the
     // kernel form a valid slice.
     unsafe { slice::from_raw_parts(phdr.cast(), phnum) }
 }
@@ -69,7 +69,7 @@ pub(in super::super) fn exe_phdrs_slice() -> &'static [Elf_Phdr] {
 /// so if we don't see it, this function returns a null pointer.
 #[inline]
 pub(in super::super) fn sysinfo_ehdr() -> *const Elf_Ehdr {
-    // Safety: This is initialized during program startup.
+    // SAFETY: This is initialized during program startup.
     unsafe { SYSINFO_EHDR.0 }
 }
 

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -54,7 +54,7 @@ pub(crate) fn membarrier_query() -> MembarrierQuery {
             c_uint(0)
         )) {
             Ok(query) => {
-                // Safety: The safety of `from_bits_unchecked` is discussed
+                // SAFETY: The safety of `from_bits_unchecked` is discussed
                 // [here]. Our "source of truth" is Linux, and here, the
                 // `query` value is coming from Linux, so we know it only
                 // contains "source of truth" valid bits.

--- a/src/backend/linux_raw/runtime/tls.rs
+++ b/src/backend/linux_raw/runtime/tls.rs
@@ -24,7 +24,7 @@ pub(crate) fn startup_tls_info() -> StartupTlsInfo {
 
     let phdrs = exe_phdrs_slice();
 
-    // Safety: We assume the phdr array pointer and length the kernel provided
+    // SAFETY: We assume the phdr array pointer and length the kernel provided
     // to the process describe a valid phdr array.
     unsafe {
         for phdr in phdrs {

--- a/src/backend/linux_raw/vdso.rs
+++ b/src/backend/linux_raw/vdso.rs
@@ -55,7 +55,7 @@ fn elf_hash(name: &CStr) -> u32 {
 
 /// Create a `Vdso` value by parsing the vDSO at the `sysinfo_ehdr` address.
 fn init_from_sysinfo_ehdr() -> Option<Vdso> {
-    // Safety: the auxv initialization code does extensive checks to ensure
+    // SAFETY: the auxv initialization code does extensive checks to ensure
     // that the value we get really is an `AT_SYSINFO_EHDR` value from the
     // kernel.
     unsafe {
@@ -255,7 +255,7 @@ impl Vdso {
         let ver_hash = elf_hash(version);
         let name_hash = elf_hash(name);
 
-        // Safety: The pointers in `self` must be valid.
+        // SAFETY: The pointers in `self` must be valid.
         unsafe {
             let mut chain = *self.bucket.add((name_hash % self.nbucket) as usize);
 

--- a/src/backend/linux_raw/vdso_wrappers.rs
+++ b/src/backend/linux_raw/vdso_wrappers.rs
@@ -27,7 +27,7 @@ use linux_raw_sys::general::{__kernel_clockid_t, __kernel_timespec};
 
 #[inline]
 pub(crate) fn clock_gettime(which_clock: ClockId) -> __kernel_timespec {
-    // Safety: `CLOCK_GETTIME` contains either null or the address of a
+    // SAFETY: `CLOCK_GETTIME` contains either null or the address of a
     // function with an ABI like libc `clock_gettime`, and calling it has
     // the side effect of writing to the result buffer, and no others.
     unsafe {
@@ -64,7 +64,7 @@ pub(crate) fn clock_gettime_dynamic(which_clock: DynamicClockId<'_>) -> io::Resu
         }
     };
 
-    // Safety: `CLOCK_GETTIME` contains either null or the address of a
+    // SAFETY: `CLOCK_GETTIME` contains either null or the address of a
     // function with an ABI like libc `clock_gettime`, and calling it has
     // the side effect of writing to the result buffer, and no others.
     unsafe {
@@ -217,7 +217,7 @@ pub(super) type SyscallType = unsafe extern "C" fn();
 /// Initialize `CLOCK_GETTIME` and return its value.
 fn init_clock_gettime() -> ClockGettimeType {
     init();
-    // Safety: Load the function address from static storage that we
+    // SAFETY: Load the function address from static storage that we
     // just initialized.
     unsafe { transmute(CLOCK_GETTIME.load(Relaxed)) }
 }
@@ -226,7 +226,7 @@ fn init_clock_gettime() -> ClockGettimeType {
 #[cfg(target_arch = "x86")]
 fn init_syscall() -> SyscallType {
     init();
-    // Safety: Load the function address from static storage that we
+    // SAFETY: Load the function address from static storage that we
     // just initialized.
     unsafe { transmute(SYSCALL.load(Relaxed)) }
 }
@@ -309,7 +309,7 @@ extern "C" {
 }
 
 fn minimal_init() {
-    // Safety: Store default function addresses in static storage so that if we
+    // SAFETY: Store default function addresses in static storage so that if we
     // end up making any system calls while we read the vDSO, they'll work.
     // If the memory happens to already be initialized, this is redundant, but
     // not harmful.
@@ -375,7 +375,7 @@ fn init() {
         if ok {
             assert!(!ptr.is_null());
 
-            // Safety: Store the computed function addresses in static storage
+            // SAFETY: Store the computed function addresses in static storage
             // so that we don't need to compute it again (but if we do, it doesn't
             // hurt anything).
             unsafe {
@@ -389,7 +389,7 @@ fn init() {
             let ptr = vdso.sym(cstr!("LINUX_2.5"), cstr!("__kernel_vsyscall"));
             assert!(!ptr.is_null());
 
-            // Safety: As above, store the computed function addresses in
+            // SAFETY: As above, store the computed function addresses in
             // static storage.
             unsafe {
                 SYSCALL.store(ptr.cast(), Relaxed);

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -44,7 +44,7 @@ macro_rules! cstr {
             // `from_bytes_with_nul_unchecked`, which as of this writing is defined
             // as `#[inline]` and completely optimizes away.
             //
-            // Safety: We have manually checked that the string does not contain
+            // SAFETY: We have manually checked that the string does not contain
             // embedded NULs above, and we append or own NUL terminator here.
             unsafe {
                 $crate::ffi::CStr::from_bytes_with_nul_unchecked(concat!($str, "\0").as_bytes())

--- a/src/fs/cwd.rs
+++ b/src/fs/cwd.rs
@@ -26,7 +26,7 @@ use backend::fd::{BorrowedFd, RawFd};
 pub const fn cwd() -> BorrowedFd<'static> {
     let at_fdcwd = backend::io::types::AT_FDCWD as RawFd;
 
-    // Safety: `AT_FDCWD` is a reserved value that is never dynamically
+    // SAFETY: `AT_FDCWD` is a reserved value that is never dynamically
     // allocated, so it'll remain valid for the duration of `'static`.
     unsafe { BorrowedFd::<'static>::borrow_raw(at_fdcwd) }
 }

--- a/src/io/fd/owned.rs
+++ b/src/io/fd/owned.rs
@@ -244,7 +244,7 @@ impl AsFd for BorrowedFd<'_> {
 impl AsFd for OwnedFd {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
-        // Safety: `OwnedFd` and `BorrowedFd` have the same validity
+        // SAFETY: `OwnedFd` and `BorrowedFd` have the same validity
         // invariants, and the `BorrowedFd` is bounded by the lifetime
         // of `&self`.
         unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }

--- a/src/io/stdio.rs
+++ b/src/io/stdio.rs
@@ -34,7 +34,7 @@ use backend::fd::{BorrowedFd, FromRawFd, RawFd};
 #[doc(alias = "STDIN_FILENO")]
 #[inline]
 pub const fn stdin() -> BorrowedFd<'static> {
-    // Safety: When "std" is enabled, the standard library assumes that the stdio
+    // SAFETY: When "std" is enabled, the standard library assumes that the stdio
     // file descriptors are all valid.
     unsafe { BorrowedFd::borrow_raw(backend::io::types::STDIN_FILENO as RawFd) }
 }
@@ -120,7 +120,7 @@ pub unsafe fn take_stdin() -> OwnedFd {
 #[doc(alias = "STDOUT_FILENO")]
 #[inline]
 pub const fn stdout() -> BorrowedFd<'static> {
-    // Safety: When "std" is enabled, the standard library assumes that the stdio
+    // SAFETY: When "std" is enabled, the standard library assumes that the stdio
     // file descriptors are all valid.
     unsafe { BorrowedFd::borrow_raw(backend::io::types::STDOUT_FILENO as RawFd) }
 }
@@ -200,7 +200,7 @@ pub unsafe fn take_stdout() -> OwnedFd {
 #[doc(alias = "STDERR_FILENO")]
 #[inline]
 pub const fn stderr() -> BorrowedFd<'static> {
-    // Safety: When "std" is enabled, the standard library assumes that the stdio
+    // SAFETY: When "std" is enabled, the standard library assumes that the stdio
     // file descriptors are all valid.
     unsafe { BorrowedFd::borrow_raw(backend::io::types::STDERR_FILENO as RawFd) }
 }

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -759,7 +759,7 @@ pub const IORING_OFF_SQES: u64 = sys::IORING_OFF_SQES as _;
 pub const fn io_uring_register_files_skip() -> BorrowedFd<'static> {
     let files_skip = sys::IORING_REGISTER_FILES_SKIP as RawFd;
 
-    // Safety: `IORING_REGISTER_FILES_SKIP` is a reserved value that is never
+    // SAFETY: `IORING_REGISTER_FILES_SKIP` is a reserved value that is never
     // dynamically allocated, so it'll remain valid for the duration of
     // `'static`.
     unsafe { BorrowedFd::<'static>::borrow_raw(files_skip) }
@@ -834,7 +834,7 @@ impl io_uring_user_data {
     /// Return the `u64` value.
     #[inline]
     pub fn u64_(self) -> u64 {
-        // Safety: All the fields have the same underlying representation.
+        // SAFETY: All the fields have the same underlying representation.
         unsafe { self.u64_ }
     }
 
@@ -847,7 +847,7 @@ impl io_uring_user_data {
     /// Return the `ptr` pointer value.
     #[inline]
     pub fn ptr(self) -> *mut c_void {
-        // Safety: All the fields have the same underlying representation.
+        // SAFETY: All the fields have the same underlying representation.
         unsafe { self.ptr }.ptr
     }
 
@@ -864,7 +864,7 @@ impl Default for io_uring_user_data {
     #[inline]
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
-        // Safety: All of Linux's io_uring structs may be zero-initialized.
+        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
         unsafe {
             ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
             s.assume_init()
@@ -874,7 +874,7 @@ impl Default for io_uring_user_data {
 
 impl core::fmt::Debug for io_uring_user_data {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // Safety: Just format as a `u64`, since formatting doesn't preserve
+        // SAFETY: Just format as a `u64`, since formatting doesn't preserve
         // provenance, and we don't have a discriminant.
         unsafe { self.u64_.fmt(fmt) }
     }
@@ -1212,7 +1212,7 @@ pub struct io_uring_buf {
 impl Default for ioprio_union {
     #[inline]
     fn default() -> Self {
-        // Safety: All of Linux's io_uring structs may be zero-initialized.
+        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
         unsafe { ::core::mem::zeroed::<Self>() }
     }
 }
@@ -1220,7 +1220,7 @@ impl Default for ioprio_union {
 impl Default for len_union {
     #[inline]
     fn default() -> Self {
-        // Safety: All of Linux's io_uring structs may be zero-initialized.
+        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
         unsafe { ::core::mem::zeroed::<Self>() }
     }
 }
@@ -1228,7 +1228,7 @@ impl Default for len_union {
 impl Default for off_or_addr2_union {
     #[inline]
     fn default() -> Self {
-        // Safety: All of Linux's io_uring structs may be zero-initialized.
+        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
         unsafe { ::core::mem::zeroed::<Self>() }
     }
 }
@@ -1236,7 +1236,7 @@ impl Default for off_or_addr2_union {
 impl Default for addr_or_splice_off_in_union {
     #[inline]
     fn default() -> Self {
-        // Safety: All of Linux's io_uring structs may be zero-initialized.
+        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
         unsafe { ::core::mem::zeroed::<Self>() }
     }
 }
@@ -1244,7 +1244,7 @@ impl Default for addr_or_splice_off_in_union {
 impl Default for addr3_or_cmd_union {
     #[inline]
     fn default() -> Self {
-        // Safety: All of Linux's io_uring structs may be zero-initialized.
+        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
         unsafe { ::core::mem::zeroed::<Self>() }
     }
 }
@@ -1252,7 +1252,7 @@ impl Default for addr3_or_cmd_union {
 impl Default for op_flags_union {
     #[inline]
     fn default() -> Self {
-        // Safety: All of Linux's io_uring structs may be zero-initialized.
+        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
         unsafe { ::core::mem::zeroed::<Self>() }
     }
 }
@@ -1260,7 +1260,7 @@ impl Default for op_flags_union {
 impl Default for buf_union {
     #[inline]
     fn default() -> Self {
-        // Safety: All of Linux's io_uring structs may be zero-initialized.
+        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
         unsafe { ::core::mem::zeroed::<Self>() }
     }
 }
@@ -1268,7 +1268,7 @@ impl Default for buf_union {
 impl Default for splice_fd_in_or_file_index_union {
     #[inline]
     fn default() -> Self {
-        // Safety: All of Linux's io_uring structs may be zero-initialized.
+        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
         unsafe { ::core::mem::zeroed::<Self>() }
     }
 }
@@ -1276,7 +1276,7 @@ impl Default for splice_fd_in_or_file_index_union {
 impl Default for register_or_sqe_op_or_sqe_flags_union {
     #[inline]
     fn default() -> Self {
-        // Safety: All of Linux's io_uring structs may be zero-initialized.
+        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
         unsafe { ::core::mem::zeroed::<Self>() }
     }
 }
@@ -1338,7 +1338,7 @@ fn io_uring_layouts() {
 
             // Check that we have all the fields.
             let _test = $name {
-                // Safety: All of io_uring's types can be zero-initialized.
+                // SAFETY: All of io_uring's types can be zero-initialized.
                 $($field: unsafe { core::mem::zeroed() }),*
             };
 

--- a/src/path/dec_int.rs
+++ b/src/path/dec_int.rs
@@ -70,7 +70,7 @@ impl DecInt {
     /// Return the raw byte buffer as a `&str`.
     #[inline]
     pub fn as_str(&self) -> &str {
-        // Safety: `DecInt` always holds a formatted decimal number, so it's
+        // SAFETY: `DecInt` always holds a formatted decimal number, so it's
         // always valid UTF-8.
         unsafe { core::str::from_utf8_unchecked(self.as_bytes()) }
     }
@@ -81,7 +81,7 @@ impl DecInt {
         let bytes_with_nul = &self.buf[..=self.len];
         debug_assert!(CStr::from_bytes_with_nul(bytes_with_nul).is_ok());
 
-        // Safety: `self.buf` holds a single decimal ASCII representation and
+        // SAFETY: `self.buf` holds a single decimal ASCII representation and
         // at least one extra NUL byte.
         unsafe { CStr::from_bytes_with_nul_unchecked(bytes_with_nul) }
     }

--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -105,7 +105,7 @@ impl Gid {
 impl Pid {
     /// A `Pid` corresponding to the init process (pid 1).
     pub const INIT: Self = Self(
-        // Safety: The init process' pid is always valid.
+        // SAFETY: The init process' pid is always valid.
         unsafe { RawNonZeroPid::new_unchecked(1) },
     );
 
@@ -140,7 +140,7 @@ impl Pid {
         let id = child.id();
         debug_assert_ne!(id, 0);
 
-        // Safety: We know the returned ID is valid because it came directly
+        // SAFETY: We know the returned ID is valid because it came directly
         // from an OS API.
         unsafe { Self::from_raw_nonzero(RawNonZeroPid::new_unchecked(id as _)) }
     }

--- a/src/process/membarrier.rs
+++ b/src/process/membarrier.rs
@@ -46,7 +46,7 @@ impl MembarrierQuery {
     /// Test whether this query result contains the given command.
     #[inline]
     pub fn contains_command(self, cmd: MembarrierCommand) -> bool {
-        // Safety: `MembarrierCommand` is an enum that only contains values
+        // SAFETY: `MembarrierCommand` is an enum that only contains values
         // also valid in `MembarrierQuery`.
         self.contains(unsafe { Self::from_bits_unchecked(cmd as _) })
     }

--- a/src/process/uname.rs
+++ b/src/process/uname.rs
@@ -65,7 +65,7 @@ impl Uname {
 
     #[inline]
     fn to_cstr<'a>(ptr: *const u8) -> &'a CStr {
-        // Safety: Strings returned from the kernel are always NUL-terminated.
+        // SAFETY: Strings returned from the kernel are always NUL-terminated.
         unsafe { CStr::from_ptr(ptr.cast()) }
     }
 }


### PR DESCRIPTION
Follow the convention [here] and in the majority of safety comments in std and use '// SAFETY:' instead of '// Safety:'.

[here]: https://std-dev-guide.rust-lang.org/documentation/safety-comments.html#inside-safe-elements