### PR TITLE
Work around a rustdoc bug

### DIFF
--- a/src/io/is_read_write.rs
+++ b/src/io/is_read_write.rs
@@ -1,4 +1,6 @@
 //! The [`is_read_write`] function.
+//!
+//! [`is_read_write`]: https://docs.rs/rustix/*/rustix/io/fn.is_read_write.html
 
 #[cfg(all(feature = "fs", feature = "net"))]
 use crate::{backend, io};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@
 //! [`OwnedFd`]: https://doc.rust-lang.org/stable/std/os/fd/struct.OwnedFd.html
 //! [I/O-safe]: https://github.com/rust-lang/rfcs/blob/master/text/3128-io-safety.md
 //! [`Result`]: https://doc.rust-lang.org/stable/std/result/enum.Result.html
-//! [`Arg`]: crate::path::Arg
+//! [`Arg`]: https://docs.rs/rustix/*/rustix/path/trait.Arg.html
 
 #![deny(missing_docs)]
 #![allow(stable_features)]

--- a/src/rand/getrandom.rs
+++ b/src/rand/getrandom.rs
@@ -1,6 +1,6 @@
 use crate::{backend, io};
 
-/// `GRND_*` constants for use with [`getrandom`].
+/// `GRND_*` constants for use with `getrandom`.
 pub use backend::rand::types::GetRandomFlags;
 
 /// `getrandom(buf, flags)`—Reads a sequence of random bytes.


### PR DESCRIPTION
Disable the documentation link in src/rand/getrandom.rs, which works around a rustdoc bug causing the build to [fail].

Also fix a few other doc links to be robust in the presence of different build configurations.

[fail]: https://docs.rs/crate/rustix/0.37.10/builds/787165