### PR TITLE
Add more procctls for FreeBSD

### DIFF
--- a/src/process/procctl.rs
+++ b/src/process/procctl.rs
@@ -468,3 +468,45 @@ pub fn trap_cap_behavior(process: ProcSelector) -> io::Result<TrapCapBehavior> {
         _ => Err(io::Errno::RANGE),
     }
 }
+
+//
+// PROC_NO_NEW_PRIVS_STATUS/PROC_NO_NEW_PRIVS_CTL
+//
+
+const PROC_NO_NEW_PRIVS_CTL: c_int = 19;
+
+const PROC_NO_NEW_PRIVS_ENABLE: c_int = 1;
+
+/// Enable the `no_new_privs` mode that ignores SUID and SGID bits
+/// on `execve` in the specified process and its future descendants.
+///
+/// This is similar to `set_no_new_privs` on Linux, with the exception
+/// that on FreeBSD there is no argument `no_new_privs` argument as it's
+/// only possible to enable this mode and there's no going back.
+///
+/// # References
+/// - [Linux: `prctl(PR_SET_NO_NEW_PRIVS,...)`]
+/// - [FreeBSD: `procctl(PROC_NO_NEW_PRIVS_CTL,...)`]
+///
+/// [Linux: `prctl(PR_SET_NO_NEW_PRIVS,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
+/// [FreeBSD: `procctl(PROC_NO_NEW_PRIVS_CTL,...)`]: https://www.freebsd.org/cgi/man.cgi?query=procctl&sektion=2
+#[inline]
+pub fn set_no_new_privs(process: ProcSelector) -> io::Result<()> {
+    unsafe { procctl_set::<c_int>(PROC_NO_NEW_PRIVS_CTL, process, &PROC_NO_NEW_PRIVS_ENABLE) }
+}
+
+const PROC_NO_NEW_PRIVS_STATUS: c_int = 20;
+
+/// Check the `no_new_privs` mode of the specified process.
+///
+/// # References
+/// - [Linux: `prctl(PR_GET_NO_NEW_PRIVS,...)`]
+/// - [FreeBSD: `procctl(PROC_NO_NEW_PRIVS_STATUS,...)`]
+///
+/// [Linux: `prctl(PR_GET_NO_NEW_PRIVS,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
+/// [FreeBSD: `procctl(PROC_NO_NEW_PRIVS_STATUS,...)`]: https://www.freebsd.org/cgi/man.cgi?query=procctl&sektion=2
+#[inline]
+pub fn no_new_privs(process: ProcSelector) -> io::Result<bool> {
+    unsafe { procctl_get_optional::<c_int>(PROC_NO_NEW_PRIVS_STATUS, process) }
+        .map(|x| x == PROC_NO_NEW_PRIVS_ENABLE)
+}

--- a/tests/process/procctl.rs
+++ b/tests/process/procctl.rs
@@ -26,3 +26,12 @@ fn test_reaper_status() {
 fn test_reaper_pids() {
     dbg!(get_reaper_pids(None).unwrap());
 }
+
+#[test]
+fn test_trapcap() {
+    assert_eq!(trap_cap_behavior(None).unwrap(), TrapCapBehavior::Disable);
+    set_trap_cap_behavior(None, TrapCapBehavior::Enable).unwrap();
+    assert_eq!(trap_cap_behavior(None).unwrap(), TrapCapBehavior::Enable);
+    set_trap_cap_behavior(None, TrapCapBehavior::Disable).unwrap();
+    assert_eq!(trap_cap_behavior(None).unwrap(), TrapCapBehavior::Disable);
+}

--- a/tests/process/procctl.rs
+++ b/tests/process/procctl.rs
@@ -35,3 +35,11 @@ fn test_trapcap() {
     set_trap_cap_behavior(None, TrapCapBehavior::Disable).unwrap();
     assert_eq!(trap_cap_behavior(None).unwrap(), TrapCapBehavior::Disable);
 }
+
+#[test]
+fn test_no_new_privs() {
+    assert!(!no_new_privs(None).unwrap());
+    set_no_new_privs(None).unwrap();
+    assert!(no_new_privs(None).unwrap());
+    // No going back but, well, we're not gonna execute SUID binaries from the test suite.
+}

--- a/tests/process/procctl.rs
+++ b/tests/process/procctl.rs
@@ -1,3 +1,4 @@
+use rustix::io;
 use rustix::process::*;
 
 #[test]
@@ -8,4 +9,20 @@ fn test_parent_process_death_signal() {
 #[test]
 fn test_trace_status() {
     dbg!(trace_status(None).unwrap());
+}
+
+#[test]
+fn test_reaper_status() {
+    assert_eq!(set_reaper_status(false), Err(io::Errno::INVAL));
+    set_reaper_status(true).unwrap();
+    let status_while_acq = dbg!(get_reaper_status(None).unwrap());
+    set_reaper_status(false).unwrap();
+    let status_while_rel = dbg!(get_reaper_status(None).unwrap());
+    assert!(status_while_acq.flags.contains(ReaperStatusFlags::OWNED));
+    assert!(!status_while_rel.flags.contains(ReaperStatusFlags::OWNED));
+}
+
+#[test]
+fn test_reaper_pids() {
+    dbg!(get_reaper_pids(None).unwrap());
 }


### PR DESCRIPTION
In particular I'm planning on playing around with the reaper API (which actually does inescapable process subtree tracking and allows signaling all descendants of a child no matter how many double-triple-forking has happened in between). Also adding a couple more random things here.