### PR TITLE
Don't re-export unstable wasi features on stable Rust. (#589)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,7 @@ jobs:
         sparcv9-sun-solaris
         aarch64-linux-android
         aarch64-apple-ios
+        wasm32-wasi
     - if: matrix.rust != '1.48'
       run: rustup target add x86_64-unknown-fuchsia
     - if: matrix.rust == '1.48'
@@ -132,6 +133,10 @@ jobs:
     - run: cargo check --workspace --release -vv --target=sparcv9-sun-solaris --features=all-apis --all-targets
     - run: cargo check --workspace --release -vv --target=aarch64-apple-ios --features=all-apis --all-targets
     - run: cargo check --workspace --release -vv --target=aarch64-linux-android --features=all-apis --all-targets
+    # Omit --all-targets for WASI until all the dev-dependencies support WASI
+    # on stable.
+    - if: matrix.rust != '1.48'
+      run: cargo check --workspace --release -vv --target=wasm32-wasi --features=all-apis
 
   check_no_default_features:
     name: Check --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ once_cell = { version = "1.5.2", optional = true }
 # `RUSTFLAGS` or enabling the `use-libc` cargo feature.
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
 linux-raw-sys = { version = "0.1.2", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
-libc_errno = { package = "errno", version = "0.2.8", default-features = false, optional = true }
+libc_errno = { package = "errno", version = "0.3.0", default-features = false, optional = true }
 libc = { version = "0.2.133", features = ["extra_traits"], optional = true }
 
 # Dependencies for platforms where only libc is supported:
@@ -48,7 +48,7 @@ libc = { version = "0.2.133", features = ["extra_traits"], optional = true }
 # On all other Unix-family platforms, and under Miri, we always use the libc
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))))'.dependencies]
-libc_errno = { package = "errno", version = "0.2.8", default-features = false }
+libc_errno = { package = "errno", version = "0.3.0", default-features = false }
 libc = { version = "0.2.133", features = ["extra_traits"] }
 
 # Additional dependencies for Linux with the libc backend:
@@ -71,7 +71,7 @@ features = [
 [dev-dependencies]
 tempfile = "3.2.0"
 libc = "0.2.133"
-libc_errno = { package = "errno", version = "0.2.8", default-features = false }
+libc_errno = { package = "errno", version = "0.3.0", default-features = false }
 io-lifetimes = { version = "1.0.0", default-features = false, features = ["close"] }
 # Don't upgrade to serial_test 0.7 for now because it depends on a
 # `parking_lot_core` version which is not compatible with our MSRV of 1.48.

--- a/build.rs
+++ b/build.rs
@@ -26,7 +26,7 @@ fn main() {
     let arch = var("CARGO_CFG_TARGET_ARCH").unwrap();
     let asm_name = format!("{}/{}.s", OUTLINE_PATH, arch);
     let asm_name_present = std::fs::metadata(&asm_name).is_ok();
-    let os_name = var("CARGO_CFG_TARGET_OS").unwrap();
+    let target_os = var("CARGO_CFG_TARGET_OS").unwrap();
     let pointer_width = var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap();
     let endian = var("CARGO_CFG_TARGET_ENDIAN").unwrap();
 
@@ -69,7 +69,7 @@ fn main() {
     // install the toolchain for it.
     if feature_use_libc
         || cfg_use_libc
-        || os_name != "linux"
+        || target_os != "linux"
         || !asm_name_present
         || is_unsupported_abi
         || miri
@@ -106,6 +106,9 @@ fn main() {
         use_feature("thumb_mode");
     }
 
+    if target_os == "wasi" {
+        use_feature_or_nothing("wasi_ext");
+    }
     println!("cargo:rerun-if-env-changed=CARGO_CFG_RUSTIX_USE_EXPERIMENTAL_ASM");
     println!("cargo:rerun-if-env-changed=CARGO_CFG_RUSTIX_USE_LIBC");
 

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -3,7 +3,7 @@
 use crate::backend;
 
 pub use crate::io::FdFlags;
-pub use backend::fs::types::{Access, Mode, OFlags};
+pub use backend::fs::types::{Access, Dev, Mode, OFlags};
 
 #[cfg(not(target_os = "redox"))]
 pub use backend::fs::types::AtFlags;
@@ -13,8 +13,5 @@ pub use backend::fs::types::{CloneFlags, CopyfileFlags};
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use backend::fs::types::{MountFlags, MountPropagationFlags, RenameFlags, ResolveFlags};
-
-#[cfg(not(target_os = "redox"))]
-pub use backend::fs::types::Dev;
 
 pub use backend::time::types::{Nsecs, Secs, Timespec};

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -217,5 +217,5 @@ pub use statx::{statx, Statx, StatxFlags, StatxTimestamp};
 #[cfg(unix)]
 pub use std::os::unix::fs::{DirEntryExt, FileExt, FileTypeExt, MetadataExt, OpenOptionsExt};
 #[cfg(feature = "std")]
-#[cfg(target_os = "wasi")]
+#[cfg(all(wasi_ext, target_os = "wasi"))]
 pub use std::os::wasi::fs::{DirEntryExt, FileExt, FileTypeExt, MetadataExt, OpenOptionsExt};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@
 #![cfg_attr(linux_raw, deny(unsafe_code))]
 #![cfg_attr(rustc_attrs, feature(rustc_attrs))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
-#![cfg_attr(all(target_os = "wasi", feature = "std"), feature(wasi_ext))]
+#![cfg_attr(all(wasi_ext, target_os = "wasi", feature = "std"), feature(wasi_ext))]
 #![cfg_attr(
     all(linux_raw, naked_functions, target_arch = "x86"),
     feature(naked_functions)
@@ -123,6 +123,9 @@
 #![allow(clippy::unnecessary_cast)]
 // It is common in linux and libc APIs for types to vary between platforms.
 #![allow(clippy::useless_conversion)]
+// Redox and WASI have enough differences that it isn't worth
+// precisely conditionallizing all the `use`s for them.
+#![cfg_attr(any(target_os = "redox", target_os = "wasi"), allow(unused_imports))]
 
 #[cfg(not(feature = "rustc-dep-of-std"))]
 extern crate alloc;

--- a/tests/backends.rs
+++ b/tests/backends.rs
@@ -51,7 +51,7 @@ fn test_backends() {
 
     #[cfg(windows)]
     let libc_dep = "windows-sys";
-    #[cfg(unix)]
+    #[cfg(any(unix, target_os = "wasi"))]
     let libc_dep = "libc";
 
     // Test the use-libc crate, which enables the "use-libc" cargo feature.


### PR DESCRIPTION
* Don't re-export unstable wasi features on stable Rust.

Avoid depending on `wasi_ext` features when compiling for wasm32-wasi on stable Rust.

* Disable `unused_imports` imports on WASI and Redox.

* Don't test --all-targets on WASI for now.

* Don't test wasm32-wasi on Rust 1.48.