### PR TITLE
kqueue: fix timers

### DIFF
--- a/examples/kq.rs
+++ b/examples/kq.rs
@@ -30,8 +30,19 @@ fn main() -> std::io::Result<()> {
             0,
         ),
         Event::new(
-            EventFilter::Timer(Some(core::time::Duration::from_secs(1))),
+            EventFilter::Timer {
+                ident: 0,
+                timer: Some(core::time::Duration::from_secs(1)),
+            },
             EventFlags::ADD,
+            0,
+        ),
+        Event::new(
+            EventFilter::Timer {
+                ident: 1,
+                timer: Some(core::time::Duration::from_secs(2)),
+            },
+            EventFlags::ADD | EventFlags::ONESHOT,
             0,
         ),
     ];
@@ -54,7 +65,10 @@ fn main() -> std::io::Result<()> {
                 EventFilter::Vnode { vnode: _, flags } => {
                     eprintln!("Current directory was touched ({:?})", flags)
                 }
-                EventFilter::Timer(_) => eprintln!("Second timer ticked"),
+                EventFilter::Timer { ident: 0, timer: _ } => eprintln!("Second timer ticked"),
+                EventFilter::Timer { ident: 1, timer: _ } => {
+                    eprintln!("One-shot two second timer ticked")
+                }
                 _ => eprintln!("Unknown event"),
             }
         }


### PR DESCRIPTION
They were passing the time as ident instead of data. Somehow this worked with non-oneshot timers, but was completely broken otherwise.

---

This is a breaking change… but the previous behavior was *completely* broken. We can't just keep the API and pass the same `ident=0` and "let users use `udata` for identifying timers", that would mean there's only one timer ever. And right now timers with the same delay would clash. Events are identified by `ident,type`, after all.