### PR TITLE
Fix `faccessat` to not fail on `EACCESS` when it doesn't need to.

### DIFF
--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -1405,15 +1405,19 @@ pub(crate) fn accessat(
     // process.
     #[cfg(not(target_os = "android"))]
     if !flags.is_empty() {
-        return unsafe {
-            ret(syscall_readonly!(
+        unsafe {
+            match ret(syscall_readonly!(
                 __NR_faccessat2,
                 dirfd,
                 path,
                 access,
                 flags
-            ))
-        };
+            )) {
+                Ok(()) => return Ok(()),
+                Err(io::Errno::NOSYS) => {}
+                Err(other) => return Err(other),
+            }
+        }
     }
 
     // Linux's `faccessat` doesn't have a flags parameter. If we have

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -20,7 +20,14 @@ fn test_file() {
         Ok(()) => (),
         Err(rustix::io::Errno::NOSYS)
         | Err(rustix::io::Errno::NOTSUP)
-        | Err(rustix::io::Errno::OPNOTSUPP) => (),
+        | Err(rustix::io::Errno::OPNOTSUPP) => {
+            #[cfg(feature = "process")]
+            if rustix::process::getuid() == rustix::process::geteuid()
+                && rustix::process::getgid() == rustix::process::getegid()
+            {
+                panic!("accessat with EACCESS should always work when the effective uid/gid match the real uid/gid")
+            }
+        }
         Err(err) => Err(err).unwrap(),
     }
 


### PR DESCRIPTION
If `faccessat2` is not supported, we can still do an `faccessat` query and emulate `EACCESS` in the case where the effective uid/gid match the real uid/gid.