### PR TITLE
Add kqueue signal filter

### DIFF
--- a/examples/kq.rs
+++ b/examples/kq.rs
@@ -1,0 +1,68 @@
+#[cfg(bsd)]
+fn main() -> std::io::Result<()> {
+    use rustix::io::kqueue::*;
+    #[cfg(feature = "fs")]
+    use rustix::{fd::AsRawFd, fs};
+
+    let kq = kqueue()?;
+    let mut out = Vec::with_capacity(10);
+
+    #[cfg(feature = "fs")]
+    let dir = fs::openat(fs::cwd(), ".", fs::OFlags::DIRECTORY, fs::Mode::empty())?;
+
+    let subs = [
+        #[cfg(feature = "process")]
+        Event::new(
+            EventFilter::Signal {
+                signal: rustix::process::Signal::Info,
+                times: 0,
+            },
+            EventFlags::ADD,
+            0,
+        ),
+        #[cfg(feature = "fs")]
+        Event::new(
+            EventFilter::Vnode {
+                vnode: dir.as_raw_fd(),
+                flags: VnodeEvents::WRITE | VnodeEvents::LINK | VnodeEvents::EXTEND,
+            },
+            EventFlags::ADD | EventFlags::CLEAR,
+            0,
+        ),
+        Event::new(
+            EventFilter::Timer(Some(core::time::Duration::from_secs(1))),
+            EventFlags::ADD,
+            0,
+        ),
+    ];
+
+    eprintln!("Listening for various events");
+    #[cfg(not(feature = "process"))]
+    eprintln!("Run with --features process to enable more!");
+    #[cfg(not(feature = "fs"))]
+    eprintln!("Run with --features fs to enable more!");
+    unsafe { kevent(&kq, &subs, &mut out, None) }?;
+
+    loop {
+        while let Some(e) = out.pop() {
+            match e.filter() {
+                #[cfg(feature = "process")]
+                EventFilter::Signal { signal, times } => {
+                    eprintln!("Got signal {:?} {} times", signal, times)
+                }
+                #[cfg(feature = "fs")]
+                EventFilter::Vnode { vnode: _, flags } => {
+                    eprintln!("Current directory was touched ({:?})", flags)
+                }
+                EventFilter::Timer(_) => eprintln!("Second timer ticked"),
+                _ => eprintln!("Unknown event"),
+            }
+        }
+        unsafe { kevent(&kq, &[], &mut out, None) }?;
+    }
+}
+
+#[cfg(not(bsd))]
+fn main() {
+    unimplemented!()
+}

--- a/src/backend/libc/process/types.rs
+++ b/src/backend/libc/process/types.rs
@@ -201,6 +201,19 @@ pub enum Signal {
     /// `SIGSYS`, aka `SIGUNUSED`
     #[doc(alias = "Unused")]
     Sys = c::SIGSYS,
+    /// `SIGEMT`
+    #[cfg(bsd)]
+    Emt = c::SIGEMT,
+    /// `SIGINFO`
+    #[cfg(bsd)]
+    Info = c::SIGINFO,
+    /// `SIGTHR`
+    #[cfg(target_os = "freebsd")]
+    #[doc(alias = "Lwp")]
+    Thr = c::SIGTHR,
+    /// `SIGLIBRT`
+    #[cfg(target_os = "freebsd")]
+    Librt = c::SIGLIBRT,
 }
 
 #[cfg(not(target_os = "wasi"))]
@@ -256,6 +269,14 @@ impl Signal {
             #[cfg(not(any(bsd, target_os = "haiku")))]
             c::SIGPWR => Some(Self::Power),
             c::SIGSYS => Some(Self::Sys),
+            #[cfg(bsd)]
+            c::SIGEMT => Some(Self::Emt),
+            #[cfg(bsd)]
+            c::SIGINFO => Some(Self::Info),
+            #[cfg(target_os = "freebsd")]
+            c::SIGTHR => Some(Self::Thr),
+            #[cfg(target_os = "freebsd")]
+            c::SIGLIBRT => Some(Self::Librt),
             _ => None,
         }
     }


### PR DESCRIPTION
Should be supported everywhere…

Usage example:

```rust
fn main() -> std::io::Result<()> {
    use rustix::io::kqueue::*;
    use rustix::process::Signal;
    let kq = kqueue()?;
    let mut out = Vec::with_capacity(10);
    unsafe {
        kevent(
            &kq,
            &[Event::new(
                EventFilter::Signal {
                    signal: Signal::Ttin,
                    times: 0,
                },
                EventFlags::ADD,
                0,
            )],
            &mut out,
            None,
        )
    }?;
    loop {
        while let Some(e) = out.pop() {
            match e.filter() {
                EventFilter::Signal { signal, times } => eprintln!("{:?} x {}", signal, times),
                EventFilter::Unknown => eprintln!("unk???"),
                _ => eprintln!("wat"),
            }
        }
        unsafe { kevent(&kq, &[], &mut out, None) }?;
    }
}
```

While here, I've also documented the output vector capacity thing.