### PR TITLE
Enable `statvfs` and `fstatvfs` on Illumos and Solaris.

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -38,7 +38,7 @@ use super::super::offset::{libc_fstat, libc_fstatat, libc_ftruncate, libc_lseek,
     target_os = "wasi",
 )))]
 use super::super::offset::{libc_fstatfs, libc_statfs};
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 use super::super::offset::{libc_fstatvfs, libc_statvfs};
 #[cfg(all(
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
@@ -92,7 +92,7 @@ use crate::fs::{cwd, RenameFlags, ResolveFlags, Statx, StatxFlags};
 #[cfg(not(any(apple, target_os = "redox", target_os = "wasi")))]
 use crate::fs::{Dev, FileType};
 use crate::fs::{Mode, OFlags, Stat, Timestamps};
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 use crate::fs::{StatVfs, StatVfsMountFlags};
 use crate::io::{self, SeekFrom};
 #[cfg(not(target_os = "wasi"))]
@@ -196,7 +196,7 @@ pub(crate) fn statfs(filename: &CStr) -> io::Result<StatFs> {
     }
 }
 
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 #[inline]
 pub(crate) fn statvfs(filename: &CStr) -> io::Result<StatVfs> {
     unsafe {
@@ -1034,7 +1034,7 @@ pub(crate) fn fstatfs(fd: BorrowedFd<'_>) -> io::Result<StatFs> {
     }
 }
 
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 pub(crate) fn fstatvfs(fd: BorrowedFd<'_>) -> io::Result<StatVfs> {
     let mut statvfs = MaybeUninit::<libc_statvfs>::uninit();
     unsafe {
@@ -1043,7 +1043,7 @@ pub(crate) fn fstatvfs(fd: BorrowedFd<'_>) -> io::Result<StatVfs> {
     }
 }
 
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 fn libc_statvfs_to_statvfs(from: libc_statvfs) -> StatVfs {
     StatVfs {
         f_bsize: from.f_bsize as u64,

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -776,7 +776,7 @@ bitflags! {
     }
 }
 
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 bitflags! {
     /// `ST_*` constants for use with [`StatVfs`].
     pub struct StatVfsMountFlags: u64 {
@@ -918,7 +918,7 @@ pub type StatFs = c::statfs64;
 ///
 /// [`statvfs`]: crate::fs::statvfs
 /// [`fstatvfs`]: crate::fs::fstatvfs
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 #[allow(missing_docs)]
 pub struct StatVfs {
     pub f_bsize: u64,

--- a/src/backend/libc/offset.rs
+++ b/src/backend/libc/offset.rs
@@ -395,7 +395,6 @@ pub(super) use c::posix_fallocate64 as libc_posix_fallocate;
 pub(super) use {c::fstatfs as libc_fstatfs, c::statfs as libc_statfs};
 #[cfg(not(any(
     linux_like,
-    solarish,
     windows,
     target_os = "haiku",
     target_os = "redox",

--- a/src/fs/abs.rs
+++ b/src/fs/abs.rs
@@ -8,7 +8,7 @@
     target_os = "wasi",
 )))]
 use crate::fs::StatFs;
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 use {
     crate::fs::StatVfs,
     crate::{backend, io, path},
@@ -48,7 +48,7 @@ pub fn statfs<P: path::Arg>(path: P) -> io::Result<StatFs> {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/statvfs.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/statvfs.2.html
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 #[inline]
 pub fn statvfs<P: path::Arg>(path: P) -> io::Result<StatVfs> {
     path.into_with_c_str(backend::fs::syscalls::statvfs)

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -31,7 +31,7 @@ pub use backend::fs::types::Stat;
 )))]
 pub use backend::fs::types::StatFs;
 
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 pub use backend::fs::types::{StatVfs, StatVfsMountFlags};
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -185,7 +185,7 @@ pub fn fstatfs<Fd: AsFd>(fd: Fd) -> io::Result<StatFs> {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/fstatvfs.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/fstatvfs.2.html
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 #[inline]
 pub fn fstatvfs<Fd: AsFd>(fd: Fd) -> io::Result<StatVfs> {
     backend::fs::syscalls::fstatvfs(fd.as_fd())

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -75,7 +75,7 @@ fn test_file() {
         assert!(statfs.f_blocks > 0);
     }
 
-    #[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
     {
         let statvfs = rustix::fs::fstatvfs(&file).unwrap();
         assert!(statvfs.f_frsize > 0);

--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -33,7 +33,7 @@ mod openat2;
 #[cfg(not(target_os = "redox"))]
 mod readdir;
 mod renameat;
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 mod statfs;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod statx;

--- a/tests/fs/statfs.rs
+++ b/tests/fs/statfs.rs
@@ -39,7 +39,7 @@ fn test_statfs_abi() {
     assert_eq!(NFS_SUPER_MAGIC, 0x0000_6969);
 }
 
-#[cfg(not(target_os = "netbsd"))]
+#[cfg(not(any(solarish, target_os = "netbsd")))]
 #[test]
 fn test_statfs() {
     let statfs = rustix::fs::statfs("Cargo.toml").unwrap();
@@ -49,7 +49,7 @@ fn test_statfs() {
     // that.
 }
 
-#[cfg(not(target_os = "netbsd"))]
+#[cfg(not(any(solarish, target_os = "netbsd")))]
 #[test]
 fn test_fstatfs() {
     let file = std::fs::File::open("Cargo.toml").unwrap();


### PR DESCRIPTION
These functions are supported on Illumos and Solaris, so enable them, and their supporting types.