### PR TITLE
Convert `AcceptFlags` into an alias for `SocketFlags`.

### DIFF
--- a/src/backend/libc/net/syscalls.rs
+++ b/src/backend/libc/net/syscalls.rs
@@ -12,7 +12,7 @@ use super::read_sockaddr::{maybe_read_sockaddr_os, read_sockaddr_os};
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 use super::send_recv::{RecvFlags, SendFlags};
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
-use super::types::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType};
+use super::types::{AddressFamily, Protocol, Shutdown, SocketFlags, SocketType};
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 use super::write_sockaddr::{encode_sockaddr_v4, encode_sockaddr_v6};
 use crate::fd::{BorrowedFd, OwnedFd};
@@ -257,7 +257,7 @@ pub(crate) fn accept(sockfd: BorrowedFd<'_>) -> io::Result<OwnedFd> {
     target_os = "redox",
     target_os = "wasi",
 )))]
-pub(crate) fn accept_with(sockfd: BorrowedFd<'_>, flags: AcceptFlags) -> io::Result<OwnedFd> {
+pub(crate) fn accept_with(sockfd: BorrowedFd<'_>, flags: SocketFlags) -> io::Result<OwnedFd> {
     unsafe {
         let owned_fd = ret_owned_fd(c::accept4(
             borrowed_fd(sockfd),
@@ -295,7 +295,7 @@ pub(crate) fn acceptfrom(sockfd: BorrowedFd<'_>) -> io::Result<(OwnedFd, Option<
 )))]
 pub(crate) fn acceptfrom_with(
     sockfd: BorrowedFd<'_>,
-    flags: AcceptFlags,
+    flags: SocketFlags,
 ) -> io::Result<(OwnedFd, Option<SocketAddrAny>)> {
     unsafe {
         let mut storage = MaybeUninit::<c::sockaddr_storage>::uninit();
@@ -314,18 +314,18 @@ pub(crate) fn acceptfrom_with(
 }
 
 /// Darwin lacks `accept4`, but does have `accept`. We define
-/// `AcceptFlags` to have no flags, so we can discard it here.
+/// `SocketFlags` to have no flags, so we can discard it here.
 #[cfg(any(apple, windows, target_os = "haiku"))]
-pub(crate) fn accept_with(sockfd: BorrowedFd<'_>, _flags: AcceptFlags) -> io::Result<OwnedFd> {
+pub(crate) fn accept_with(sockfd: BorrowedFd<'_>, _flags: SocketFlags) -> io::Result<OwnedFd> {
     accept(sockfd)
 }
 
 /// Darwin lacks `accept4`, but does have `accept`. We define
-/// `AcceptFlags` to have no flags, so we can discard it here.
+/// `SocketFlags` to have no flags, so we can discard it here.
 #[cfg(any(apple, windows, target_os = "haiku"))]
 pub(crate) fn acceptfrom_with(
     sockfd: BorrowedFd<'_>,
-    _flags: AcceptFlags,
+    _flags: SocketFlags,
 ) -> io::Result<(OwnedFd, Option<SocketAddrAny>)> {
     acceptfrom(sockfd)
 }

--- a/src/backend/libc/net/types.rs
+++ b/src/backend/libc/net/types.rs
@@ -464,25 +464,12 @@ pub enum Shutdown {
 }
 
 bitflags! {
-    /// `SOCK_*` constants for use with [`accept_with`] and [`acceptfrom_with`].
+    /// `SOCK_*` constants for use with [`socket_with`], [`accept_with`] and
+    /// [`acceptfrom_with`].
     ///
+    /// [`socket_with`]: crate::net::socket_with
     /// [`accept_with`]: crate::net::accept_with
     /// [`acceptfrom_with`]: crate::net::acceptfrom_with
-    pub struct AcceptFlags: c::c_int {
-        /// `SOCK_NONBLOCK`
-        #[cfg(not(any(apple, windows, target_os = "haiku")))]
-        const NONBLOCK = c::SOCK_NONBLOCK;
-
-        /// `SOCK_CLOEXEC`
-        #[cfg(not(any(apple, windows, target_os = "haiku")))]
-        const CLOEXEC = c::SOCK_CLOEXEC;
-    }
-}
-
-bitflags! {
-    /// `SOCK_*` constants for use with [`socket`].
-    ///
-    /// [`socket`]: crate::net::socket
     pub struct SocketFlags: c::c_int {
         /// `SOCK_NONBLOCK`
         #[cfg(not(any(apple, windows, target_os = "haiku")))]

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -615,9 +615,9 @@ impl<'a, Num: ArgNumber> From<crate::net::SendFlags> for ArgReg<'a, Num> {
 }
 
 #[cfg(feature = "net")]
-impl<'a, Num: ArgNumber> From<crate::net::AcceptFlags> for ArgReg<'a, Num> {
+impl<'a, Num: ArgNumber> From<crate::net::SocketFlags> for ArgReg<'a, Num> {
     #[inline]
-    fn from(flags: crate::net::AcceptFlags) -> Self {
+    fn from(flags: crate::net::SocketFlags) -> Self {
         c_uint(flags.bits())
     }
 }

--- a/src/backend/linux_raw/net/syscalls.rs
+++ b/src/backend/linux_raw/net/syscalls.rs
@@ -13,7 +13,7 @@ use super::super::conv::{
 };
 use super::read_sockaddr::{initialize_family_to_unspec, maybe_read_sockaddr_os, read_sockaddr_os};
 use super::send_recv::{RecvFlags, SendFlags};
-use super::types::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType};
+use super::types::{AddressFamily, Protocol, Shutdown, SocketFlags, SocketType};
 use super::write_sockaddr::{encode_sockaddr_v4, encode_sockaddr_v6};
 use crate::fd::{BorrowedFd, OwnedFd};
 use crate::io;
@@ -143,7 +143,7 @@ pub(crate) fn accept(fd: BorrowedFd<'_>) -> io::Result<OwnedFd> {
 }
 
 #[inline]
-pub(crate) fn accept_with(fd: BorrowedFd<'_>, flags: AcceptFlags) -> io::Result<OwnedFd> {
+pub(crate) fn accept_with(fd: BorrowedFd<'_>, flags: SocketFlags) -> io::Result<OwnedFd> {
     #[cfg(not(target_arch = "x86"))]
     unsafe {
         let fd = ret_owned_fd(syscall_readonly!(__NR_accept4, fd, zero(), zero(), flags))?;
@@ -200,7 +200,7 @@ pub(crate) fn acceptfrom(fd: BorrowedFd<'_>) -> io::Result<(OwnedFd, Option<Sock
 #[inline]
 pub(crate) fn acceptfrom_with(
     fd: BorrowedFd<'_>,
-    flags: AcceptFlags,
+    flags: SocketFlags,
 ) -> io::Result<(OwnedFd, Option<SocketAddrAny>)> {
     #[cfg(not(target_arch = "x86"))]
     unsafe {

--- a/src/backend/linux_raw/net/types.rs
+++ b/src/backend/linux_raw/net/types.rs
@@ -241,22 +241,12 @@ pub enum Shutdown {
 }
 
 bitflags! {
-    /// `SOCK_*` constants for use with [`accept_with`] and [`acceptfrom_with`].
+    /// `SOCK_*` constants for use with [`socket_with`], [`accept_with`] and
+    /// [`acceptfrom_with`].
     ///
+    /// [`socket_with`]: crate::net::socket_with
     /// [`accept_with`]: crate::net::accept_with
     /// [`acceptfrom_with`]: crate::net::acceptfrom_with
-    pub struct AcceptFlags: c::c_uint {
-        /// `SOCK_NONBLOCK`
-        const NONBLOCK = c::O_NONBLOCK;
-        /// `SOCK_CLOEXEC`
-        const CLOEXEC = c::O_CLOEXEC;
-    }
-}
-
-bitflags! {
-    /// `SOCK_*` constants for use with [`socket`].
-    ///
-    /// [`socket`]: crate::net::socket
     pub struct SocketFlags: c::c_uint {
         /// `SOCK_NONBLOCK`
         const NONBLOCK = c::O_NONBLOCK;

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -978,7 +978,7 @@ pub union op_flags_union {
     #[doc(alias = "msg_flags")]
     pub recv_flags: crate::net::RecvFlags,
     pub timeout_flags: IoringTimeoutFlags,
-    pub accept_flags: crate::net::AcceptFlags,
+    pub accept_flags: crate::net::SocketFlags,
     pub cancel_flags: IoringAsyncCancelFlags,
     pub open_flags: crate::fs::OFlags,
     pub statx_flags: crate::fs::AtFlags,

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -5,9 +5,10 @@ use backend::fd::{AsFd, BorrowedFd};
 
 #[cfg(unix)]
 pub use backend::net::addr::SocketAddrUnix;
-pub use backend::net::types::{
-    AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType,
-};
+pub use backend::net::types::{AddressFamily, Protocol, Shutdown, SocketFlags, SocketType};
+
+/// Compatibility alias for `SocketFlags`. Use `SocketFlags` instead of this.
+pub type AcceptFlags = SocketFlags;
 
 impl Default for Protocol {
     #[inline]
@@ -342,7 +343,7 @@ pub fn accept<Fd: AsFd>(sockfd: Fd) -> io::Result<OwnedFd> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/accept4.2.html
 #[inline]
 #[doc(alias = "accept4")]
-pub fn accept_with<Fd: AsFd>(sockfd: Fd, flags: AcceptFlags) -> io::Result<OwnedFd> {
+pub fn accept_with<Fd: AsFd>(sockfd: Fd, flags: SocketFlags) -> io::Result<OwnedFd> {
     backend::net::syscalls::accept_with(sockfd.as_fd(), flags)
 }
 
@@ -383,7 +384,7 @@ pub fn acceptfrom<Fd: AsFd>(sockfd: Fd) -> io::Result<(OwnedFd, Option<SocketAdd
 #[doc(alias = "accept4")]
 pub fn acceptfrom_with<Fd: AsFd>(
     sockfd: Fd,
-    flags: AcceptFlags,
+    flags: SocketFlags,
 ) -> io::Result<(OwnedFd, Option<SocketAddrAny>)> {
     backend::net::syscalls::acceptfrom_with(sockfd.as_fd(), flags)
 }


### PR DESCRIPTION
`AcceptFlags` has the same values as `SocketFlags`, and there are use cases where it's convenient for the two to have the same type. So make `AcceptFlags` be an alias for `SocketFlags`. In future releases, we can deprecate it and eventually remove it.