### PR TITLE
Add setresuid_thread and setresgid_thread

### DIFF
--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -330,6 +330,34 @@ pub(crate) fn setuid_thread(uid: crate::process::Uid) -> io::Result<()> {
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
+pub(crate) fn setresuid_thread(
+    ruid: crate::process::Uid,
+    euid: crate::process::Uid,
+    suid: crate::process::Uid,
+) -> io::Result<()> {
+    #[cfg(any(target_arch = "x86", target_arch = "arm", target_arch = "sparc"))]
+    const SYS: c::c_long = c::SYS_setresuid32 as c::c_long;
+    #[cfg(not(any(target_arch = "x86", target_arch = "arm", target_arch = "sparc")))]
+    const SYS: c::c_long = c::SYS_setresuid as c::c_long;
+    unsafe { syscall_ret(c::syscall(SYS, ruid.as_raw(), euid.as_raw(), suid.as_raw())) }
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[inline]
 pub(crate) fn setgid_thread(gid: crate::process::Gid) -> io::Result<()> {
     unsafe { syscall_ret(c::syscall(c::SYS_setgid, gid.as_raw())) }
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[inline]
+pub(crate) fn setresgid_thread(
+    rgid: crate::process::Gid,
+    egid: crate::process::Gid,
+    sgid: crate::process::Gid,
+) -> io::Result<()> {
+    #[cfg(any(target_arch = "x86", target_arch = "arm", target_arch = "sparc"))]
+    const SYS: c::c_long = c::SYS_setresgid32 as c::c_long;
+    #[cfg(not(any(target_arch = "x86", target_arch = "arm", target_arch = "sparc")))]
+    const SYS: c::c_long = c::SYS_setresgid as c::c_long;
+    unsafe { syscall_ret(c::syscall(SYS, rgid.as_raw(), egid.as_raw(), sgid.as_raw())) }
 }

--- a/src/backend/linux_raw/thread/syscalls.rs
+++ b/src/backend/linux_raw/thread/syscalls.rs
@@ -321,6 +321,38 @@ pub(crate) fn setuid_thread(uid: crate::process::Uid) -> io::Result<()> {
 }
 
 #[inline]
+pub(crate) fn setresuid_thread(
+    ruid: crate::process::Uid,
+    euid: crate::process::Uid,
+    suid: crate::process::Uid,
+) -> io::Result<()> {
+    #[cfg(any(target_arch = "x86", target_arch = "arm", target_arch = "sparc"))]
+    unsafe {
+        ret(syscall_readonly!(__NR_setresuid32, ruid, euid, suid))
+    }
+    #[cfg(not(any(target_arch = "x86", target_arch = "arm", target_arch = "sparc")))]
+    unsafe {
+        ret(syscall_readonly!(__NR_setresuid, ruid, euid, suid))
+    }
+}
+
+#[inline]
 pub(crate) fn setgid_thread(gid: crate::process::Gid) -> io::Result<()> {
     unsafe { ret(syscall_readonly!(__NR_setgid, gid)) }
+}
+
+#[inline]
+pub(crate) fn setresgid_thread(
+    rgid: crate::process::Gid,
+    egid: crate::process::Gid,
+    sgid: crate::process::Gid,
+) -> io::Result<()> {
+    #[cfg(any(target_arch = "x86", target_arch = "arm", target_arch = "sparc"))]
+    unsafe {
+        ret(syscall_readonly!(__NR_setresgid32, rgid, egid, sgid))
+    }
+    #[cfg(not(any(target_arch = "x86", target_arch = "arm", target_arch = "sparc")))]
+    unsafe {
+        ret(syscall_readonly!(__NR_setresgid, rgid, egid, sgid))
+    }
 }

--- a/src/thread/id.rs
+++ b/src/thread/id.rs
@@ -40,6 +40,29 @@ pub fn set_thread_uid(uid: Uid) -> io::Result<()> {
     backend::thread::syscalls::setuid_thread(uid)
 }
 
+/// `setresuid(ruid, euid, suid)`
+///
+/// # Warning
+///
+/// This is not the setresxid you are looking for... POSIX requires xids to be
+/// process granular, but on Linux they are per-thread. Thus, this call only
+/// changes the xid for the current *thread*, not the entire process even
+/// though that is in violation of the POSIX standard.
+///
+/// For details on this distinction, see the C library vs. kernel differences
+/// in the [man page][linux_notes] and the notes in [`set_thread_uid`]. This
+/// call implements the kernel behavior.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/setresuid.2.html
+/// [linux_notes]: https://man7.org/linux/man-pages/man2/setresuid.2.html#NOTES
+#[inline]
+pub fn set_thread_res_uid(ruid: Uid, euid: Uid, suid: Uid) -> io::Result<()> {
+    backend::thread::syscalls::setresuid_thread(ruid, euid, suid)
+}
+
 /// `setgid(gid)`
 ///
 /// # Warning
@@ -62,4 +85,27 @@ pub fn set_thread_uid(uid: Uid) -> io::Result<()> {
 #[inline]
 pub fn set_thread_gid(gid: Gid) -> io::Result<()> {
     backend::thread::syscalls::setgid_thread(gid)
+}
+
+/// `setresgid(rgid, egid, sgid)`
+///
+/// # Warning
+///
+/// This is not the setresxid you are looking for... POSIX requires xids to be
+/// process granular, but on Linux they are per-thread. Thus, this call only
+/// changes the xid for the current *thread*, not the entire process even
+/// though that is in violation of the POSIX standard.
+///
+/// For details on this distinction, see the C library vs. kernel differences
+/// in the [man page][linux_notes] and the notes in [`set_thread_gid`]. This
+/// call implements the kernel behavior.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/setresgid.2.html
+/// [linux_notes]: https://man7.org/linux/man-pages/man2/setresgid.2.html#NOTES
+#[inline]
+pub fn set_thread_res_gid(rgid: Gid, egid: Gid, sgid: Gid) -> io::Result<()> {
+    backend::thread::syscalls::setresgid_thread(rgid, egid, sgid)
 }

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -18,7 +18,7 @@ pub use clock::*;
 #[cfg(linux_raw)]
 pub use futex::{futex, FutexFlags, FutexOperation};
 #[cfg(any(target_os = "android", target_os = "linux"))]
-pub use id::{gettid, set_thread_gid, set_thread_uid};
+pub use id::{gettid, set_thread_gid, set_thread_res_gid, set_thread_res_uid, set_thread_uid};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use libcap::{capabilities, set_capabilities, CapabilityFlags, CapabilitySets};
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/tests/thread/id.rs
+++ b/tests/thread/id.rs
@@ -11,6 +11,18 @@ fn test_setuid() {
 }
 
 #[test]
+fn test_setresuid() {
+    let uid = process::getuid();
+    thread::set_thread_res_uid(uid, uid, uid).unwrap();
+}
+
+#[test]
 fn test_setgid() {
     thread::set_thread_gid(process::getgid()).unwrap();
+}
+
+#[test]
+fn test_setresgid() {
+    let gid = process::getgid();
+    thread::set_thread_res_gid(gid, gid, gid).unwrap();
 }


### PR DESCRIPTION
These functions support setting the real, effective, and saved UID/GID
in one call.
