### PR TITLE
Make `sigprocmask`'s argument optional.

### DIFF
--- a/src/backend/linux_raw/runtime/syscalls.rs
+++ b/src/backend/linux_raw/runtime/syscalls.rs
@@ -144,12 +144,13 @@ pub(crate) unsafe fn tkill(tid: Pid, sig: Signal) -> io::Result<()> {
 }
 
 #[inline]
-pub(crate) unsafe fn sigprocmask(how: How, set: &Sigset) -> io::Result<Sigset> {
+pub(crate) unsafe fn sigprocmask(how: How, new: Option<&Sigset>) -> io::Result<Sigset> {
     let mut old = MaybeUninit::<Sigset>::uninit();
+    let new = optional_as_ptr(new.as_ref());
     ret(syscall!(
         __NR_rt_sigprocmask,
         how,
-        by_ref(set),
+        new,
         &mut old,
         size_of::<kernel_sigset_t, _>()
     ))?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -371,7 +371,7 @@ pub unsafe fn tkill(tid: Pid, sig: Signal) -> io::Result<()> {
 #[cfg(linux_raw)]
 #[inline]
 #[doc(alias = "pthread_sigmask")]
-pub unsafe fn sigprocmask(how: How, set: &Sigset) -> io::Result<Sigset> {
+pub unsafe fn sigprocmask(how: How, set: Option<&Sigset>) -> io::Result<Sigset> {
     backend::runtime::syscalls::sigprocmask(how, set)
 }
 


### PR DESCRIPTION
In the C API, `sigprocmask`'s `set` argument can be NULL, in which case the call doesn't change the mask.