### PR TITLE
Implement `test_kill_process{,_group}`

### DIFF
--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -548,6 +548,18 @@ pub(crate) fn kill_current_process_group(sig: Signal) -> io::Result<()> {
     unsafe { ret(c::kill(0, sig as i32)) }
 }
 
+#[cfg(not(target_os = "wasi"))]
+#[inline]
+pub(crate) fn test_kill_process(pid: Pid) -> io::Result<()> {
+    unsafe { ret(c::kill(pid.as_raw_nonzero().get(), 0)) }
+}
+
+#[cfg(not(target_os = "wasi"))]
+#[inline]
+pub(crate) fn test_kill_process_group(pid: Pid) -> io::Result<()> {
+    unsafe { ret(c::kill(pid.as_raw_nonzero().get().wrapping_neg(), 0)) }
+}
+
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 pub(crate) unsafe fn prctl(

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -646,6 +646,22 @@ pub(crate) fn kill_current_process_group(sig: Signal) -> io::Result<()> {
 }
 
 #[inline]
+pub(crate) fn test_kill_process(pid: Pid) -> io::Result<()> {
+    unsafe { ret(syscall_readonly!(__NR_kill, pid, pass_usize(0))) }
+}
+
+#[inline]
+pub(crate) fn test_kill_process_group(pid: Pid) -> io::Result<()> {
+    unsafe {
+        ret(syscall_readonly!(
+            __NR_kill,
+            negative_pid(pid),
+            pass_usize(0)
+        ))
+    }
+}
+
+#[inline]
 pub(crate) unsafe fn prctl(
     option: c::c_int,
     arg2: *mut c::c_void,

--- a/src/process/kill.rs
+++ b/src/process/kill.rs
@@ -49,3 +49,33 @@ pub fn kill_process_group(pid: Pid, sig: Signal) -> io::Result<()> {
 pub fn kill_current_process_group(sig: Signal) -> io::Result<()> {
     backend::process::syscalls::kill_current_process_group(sig)
 }
+
+/// `kill(pid, 0)`—Check validity of pid and permissions to send signals to
+/// the process, without actually send signals.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/kill.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/kill.2.html
+#[inline]
+#[doc(alias = "kill")]
+pub fn test_kill_process(pid: Pid) -> io::Result<()> {
+    backend::process::syscalls::test_kill_process(pid)
+}
+
+/// `kill(-pid, 0)`—Check validity of pid and permissions to send signals to
+/// all processes in the process group, without actually send signals.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/kill.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/kill.2.html
+#[inline]
+#[doc(alias = "kill")]
+pub fn test_kill_process_group(pid: Pid) -> io::Result<()> {
+    backend::process::syscalls::test_kill_process_group(pid)
+}


### PR DESCRIPTION
They pass zero as signal to test the ability to kill() without actually sending signals. This behavior is part of POSIX.
https://pubs.opengroup.org/onlinepubs/9699919799/functions/kill.html

Rationale: `0` is not a valid `Signal` so should not be added as a new variant. Changing existing API of `kill_process*` to accept `Option<Signal>` is breaking and complicates the most usual usage of `kill()`. Thus I added two additional APIs instead.

Note sure about the naming, `test_` prefix reminds me about "unit tests". But IMO its better than `try_` (actually performs actions sometimes?) or `check_` (returns `bool`? assertion?).