### PR TITLE
procctl: Add new getpids flags

### DIFF
--- a/src/process/procctl.rs
+++ b/src/process/procctl.rs
@@ -282,6 +282,12 @@ bitflags! {
         const CHILD = 2;
         /// The reported process is itself a reaper. Descendants of a subordinate reaper are not reported.
         const REAPER = 4;
+        /// The reported process is in the zombie state.
+        const ZOMBIE = 8;
+        /// The reported process is stopped by SIGSTOP/SIGTSTP.
+        const STOPPED = 16;
+        /// The reported process is in the process of exiting.
+        const EXITING = 32;
     }
 }
 


### PR DESCRIPTION
Landed these in -current [a few days ago](https://cgit.freebsd.org/src/commit/?id=77f0e198d9134b6ca2650d3a84d7db2d786ec0c0), should appear in -stable soon too 🎉 