### PR TITLE
Add safety comments for the `waitid` implementation.

### DIFF
--- a/src/backend/linux_raw/process/wait.rs
+++ b/src/backend/linux_raw/process/wait.rs
@@ -58,8 +58,8 @@ impl SiginfoExt for siginfo_t {
     ///
     /// # Safety
     ///
-    /// The `si_code` and `si_signo` fields must indicate that the `si_status`
-    /// field holds a valid value.
+    /// `si_signo` must equal `SIGCHLD` (as it is guaranteed to do after a
+    /// `waitid` call).
     #[inline]
     #[rustfmt::skip]
     unsafe fn si_status(&self) -> c_int {


### PR DESCRIPTION
My reading of POSIX is that it [specifies] that the `siginfo_t` returned by a `waitid` call always has a valid `si_status` value, so add this in a SAFETY comment.

@valpackett I was looking at the code in #590 some more to see if we can come up with a safety comment for the unsafe block. The underlying platform documentation isn't super clear about this, but I think POSIX gives us the guarantee we need. Does this look right to you?

[specifies]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/signal.h.html