### PR TITLE
Remove outdated references to nightly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ portable APIs built on this functionality, see the [`cap-std`], [`memfd`],
    arm (v5 onwards), mipsel, and mips64el, with stable, nightly, and 1.48 Rust.
     - By being implemented entirely in Rust, avoiding `libc`, `errno`, and pthread
       cancellation, and employing some specialized optimizations, most functions
-      compile down to very efficient code. On nightly Rust, they can often be
-      fully inlined into user code.
+      compile down to very efficient code, which can often be fully inlined into
+      user code.
     - Most functions in `linux_raw` preserve memory, I/O safety, and pointer
       provenance all the way down to the syscalls.
 

--- a/src/backend/linux_raw/arch/mod.rs
+++ b/src/backend/linux_raw/arch/mod.rs
@@ -1,8 +1,8 @@
 //! Architecture-specific syscall code.
 //!
 //! `rustix` has inline assembly sequences using `asm!`, but that requires
-//! nightly Rust, so it also has out-of-line ("outline") assembly sequences
-//! in .s files. And 32-bit x86 is special (see comments below).
+//! Rust 1.59, so it also has out-of-line ("outline") assembly sequences in .s
+//! files. And 32-bit x86 is special (see comments below).
 //!
 //! This module also has a `choose` submodule which chooses a scheme and is
 //! what most of the `rustix` syscalls use.

--- a/src/backend/linux_raw/io/io_slice.rs
+++ b/src/backend/linux_raw/io/io_slice.rs
@@ -8,7 +8,7 @@ use core::marker::PhantomData;
 use core::slice;
 use linux_raw_sys::general::__kernel_size_t;
 
-/// <https://doc.rust-lang.org/nightly/std/io/struct.IoSlice.html>
+/// <https://doc.rust-lang.org/stable/std/io/struct.IoSlice.html>
 #[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct IoSlice<'a> {
@@ -17,7 +17,7 @@ pub struct IoSlice<'a> {
 }
 
 impl<'a> IoSlice<'a> {
-    /// <https://doc.rust-lang.org/nightly/std/io/struct.IoSlice.html#method.new>
+    /// <https://doc.rust-lang.org/stable/std/io/struct.IoSlice.html#method.new>
     #[inline]
     pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
         IoSlice {
@@ -29,7 +29,7 @@ impl<'a> IoSlice<'a> {
         }
     }
 
-    /// <https://doc.rust-lang.org/nightly/std/io/struct.IoSlice.html#method.advance>
+    /// <https://doc.rust-lang.org/stable/std/io/struct.IoSlice.html#method.advance>
     #[inline]
     pub fn advance(&mut self, n: usize) {
         if self.vec.iov_len < n as _ {
@@ -42,14 +42,14 @@ impl<'a> IoSlice<'a> {
         }
     }
 
-    /// <https://doc.rust-lang.org/nightly/std/io/struct.IoSlice.html#method.as_slice>
+    /// <https://doc.rust-lang.org/stable/std/io/struct.IoSlice.html#method.as_slice>
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len as usize) }
     }
 }
 
-/// <https://doc.rust-lang.org/nightly/std/io/struct.IoSliceMut.html>
+/// <https://doc.rust-lang.org/stable/std/io/struct.IoSliceMut.html>
 #[repr(transparent)]
 pub struct IoSliceMut<'a> {
     vec: c::iovec,
@@ -57,7 +57,7 @@ pub struct IoSliceMut<'a> {
 }
 
 impl<'a> IoSliceMut<'a> {
-    /// <https://doc.rust-lang.org/nightly/std/io/struct.IoSliceMut.html#method.new>
+    /// <https://doc.rust-lang.org/stable/std/io/struct.IoSliceMut.html#method.new>
     #[inline]
     pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
         IoSliceMut {
@@ -69,7 +69,7 @@ impl<'a> IoSliceMut<'a> {
         }
     }
 
-    /// <https://doc.rust-lang.org/nightly/std/io/struct.IoSliceMut.html#method.advance>
+    /// <https://doc.rust-lang.org/stable/std/io/struct.IoSliceMut.html#method.advance>
     #[inline]
     pub fn advance(&mut self, n: usize) {
         if self.vec.iov_len < n as _ {
@@ -82,13 +82,13 @@ impl<'a> IoSliceMut<'a> {
         }
     }
 
-    /// <https://doc.rust-lang.org/nightly/std/io/struct.IoSliceMut.html#method.as_slice>
+    /// <https://doc.rust-lang.org/stable/std/io/struct.IoSliceMut.html#method.as_slice>
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len as usize) }
     }
 
-    /// <https://doc.rust-lang.org/nightly/std/io/struct.IoSliceMut.html#method.as_slice_mut>
+    /// <https://doc.rust-lang.org/stable/std/io/struct.IoSliceMut.html#method.as_slice_mut>
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
         unsafe {

--- a/src/backend/linux_raw/param/auxv.rs
+++ b/src/backend/linux_raw/param/auxv.rs
@@ -140,7 +140,7 @@ fn init_from_proc_self_auxv() {
     let file = crate::fs::openat(
         crate::fs::cwd(),
         "/proc/self/auxv",
-        OFlags::empty(),
+        OFlags::RDONLY,
         Mode::empty(),
     )
     .unwrap();


### PR DESCRIPTION
Inline asm is available in stable Rust versions now, so move references to nightly.

Also fix the Linux auxv code to use `OFlags::RDONLY` when opening /proc/self/auxv. `OFlags::empty()` worked because on Linux `O_RDONLY` has the value zero, but using `RDONLY` makes to code more obvious.