### PR TITLE
Backport patches to 0.36

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,6 +211,8 @@ jobs:
     - run: cargo check -Z build-std --target x86_64-unknown-dragonfly --all-targets --features=all-apis
     - run: cargo check -Z build-std --target sparc-unknown-linux-gnu --all-targets --features=all-apis
     - run: cargo check -Z build-std --target armv7-unknown-freebsd --all-targets --features=all-apis
+    # Omit --all-targets on gnu_ilp32 because dev-dependency tempfile depends on an older rustix
+    - run: cargo check -Z build-std --target aarch64-unknown-linux-gnu_ilp32 --features=all-apis
     # Omit --all-targets on haiku because not all the tests build yet.
     - run: cargo check -Z build-std --target x86_64-unknown-haiku --features=all-apis
     # x86_64-uwp-windows-msvc isn't currently working.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,9 +75,9 @@ jobs:
         sparcv9-sun-solaris
         aarch64-linux-android
         aarch64-apple-ios
-    - if: matrix.rust == 'nightly'
+    - if: matrix.rust != '1.48'
       run: rustup target add x86_64-unknown-fuchsia
-    - if: matrix.rust != 'nightly'
+    - if: matrix.rust == '1.48'
       run: rustup target add x86_64-fuchsia
 
     - name: Install cross-compilation tools
@@ -102,9 +102,9 @@ jobs:
     - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin --features=all-apis --all-targets
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-freebsd --features=all-apis --all-targets
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-netbsd --features=all-apis --all-targets
-    - if: matrix.rust == 'nightly'
+    - if: matrix.rust != '1.48'
       run: cargo check --workspace --release -vv --target=x86_64-unknown-fuchsia --features=all-apis --all-targets
-    - if: matrix.rust != 'nightly'
+    - if: matrix.rust == '1.48'
       run: cargo check --workspace --release -vv --target=x86_64-fuchsia --features=all-apis --all-targets
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-illumos --features=all-apis --all-targets
     - run: cargo check --workspace --release -vv --target=i686-unknown-linux-gnu --features=all-apis --all-targets

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,14 @@ jobs:
 
     - name: Use specific dependency versions for Rust 1.48 compatibility.
       if: matrix.rust == '1.48'
-      run: cargo update --package=once_cell --precise 1.14.0
+      run: |
+        cargo update --package=once_cell --precise 1.14.0
+        cargo update --package=io-lifetimes --precise 1.0.6
+        for crate in test-crates/*; do
+            cd $crate
+            cargo update --package=io-lifetimes --precise 1.0.6
+            cd - >/dev/null
+        done
 
     - run: cargo check --workspace --release -vv --all-targets
     - run: cargo check --workspace --release -vv --features=all-apis --all-targets
@@ -516,7 +523,14 @@ jobs:
 
     - name: Use specific dependency versions for Rust 1.48 compatibility.
       if: matrix.rust == '1.48'
-      run: cargo update --package=once_cell --precise 1.14.0
+      run: |
+        cargo update --package=once_cell --precise 1.14.0
+        cargo update --package=io-lifetimes --precise 1.0.6
+        for crate in test-crates/*; do
+            cd $crate
+            cargo update --package=io-lifetimes --precise 1.0.6
+            cd - >/dev/null
+        done
 
     - run: |
         # Run the tests, and check the prebuilt release libraries.

--- a/build.rs
+++ b/build.rs
@@ -117,7 +117,7 @@ fn main() {
     println!("cargo:rerun-if-env-changed=CARGO_ENCODED_RUSTFLAGS");
     println!("cargo:rerun-if-env-changed=RUSTC");
     println!("cargo:rerun-if-env-changed=TARGET");
-    println!("cargo:rerun-if-env-changed=CARGO_RUSTC_WRAPPER");
+    println!("cargo:rerun-if-env-changed=RUSTC_WRAPPER");
     println!("cargo:rerun-if-env-changed=PROFILE");
 }
 
@@ -199,7 +199,7 @@ fn can_compile<T: AsRef<str>>(test: T) -> bool {
     let rustc = var("RUSTC").unwrap();
     let target = var("TARGET").unwrap();
 
-    let mut cmd = if let Ok(wrapper) = var("CARGO_RUSTC_WRAPPER") {
+    let mut cmd = if let Ok(wrapper) = var("RUSTC_WRAPPER") {
         let mut cmd = std::process::Command::new(wrapper);
         // The wrapper's first argument is supposed to be the path to rustc.
         cmd.arg(rustc);

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -1485,13 +1485,20 @@ fn stat64_to_stat(s64: c::stat64) -> io::Result<Stat> {
 mod sys {
     use super::{c, BorrowedFd, Statx};
 
+    // Some versions of the libc bindings don't have these, so provide
+    // our own definitions (which may become unused when libc gains
+    // bindings for them).
     #[cfg(all(target_os = "android", target_arch = "arm"))]
+    #[allow(dead_code)]
     const SYS_statx: c::c_long = 397;
     #[cfg(all(target_os = "android", target_arch = "x86"))]
+    #[allow(dead_code)]
     const SYS_statx: c::c_long = 383;
     #[cfg(all(target_os = "android", target_arch = "aarch64"))]
+    #[allow(dead_code)]
     const SYS_statx: c::c_long = 291;
     #[cfg(all(target_os = "android", target_arch = "x86_64"))]
+    #[allow(dead_code)]
     const SYS_statx: c::c_long = 332;
 
     weak_or_syscall! {

--- a/src/fs/raw_dir.rs
+++ b/src/fs/raw_dir.rs
@@ -195,8 +195,8 @@ impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
 
         Some(Ok(RawDirEntry {
             file_type: dirent.d_type,
-            inode_number: dirent.d_ino,
-            next_entry_cookie: dirent.d_off,
+            inode_number: dirent.d_ino.into(),
+            next_entry_cookie: dirent.d_off.into(),
             // SAFETY: the kernel guarantees a NUL terminated string.
             file_name: unsafe { CStr::from_ptr(dirent.d_name.as_ptr().cast()) },
         }))


### PR DESCRIPTION
This backports several fixes, including the `CARGO_RUSTC_WRAPPER` fix, to the 0.36 release branch.