### PR TITLE
Implement `getxattr`, `setxattr`, etc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ once_cell = { version = "1.5.2", optional = true }
 # libc backend can be selected via adding `--cfg=rustix_use_libc` to
 # `RUSTFLAGS` or enabling the `use-libc` cargo feature.
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
-linux-raw-sys = { version = "0.3.0", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
+linux-raw-sys = { version = "0.3.2", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 libc_errno = { package = "errno", version = "0.3.1", default-features = false, optional = true }
 libc = { version = "0.2.141", features = ["extra_traits"], optional = true }
 
@@ -56,7 +56,7 @@ libc = { version = "0.2.141", features = ["extra_traits"] }
 # Some syscalls do not have libc wrappers, such as in `io_uring`. For these,
 # the libc backend uses the linux-raw-sys ABI and `libc::syscall`.
 [target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64"))))))))'.dependencies]
-linux-raw-sys = { version = "0.3.0", default-features = false, features = ["general", "no_std"] }
+linux-raw-sys = { version = "0.3.2", default-features = false, features = ["general", "no_std"] }
 
 # For the libc backend on Windows, use the Winsock2 API in windows-sys.
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/src/backend/libc/conv.rs
+++ b/src/backend/libc/conv.rs
@@ -88,20 +88,22 @@ pub(super) fn ret_u32(raw: c::c_int) -> io::Result<u32> {
 }
 
 #[inline]
-pub(super) fn ret_ssize_t(raw: c::ssize_t) -> io::Result<c::ssize_t> {
+pub(super) fn ret_usize(raw: c::ssize_t) -> io::Result<usize> {
     if raw == -1 {
         Err(io::Errno::last_os_error())
     } else {
-        Ok(raw)
+        debug_assert!(raw >= 0);
+        Ok(raw as usize)
     }
 }
 
 #[inline]
-pub(super) fn syscall_ret_ssize_t(raw: c::c_long) -> io::Result<c::ssize_t> {
+pub(super) fn syscall_ret_usize(raw: c::c_long) -> io::Result<usize> {
     if raw == -1 {
         Err(io::Errno::last_os_error())
     } else {
-        Ok(raw as c::ssize_t)
+        debug_assert!(raw >= 0);
+        Ok(raw as c::ssize_t as usize)
     }
 }
 
@@ -210,13 +212,13 @@ pub(super) fn send_recv_len(len: usize) -> i32 {
 /// Convert the return value of a `send` or `recv` call.
 #[cfg(not(windows))]
 #[inline]
-pub(super) fn ret_send_recv(len: isize) -> io::Result<c::ssize_t> {
-    ret_ssize_t(len)
+pub(super) fn ret_send_recv(len: isize) -> io::Result<usize> {
+    ret_usize(len)
 }
 
 /// Convert the return value of a `send` or `recv` call.
 #[cfg(windows)]
 #[inline]
-pub(super) fn ret_send_recv(len: i32) -> io::Result<c::ssize_t> {
-    ret_ssize_t(len as isize)
+pub(super) fn ret_send_recv(len: i32) -> io::Result<usize> {
+    ret_usize(len as isize)
 }

--- a/src/backend/libc/rand/syscalls.rs
+++ b/src/backend/libc/rand/syscalls.rs
@@ -1,7 +1,7 @@
 //! libc syscalls supporting `rustix::rand`.
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-use {super::super::c, super::super::conv::ret_ssize_t, crate::io, crate::rand::GetRandomFlags};
+use {super::super::c, super::super::conv::ret_usize, crate::io, crate::rand::GetRandomFlags};
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub(crate) fn getrandom(buf: &mut [u8], flags: GetRandomFlags) -> io::Result<usize> {
@@ -10,7 +10,5 @@ pub(crate) fn getrandom(buf: &mut [u8], flags: GetRandomFlags) -> io::Result<usi
         fn getrandom(buf: *mut c::c_void, buflen: c::size_t, flags: c::c_uint) via SYS_getrandom -> c::ssize_t
     }
 
-    let nread =
-        unsafe { ret_ssize_t(getrandom(buf.as_mut_ptr().cast(), buf.len(), flags.bits()))? };
-    Ok(nread as usize)
+    unsafe { ret_usize(getrandom(buf.as_mut_ptr().cast(), buf.len(), flags.bits())) }
 }

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -30,3 +30,4 @@ pub(crate) use linux_raw_sys::general::{
     SO_REUSEADDR, SO_SNDBUF, SO_SNDTIMEO_NEW, SO_SNDTIMEO_OLD, SO_TYPE, TCP_NODELAY,
 };
 pub(crate) use linux_raw_sys::general::{NFS_SUPER_MAGIC, PROC_SUPER_MAGIC, UTIME_NOW, UTIME_OMIT};
+pub(crate) use linux_raw_sys::general::{XATTR_CREATE, XATTR_REPLACE};

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -314,6 +314,14 @@ impl<'a, Num: ArgNumber> From<crate::fs::AtFlags> for ArgReg<'a, Num> {
 }
 
 #[cfg(feature = "fs")]
+impl<'a, Num: ArgNumber> From<crate::fs::XattrFlags> for ArgReg<'a, Num> {
+    #[inline]
+    fn from(flags: crate::fs::XattrFlags) -> Self {
+        c_uint(flags.bits())
+    }
+}
+
+#[cfg(feature = "fs")]
 impl<'a, Num: ArgNumber> From<crate::fs::inotify::CreateFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::fs::inotify::CreateFlags) -> Self {

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -10,7 +10,7 @@
 use super::super::c;
 use super::super::conv::{
     by_ref, c_int, c_uint, dev_t, oflags_for_open_how, opt_mut, pass_usize, raw_fd, ret, ret_c_int,
-    ret_c_uint, ret_infallible, ret_owned_fd, ret_usize, size_of, slice_mut, zero,
+    ret_c_uint, ret_infallible, ret_owned_fd, ret_usize, size_of, slice, slice_mut, zero,
 };
 #[cfg(target_pointer_width = "64")]
 use super::super::conv::{loff_t, loff_t_from_u64, ret_u64};
@@ -26,7 +26,7 @@ use crate::ffi::CStr;
 use crate::fs::{
     inotify, Access, Advice, AtFlags, FallocateFlags, FileType, FlockOperation, MemfdFlags, Mode,
     OFlags, RenameFlags, ResolveFlags, SealFlags, Stat, StatFs, StatVfs, StatVfsMountFlags,
-    StatxFlags, Timestamps,
+    StatxFlags, Timestamps, XattrFlags,
 };
 use crate::io::{self, SeekFrom};
 use crate::process::{Gid, Uid};
@@ -1509,4 +1509,139 @@ pub(crate) fn inotify_add_watch(
 #[inline]
 pub(crate) fn inotify_rm_watch(infd: BorrowedFd<'_>, wfd: i32) -> io::Result<()> {
     unsafe { ret(syscall_readonly!(__NR_inotify_rm_watch, infd, c_int(wfd))) }
+}
+
+#[inline]
+pub(crate) fn getxattr(path: &CStr, name: &CStr, value: &mut [u8]) -> io::Result<usize> {
+    let (value_addr_mut, value_len) = slice_mut(value);
+    unsafe {
+        ret_usize(syscall!(
+            __NR_getxattr,
+            path,
+            name,
+            value_addr_mut,
+            value_len
+        ))
+    }
+}
+
+#[inline]
+pub(crate) fn lgetxattr(path: &CStr, name: &CStr, value: &mut [u8]) -> io::Result<usize> {
+    let (value_addr_mut, value_len) = slice_mut(value);
+    unsafe {
+        ret_usize(syscall!(
+            __NR_lgetxattr,
+            path,
+            name,
+            value_addr_mut,
+            value_len
+        ))
+    }
+}
+
+#[inline]
+pub(crate) fn fgetxattr(fd: BorrowedFd<'_>, name: &CStr, value: &mut [u8]) -> io::Result<usize> {
+    let (value_addr_mut, value_len) = slice_mut(value);
+    unsafe {
+        ret_usize(syscall!(
+            __NR_fgetxattr,
+            fd,
+            name,
+            value_addr_mut,
+            value_len
+        ))
+    }
+}
+
+#[inline]
+pub(crate) fn setxattr(
+    path: &CStr,
+    name: &CStr,
+    value: &[u8],
+    flags: XattrFlags,
+) -> io::Result<()> {
+    let (value_addr, value_len) = slice(value);
+    unsafe {
+        ret(syscall_readonly!(
+            __NR_setxattr,
+            path,
+            name,
+            value_addr,
+            value_len,
+            flags
+        ))
+    }
+}
+
+#[inline]
+pub(crate) fn lsetxattr(
+    path: &CStr,
+    name: &CStr,
+    value: &[u8],
+    flags: XattrFlags,
+) -> io::Result<()> {
+    let (value_addr, value_len) = slice(value);
+    unsafe {
+        ret(syscall_readonly!(
+            __NR_lsetxattr,
+            path,
+            name,
+            value_addr,
+            value_len,
+            flags
+        ))
+    }
+}
+
+#[inline]
+pub(crate) fn fsetxattr(
+    fd: BorrowedFd<'_>,
+    name: &CStr,
+    value: &[u8],
+    flags: XattrFlags,
+) -> io::Result<()> {
+    let (value_addr, value_len) = slice(value);
+    unsafe {
+        ret(syscall_readonly!(
+            __NR_fsetxattr,
+            fd,
+            name,
+            value_addr,
+            value_len,
+            flags
+        ))
+    }
+}
+
+#[inline]
+pub(crate) fn listxattr(path: &CStr, list: &mut [c::c_char]) -> io::Result<usize> {
+    let (list_addr_mut, list_len) = slice_mut(list);
+    unsafe { ret_usize(syscall!(__NR_listxattr, path, list_addr_mut, list_len)) }
+}
+
+#[inline]
+pub(crate) fn llistxattr(path: &CStr, list: &mut [c::c_char]) -> io::Result<usize> {
+    let (list_addr_mut, list_len) = slice_mut(list);
+    unsafe { ret_usize(syscall!(__NR_llistxattr, path, list_addr_mut, list_len)) }
+}
+
+#[inline]
+pub(crate) fn flistxattr(fd: BorrowedFd<'_>, list: &mut [c::c_char]) -> io::Result<usize> {
+    let (list_addr_mut, list_len) = slice_mut(list);
+    unsafe { ret_usize(syscall!(__NR_flistxattr, fd, list_addr_mut, list_len)) }
+}
+
+#[inline]
+pub(crate) fn removexattr(path: &CStr, name: &CStr) -> io::Result<()> {
+    unsafe { ret(syscall!(__NR_removexattr, path, name)) }
+}
+
+#[inline]
+pub(crate) fn lremovexattr(path: &CStr, name: &CStr) -> io::Result<()> {
+    unsafe { ret(syscall!(__NR_lremovexattr, path, name)) }
+}
+
+#[inline]
+pub(crate) fn fremovexattr(fd: BorrowedFd<'_>, name: &CStr) -> io::Result<()> {
+    unsafe { ret(syscall!(__NR_fremovexattr, fd, name)) }
 }

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -45,6 +45,8 @@ mod statx;
 // TODO: Enable `sync` for solarish when upstream is updated.
 #[cfg(not(any(solarish, target_os = "redox", target_os = "wasi")))]
 mod sync;
+#[cfg(any(apple, target_os = "android", target_os = "linux"))]
+mod xattr;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use crate::backend::fs::inotify;
@@ -92,6 +94,8 @@ pub use sendfile::sendfile;
 pub use statx::{statx, Statx, StatxFlags, StatxTimestamp};
 #[cfg(not(any(solarish, target_os = "redox", target_os = "wasi")))]
 pub use sync::sync;
+#[cfg(any(apple, target_os = "android", target_os = "linux"))]
+pub use xattr::*;
 
 /// Re-export types common to POSIX-ish platforms.
 #[cfg(feature = "std")]

--- a/src/fs/xattr.rs
+++ b/src/fs/xattr.rs
@@ -1,0 +1,197 @@
+use crate::{backend, io, path};
+use backend::c;
+use backend::fd::AsFd;
+use bitflags::bitflags;
+
+bitflags! {
+    /// `XATTR_*` constants for use with [`setxattr`], and other `*setxattr`
+    /// functions.
+    pub struct XattrFlags: c::c_uint {
+        /// `XATTR_CREATE`
+        const CREATE = c::XATTR_CREATE as c::c_uint;
+
+        /// `XATTR_REPLACE`
+        const REPLACE = c::XATTR_REPLACE as c::c_uint;
+    }
+}
+
+/// `getxattr(path, name, value.as_ptr(), value.len())`—Get extended
+/// filesystem attributes.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/getxattr.2.html
+#[inline]
+pub fn getxattr<P: path::Arg, Name: path::Arg>(
+    path: P,
+    name: Name,
+    value: &mut [u8],
+) -> io::Result<usize> {
+    path.into_with_c_str(|path| {
+        name.into_with_c_str(|name| backend::fs::syscalls::getxattr(path, name, value))
+    })
+}
+
+/// `lgetxattr(path, name, value.as_ptr(), value.len())`—Get extended
+/// filesystem attributes, without following symlinks in the last path
+/// component.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/lgetxattr.2.html
+#[inline]
+pub fn lgetxattr<P: path::Arg, Name: path::Arg>(
+    path: P,
+    name: Name,
+    value: &mut [u8],
+) -> io::Result<usize> {
+    path.into_with_c_str(|path| {
+        name.into_with_c_str(|name| backend::fs::syscalls::lgetxattr(path, name, value))
+    })
+}
+
+/// `fgetxattr(fd, name, value.as_ptr(), value.len())`—Get extended
+/// filesystem attributes on an open file descriptor.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/fgetxattr.2.html
+#[inline]
+pub fn fgetxattr<Fd: AsFd, Name: path::Arg>(
+    fd: Fd,
+    name: Name,
+    value: &mut [u8],
+) -> io::Result<usize> {
+    name.into_with_c_str(|name| backend::fs::syscalls::fgetxattr(fd.as_fd(), name, value))
+}
+
+/// `setxattr(path, name, value.as_ptr(), value.len(), flags)`—Set extended
+/// filesystem attributes.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/setxattr.2.html
+#[inline]
+pub fn setxattr<P: path::Arg, Name: path::Arg>(
+    path: P,
+    name: Name,
+    value: &[u8],
+    flags: XattrFlags,
+) -> io::Result<()> {
+    path.into_with_c_str(|path| {
+        name.into_with_c_str(|name| backend::fs::syscalls::setxattr(path, name, value, flags))
+    })
+}
+
+/// `setxattr(path, name, value.as_ptr(), value.len(), flags)`—Set extended
+/// filesystem attributes, without following symlinks in the last path
+/// component.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/lsetxattr.2.html
+#[inline]
+pub fn lsetxattr<P: path::Arg, Name: path::Arg>(
+    path: P,
+    name: Name,
+    value: &[u8],
+    flags: XattrFlags,
+) -> io::Result<()> {
+    path.into_with_c_str(|path| {
+        name.into_with_c_str(|name| backend::fs::syscalls::lsetxattr(path, name, value, flags))
+    })
+}
+
+/// `fsetxattr(fd, name, value.as_ptr(), value.len(), flags)`—Set extended
+/// filesystem attributes on an open file descriptor.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/fsetxattr.2.html
+#[inline]
+pub fn fsetxattr<Fd: AsFd, Name: path::Arg>(
+    fd: Fd,
+    name: Name,
+    value: &[u8],
+    flags: XattrFlags,
+) -> io::Result<()> {
+    name.into_with_c_str(|name| backend::fs::syscalls::fsetxattr(fd.as_fd(), name, value, flags))
+}
+
+/// `listxattr(path, list.as_ptr(), list.len())`—List extended filesystem
+/// attributes.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/listxattr.2.html
+#[inline]
+pub fn listxattr<P: path::Arg>(path: P, list: &mut [c::c_char]) -> io::Result<usize> {
+    path.into_with_c_str(|path| backend::fs::syscalls::listxattr(path, list))
+}
+
+/// `llistxattr(path, list.as_ptr(), list.len())`—List extended filesystem
+/// attributes, without following symlinks in the last path component.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/llistxattr.2.html
+#[inline]
+pub fn llistxattr<P: path::Arg>(path: P, list: &mut [c::c_char]) -> io::Result<usize> {
+    path.into_with_c_str(|path| backend::fs::syscalls::llistxattr(path, list))
+}
+
+/// `flistxattr(fd, list.as_ptr(), list.len())`—List extended filesystem
+/// attributes on an open file descriptor.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/flistxattr.2.html
+#[inline]
+pub fn flistxattr<Fd: AsFd>(fd: Fd, list: &mut [c::c_char]) -> io::Result<usize> {
+    backend::fs::syscalls::flistxattr(fd.as_fd(), list)
+}
+
+/// `removexattr(path, name)`—Remove an extended filesystem attribute.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/removexattr.2.html
+pub fn removexattr<P: path::Arg, Name: path::Arg>(path: P, name: Name) -> io::Result<()> {
+    path.into_with_c_str(|path| {
+        name.into_with_c_str(|name| backend::fs::syscalls::removexattr(path, name))
+    })
+}
+
+/// `lremovexattr(path, name)`—Remove an extended filesystem attribute,
+/// without following symlinks in the last path component.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/lremovexattr.2.html
+pub fn lremovexattr<P: path::Arg, Name: path::Arg>(path: P, name: Name) -> io::Result<()> {
+    path.into_with_c_str(|path| {
+        name.into_with_c_str(|name| backend::fs::syscalls::lremovexattr(path, name))
+    })
+}
+
+/// `fremovexattr(fd, name)`—Remove an extended filesystem attribute on an
+/// open file descriptor.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/fremovexattr.2.html
+pub fn fremovexattr<Fd: AsFd, Name: path::Arg>(fd: Fd, name: Name) -> io::Result<()> {
+    name.into_with_c_str(|name| backend::fs::syscalls::fremovexattr(fd.as_fd(), name))
+}

--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -38,4 +38,6 @@ mod statfs;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod statx;
 mod utimensat;
+#[cfg(any(apple, target_os = "android", target_os = "linux"))]
+mod xattr;
 mod y2038;

--- a/tests/fs/xattr.rs
+++ b/tests/fs/xattr.rs
@@ -1,0 +1,121 @@
+use std::io;
+
+#[test]
+fn xattr_basic() {
+    use rustix::fs::XattrFlags;
+
+    // The error code when an attribute doesn't exist.
+    #[cfg(not(apple))]
+    let enodata = libc::ENODATA;
+    #[cfg(apple)]
+    let enodata = libc::ENOATTR;
+
+    assert_eq!(
+        rustix::fs::getxattr("/no/such/path", "user.test", &mut [])
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+    assert_eq!(
+        rustix::fs::lgetxattr("/no/such/path", "user.test", &mut [])
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+    assert_eq!(
+        rustix::fs::setxattr("/no/such/path", "user.test", &[], XattrFlags::REPLACE)
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+    assert_eq!(
+        rustix::fs::lsetxattr("/no/such/path", "user.test", &[], XattrFlags::REPLACE)
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+    assert_eq!(
+        rustix::fs::listxattr("/no/such/path", &mut [])
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+    assert_eq!(
+        rustix::fs::llistxattr("/no/such/path", &mut [])
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+    assert_eq!(
+        rustix::fs::removexattr("/no/such/path", "user.test")
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+    assert_eq!(
+        rustix::fs::lremovexattr("/no/such/path", "user.test")
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+
+    assert_eq!(
+        rustix::fs::getxattr("Cargo.toml", "user.test", &mut [])
+            .unwrap_err()
+            .raw_os_error(),
+        enodata
+    );
+    assert_eq!(
+        rustix::fs::lgetxattr("Cargo.toml", "user.test", &mut [])
+            .unwrap_err()
+            .raw_os_error(),
+        enodata
+    );
+    assert_eq!(
+        rustix::fs::setxattr("Cargo.toml", "user.test", &[], XattrFlags::REPLACE)
+            .unwrap_err()
+            .raw_os_error(),
+        enodata
+    );
+    assert_eq!(
+        rustix::fs::lsetxattr("Cargo.toml", "user.test", &[], XattrFlags::REPLACE)
+            .unwrap_err()
+            .raw_os_error(),
+        enodata
+    );
+    assert_eq!(rustix::fs::listxattr("Cargo.toml", &mut []).unwrap(), 0);
+    assert_eq!(rustix::fs::llistxattr("Cargo.toml", &mut []).unwrap(), 0);
+    assert_eq!(
+        rustix::fs::removexattr("Cargo.toml", "user.test")
+            .unwrap_err()
+            .raw_os_error(),
+        enodata
+    );
+    assert_eq!(
+        rustix::fs::lremovexattr("Cargo.toml", "user.test")
+            .unwrap_err()
+            .raw_os_error(),
+        enodata
+    );
+
+    let file = std::fs::File::open("Cargo.toml").unwrap();
+    assert_eq!(
+        rustix::fs::fgetxattr(&file, "user.test", &mut [])
+            .unwrap_err()
+            .raw_os_error(),
+        enodata
+    );
+    assert_eq!(
+        rustix::fs::fsetxattr(&file, "user.test", &[], XattrFlags::REPLACE)
+            .unwrap_err()
+            .raw_os_error(),
+        enodata
+    );
+    assert_eq!(rustix::fs::flistxattr(&file, &mut []).unwrap(), 0);
+    assert_eq!(
+        rustix::fs::fremovexattr(&file, "user.test")
+            .unwrap_err()
+            .raw_os_error(),
+        enodata
+    );
+}


### PR DESCRIPTION
This also changes the libc backend's `ret_ssize_t` to `ret_usize`, since that's what functions that return `ret_ssize_t` are conceptually doing, and this eliminates a lot of `as usize` casts.