### PR TITLE
Remove workarounds for things fixed in upstream crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ once_cell = { version = "1.5.2", optional = true }
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
 linux-raw-sys = { version = "0.3.3", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 libc_errno = { package = "errno", version = "0.3.1", default-features = false, optional = true }
-libc = { version = "0.2.141", features = ["extra_traits"], optional = true }
+libc = { version = "0.2.142", features = ["extra_traits"], optional = true }
 
 # Dependencies for platforms where only libc is supported:
 #
@@ -49,7 +49,7 @@ libc = { version = "0.2.141", features = ["extra_traits"], optional = true }
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.0", default-features = false }
-libc = { version = "0.2.141", features = ["extra_traits"] }
+libc = { version = "0.2.142", features = ["extra_traits"] }
 
 # Additional dependencies for Linux with the libc backend:
 #
@@ -70,7 +70,7 @@ features = [
 
 [dev-dependencies]
 tempfile = "3.4.0"
-libc = "0.2.141"
+libc = "0.2.142"
 libc_errno = { package = "errno", version = "0.3.0", default-features = false }
 io-lifetimes = { version = "1.0.10", default-features = false, features = ["close"] }
 # Don't upgrade to serial_test 0.7 for now because it depends on a

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -972,18 +972,9 @@ pub(crate) fn syncfs(fd: BorrowedFd<'_>) -> io::Result<()> {
     }
 }
 
-#[cfg(not(any(solarish, target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn sync() {
-    // TODO: Remove this when upstream libc adds `sync`.
-    #[cfg(target_os = "android")]
-    unsafe {
-        syscall_ret(c::syscall(c::SYS_sync)).ok();
-    }
-
-    #[cfg(not(target_os = "android"))]
-    unsafe {
-        c::sync()
-    }
+    unsafe { c::sync() }
 }
 
 pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -341,13 +341,15 @@ pub(crate) fn ioctl_fionbio(fd: BorrowedFd<'_>, value: bool) -> io::Result<()> {
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub(crate) fn ioctl_ficlone(fd: BorrowedFd<'_>, src_fd: BorrowedFd<'_>) -> io::Result<()> {
-    // TODO: Enable `ioctl_ficlone` for android when upstream is updated.
-    // TODO: Enable `ioctl_ficlone` for more architectures when upstream is
-    // updated.
-    #[cfg(all(
-        target_os = "linux",
-        any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")
-    ))]
+    // TODO: Enable this on mips and power once libc is updated.
+    #[cfg(not(any(
+        target_arch = "mips",
+        target_arch = "mips64",
+        target_arch = "powerpc",
+        target_arch = "powerpc64",
+        target_arch = "sparc",
+        target_arch = "sparc64"
+    )))]
     unsafe {
         ret(c::ioctl(
             borrowed_fd(fd),
@@ -355,10 +357,15 @@ pub(crate) fn ioctl_ficlone(fd: BorrowedFd<'_>, src_fd: BorrowedFd<'_>) -> io::R
             borrowed_fd(src_fd),
         ))
     }
-    #[cfg(not(all(
-        target_os = "linux",
-        any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")
-    )))]
+
+    #[cfg(any(
+        target_arch = "mips",
+        target_arch = "mips64",
+        target_arch = "powerpc",
+        target_arch = "powerpc64",
+        target_arch = "sparc",
+        target_arch = "sparc64"
+    ))]
     {
         let _ = fd;
         let _ = src_fd;

--- a/src/backend/libc/offset.rs
+++ b/src/backend/libc/offset.rs
@@ -36,12 +36,11 @@ pub(super) use c::{rlimit as libc_rlimit, RLIM_INFINITY as LIBC_RLIM_INFINITY};
 #[cfg(not(any(linux_like, windows, target_os = "fuchsia", target_os = "wasi")))]
 pub(super) use c::{getrlimit as libc_getrlimit, setrlimit as libc_setrlimit};
 
-// TODO: Add `RLIM64_INFINITY` to upstream libc.
 #[cfg(linux_like)]
-pub(super) const LIBC_RLIM_INFINITY: u64 = !0_u64;
-
-#[cfg(linux_like)]
-pub(super) use c::{getrlimit64 as libc_getrlimit, setrlimit64 as libc_setrlimit};
+pub(super) use c::{
+    getrlimit64 as libc_getrlimit, setrlimit64 as libc_setrlimit,
+    RLIM64_INFINITY as LIBC_RLIM_INFINITY,
+};
 
 #[cfg(linux_like)]
 #[cfg(feature = "mm")]

--- a/src/backend/libc/process/types.rs
+++ b/src/backend/libc/process/types.rs
@@ -7,8 +7,6 @@ use super::super::c;
 /// [`membarrier`]: crate::process::membarrier
 /// [`membarrier_cpu`]: crate::process::membarrier_cpu
 /// [`membarrier_query`]: crate::process::membarrier_query
-// TODO: These are not yet exposed through libc, so we define the
-// constants ourselves.
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[repr(u32)]
@@ -16,23 +14,24 @@ pub enum MembarrierCommand {
     /// `MEMBARRIER_CMD_GLOBAL`
     #[doc(alias = "Shared")]
     #[doc(alias = "MEMBARRIER_CMD_SHARED")]
-    Global = 1,
+    Global = c::MEMBARRIER_CMD_GLOBAL as u32,
     /// `MEMBARRIER_CMD_GLOBAL_EXPEDITED`
-    GlobalExpedited = 2,
+    GlobalExpedited = c::MEMBARRIER_CMD_GLOBAL_EXPEDITED as u32,
     /// `MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED`
-    RegisterGlobalExpedited = 4,
+    RegisterGlobalExpedited = c::MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED as u32,
     /// `MEMBARRIER_CMD_PRIVATE_EXPEDITED`
-    PrivateExpedited = 8,
+    PrivateExpedited = c::MEMBARRIER_CMD_PRIVATE_EXPEDITED as u32,
     /// `MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED`
-    RegisterPrivateExpedited = 16,
+    RegisterPrivateExpedited = c::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED as u32,
     /// `MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE`
-    PrivateExpeditedSyncCore = 32,
+    PrivateExpeditedSyncCore = c::MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE as u32,
     /// `MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_SYNC_CORE`
-    RegisterPrivateExpeditedSyncCore = 64,
+    RegisterPrivateExpeditedSyncCore =
+        c::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_SYNC_CORE as u32,
     /// `MEMBARRIER_CMD_PRIVATE_EXPEDITED_RSEQ` (since Linux 5.10)
-    PrivateExpeditedRseq = 128,
+    PrivateExpeditedRseq = c::MEMBARRIER_CMD_PRIVATE_EXPEDITED_RSEQ as u32,
     /// `MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_RSEQ` (since Linux 5.10)
-    RegisterPrivateExpeditedRseq = 256,
+    RegisterPrivateExpeditedRseq = c::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_RSEQ as u32,
 }
 
 /// A resource value for use with [`getrlimit`], [`setrlimit`], and

--- a/src/backend/libc/winsock_c.rs
+++ b/src/backend/libc/winsock_c.rs
@@ -9,48 +9,12 @@ pub(crate) use libc::{
     c_char, c_int, c_long, c_longlong, c_schar, c_short, c_uchar, c_uint, c_ulong, c_ulonglong,
     c_ushort, c_void, ssize_t,
 };
-pub(crate) type socklen_t = i32;
 
-// windows-sys declares these constants as unsigned. For better compatibility
-// with Unix-family APIs, redeclare them as signed. Filed upstream:
-// <https://github.com/microsoft/windows-rs/issues/1718>
+// windows-sys declares these constants as u16. For better compatibility
+// with Unix-family APIs, redeclare them as u32.
 pub(crate) const AF_INET: i32 = WinSock::AF_INET as _;
 pub(crate) const AF_INET6: i32 = WinSock::AF_INET6 as _;
 pub(crate) const AF_UNSPEC: i32 = WinSock::AF_UNSPEC as _;
-pub(crate) const SO_TYPE: i32 = WinSock::SO_TYPE as _;
-pub(crate) const SO_REUSEADDR: i32 = WinSock::SO_REUSEADDR as _;
-pub(crate) const SO_BROADCAST: i32 = WinSock::SO_BROADCAST as _;
-pub(crate) const SO_LINGER: i32 = WinSock::SO_LINGER as _;
-pub(crate) const SOL_SOCKET: i32 = WinSock::SOL_SOCKET as _;
-pub(crate) const SO_RCVTIMEO: i32 = WinSock::SO_RCVTIMEO as _;
-pub(crate) const SO_SNDTIMEO: i32 = WinSock::SO_SNDTIMEO as _;
-pub(crate) const SO_ERROR: i32 = WinSock::SO_ERROR as _;
-pub(crate) const IP_TTL: i32 = WinSock::IP_TTL as _;
-pub(crate) const TCP_NODELAY: i32 = WinSock::TCP_NODELAY as _;
-pub(crate) const IP_ADD_MEMBERSHIP: i32 = WinSock::IP_ADD_MEMBERSHIP as _;
-pub(crate) const IP_DROP_MEMBERSHIP: i32 = WinSock::IP_DROP_MEMBERSHIP as _;
-pub(crate) const IP_MULTICAST_TTL: i32 = WinSock::IP_MULTICAST_TTL as _;
-pub(crate) const IP_MULTICAST_LOOP: i32 = WinSock::IP_MULTICAST_LOOP as _;
-pub(crate) const IPV6_ADD_MEMBERSHIP: i32 = WinSock::IPV6_ADD_MEMBERSHIP as _;
-pub(crate) const IPV6_DROP_MEMBERSHIP: i32 = WinSock::IPV6_DROP_MEMBERSHIP as _;
-pub(crate) const IPV6_MULTICAST_LOOP: i32 = WinSock::IPV6_MULTICAST_LOOP as _;
-pub(crate) const IPV6_V6ONLY: i32 = WinSock::IPV6_V6ONLY as _;
-pub(crate) const POLLERR: i16 = WinSock::POLLERR as _;
-pub(crate) const POLLIN: i16 = WinSock::POLLIN as _;
-pub(crate) const POLLNVAL: i16 = WinSock::POLLNVAL as _;
-pub(crate) const POLLHUP: i16 = WinSock::POLLHUP as _;
-pub(crate) const POLLPRI: i16 = WinSock::POLLPRI as _;
-pub(crate) const POLLOUT: i16 = WinSock::POLLOUT as _;
-pub(crate) const POLLRDNORM: i16 = WinSock::POLLRDNORM as _;
-pub(crate) const POLLWRNORM: i16 = WinSock::POLLWRNORM as _;
-pub(crate) const POLLRDBAND: i16 = WinSock::POLLRDBAND as _;
-pub(crate) const POLLWRBAND: i16 = WinSock::POLLWRBAND as _;
-
-// As above, cast the types for better compatibility, and also rename these to
-// their Unix names.
-pub(crate) const SHUT_RDWR: i32 = WinSock::SD_BOTH as _;
-pub(crate) const SHUT_RD: i32 = WinSock::SD_RECEIVE as _;
-pub(crate) const SHUT_WR: i32 = WinSock::SD_SEND as _;
 
 // Include the contents of `WinSock`, renaming as needed to match POSIX.
 //
@@ -58,11 +22,16 @@ pub(crate) const SHUT_WR: i32 = WinSock::SD_SEND as _;
 // `WSAECANCELLED` will be removed in the future.
 // <https://docs.microsoft.com/en-us/windows/win32/api/ws2spi/nc-ws2spi-lpnsplookupserviceend#remarks>
 pub(crate) use WinSock::{
-    closesocket as close, ioctlsocket as ioctl, WSAPoll as poll, ADDRESS_FAMILY as sa_family_t,
-    ADDRINFOA as addrinfo, IN6_ADDR as in6_addr, IN_ADDR as in_addr, IPV6_MREQ as ipv6_mreq,
-    IP_MREQ as ip_mreq, LINGER as linger, SOCKADDR as sockaddr, SOCKADDR_IN as sockaddr_in,
-    SOCKADDR_IN6 as sockaddr_in6, SOCKADDR_STORAGE as sockaddr_storage, WSAEACCES as EACCES,
-    WSAEADDRINUSE as EADDRINUSE, WSAEADDRNOTAVAIL as EADDRNOTAVAIL,
+    closesocket as close, ioctlsocket as ioctl, socklen_t, WSAPoll as poll,
+    ADDRESS_FAMILY as sa_family_t, ADDRINFOA as addrinfo, IN6_ADDR as in6_addr, IN_ADDR as in_addr,
+    IPV6_ADD_MEMBERSHIP, IPV6_DROP_MEMBERSHIP, IPV6_MREQ as ipv6_mreq, IPV6_MULTICAST_LOOP,
+    IPV6_V6ONLY, IP_ADD_MEMBERSHIP, IP_DROP_MEMBERSHIP, IP_MREQ as ip_mreq, IP_MULTICAST_LOOP,
+    IP_MULTICAST_TTL, IP_TTL, LINGER as linger, POLLERR, POLLHUP, POLLIN, POLLNVAL, POLLOUT,
+    POLLPRI, POLLRDBAND, POLLRDNORM, POLLWRBAND, POLLWRNORM, SD_BOTH as SHUT_RDWR,
+    SD_RECEIVE as SHUT_RD, SD_SEND as SHUT_WR, SOCKADDR as sockaddr, SOCKADDR_IN as sockaddr_in,
+    SOCKADDR_IN6 as sockaddr_in6, SOCKADDR_STORAGE as sockaddr_storage, SOL_SOCKET, SO_BROADCAST,
+    SO_ERROR, SO_LINGER, SO_RCVTIMEO, SO_REUSEADDR, SO_SNDTIMEO, SO_TYPE, TCP_NODELAY,
+    WSAEACCES as EACCES, WSAEADDRINUSE as EADDRINUSE, WSAEADDRNOTAVAIL as EADDRNOTAVAIL,
     WSAEAFNOSUPPORT as EAFNOSUPPORT, WSAEALREADY as EALREADY, WSAEBADF as EBADF,
     WSAECONNABORTED as ECONNABORTED, WSAECONNREFUSED as ECONNREFUSED, WSAECONNRESET as ECONNRESET,
     WSAEDESTADDRREQ as EDESTADDRREQ, WSAEDISCON as EDISCON, WSAEDQUOT as EDQUOT,

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -42,8 +42,7 @@ mod raw_dir;
 mod sendfile;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod statx;
-// TODO: Enable `sync` for solarish when upstream is updated.
-#[cfg(not(any(solarish, target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 mod sync;
 #[cfg(any(apple, target_os = "android", target_os = "linux"))]
 mod xattr;
@@ -92,7 +91,7 @@ pub use raw_dir::{RawDir, RawDirEntry};
 pub use sendfile::sendfile;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use statx::{statx, Statx, StatxFlags, StatxTimestamp};
-#[cfg(not(any(solarish, target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub use sync::sync;
 #[cfg(any(apple, target_os = "android", target_os = "linux"))]
 pub use xattr::*;

--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -2,7 +2,6 @@
 
 #![cfg(feature = "fs")]
 #![cfg(not(windows))]
-#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 #![cfg_attr(core_c_str, feature(core_c_str))]
 

--- a/tests/io/ioctl.rs
+++ b/tests/io/ioctl.rs
@@ -14,11 +14,16 @@ fn test_ioctls() {
     );
 }
 
-// TODO: Enable `ioctl_ficlone` for android when upstream is updated.
-// TODO: Enable `ioctl_ficlone` for more architectures when upstream is
-// updated.
-#[cfg(any(target_os = "linux"))]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
+// TODO: Enable this on mips and power once libc is updated.
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(not(any(
+    target_arch = "mips",
+    target_arch = "mips64",
+    target_arch = "powerpc",
+    target_arch = "powerpc64",
+    target_arch = "sparc",
+    target_arch = "sparc64"
+)))]
 #[test]
 fn test_ioctl_fioclone() {
     let src = std::fs::File::open("Cargo.toml").unwrap();

--- a/tests/io/main.rs
+++ b/tests/io/main.rs
@@ -1,6 +1,5 @@
 //! Tests for [`rustix::io`].
 
-#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 
 #[cfg(not(feature = "rustc-dep-of-std"))]
@@ -27,5 +26,5 @@ mod procfs;
 #[cfg(not(target_os = "redox"))] // redox doesn't have cwd/openat
 #[cfg(not(target_os = "wasi"))] // wasi support for `S_IRUSR` etc. submitted to libc in #2264
 mod read_write;
-#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "android"))]
+#[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 mod seals;

--- a/tests/mm/main.rs
+++ b/tests/mm/main.rs
@@ -1,12 +1,11 @@
 //! Tests for [`rustix::mm`].
 
 #![cfg(feature = "mm")]
-#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 
 #[cfg(not(any(windows, target_os = "wasi")))]
 mod mlock;
 #[cfg(not(any(windows, target_os = "wasi")))]
 mod mmap;
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "wasi")))]
 mod prot;

--- a/tests/param/main.rs
+++ b/tests/param/main.rs
@@ -2,7 +2,6 @@
 
 #![cfg(feature = "param")]
 #![cfg(not(windows))]
-#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 #![cfg_attr(core_c_str, feature(core_c_str))]
 

--- a/tests/path/main.rs
+++ b/tests/path/main.rs
@@ -2,7 +2,6 @@
 
 #![cfg(any(feature = "fs", feature = "net"))]
 #![cfg(not(windows))]
-#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 #![cfg_attr(core_c_str, feature(core_c_str))]
 #![cfg_attr(alloc_c_string, feature(alloc_c_string))]

--- a/tests/process/main.rs
+++ b/tests/process/main.rs
@@ -2,7 +2,6 @@
 
 #![cfg(feature = "process")]
 #![cfg(not(windows))]
-#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 #![cfg_attr(core_c_str, feature(core_c_str))]
 

--- a/tests/rand/main.rs
+++ b/tests/rand/main.rs
@@ -2,7 +2,6 @@
 
 #![cfg(feature = "rand")]
 #![cfg(not(windows))]
-#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/tests/termios/main.rs
+++ b/tests/termios/main.rs
@@ -1,6 +1,5 @@
 //! Tests for [`rustix::termios`].
 
-#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 #![cfg(feature = "termios")]
 

--- a/tests/time/main.rs
+++ b/tests/time/main.rs
@@ -2,7 +2,6 @@
 
 #![cfg(feature = "time")]
 #![cfg(not(windows))]
-#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]


### PR DESCRIPTION
Remove workarounds for issues that are now fixed in upstream libc, windows-sys, and rust.