### PR TITLE
Add a `tkill` implementation to `rustix::runtime`.

### DIFF
--- a/src/backend/linux_raw/runtime/syscalls.rs
+++ b/src/backend/linux_raw/runtime/syscalls.rs
@@ -136,3 +136,8 @@ pub(crate) unsafe fn sigaltstack(new: Option<Stack>) -> io::Result<Stack> {
     ret(syscall!(__NR_sigaltstack, new, old.as_mut_ptr()))?;
     Ok(old.assume_init())
 }
+
+#[inline]
+pub(crate) unsafe fn tkill(tid: Pid, sig: Signal) -> io::Result<()> {
+    ret(syscall_readonly!(__NR_tkill, tid, sig))
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -313,3 +313,20 @@ pub unsafe fn sigaction(signal: Signal, new: Option<Sigaction>) -> io::Result<Si
 pub unsafe fn sigaltstack(new: Option<Stack>) -> io::Result<Stack> {
     backend::runtime::syscalls::sigaltstack(new)
 }
+
+/// `tkill(tid, sig)`—Send a signal to a thread.
+///
+/// # Safety
+///
+/// You're on your own. And on top of all the troubles with signal handlers,
+/// this implementation is highly experimental.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/tkill.2.html
+#[cfg(linux_raw)]
+#[inline]
+pub unsafe fn tkill(tid: Pid, sig: Signal) -> io::Result<()> {
+    backend::runtime::syscalls::tkill(tid, sig)
+}


### PR DESCRIPTION
As with the rest of `rustix::runtime`, this is experimental.