### PR TITLE
Use the new kernel `kernel_sigaction` and `kernel_sigset_t` types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ once_cell = { version = "1.5.2", optional = true }
 # libc backend can be selected via adding `--cfg=rustix_use_libc` to
 # `RUSTFLAGS` or enabling the `use-libc` cargo feature.
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
-linux-raw-sys = { version = "0.3.2", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
+linux-raw-sys = { version = "0.3.3", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 libc_errno = { package = "errno", version = "0.3.1", default-features = false, optional = true }
 libc = { version = "0.2.141", features = ["extra_traits"], optional = true }
 
@@ -56,7 +56,7 @@ libc = { version = "0.2.141", features = ["extra_traits"] }
 # Some syscalls do not have libc wrappers, such as in `io_uring`. For these,
 # the libc backend uses the linux-raw-sys ABI and `libc::syscall`.
 [target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64"))))))))'.dependencies]
-linux-raw-sys = { version = "0.3.2", default-features = false, features = ["general", "no_std"] }
+linux-raw-sys = { version = "0.3.3", default-features = false, features = ["general", "no_std"] }
 
 # For the libc backend on Windows, use the Winsock2 API in windows-sys.
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -36,7 +36,7 @@ use linux_raw_sys::ioctl::{BLKPBSZGET, BLKSSZGET, FICLONE, FIONBIO, FIONREAD, TI
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use {
     super::super::conv::{opt_ref, size_of},
-    linux_raw_sys::general::{__kernel_timespec, sigset_t},
+    linux_raw_sys::general::{__kernel_timespec, kernel_sigset_t},
 };
 
 #[inline]
@@ -555,7 +555,7 @@ pub(crate) fn poll(fds: &mut [PollFd<'_>], timeout: c::c_int) -> io::Result<usiz
             fds_len,
             opt_ref(timeout.as_ref()),
             zero(),
-            size_of::<sigset_t, _>()
+            size_of::<kernel_sigset_t, _>()
         ))
     }
     #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]

--- a/src/backend/linux_raw/runtime/syscalls.rs
+++ b/src/backend/linux_raw/runtime/syscalls.rs
@@ -20,7 +20,7 @@ use crate::fs::AtFlags;
 use crate::io;
 use crate::process::{Pid, RawNonZeroPid, Signal};
 use crate::runtime::{Sigaction, Stack};
-use linux_raw_sys::general::{__kernel_pid_t, sigset_t, PR_SET_NAME, SIGCHLD};
+use linux_raw_sys::general::{__kernel_pid_t, kernel_sigset_t, PR_SET_NAME, SIGCHLD};
 #[cfg(target_arch = "x86_64")]
 use {super::super::conv::ret_infallible, linux_raw_sys::general::ARCH_SET_FS};
 
@@ -121,7 +121,7 @@ pub(crate) unsafe fn sigaction(signal: Signal, new: Option<Sigaction>) -> io::Re
         signal,
         new,
         old.as_mut_ptr(),
-        size_of::<sigset_t, _>()
+        size_of::<kernel_sigset_t, _>()
     ))?;
     Ok(old.assume_init())
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -37,7 +37,7 @@ use core::ffi::c_void;
 
 /// `sigaction`
 #[cfg(linux_raw)]
-pub type Sigaction = linux_raw_sys::general::sigaction;
+pub type Sigaction = linux_raw_sys::general::kernel_sigaction;
 
 /// `stack_t`
 #[cfg(linux_raw)]


### PR DESCRIPTION
Migrate the signal-handling code to use the new kernel types defined in sunfishcode/linux-raw-sys#51.