### PR TITLE
Add `ioctl` cargo feature for `linux-raw-sys` ...

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ libc = { version = "0.2.142", features = ["extra_traits"] }
 # Some syscalls do not have libc wrappers, such as in `io_uring`. For these,
 # the libc backend uses the linux-raw-sys ABI and `libc::syscall`.
 [target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64"))))))))'.dependencies]
-linux-raw-sys = { version = "0.3.6", default-features = false, features = ["general", "no_std"] }
+linux-raw-sys = { version = "0.3.6", default-features = false, features = ["general", "ioctl", "no_std"] }
 
 # For the libc backend on Windows, use the Winsock2 API in windows-sys.
 [target.'cfg(windows)'.dependencies.windows-sys]


### PR DESCRIPTION
... when using `libc` backend.

May fix issue described in https://github.com/bytecodealliance/rustix/pull/637#issuecomment-1528848589 and [CI errors for `nix`](https://github.com/nix-rust/nix/pull/2029/checks?check_run_id=13122856368) under some Linux and Android targets, when using `rustix` `>=0.37.16`. (Tested locally, it does fix `nix`'s test build errors on `mips-unknown-linux-gnu`)