### PR TITLE
Fix building under miri and other use-libc configurations.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,7 +155,9 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
     - run: cargo check --workspace --release --no-default-features -vv
+    - run: cargo check --workspace --release --no-default-features --features use-libc -vv
     - run: cargo check --workspace --release --no-default-features --features all-apis -vv
+    - run: cargo check --workspace --release --no-default-features --features all-apis,use-libc -vv
 
   check_nightly:
     name: Check nightly-only targets

--- a/src/backend/libc/fs/dir.rs
+++ b/src/backend/libc/fs/dir.rs
@@ -19,7 +19,6 @@ use crate::fs::{fstatvfs, StatVfs};
 use crate::io;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 use crate::process::fchdir;
-#[cfg(target_os = "wasi")]
 use alloc::borrow::ToOwned;
 #[cfg(not(linux_like))]
 use c::readdir as libc_readdir;


### PR DESCRIPTION
The main fix here is obviated by #645, so this now just contains a fix for default-features = false with the libc backend.