### PR TITLE
Only use RUSTC_WRAPPER when non empty

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -240,7 +240,11 @@ fn can_compile<T: AsRef<str>>(test: T) -> bool {
     let rustc = var("RUSTC").unwrap();
     let target = var("TARGET").unwrap();
 
-    let mut cmd = if let Ok(wrapper) = var("RUSTC_WRAPPER") {
+    let wrapper = var("RUSTC_WRAPPER")
+        .ok()
+        .and_then(|w| if w.is_empty() { None } else { Some(w) });
+
+    let mut cmd = if let Some(wrapper) = wrapper {
         let mut cmd = std::process::Command::new(wrapper);
         // The wrapper's first argument is supposed to be the path to rustc.
         cmd.arg(rustc);


### PR DESCRIPTION
We have a build that sets RUSTC_WRAPPER to either sccache or empty string -> after latest release it is now failing on the empty string case.

https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-reads suggests this should be acceptable:

> Setting this to the empty string overwrites the config and resets cargo to not use a wrapper.


Thanks!