### PR TITLE
Avoid depending on the libc crate on Windows.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ libc = { version = "0.2.142", features = ["extra_traits"], optional = true }
 #
 # On all other Unix-family platforms, and under Miri, we always use the libc
 # backend, so enable its dependencies unconditionally.
-[target.'cfg(any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))))'.dependencies]
+[target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64"))))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.0", default-features = false }
 libc = { version = "0.2.142", features = ["extra_traits"] }
 
@@ -67,6 +67,13 @@ features = [
     "Win32_NetworkManagement_IpHelper",
     "Win32_System_Threading"
 ]
+
+# For the libc backend on Windows, also use the errno crate, which has Windows
+# support.
+[target.'cfg(windows)'.dependencies.libc_errno]
+version = "0.3.1"
+package = "errno"
+default-features = false
 
 [dev-dependencies]
 tempfile = "3.4.0"

--- a/src/backend/libc/winsock_c.rs
+++ b/src/backend/libc/winsock_c.rs
@@ -5,10 +5,20 @@
 
 use windows_sys::Win32::Networking::WinSock;
 
-pub(crate) use libc::{
-    c_char, c_int, c_long, c_longlong, c_schar, c_short, c_uchar, c_uint, c_ulong, c_ulonglong,
-    c_ushort, c_void, ssize_t,
-};
+// Define the basic C types. With Rust 1.64, we can use these from `core::ffi`.
+pub(crate) type c_schar = i8;
+pub(crate) type c_uchar = u8;
+pub(crate) type c_short = i16;
+pub(crate) type c_ushort = u16;
+pub(crate) type c_int = i32;
+pub(crate) type c_uint = u32;
+pub(crate) type c_longlong = i64;
+pub(crate) type c_ulonglong = u64;
+pub(crate) type ssize_t = isize;
+pub(crate) type c_char = i8;
+pub(crate) type c_long = i32;
+pub(crate) type c_ulong = u32;
+pub(crate) use core::ffi::c_void;
 
 // windows-sys declares these constants as u16. For better compatibility
 // with Unix-family APIs, redeclare them as u32.

--- a/tests/backends.rs
+++ b/tests/backends.rs
@@ -93,6 +93,13 @@ fn test_backends() {
         "use-default with --features=rustix/use-libc does not depend on {}",
         libc_dep
     );
+
+    // Test that the windows crate does not depend on libc.
+    #[cfg(windows)]
+    assert!(
+        !has_dependency("test-crates/use-default", &[], &[], &[], "libc"),
+        "use-default depends on libc on windows",
+    );
 }
 
 /// Test whether the crate at directory `dir` has a dependency on `dependency`,


### PR DESCRIPTION
rustix uses windows-sys exclusively for performing OS calls on Windows. The libc crate was just being used for its definitions of the C ffi types, so instead of pulling in the whole libc crate, just declare the types we need manually.