### PR TITLE
Avoid statically depending on `syncfs` on Android.

### DIFF
--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -37,6 +37,8 @@ mod renameat;
 mod statfs;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod statx;
+#[cfg(not(any(solarish, target_os = "redox", target_os = "wasi")))]
+mod sync;
 mod utimensat;
 #[cfg(any(apple, target_os = "android", target_os = "linux"))]
 mod xattr;

--- a/tests/fs/sync.rs
+++ b/tests/fs/sync.rs
@@ -1,0 +1,11 @@
+#[test]
+fn test_sync() {
+    rustix::fs::sync();
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[test]
+fn test_syncfs() {
+    let f = std::fs::File::open("Cargo.toml").unwrap();
+    rustix::fs::syncfs(&f).unwrap();
+}


### PR DESCRIPTION
Some versions of Android libc lack a `syncfs` function, so use `libc::syscall` to call it on Android.

Fixes #617.