### PR TITLE
Add more safety comments.

### DIFF
--- a/src/io/stdio.rs
+++ b/src/io/stdio.rs
@@ -331,8 +331,9 @@ pub const fn raw_stderr() -> RawFd {
 /// Utility function to safely `dup2` over stdin (fd 0).
 #[cfg(not(any(windows, target_os = "wasi")))]
 #[inline]
-#[allow(unsafe_code)]
 pub fn dup2_stdin<Fd: AsFd>(fd: Fd) -> io::Result<()> {
+    // SAFETY: We pass the returned `OwnedFd` to `forget` so that it isn't
+    // dropped.
     let mut target = unsafe { io::take_stdin() };
     backend::io::syscalls::dup2(fd.as_fd(), &mut target)?;
     core::mem::forget(target);
@@ -342,8 +343,9 @@ pub fn dup2_stdin<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 /// Utility function to safely `dup2` over stdout (fd 1).
 #[cfg(not(any(windows, target_os = "wasi")))]
 #[inline]
-#[allow(unsafe_code)]
 pub fn dup2_stdout<Fd: AsFd>(fd: Fd) -> io::Result<()> {
+    // SAFETY: We pass the returned `OwnedFd` to `forget` so that it isn't
+    // dropped.
     let mut target = unsafe { io::take_stdout() };
     backend::io::syscalls::dup2(fd.as_fd(), &mut target)?;
     core::mem::forget(target);
@@ -353,8 +355,9 @@ pub fn dup2_stdout<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 /// Utility function to safely `dup2` over stderr (fd 2).
 #[cfg(not(any(windows, target_os = "wasi")))]
 #[inline]
-#[allow(unsafe_code)]
 pub fn dup2_stderr<Fd: AsFd>(fd: Fd) -> io::Result<()> {
+    // SAFETY: We pass the returned `OwnedFd` to `forget` so that it isn't
+    // dropped.
     let mut target = unsafe { io::take_stderr() };
     backend::io::syscalls::dup2(fd.as_fd(), &mut target)?;
     core::mem::forget(target);

--- a/src/path/arg.rs
+++ b/src/path/arg.rs
@@ -954,9 +954,11 @@ where
     let mut buf = MaybeUninit::<[u8; SMALL_PATH_BUFFER_SIZE]>::uninit();
     let buf_ptr = buf.as_mut_ptr() as *mut u8;
 
+    // This helps test our safety condition below.
+    debug_assert!(bytes.len() + 1 <= SMALL_PATH_BUFFER_SIZE);
+
     // SAFETY: bytes.len() < SMALL_PATH_BUFFER_SIZE which means we have space for
     // bytes.len() + 1 u8s:
-    debug_assert!(bytes.len() + 1 <= SMALL_PATH_BUFFER_SIZE);
     unsafe {
         ptr::copy_nonoverlapping(bytes.as_ptr(), buf_ptr, bytes.len());
         buf_ptr.add(bytes.len()).write(0);


### PR DESCRIPTION
Add safety comments to the new `dup2_*` functions, and adjust a safety comment inside `with_c_str` so that it can be found by tooling.