### PR TITLE
Expand support for `accessat`

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -47,8 +47,6 @@ use crate::fd::{BorrowedFd, OwnedFd};
 use crate::ffi::CStr;
 #[cfg(apple)]
 use crate::ffi::CString;
-#[cfg(not(solarish))]
-use crate::fs::Access;
 #[cfg(not(any(
     apple,
     netbsdlike,
@@ -91,7 +89,7 @@ use crate::fs::XattrFlags;
 use crate::fs::{cwd, RenameFlags, ResolveFlags, Statx, StatxFlags};
 #[cfg(not(any(apple, target_os = "redox", target_os = "wasi")))]
 use crate::fs::{Dev, FileType};
-use crate::fs::{Mode, OFlags, Stat, Timestamps};
+use crate::fs::{Mode, OFlags, Stat, Timestamps, Access};
 #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 use crate::fs::{StatVfs, StatVfsMountFlags};
 use crate::io::{self, SeekFrom};
@@ -400,7 +398,7 @@ fn statat_old(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io::Result<
     }
 }
 
-#[cfg(not(any(solarish, target_os = "emscripten", target_os = "redox")))]
+#[cfg(not(any(target_os = "emscripten", target_os = "redox")))]
 pub(crate) fn accessat(
     dirfd: BorrowedFd<'_>,
     path: &CStr,

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -87,9 +87,9 @@ use crate::fs::StatFs;
 use crate::fs::XattrFlags;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use crate::fs::{cwd, RenameFlags, ResolveFlags, Statx, StatxFlags};
+use crate::fs::{Access, Mode, OFlags, Stat, Timestamps};
 #[cfg(not(any(apple, target_os = "redox", target_os = "wasi")))]
 use crate::fs::{Dev, FileType};
-use crate::fs::{Mode, OFlags, Stat, Timestamps, Access};
 #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 use crate::fs::{StatVfs, StatVfsMountFlags};
 use crate::io::{self, SeekFrom};

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -1419,11 +1419,13 @@ pub(crate) fn accessat(
         return unsafe { ret(syscall_readonly!(__NR_faccessat, dirfd, path, access)) };
     }
 
-    if flags.bits() != AT_EACCESS {
+    if !flags
+        .difference(AtFlags::EACCESS | AtFlags::SYMLINK_NOFOLLOW)
+        .is_empty()
+    {
         return Err(io::Errno::INVAL);
     }
 
-    // TODO: Use faccessat2 in newer Linux versions.
     Err(io::Errno::NOSYS)
 }
 

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -13,7 +13,7 @@ use crate::fs::CloneFlags;
 use crate::fs::FileType;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use crate::fs::RenameFlags;
-use crate::fs::{AtFlags, Mode, OFlags, Stat, Timestamps, Access};
+use crate::fs::{Access, AtFlags, Mode, OFlags, Stat, Timestamps};
 use crate::path::SMALL_PATH_BUFFER_SIZE;
 #[cfg(not(target_os = "wasi"))]
 use crate::process::{Gid, Uid};

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -7,15 +7,13 @@
 
 use crate::fd::OwnedFd;
 use crate::ffi::{CStr, CString};
-#[cfg(not(solarish))]
-use crate::fs::Access;
 #[cfg(apple)]
 use crate::fs::CloneFlags;
 #[cfg(not(any(apple, target_os = "wasi")))]
 use crate::fs::FileType;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use crate::fs::RenameFlags;
-use crate::fs::{AtFlags, Mode, OFlags, Stat, Timestamps};
+use crate::fs::{AtFlags, Mode, OFlags, Stat, Timestamps, Access};
 use crate::path::SMALL_PATH_BUFFER_SIZE;
 #[cfg(not(target_os = "wasi"))]
 use crate::process::{Gid, Uid};
@@ -271,7 +269,6 @@ pub fn statat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, flags: AtFlags) -> io:
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/faccessat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/faccessat.2.html
-#[cfg(not(solarish))]
 #[inline]
 #[doc(alias = "faccessat")]
 pub fn accessat<P: path::Arg, Fd: AsFd>(

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -9,6 +9,7 @@ fn test_file() {
     )
     .unwrap();
 
+    #[cfg(not(any(target_os = "emscripten", target_os = "android")))]
     #[allow(unreachable_patterns)]
     match rustix::fs::accessat(
         rustix::fs::cwd(),

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -9,6 +9,20 @@ fn test_file() {
     )
     .unwrap();
 
+    #[allow(unreachable_patterns)]
+    match rustix::fs::accessat(
+        rustix::fs::cwd(),
+        "Cargo.toml",
+        rustix::fs::Access::READ_OK,
+        rustix::fs::AtFlags::EACCESS,
+    ) {
+        Ok(()) => (),
+        Err(rustix::io::Errno::NOSYS)
+        | Err(rustix::io::Errno::NOTSUP)
+        | Err(rustix::io::Errno::OPNOTSUPP) => (),
+        Err(err) => Err(err).unwrap(),
+    }
+
     assert_eq!(
         rustix::fs::openat(
             rustix::fs::cwd(),

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -1,7 +1,6 @@
 #[cfg(not(target_os = "redox"))]
 #[test]
 fn test_file() {
-    #[cfg(not(solarish))]
     rustix::fs::accessat(
         rustix::fs::cwd(),
         "Cargo.toml",

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -24,6 +24,16 @@ fn test_file() {
     }
 
     assert_eq!(
+        rustix::fs::accessat(
+            rustix::fs::cwd(),
+            "Cargo.toml",
+            rustix::fs::Access::READ_OK,
+            rustix::fs::AtFlags::SYMLINK_FOLLOW,
+        ),
+        Err(rustix::io::Errno::INVAL)
+    );
+
+    assert_eq!(
         rustix::fs::openat(
             rustix::fs::cwd(),
             "Cagro.motl",


### PR DESCRIPTION
 - Support `accessat` on Solarish platforms
 - Support `accessat` with flags on newer Linux platforms
 - Use the correct error code for unrecognized flags.
