### PR TITLE
Add dup2_std{in,out,err} safe helpers

### DIFF
--- a/src/io/dup.rs
+++ b/src/io/dup.rs
@@ -44,6 +44,9 @@ pub fn dup<Fd: AsFd>(fd: Fd) -> io::Result<OwnedFd> {
 /// set `O_CLOEXEC`, use [`dup3`] with [`DupFlags::CLOEXEC`] on platforms which
 /// support it, or [`fcntl_dupfd_cloexec`]
 ///
+/// For `dup2` to stdin, stdout, and stderr, see [`crate::io::stdio::dup2_stdin`],
+/// [`crate::io::stdio::dup2_stdout`], and [`crate::io::stdio::dup2_stderr`].
+///
 /// # References
 ///  - [POSIX]
 ///  - [Linux]


### PR DESCRIPTION
Doing a dup2 over one of the stdio fds is safe, but currently requires a
three-line unsafe dance: unsafely get an OwnedFd for the target fd,
`dup2` over it, then `std::mem::forget` the OwnedFd so it doesn't get
closed.

Encapsulate that in a trio of safe helpers.
