### PR TITLE
Fix no-std builds for MacOS and BSDs

### DIFF
--- a/src/net/send_recv/msg.rs
+++ b/src/net/send_recv/msg.rs
@@ -168,14 +168,12 @@ impl<'buf, 'slice, 'fd> SendAncillaryBuffer<'buf, 'slice, 'fd> {
         self.length = new_length;
 
         // Get the last header in the buffer.
-        let mut last_header = leap!(messages::Messages::new(buffer).last());
+        let last_header = leap!(messages::Messages::new(buffer).last());
 
         // Set the header fields.
-        unsafe {
-            last_header.cmsg_len = c::CMSG_LEN(source_len) as _;
-            last_header.cmsg_level = cmsg_level;
-            last_header.cmsg_type = cmsg_type;
-        }
+        last_header.cmsg_len = unsafe { c::CMSG_LEN(source_len) } as _;
+        last_header.cmsg_level = cmsg_level;
+        last_header.cmsg_type = cmsg_type;
 
         // Get the pointer to the payload and copy the data.
         unsafe {

--- a/src/process/procctl.rs
+++ b/src/process/procctl.rs
@@ -5,6 +5,7 @@
 
 #![allow(unsafe_code)]
 
+use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 use core::ptr;
 
@@ -329,7 +330,7 @@ pub fn get_reaper_pids(process: ProcSelector) -> io::Result<Vec<PidInfo>> {
     // Sadly no better way to guarantee that we get all the results than to
     // allocate ~8MB of memory..
     const PID_MAX: usize = 99999;
-    let mut pids: Vec<procctl_reaper_pidinfo> = vec![Default::default(); PID_MAX];
+    let mut pids: Vec<procctl_reaper_pidinfo> = alloc::vec![Default::default(); PID_MAX];
     let mut pinfo = procctl_reaper_pids {
         rp_count: PID_MAX as _,
         rp_pad0: [0; 15],

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -256,7 +256,7 @@ pub enum WaitId<'a> {
     /// Eat the lifetime for non-Linux platforms.
     #[doc(hidden)]
     #[cfg(not(target_os = "linux"))]
-    __EatLifetime(std::marker::PhantomData<&'a ()>),
+    __EatLifetime(core::marker::PhantomData<&'a ()>),
     // TODO(notgull): Once this crate has the concept of PGIDs, add a WaitId::Pgid
 }
 


### PR DESCRIPTION
Now to my knowledge all targets except windows compile fine for no-std again.