### PR TITLE
Add a `test_kill_current_process_group` function.

### DIFF
--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -560,6 +560,12 @@ pub(crate) fn test_kill_process_group(pid: Pid) -> io::Result<()> {
     unsafe { ret(c::kill(pid.as_raw_nonzero().get().wrapping_neg(), 0)) }
 }
 
+#[cfg(not(target_os = "wasi"))]
+#[inline]
+pub(crate) fn test_kill_current_process_group() -> io::Result<()> {
+    unsafe { ret(c::kill(0, 0)) }
+}
+
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 pub(crate) unsafe fn prctl(

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -662,6 +662,11 @@ pub(crate) fn test_kill_process_group(pid: Pid) -> io::Result<()> {
 }
 
 #[inline]
+pub(crate) fn test_kill_current_process_group() -> io::Result<()> {
+    unsafe { ret(syscall_readonly!(__NR_kill, pass_usize(0), pass_usize(0))) }
+}
+
+#[inline]
 pub(crate) unsafe fn prctl(
     option: c::c_int,
     arg2: *mut c::c_void,

--- a/src/process/kill.rs
+++ b/src/process/kill.rs
@@ -51,7 +51,7 @@ pub fn kill_current_process_group(sig: Signal) -> io::Result<()> {
 }
 
 /// `kill(pid, 0)`—Check validity of pid and permissions to send signals to
-/// the process, without actually send signals.
+/// the process, without actually sending any signals.
 ///
 /// # References
 ///  - [POSIX]
@@ -66,7 +66,7 @@ pub fn test_kill_process(pid: Pid) -> io::Result<()> {
 }
 
 /// `kill(-pid, 0)`—Check validity of pid and permissions to send signals to
-/// all processes in the process group, without actually send signals.
+/// all processes in the process group, without actually sending any signals.
 ///
 /// # References
 ///  - [POSIX]
@@ -78,4 +78,20 @@ pub fn test_kill_process(pid: Pid) -> io::Result<()> {
 #[doc(alias = "kill")]
 pub fn test_kill_process_group(pid: Pid) -> io::Result<()> {
     backend::process::syscalls::test_kill_process_group(pid)
+}
+
+/// `kill(0, 0)`—Check validity of pid and permissions to send signals to the
+/// all processes in the current process group, without actually sending any
+/// signals.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/kill.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/kill.2.html
+#[inline]
+#[doc(alias = "kill")]
+pub fn test_kill_current_process_group() -> io::Result<()> {
+    backend::process::syscalls::test_kill_current_process_group()
 }


### PR DESCRIPTION
Similar to the `test_kill_process_group` function added in #608, add a `test_kill_current_process_group` for the 0 pid case.