### PR TITLE
Don't re-export unstable wasi features on stable Rust.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,7 +133,9 @@ jobs:
     - run: cargo check --workspace --release -vv --target=sparcv9-sun-solaris --features=all-apis --all-targets
     - run: cargo check --workspace --release -vv --target=aarch64-apple-ios --features=all-apis --all-targets
     - run: cargo check --workspace --release -vv --target=aarch64-linux-android --features=all-apis --all-targets
-    - run: cargo check --workspace --release -vv --target=wasm32-wasi --features=all-apis --all-targets
+    # Omit --all-targets for WASI until all the dev-dependencies support WASI
+    # on stable.
+    - run: cargo check --workspace --release -vv --target=wasm32-wasi --features=all-apis
 
   check_no_default_features:
     name: Check --no-default-features

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,7 @@ jobs:
         sparcv9-sun-solaris
         aarch64-linux-android
         aarch64-apple-ios
+        wasm32-wasi
     - if: matrix.rust != '1.48'
       run: rustup target add x86_64-unknown-fuchsia
     - if: matrix.rust == '1.48'
@@ -132,6 +133,7 @@ jobs:
     - run: cargo check --workspace --release -vv --target=sparcv9-sun-solaris --features=all-apis --all-targets
     - run: cargo check --workspace --release -vv --target=aarch64-apple-ios --features=all-apis --all-targets
     - run: cargo check --workspace --release -vv --target=aarch64-linux-android --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=wasm32-wasi --features=all-apis --all-targets
 
   check_no_default_features:
     name: Check --no-default-features

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,7 +135,8 @@ jobs:
     - run: cargo check --workspace --release -vv --target=aarch64-linux-android --features=all-apis --all-targets
     # Omit --all-targets for WASI until all the dev-dependencies support WASI
     # on stable.
-    - run: cargo check --workspace --release -vv --target=wasm32-wasi --features=all-apis
+    - if: matrix.rust != '1.48'
+      run: cargo check --workspace --release -vv --target=wasm32-wasi --features=all-apis
 
   check_no_default_features:
     name: Check --no-default-features

--- a/build.rs
+++ b/build.rs
@@ -138,6 +138,9 @@ fn main() {
     {
         use_feature("bsd");
     }
+    if target_os == "wasi" {
+        use_feature_or_nothing("wasi_ext");
+    }
 
     println!("cargo:rerun-if-env-changed=CARGO_CFG_RUSTIX_USE_EXPERIMENTAL_ASM");
     println!("cargo:rerun-if-env-changed=CARGO_CFG_RUSTIX_USE_LIBC");

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -3,7 +3,7 @@
 use crate::backend;
 
 pub use crate::io::FdFlags;
-pub use backend::fs::types::{Access, Mode, OFlags};
+pub use backend::fs::types::{Access, Dev, Mode, OFlags};
 
 #[cfg(not(target_os = "redox"))]
 pub use backend::fs::types::AtFlags;
@@ -13,8 +13,5 @@ pub use backend::fs::types::{CloneFlags, CopyfileFlags};
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use backend::fs::types::*;
-
-#[cfg(not(target_os = "redox"))]
-pub use backend::fs::types::Dev;
 
 pub use backend::time::types::{Nsecs, Secs, Timespec};

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -98,5 +98,5 @@ pub use sync::sync;
 #[cfg(unix)]
 pub use std::os::unix::fs::{DirEntryExt, FileExt, FileTypeExt, MetadataExt, OpenOptionsExt};
 #[cfg(feature = "std")]
-#[cfg(target_os = "wasi")]
+#[cfg(all(wasi_ext, target_os = "wasi"))]
 pub use std::os::wasi::fs::{DirEntryExt, FileExt, FileTypeExt, MetadataExt, OpenOptionsExt};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@
 #![cfg_attr(linux_raw, deny(unsafe_code))]
 #![cfg_attr(rustc_attrs, feature(rustc_attrs))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
-#![cfg_attr(all(target_os = "wasi", feature = "std"), feature(wasi_ext))]
+#![cfg_attr(all(wasi_ext, target_os = "wasi", feature = "std"), feature(wasi_ext))]
 #![cfg_attr(
     all(linux_raw, naked_functions, target_arch = "x86"),
     feature(naked_functions)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,9 @@
 #![allow(clippy::unnecessary_cast)]
 // It is common in linux and libc APIs for types to vary between platforms.
 #![allow(clippy::useless_conversion)]
+// Redox and WASI have enough differences that it isn't worth
+// precisely conditionallizing all the `use`s for them.
+#![cfg_attr(any(target_os = "redox", target_os = "wasi"), allow(unused_imports))]
 
 #[cfg(not(feature = "rustc-dep-of-std"))]
 extern crate alloc;

--- a/tests/backends.rs
+++ b/tests/backends.rs
@@ -51,7 +51,7 @@ fn test_backends() {
 
     #[cfg(windows)]
     let libc_dep = "windows-sys";
-    #[cfg(unix)]
+    #[cfg(any(unix, target_os = "wasi"))]
     let libc_dep = "libc";
 
     // Test the use-libc crate, which enables the "use-libc" cargo feature.


### PR DESCRIPTION
Avoid depending on `wasi_ext` features when compiling for wasm32-wasi on stable Rust.