### PR TITLE
Remove code no longer needed with the latest libc crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ once_cell = { version = "1.5.2", optional = true }
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
 linux-raw-sys = { version = "0.3.0", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 libc_errno = { package = "errno", version = "0.3.0", default-features = false, optional = true }
-libc = { version = "0.2.133", features = ["extra_traits"], optional = true }
+libc = { version = "0.2.140", features = ["extra_traits"], optional = true }
 
 # Dependencies for platforms where only libc is supported:
 #
@@ -49,7 +49,7 @@ libc = { version = "0.2.133", features = ["extra_traits"], optional = true }
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.0", default-features = false }
-libc = { version = "0.2.133", features = ["extra_traits"] }
+libc = { version = "0.2.140", features = ["extra_traits"] }
 
 # Additional dependencies for Linux with the libc backend:
 #
@@ -69,8 +69,8 @@ features = [
 ]
 
 [dev-dependencies]
-tempfile = "3.2.0"
-libc = "0.2.133"
+tempfile = "3.4.0"
+libc = "0.2.140"
 libc_errno = { package = "errno", version = "0.3.0", default-features = false }
 io-lifetimes = { version = "1.0.0", default-features = false, features = ["close"] }
 # Don't upgrade to serial_test 0.7 for now because it depends on a

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -1445,22 +1445,6 @@ fn stat64_to_stat(s64: c::stat64) -> io::Result<Stat> {
 mod sys {
     use super::{c, BorrowedFd, Statx};
 
-    // Some versions of the libc bindings don't have these, so provide
-    // our own definitions (which may become unused when libc gains
-    // bindings for them).
-    #[cfg(all(target_os = "android", target_arch = "arm"))]
-    #[allow(dead_code)]
-    const SYS_statx: c::c_long = 397;
-    #[cfg(all(target_os = "android", target_arch = "x86"))]
-    #[allow(dead_code)]
-    const SYS_statx: c::c_long = 383;
-    #[cfg(all(target_os = "android", target_arch = "aarch64"))]
-    #[allow(dead_code)]
-    const SYS_statx: c::c_long = 291;
-    #[cfg(all(target_os = "android", target_arch = "x86_64"))]
-    #[allow(dead_code)]
-    const SYS_statx: c::c_long = 332;
-
     weak_or_syscall! {
         pub(super) fn statx(
             dirfd_: BorrowedFd<'_>,

--- a/src/backend/libc/time/types.rs
+++ b/src/backend/libc/time/types.rs
@@ -300,7 +300,7 @@ bitflags! {
 
         /// `TFD_TIMER_CANCEL_ON_SET`
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        const CANCEL_ON_SET = 2; // TODO: upstream TFD_TIMER_CANCEL_ON_SET
+        const CANCEL_ON_SET = c::TFD_TIMER_CANCEL_ON_SET;
     }
 }
 


### PR DESCRIPTION
Update to the latest libc crate and remove some code which is no longer needed.