### PR TITLE
Fix a spurious `.as_ref()` in the `sigprocmask`.

### DIFF
--- a/src/backend/linux_raw/runtime/syscalls.rs
+++ b/src/backend/linux_raw/runtime/syscalls.rs
@@ -146,7 +146,7 @@ pub(crate) unsafe fn tkill(tid: Pid, sig: Signal) -> io::Result<()> {
 #[inline]
 pub(crate) unsafe fn sigprocmask(how: How, new: Option<&Sigset>) -> io::Result<Sigset> {
     let mut old = MaybeUninit::<Sigset>::uninit();
-    let new = optional_as_ptr(new.as_ref());
+    let new = optional_as_ptr(new);
     ret(syscall!(
         __NR_rt_sigprocmask,
         how,


### PR DESCRIPTION
`sigprocmask` is in the undocumented experimental `runtime` API.