### PR TITLE
Provide safe wrapper for EXT4_IOC_RESIZE_FS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ once_cell = { version = "1.5.2", optional = true }
 # libc backend can be selected via adding `--cfg=rustix_use_libc` to
 # `RUSTFLAGS` or enabling the `use-libc` cargo feature.
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
-linux-raw-sys = { version = "0.3.3", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
+linux-raw-sys = { version = "0.3.6", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 libc_errno = { package = "errno", version = "0.3.1", default-features = false, optional = true }
 libc = { version = "0.2.142", features = ["extra_traits"], optional = true }
 
@@ -56,7 +56,7 @@ libc = { version = "0.2.142", features = ["extra_traits"] }
 # Some syscalls do not have libc wrappers, such as in `io_uring`. For these,
 # the libc backend uses the linux-raw-sys ABI and `libc::syscall`.
 [target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64"))))))))'.dependencies]
-linux-raw-sys = { version = "0.3.3", default-features = false, features = ["general", "no_std"] }
+linux-raw-sys = { version = "0.3.6", default-features = false, features = ["general", "no_std"] }
 
 # For the libc backend on Windows, use the Winsock2 API in windows-sys.
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -373,6 +373,18 @@ pub(crate) fn ioctl_ficlone(fd: BorrowedFd<'_>, src_fd: BorrowedFd<'_>) -> io::R
     }
 }
 
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[inline]
+pub(crate) fn ext4_ioc_resize_fs(fd: BorrowedFd<'_>, blocks: u64) -> io::Result<()> {
+    unsafe {
+        ret(c::ioctl(
+            borrowed_fd(fd),
+            linux_raw_sys::ioctl::EXT4_IOC_RESIZE_FS as _,
+            &blocks,
+        ))
+    }
+}
+
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[cfg(all(feature = "fs", feature = "net"))]
 pub(crate) fn is_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -376,13 +376,14 @@ pub(crate) fn ioctl_ficlone(fd: BorrowedFd<'_>, src_fd: BorrowedFd<'_>) -> io::R
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 pub(crate) fn ext4_ioc_resize_fs(fd: BorrowedFd<'_>, blocks: u64) -> io::Result<()> {
-    unsafe {
-        ret(c::ioctl(
-            borrowed_fd(fd),
-            linux_raw_sys::ioctl::EXT4_IOC_RESIZE_FS as _,
-            &blocks,
-        ))
-    }
+    // TODO: Fix linux-raw-sys to define ioctl codes for sparc.
+    #[cfg(any(target_arch = "sparc", target_arch = "sparc64"))]
+    const EXT4_IOC_RESIZE_FS: u32 = 0x8008_6610;
+
+    #[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))]
+    use linux_raw_sys::ioctl::EXT4_IOC_RESIZE_FS;
+
+    unsafe { ret(c::ioctl(borrowed_fd(fd), EXT4_IOC_RESIZE_FS as _, &blocks)) }
 }
 
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -32,7 +32,9 @@ use linux_raw_sys::general::{
     epoll_event, EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD, F_DUPFD_CLOEXEC, F_GETFD, F_SETFD,
     UIO_MAXIOV,
 };
-use linux_raw_sys::ioctl::{BLKPBSZGET, BLKSSZGET, FICLONE, FIONBIO, FIONREAD, TIOCEXCL, TIOCNXCL};
+use linux_raw_sys::ioctl::{
+    BLKPBSZGET, BLKSSZGET, EXT4_IOC_RESIZE_FS, FICLONE, FIONBIO, FIONREAD, TIOCEXCL, TIOCNXCL,
+};
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use {
     super::super::conv::{opt_ref, size_of},
@@ -355,6 +357,18 @@ pub(crate) fn ioctl_blkpbszget(fd: BorrowedFd) -> io::Result<u32> {
 #[inline]
 pub(crate) fn ioctl_ficlone(fd: BorrowedFd<'_>, src_fd: BorrowedFd<'_>) -> io::Result<()> {
     unsafe { ret(syscall_readonly!(__NR_ioctl, fd, c_uint(FICLONE), src_fd)) }
+}
+
+#[inline]
+pub(crate) fn ext4_ioc_resize_fs(fd: BorrowedFd<'_>, blocks: u64) -> io::Result<()> {
+    unsafe {
+        ret(syscall_readonly!(
+            __NR_ioctl,
+            fd,
+            c_uint(EXT4_IOC_RESIZE_FS),
+            &blocks as *const u64
+        ))
+    }
 }
 
 #[cfg(all(feature = "fs", feature = "net"))]

--- a/src/io/ioctl.rs
+++ b/src/io/ioctl.rs
@@ -136,3 +136,11 @@ pub fn ioctl_blkpbszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
 pub fn ioctl_ficlone<Fd: AsFd, SrcFd: AsFd>(fd: Fd, src_fd: SrcFd) -> io::Result<()> {
     backend::io::syscalls::ioctl_ficlone(fd.as_fd(), src_fd.as_fd())
 }
+
+/// `ioctl(fd, EXT4_IOC_RESIZE_FS, blocks)`—Resize ext4 filesystem on fd.
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[inline]
+#[doc(alias = "EXT4_IOC_RESIZE_FS")]
+pub fn ext4_ioc_resize_fs<Fd: AsFd>(fd: Fd, blocks: u64) -> io::Result<()> {
+    backend::io::syscalls::ext4_ioc_resize_fs(fd.as_fd(), blocks)
+}


### PR DESCRIPTION
I'm assuming that you don't want a production rustix to depend on a prerelease
linux-raw-sys. Let me know how you'd like to handle this.
