### PR TITLE
Enable available termios flags on macOS

### DIFF
--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -66,39 +66,30 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
             }
 
             print!(" - in flags:");
-            #[cfg(not(apple))]
             if (term.c_iflag & IGNBRK) != 0 {
                 print!(" IGNBRK");
             }
-            #[cfg(not(apple))]
             if (term.c_iflag & BRKINT) != 0 {
                 print!(" BRKINT");
             }
-            #[cfg(not(apple))]
             if (term.c_iflag & IGNPAR) != 0 {
                 print!(" IGNPAR");
             }
-            #[cfg(not(apple))]
             if (term.c_iflag & PARMRK) != 0 {
                 print!(" PARMRK");
             }
-            #[cfg(not(apple))]
             if (term.c_iflag & INPCK) != 0 {
                 print!(" INPCK");
             }
-            #[cfg(not(apple))]
             if (term.c_iflag & ISTRIP) != 0 {
                 print!(" ISTRIP");
             }
-            #[cfg(not(apple))]
             if (term.c_iflag & INLCR) != 0 {
                 print!(" INLCR");
             }
-            #[cfg(not(apple))]
             if (term.c_iflag & IGNCR) != 0 {
                 print!(" IGNCR");
             }
-            #[cfg(not(apple))]
             if (term.c_iflag & ICRNL) != 0 {
                 print!(" ICRNL");
             }
@@ -106,19 +97,16 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
             if (term.c_iflag & IUCLC) != 0 {
                 print!(" IUCLC");
             }
-            #[cfg(not(apple))]
             if (term.c_iflag & IXON) != 0 {
                 print!(" IXON");
             }
-            #[cfg(not(apple))]
             if (term.c_iflag & IXANY) != 0 {
                 print!(" IXANY");
             }
-            #[cfg(not(apple))]
             if (term.c_iflag & IXOFF) != 0 {
                 print!(" IXOFF");
             }
-            #[cfg(not(any(apple, target_os = "haiku")))]
+            #[cfg(not(target_os = "haiku"))]
             if (term.c_iflag & IMAXBEL) != 0 {
                 print!(" IMAXBEL");
             }
@@ -136,7 +124,6 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
             println!();
 
             print!(" - out flags:");
-            #[cfg(not(apple))]
             if (term.c_oflag & OPOST) != 0 {
                 print!(" OPOST");
             }
@@ -144,19 +131,15 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
             if (term.c_oflag & OLCUC) != 0 {
                 print!(" OLCUC");
             }
-            #[cfg(not(apple))]
             if (term.c_oflag & ONLCR) != 0 {
                 print!(" ONLCR");
             }
-            #[cfg(not(apple))]
             if (term.c_oflag & OCRNL) != 0 {
                 print!(" OCRNL");
             }
-            #[cfg(not(apple))]
             if (term.c_oflag & ONOCR) != 0 {
                 print!(" ONOCR");
             }
-            #[cfg(not(apple))]
             if (term.c_oflag & ONLRET) != 0 {
                 print!(" ONLRET");
             }
@@ -176,13 +159,7 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
             if (term.c_oflag & CRDLY) != 0 {
                 print!(" CRDLY");
             }
-            #[cfg(not(any(
-                apple,
-                netbsdlike,
-                solarish,
-                target_os = "dragonfly",
-                target_os = "redox",
-            )))]
+            #[cfg(not(any(netbsdlike, solarish, target_os = "dragonfly", target_os = "redox",)))]
             if (term.c_oflag & TABDLY) != 0 {
                 print!(" TABDLY");
             }
@@ -215,31 +192,24 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
             if (term.c_cflag & CBAUDEX) != 0 {
                 print!(" CBAUDEX");
             }
-            #[cfg(not(apple))]
             if (term.c_cflag & CSIZE) != 0 {
                 print!(" CSIZE");
             }
-            #[cfg(not(apple))]
             if (term.c_cflag & CSTOPB) != 0 {
                 print!(" CSTOPB");
             }
-            #[cfg(not(apple))]
             if (term.c_cflag & CREAD) != 0 {
                 print!(" CREAD");
             }
-            #[cfg(not(apple))]
             if (term.c_cflag & PARENB) != 0 {
                 print!(" PARENB");
             }
-            #[cfg(not(apple))]
             if (term.c_cflag & PARODD) != 0 {
                 print!(" PARODD");
             }
-            #[cfg(not(apple))]
             if (term.c_cflag & HUPCL) != 0 {
                 print!(" HUPCL");
             }
-            #[cfg(not(apple))]
             if (term.c_cflag & CLOCAL) != 0 {
                 print!(" CLOCAL");
             }
@@ -262,14 +232,12 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
             if (term.c_cflag & CMSPAR) != 0 {
                 print!(" CMSPAR");
             }
-            #[cfg(not(apple))]
             if (term.c_cflag & CRTSCTS) != 0 {
                 print!(" CRTSCTS");
             }
             println!();
 
             print!(" - local flags:");
-            #[cfg(not(apple))]
             if (term.c_lflag & ISIG) != 0 {
                 print!(" ISIG");
             }
@@ -280,51 +248,39 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
             if (term.c_lflag & XCASE) != 0 {
                 print!(" XCASE");
             }
-            #[cfg(not(apple))]
             if (term.c_lflag & ECHO) != 0 {
                 print!(" ECHO");
             }
-            #[cfg(not(apple))]
             if (term.c_lflag & ECHOE) != 0 {
                 print!(" ECHOE");
             }
-            #[cfg(not(apple))]
             if (term.c_lflag & ECHOK) != 0 {
                 print!(" ECHOK");
             }
-            #[cfg(not(apple))]
             if (term.c_lflag & ECHONL) != 0 {
                 print!(" ECHONL");
             }
-            #[cfg(not(apple))]
             if (term.c_lflag & ECHOCTL) != 0 {
                 print!(" ECHOCTL");
             }
-            #[cfg(not(apple))]
             if (term.c_lflag & ECHOPRT) != 0 {
                 print!(" ECHOPRT");
             }
-            #[cfg(not(apple))]
             if (term.c_lflag & ECHOKE) != 0 {
                 print!(" ECHOKE");
             }
-            #[cfg(not(apple))]
             if (term.c_lflag & FLUSHO) != 0 {
                 print!(" FLUSHO");
             }
-            #[cfg(not(apple))]
             if (term.c_lflag & NOFLSH) != 0 {
                 print!(" NOFLSH");
             }
-            #[cfg(not(apple))]
             if (term.c_lflag & TOSTOP) != 0 {
                 print!(" TOSTOP");
             }
-            #[cfg(not(apple))]
             if (term.c_lflag & PENDIN) != 0 {
                 print!(" PENDIN");
             }
-            #[cfg(not(apple))]
             if (term.c_lflag & IEXTEN) != 0 {
                 print!(" IEXTEN");
             }

--- a/src/backend/libc/termios/types.rs
+++ b/src/backend/libc/termios/types.rs
@@ -171,49 +171,49 @@ pub const VLNEXT: usize = c::VLNEXT as usize;
 pub const VEOL2: usize = c::VEOL2 as usize;
 
 /// `IGNBRK`
-pub const IGNBRK: c::c_uint = c::IGNBRK;
+pub const IGNBRK: Tcflag = c::IGNBRK;
 
 /// `BRKINT`
-pub const BRKINT: c::c_uint = c::BRKINT;
+pub const BRKINT: Tcflag = c::BRKINT;
 
 /// `IGNPAR`
-pub const IGNPAR: c::c_uint = c::IGNPAR;
+pub const IGNPAR: Tcflag = c::IGNPAR;
 
 /// `PARMRK`
-pub const PARMRK: c::c_uint = c::PARMRK;
+pub const PARMRK: Tcflag = c::PARMRK;
 
 /// `INPCK`
-pub const INPCK: c::c_uint = c::INPCK;
+pub const INPCK: Tcflag = c::INPCK;
 
 /// `ISTRIP`
-pub const ISTRIP: c::c_uint = c::ISTRIP;
+pub const ISTRIP: Tcflag = c::ISTRIP;
 
 /// `INLCR`
-pub const INLCR: c::c_uint = c::INLCR;
+pub const INLCR: Tcflag = c::INLCR;
 
 /// `IGNCR`
-pub const IGNCR: c::c_uint = c::IGNCR;
+pub const IGNCR: Tcflag = c::IGNCR;
 
 /// `ICRNL`
-pub const ICRNL: c::c_uint = c::ICRNL;
+pub const ICRNL: Tcflag = c::ICRNL;
 
 /// `IUCLC`
 #[cfg(any(solarish, target_os = "haiku"))]
-pub const IUCLC: c::c_uint = c::IUCLC;
+pub const IUCLC: Tcflag = c::IUCLC;
 
 /// `IXON`
-pub const IXON: c::c_uint = c::IXON;
+pub const IXON: Tcflag = c::IXON;
 
 /// `IXANY`
 #[cfg(not(target_os = "redox"))]
-pub const IXANY: c::c_uint = c::IXANY;
+pub const IXANY: Tcflag = c::IXANY;
 
 /// `IXOFF`
-pub const IXOFF: c::c_uint = c::IXOFF;
+pub const IXOFF: Tcflag = c::IXOFF;
 
 /// `IMAXBEL`
 #[cfg(not(any(target_os = "haiku", target_os = "redox")))]
-pub const IMAXBEL: c::c_uint = c::IMAXBEL;
+pub const IMAXBEL: Tcflag = c::IMAXBEL;
 
 /// `IUTF8`
 #[cfg(not(any(
@@ -227,10 +227,10 @@ pub const IMAXBEL: c::c_uint = c::IMAXBEL;
     target_os = "openbsd",
     target_os = "redox",
 )))]
-pub const IUTF8: c::c_uint = c::IUTF8;
+pub const IUTF8: Tcflag = c::IUTF8;
 
 /// `OPOST`
-pub const OPOST: c::c_uint = c::OPOST;
+pub const OPOST: Tcflag = c::OPOST;
 
 /// `OLCUC`
 #[cfg(not(any(
@@ -241,47 +241,47 @@ pub const OPOST: c::c_uint = c::OPOST;
     target_os = "netbsd",
     target_os = "redox",
 )))]
-pub const OLCUC: c::c_uint = c::OLCUC;
+pub const OLCUC: Tcflag = c::OLCUC;
 
 /// `ONLCR`
-pub const ONLCR: c::c_uint = c::ONLCR;
+pub const ONLCR: Tcflag = c::ONLCR;
 
 /// `OCRNL`
-pub const OCRNL: c::c_uint = c::OCRNL;
+pub const OCRNL: Tcflag = c::OCRNL;
 
 /// `ONOCR`
-pub const ONOCR: c::c_uint = c::ONOCR;
+pub const ONOCR: Tcflag = c::ONOCR;
 
 /// `ONLRET`
-pub const ONLRET: c::c_uint = c::ONLRET;
+pub const ONLRET: Tcflag = c::ONLRET;
 
 /// `OFILL`
 #[cfg(not(bsd))]
-pub const OFILL: c::c_uint = c::OFILL;
+pub const OFILL: Tcflag = c::OFILL;
 
 /// `OFDEL`
 #[cfg(not(bsd))]
-pub const OFDEL: c::c_uint = c::OFDEL;
+pub const OFDEL: Tcflag = c::OFDEL;
 
 /// `NLDLY`
 #[cfg(not(any(bsd, solarish, target_os = "redox")))]
-pub const NLDLY: c::c_uint = c::NLDLY;
+pub const NLDLY: Tcflag = c::NLDLY;
 
 /// `NL0`
 #[cfg(not(any(bsd, solarish, target_os = "fuchsia", target_os = "redox")))]
-pub const NL0: c::c_uint = c::NL0;
+pub const NL0: Tcflag = c::NL0;
 
 /// `NL1`
 #[cfg(not(any(bsd, solarish, target_os = "fuchsia", target_os = "redox")))]
-pub const NL1: c::c_uint = c::NL1;
+pub const NL1: Tcflag = c::NL1;
 
 /// `CRDLY`
 #[cfg(not(any(bsd, solarish, target_os = "redox")))]
-pub const CRDLY: c::c_uint = c::CRDLY;
+pub const CRDLY: Tcflag = c::CRDLY;
 
 /// `CR0`
 #[cfg(not(any(bsd, solarish, target_os = "fuchsia", target_os = "redox")))]
-pub const CR0: c::c_uint = c::CR0;
+pub const CR0: Tcflag = c::CR0;
 
 /// `CR1`
 #[cfg(not(any(
@@ -292,7 +292,7 @@ pub const CR0: c::c_uint = c::CR0;
     target_os = "fuchsia",
     target_os = "redox",
 )))]
-pub const CR1: c::c_uint = c::CR1;
+pub const CR1: Tcflag = c::CR1;
 
 /// `CR2`
 #[cfg(not(any(
@@ -303,7 +303,7 @@ pub const CR1: c::c_uint = c::CR1;
     target_os = "fuchsia",
     target_os = "redox",
 )))]
-pub const CR2: c::c_uint = c::CR2;
+pub const CR2: Tcflag = c::CR2;
 
 /// `CR3`
 #[cfg(not(any(
@@ -314,11 +314,11 @@ pub const CR2: c::c_uint = c::CR2;
     target_os = "fuchsia",
     target_os = "redox",
 )))]
-pub const CR3: c::c_uint = c::CR3;
+pub const CR3: Tcflag = c::CR3;
 
 /// `TABDLY`
 #[cfg(not(any(netbsdlike, solarish, target_os = "dragonfly", target_os = "redox",)))]
-pub const TABDLY: c::c_uint = c::TABDLY;
+pub const TABDLY: Tcflag = c::TABDLY;
 
 /// `TAB0`
 #[cfg(not(any(
@@ -328,7 +328,7 @@ pub const TABDLY: c::c_uint = c::TABDLY;
     target_os = "fuchsia",
     target_os = "redox",
 )))]
-pub const TAB0: c::c_uint = c::TAB0;
+pub const TAB0: Tcflag = c::TAB0;
 
 /// `TAB1`
 #[cfg(not(any(
@@ -339,7 +339,7 @@ pub const TAB0: c::c_uint = c::TAB0;
     target_os = "fuchsia",
     target_os = "redox",
 )))]
-pub const TAB1: c::c_uint = c::TAB1;
+pub const TAB1: Tcflag = c::TAB1;
 
 /// `TAB2`
 #[cfg(not(any(
@@ -350,7 +350,7 @@ pub const TAB1: c::c_uint = c::TAB1;
     target_os = "fuchsia",
     target_os = "redox",
 )))]
-pub const TAB2: c::c_uint = c::TAB2;
+pub const TAB2: Tcflag = c::TAB2;
 
 /// `TAB3`
 #[cfg(not(any(
@@ -361,15 +361,15 @@ pub const TAB2: c::c_uint = c::TAB2;
     target_os = "fuchsia",
     target_os = "redox",
 )))]
-pub const TAB3: c::c_uint = c::TAB3;
+pub const TAB3: Tcflag = c::TAB3;
 
 /// `BSDLY`
 #[cfg(not(any(bsd, solarish, target_os = "redox")))]
-pub const BSDLY: c::c_uint = c::BSDLY;
+pub const BSDLY: Tcflag = c::BSDLY;
 
 /// `BS0`
 #[cfg(not(any(bsd, solarish, target_os = "fuchsia", target_os = "redox")))]
-pub const BS0: c::c_uint = c::BS0;
+pub const BS0: Tcflag = c::BS0;
 
 /// `BS1`
 #[cfg(not(any(
@@ -380,15 +380,15 @@ pub const BS0: c::c_uint = c::BS0;
     target_os = "fuchsia",
     target_os = "redox",
 )))]
-pub const BS1: c::c_uint = c::BS1;
+pub const BS1: Tcflag = c::BS1;
 
 /// `FFDLY`
 #[cfg(not(any(target_env = "musl", bsd, solarish, target_os = "redox")))]
-pub const FFDLY: c::c_uint = c::FFDLY;
+pub const FFDLY: Tcflag = c::FFDLY;
 
 /// `FF0`
 #[cfg(not(any(bsd, solarish, target_os = "fuchsia", target_os = "redox")))]
-pub const FF0: c::c_uint = c::FF0;
+pub const FF0: Tcflag = c::FF0;
 
 /// `FF1`
 #[cfg(not(any(
@@ -399,15 +399,15 @@ pub const FF0: c::c_uint = c::FF0;
     target_os = "fuchsia",
     target_os = "redox",
 )))]
-pub const FF1: c::c_uint = c::FF1;
+pub const FF1: Tcflag = c::FF1;
 
 /// `VTDLY`
 #[cfg(not(any(target_env = "musl", bsd, solarish, target_os = "redox")))]
-pub const VTDLY: c::c_uint = c::VTDLY;
+pub const VTDLY: Tcflag = c::VTDLY;
 
 /// `VT0`
 #[cfg(not(any(bsd, solarish, target_os = "fuchsia", target_os = "redox")))]
-pub const VT0: c::c_uint = c::VT0;
+pub const VT0: Tcflag = c::VT0;
 
 /// `VT1`
 #[cfg(not(any(
@@ -418,7 +418,7 @@ pub const VT0: c::c_uint = c::VT0;
     target_os = "fuchsia",
     target_os = "redox",
 )))]
-pub const VT1: c::c_uint = c::VT1;
+pub const VT1: Tcflag = c::VT1;
 
 /// `B0`
 pub const B0: Speed = c::B0;
@@ -570,68 +570,68 @@ pub const B4000000: Speed = c::B4000000;
 
 /// `BOTHER`
 #[cfg(any(target_os = "android", target_os = "linux"))]
-pub const BOTHER: c::c_uint = c::BOTHER;
+pub const BOTHER: Speed = c::BOTHER;
 
 /// `CSIZE`
-pub const CSIZE: c::c_uint = c::CSIZE;
+pub const CSIZE: Tcflag = c::CSIZE;
 
 /// `CS5`
-pub const CS5: c::c_uint = c::CS5;
+pub const CS5: Tcflag = c::CS5;
 
 /// `CS6`
-pub const CS6: c::c_uint = c::CS6;
+pub const CS6: Tcflag = c::CS6;
 
 /// `CS7`
-pub const CS7: c::c_uint = c::CS7;
+pub const CS7: Tcflag = c::CS7;
 
 /// `CS8`
-pub const CS8: c::c_uint = c::CS8;
+pub const CS8: Tcflag = c::CS8;
 
 /// `CSTOPB`
-pub const CSTOPB: c::c_uint = c::CSTOPB;
+pub const CSTOPB: Tcflag = c::CSTOPB;
 
 /// `CREAD`
-pub const CREAD: c::c_uint = c::CREAD;
+pub const CREAD: Tcflag = c::CREAD;
 
 /// `PARENB`
-pub const PARENB: c::c_uint = c::PARENB;
+pub const PARENB: Tcflag = c::PARENB;
 
 /// `PARODD`
-pub const PARODD: c::c_uint = c::PARODD;
+pub const PARODD: Tcflag = c::PARODD;
 
 /// `HUPCL`
-pub const HUPCL: c::c_uint = c::HUPCL;
+pub const HUPCL: Tcflag = c::HUPCL;
 
 /// `CLOCAL`
-pub const CLOCAL: c::c_uint = c::CLOCAL;
+pub const CLOCAL: Tcflag = c::CLOCAL;
 
 /// `ISIG`
-pub const ISIG: c::c_uint = c::ISIG;
+pub const ISIG: Tcflag = c::ISIG;
 
 /// `ICANON`—A flag for the `c_lflag` field of [`Termios`] indicating
 /// canonical mode.
 pub const ICANON: Tcflag = c::ICANON;
 
 /// `ECHO`
-pub const ECHO: c::c_uint = c::ECHO;
+pub const ECHO: Tcflag = c::ECHO;
 
 /// `ECHOE`
-pub const ECHOE: c::c_uint = c::ECHOE;
+pub const ECHOE: Tcflag = c::ECHOE;
 
 /// `ECHOK`
-pub const ECHOK: c::c_uint = c::ECHOK;
+pub const ECHOK: Tcflag = c::ECHOK;
 
 /// `ECHONL`
-pub const ECHONL: c::c_uint = c::ECHONL;
+pub const ECHONL: Tcflag = c::ECHONL;
 
 /// `NOFLSH`
-pub const NOFLSH: c::c_uint = c::NOFLSH;
+pub const NOFLSH: Tcflag = c::NOFLSH;
 
 /// `TOSTOP`
-pub const TOSTOP: c::c_uint = c::TOSTOP;
+pub const TOSTOP: Tcflag = c::TOSTOP;
 
 /// `IEXTEN`
-pub const IEXTEN: c::c_uint = c::IEXTEN;
+pub const IEXTEN: Tcflag = c::IEXTEN;
 
 /// `EXTA`
 #[cfg(not(any(
@@ -640,7 +640,7 @@ pub const IEXTEN: c::c_uint = c::IEXTEN;
     target_os = "haiku",
     target_os = "redox",
 )))]
-pub const EXTA: c::c_uint = c::EXTA;
+pub const EXTA: Speed = c::EXTA;
 
 /// `EXTB`
 #[cfg(not(any(
@@ -649,11 +649,11 @@ pub const EXTA: c::c_uint = c::EXTA;
     target_os = "haiku",
     target_os = "redox",
 )))]
-pub const EXTB: c::c_uint = c::EXTB;
+pub const EXTB: Speed = c::EXTB;
 
 /// `CBAUD`
 #[cfg(not(any(bsd, target_os = "haiku", target_os = "redox")))]
-pub const CBAUD: c::c_uint = c::CBAUD;
+pub const CBAUD: Tcflag = c::CBAUD;
 
 /// `CBAUDEX`
 #[cfg(not(any(
@@ -663,7 +663,7 @@ pub const CBAUD: c::c_uint = c::CBAUD;
     target_os = "haiku",
     target_os = "redox",
 )))]
-pub const CBAUDEX: c::c_uint = c::CBAUDEX;
+pub const CBAUDEX: Tcflag = c::CBAUDEX;
 
 /// `CIBAUD`
 #[cfg(not(any(
@@ -674,13 +674,13 @@ pub const CBAUDEX: c::c_uint = c::CBAUDEX;
     target_os = "haiku",
     target_os = "redox",
 )))]
-pub const CIBAUD: c::tcflag_t = c::CIBAUD;
+pub const CIBAUD: Tcflag = c::CIBAUD;
 
 /// `CIBAUD`
 // glibc on powerpc lacks a definition for `CIBAUD`, even though the Linux
 // headers and Musl on powerpc both have one. So define it manually.
 #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
-pub const CIBAUD: c::tcflag_t = 0o77600000;
+pub const CIBAUD: Tcflag = 0o77600000;
 
 /// `CMSPAR`
 #[cfg(not(any(
@@ -691,39 +691,39 @@ pub const CIBAUD: c::tcflag_t = 0o77600000;
     target_os = "haiku",
     target_os = "redox",
 )))]
-pub const CMSPAR: c::c_uint = c::CMSPAR;
+pub const CMSPAR: Tcflag = c::CMSPAR;
 
 /// `CRTSCTS`
 #[cfg(not(any(target_os = "aix", target_os = "redox")))]
-pub const CRTSCTS: c::c_uint = c::CRTSCTS;
+pub const CRTSCTS: Tcflag = c::CRTSCTS;
 
 /// `XCASE`
 #[cfg(any(target_arch = "s390x", target_os = "haiku"))]
-pub const XCASE: c::c_uint = c::XCASE;
+pub const XCASE: Tcflag = c::XCASE;
 
 /// `ECHOCTL`
 #[cfg(not(any(target_os = "redox")))]
-pub const ECHOCTL: c::c_uint = c::ECHOCTL;
+pub const ECHOCTL: Tcflag = c::ECHOCTL;
 
 /// `ECHOPRT`
 #[cfg(not(any(target_os = "redox")))]
-pub const ECHOPRT: c::c_uint = c::ECHOPRT;
+pub const ECHOPRT: Tcflag = c::ECHOPRT;
 
 /// `ECHOKE`
 #[cfg(not(any(target_os = "redox")))]
-pub const ECHOKE: c::c_uint = c::ECHOKE;
+pub const ECHOKE: Tcflag = c::ECHOKE;
 
 /// `FLUSHO`
 #[cfg(not(any(target_os = "redox")))]
-pub const FLUSHO: c::c_uint = c::FLUSHO;
+pub const FLUSHO: Tcflag = c::FLUSHO;
 
 /// `PENDIN`
 #[cfg(not(any(target_os = "redox")))]
-pub const PENDIN: c::c_uint = c::PENDIN;
+pub const PENDIN: Tcflag = c::PENDIN;
 
 /// `EXTPROC`
 #[cfg(not(any(target_os = "aix", target_os = "haiku", target_os = "redox")))]
-pub const EXTPROC: c::c_uint = c::EXTPROC;
+pub const EXTPROC: Tcflag = c::EXTPROC;
 
 /// `XTABS`
 #[cfg(not(any(
@@ -733,4 +733,4 @@ pub const EXTPROC: c::c_uint = c::EXTPROC;
     target_os = "haiku",
     target_os = "redox",
 )))]
-pub const XTABS: c::c_uint = c::XTABS;
+pub const XTABS: Tcflag = c::XTABS;

--- a/src/backend/libc/termios/types.rs
+++ b/src/backend/libc/termios/types.rs
@@ -171,39 +171,30 @@ pub const VLNEXT: usize = c::VLNEXT as usize;
 pub const VEOL2: usize = c::VEOL2 as usize;
 
 /// `IGNBRK`
-#[cfg(not(apple))]
 pub const IGNBRK: c::c_uint = c::IGNBRK;
 
 /// `BRKINT`
-#[cfg(not(apple))]
 pub const BRKINT: c::c_uint = c::BRKINT;
 
 /// `IGNPAR`
-#[cfg(not(apple))]
 pub const IGNPAR: c::c_uint = c::IGNPAR;
 
 /// `PARMRK`
-#[cfg(not(apple))]
 pub const PARMRK: c::c_uint = c::PARMRK;
 
 /// `INPCK`
-#[cfg(not(apple))]
 pub const INPCK: c::c_uint = c::INPCK;
 
 /// `ISTRIP`
-#[cfg(not(apple))]
 pub const ISTRIP: c::c_uint = c::ISTRIP;
 
 /// `INLCR`
-#[cfg(not(apple))]
 pub const INLCR: c::c_uint = c::INLCR;
 
 /// `IGNCR`
-#[cfg(not(apple))]
 pub const IGNCR: c::c_uint = c::IGNCR;
 
 /// `ICRNL`
-#[cfg(not(apple))]
 pub const ICRNL: c::c_uint = c::ICRNL;
 
 /// `IUCLC`
@@ -211,24 +202,21 @@ pub const ICRNL: c::c_uint = c::ICRNL;
 pub const IUCLC: c::c_uint = c::IUCLC;
 
 /// `IXON`
-#[cfg(not(apple))]
 pub const IXON: c::c_uint = c::IXON;
 
 /// `IXANY`
-#[cfg(not(any(apple, target_os = "redox")))]
+#[cfg(not(target_os = "redox"))]
 pub const IXANY: c::c_uint = c::IXANY;
 
 /// `IXOFF`
-#[cfg(not(apple))]
 pub const IXOFF: c::c_uint = c::IXOFF;
 
 /// `IMAXBEL`
-#[cfg(not(any(apple, target_os = "haiku", target_os = "redox")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox")))]
 pub const IMAXBEL: c::c_uint = c::IMAXBEL;
 
 /// `IUTF8`
 #[cfg(not(any(
-    apple,
     solarish,
     target_os = "aix",
     target_os = "dragonfly",
@@ -242,7 +230,6 @@ pub const IMAXBEL: c::c_uint = c::IMAXBEL;
 pub const IUTF8: c::c_uint = c::IUTF8;
 
 /// `OPOST`
-#[cfg(not(apple))]
 pub const OPOST: c::c_uint = c::OPOST;
 
 /// `OLCUC`
@@ -257,19 +244,15 @@ pub const OPOST: c::c_uint = c::OPOST;
 pub const OLCUC: c::c_uint = c::OLCUC;
 
 /// `ONLCR`
-#[cfg(not(apple))]
 pub const ONLCR: c::c_uint = c::ONLCR;
 
 /// `OCRNL`
-#[cfg(not(apple))]
 pub const OCRNL: c::c_uint = c::OCRNL;
 
 /// `ONOCR`
-#[cfg(not(apple))]
 pub const ONOCR: c::c_uint = c::ONOCR;
 
 /// `ONLRET`
-#[cfg(not(apple))]
 pub const ONLRET: c::c_uint = c::ONLRET;
 
 /// `OFILL`
@@ -334,18 +317,11 @@ pub const CR2: c::c_uint = c::CR2;
 pub const CR3: c::c_uint = c::CR3;
 
 /// `TABDLY`
-#[cfg(not(any(
-    apple,
-    netbsdlike,
-    solarish,
-    target_os = "dragonfly",
-    target_os = "redox",
-)))]
+#[cfg(not(any(netbsdlike, solarish, target_os = "dragonfly", target_os = "redox",)))]
 pub const TABDLY: c::c_uint = c::TABDLY;
 
 /// `TAB0`
 #[cfg(not(any(
-    apple,
     netbsdlike,
     solarish,
     target_os = "dragonfly",
@@ -597,51 +573,39 @@ pub const B4000000: Speed = c::B4000000;
 pub const BOTHER: c::c_uint = c::BOTHER;
 
 /// `CSIZE`
-#[cfg(not(apple))]
 pub const CSIZE: c::c_uint = c::CSIZE;
 
 /// `CS5`
-#[cfg(not(apple))]
 pub const CS5: c::c_uint = c::CS5;
 
 /// `CS6`
-#[cfg(not(apple))]
 pub const CS6: c::c_uint = c::CS6;
 
 /// `CS7`
-#[cfg(not(apple))]
 pub const CS7: c::c_uint = c::CS7;
 
 /// `CS8`
-#[cfg(not(apple))]
 pub const CS8: c::c_uint = c::CS8;
 
 /// `CSTOPB`
-#[cfg(not(apple))]
 pub const CSTOPB: c::c_uint = c::CSTOPB;
 
 /// `CREAD`
-#[cfg(not(apple))]
 pub const CREAD: c::c_uint = c::CREAD;
 
 /// `PARENB`
-#[cfg(not(apple))]
 pub const PARENB: c::c_uint = c::PARENB;
 
 /// `PARODD`
-#[cfg(not(apple))]
 pub const PARODD: c::c_uint = c::PARODD;
 
 /// `HUPCL`
-#[cfg(not(apple))]
 pub const HUPCL: c::c_uint = c::HUPCL;
 
 /// `CLOCAL`
-#[cfg(not(apple))]
 pub const CLOCAL: c::c_uint = c::CLOCAL;
 
 /// `ISIG`
-#[cfg(not(apple))]
 pub const ISIG: c::c_uint = c::ISIG;
 
 /// `ICANON`—A flag for the `c_lflag` field of [`Termios`] indicating
@@ -649,36 +613,28 @@ pub const ISIG: c::c_uint = c::ISIG;
 pub const ICANON: Tcflag = c::ICANON;
 
 /// `ECHO`
-#[cfg(not(apple))]
 pub const ECHO: c::c_uint = c::ECHO;
 
 /// `ECHOE`
-#[cfg(not(apple))]
 pub const ECHOE: c::c_uint = c::ECHOE;
 
 /// `ECHOK`
-#[cfg(not(apple))]
 pub const ECHOK: c::c_uint = c::ECHOK;
 
 /// `ECHONL`
-#[cfg(not(apple))]
 pub const ECHONL: c::c_uint = c::ECHONL;
 
 /// `NOFLSH`
-#[cfg(not(apple))]
 pub const NOFLSH: c::c_uint = c::NOFLSH;
 
 /// `TOSTOP`
-#[cfg(not(apple))]
 pub const TOSTOP: c::c_uint = c::TOSTOP;
 
 /// `IEXTEN`
-#[cfg(not(apple))]
 pub const IEXTEN: c::c_uint = c::IEXTEN;
 
 /// `EXTA`
 #[cfg(not(any(
-    apple,
     solarish,
     target_os = "emscripten",
     target_os = "haiku",
@@ -688,7 +644,6 @@ pub const EXTA: c::c_uint = c::EXTA;
 
 /// `EXTB`
 #[cfg(not(any(
-    apple,
     solarish,
     target_os = "emscripten",
     target_os = "haiku",
@@ -739,7 +694,7 @@ pub const CIBAUD: c::tcflag_t = 0o77600000;
 pub const CMSPAR: c::c_uint = c::CMSPAR;
 
 /// `CRTSCTS`
-#[cfg(not(any(apple, target_os = "aix", target_os = "redox")))]
+#[cfg(not(any(target_os = "aix", target_os = "redox")))]
 pub const CRTSCTS: c::c_uint = c::CRTSCTS;
 
 /// `XCASE`
@@ -747,27 +702,27 @@ pub const CRTSCTS: c::c_uint = c::CRTSCTS;
 pub const XCASE: c::c_uint = c::XCASE;
 
 /// `ECHOCTL`
-#[cfg(not(any(apple, target_os = "redox")))]
+#[cfg(not(any(target_os = "redox")))]
 pub const ECHOCTL: c::c_uint = c::ECHOCTL;
 
 /// `ECHOPRT`
-#[cfg(not(any(apple, target_os = "redox")))]
+#[cfg(not(any(target_os = "redox")))]
 pub const ECHOPRT: c::c_uint = c::ECHOPRT;
 
 /// `ECHOKE`
-#[cfg(not(any(apple, target_os = "redox")))]
+#[cfg(not(any(target_os = "redox")))]
 pub const ECHOKE: c::c_uint = c::ECHOKE;
 
 /// `FLUSHO`
-#[cfg(not(any(apple, target_os = "redox")))]
+#[cfg(not(any(target_os = "redox")))]
 pub const FLUSHO: c::c_uint = c::FLUSHO;
 
 /// `PENDIN`
-#[cfg(not(any(apple, target_os = "redox")))]
+#[cfg(not(any(target_os = "redox")))]
 pub const PENDIN: c::c_uint = c::PENDIN;
 
 /// `EXTPROC`
-#[cfg(not(any(apple, target_os = "aix", target_os = "haiku", target_os = "redox")))]
+#[cfg(not(any(target_os = "aix", target_os = "haiku", target_os = "redox")))]
 pub const EXTPROC: c::c_uint = c::EXTPROC;
 
 /// `XTABS`


### PR DESCRIPTION
These flags seem to exist on macOS, and this helps portable code run on
macOS.

I checked many of these to confirm they exist; let's see if this passes CI.
