### PR TITLE
Make `linkat`, `unlinkat`, and `renameat` weak on macos.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -536,6 +536,8 @@ jobs:
         cargo test --verbose --features=all-impls,all-apis,cc --release --workspace -- --nocapture
       env:
         RUST_BACKTRACE: full
+        MACOSX_DEPLOYMENT_TARGET: 10.7
+        MACOSX_SDK_VERSION: 10.7
       if: matrix.rust != '1.48'
 
     - run: |
@@ -545,6 +547,8 @@ jobs:
         cargo test --verbose --features=fs-err,all-apis,cc --release --workspace -- --nocapture
       env:
         RUST_BACKTRACE: full
+        MACOSX_DEPLOYMENT_TARGET: 10.7
+        MACOSX_SDK_VERSION: 10.7
       if: matrix.rust == '1.48'
 
     - run: |
@@ -552,6 +556,8 @@ jobs:
         cargo check --features=all-impls,all-apis,cc
       env:
         RUST_BACKTRACE: full
+        MACOSX_DEPLOYMENT_TARGET: 10.7
+        MACOSX_SDK_VERSION: 10.7
       if: matrix.rust != '1.48'
 
     - run: |
@@ -561,6 +567,8 @@ jobs:
         cargo check --features=fs-err,all-apis,cc
       env:
         RUST_BACKTRACE: full
+        MACOSX_DEPLOYMENT_TARGET: 10.7
+        MACOSX_SDK_VERSION: 10.7
       if: matrix.rust == '1.48'
 
   test_use_libc:

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -254,22 +254,33 @@ pub(crate) fn linkat(
     // macOS <= 10.9 lacks `linkat`.
     #[cfg(target_os = "macos")]
     unsafe {
-        syscall! {
+        weak! {
             fn linkat(
-                olddirfd: c::c_int,
-                oldpath: *const c::c_char,
-                newdirfd: c::c_int,
-                newpath: *const c::c_char,
-                flags: c::c_int
-            ) via SYS_linkat -> c::c_int
+                c::c_int,
+                *const c::c_char,
+                c::c_int,
+                *const c::c_char,
+                c::c_int
+            ) -> c::c_int
         }
-        ret(linkat(
-            borrowed_fd(old_dirfd),
-            c_str(old_path),
-            borrowed_fd(new_dirfd),
-            c_str(new_path),
-            flags.bits(),
-        ))
+        // If we have `linkat`, use it.
+        if let Some(libc_linkat) = linkat.get() {
+            return ret(libc_linkat(
+                borrowed_fd(old_dirfd),
+                c_str(old_path),
+                borrowed_fd(new_dirfd),
+                c_str(new_path),
+                flags.bits(),
+            ));
+        }
+        // Otherwise, see if we can emulate the `AT_FDCWD` case.
+        if borrowed_fd(old_dirfd) != c::AT_FDCWD || borrowed_fd(new_dirfd) != c::AT_FDCWD {
+            return Err(io::Errno::NOSYS);
+        }
+        if !flags.is_empty() {
+            return Err(io::Errno::INVAL);
+        }
+        ret(c::link(c_str(old_path), c_str(new_path)))
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -289,14 +300,29 @@ pub(crate) fn unlinkat(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io
     // macOS <= 10.9 lacks `unlinkat`.
     #[cfg(target_os = "macos")]
     unsafe {
-        syscall! {
+        weak! {
             fn unlinkat(
-                dirfd: c::c_int,
-                pathname: *const c::c_char,
-                flags: c::c_int
-            ) via SYS_unlinkat -> c::c_int
+                c::c_int,
+                *const c::c_char,
+                c::c_int
+            ) -> c::c_int
         }
-        ret(unlinkat(borrowed_fd(dirfd), c_str(path), flags.bits()))
+        // If we have `unlinkat`, use it.
+        if let Some(libc_unlinkat) = unlinkat.get() {
+            return ret(libc_unlinkat(borrowed_fd(dirfd), c_str(path), flags.bits()));
+        }
+        // Otherwise, see if we can emulate the `AT_FDCWD` case.
+        if borrowed_fd(dirfd) != c::AT_FDCWD {
+            return Err(io::Errno::NOSYS);
+        }
+        if flags.intersects(!AtFlags::REMOVEDIR) {
+            return Err(io::Errno::INVAL);
+        }
+        if flags.contains(AtFlags::REMOVEDIR) {
+            ret(c::rmdir(c_str(path)))
+        } else {
+            ret(c::unlink(c_str(path)))
+        }
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -315,20 +341,28 @@ pub(crate) fn renameat(
     // macOS <= 10.9 lacks `renameat`.
     #[cfg(target_os = "macos")]
     unsafe {
-        syscall! {
+        weak! {
             fn renameat(
-                olddirfd: c::c_int,
-                oldpath: *const c::c_char,
-                newdirfd: c::c_int,
-                newpath: *const c::c_char
-            ) via SYS_linkat -> c::c_int
+                c::c_int,
+                *const c::c_char,
+                c::c_int,
+                *const c::c_char
+            ) -> c::c_int
         }
-        ret(renameat(
-            borrowed_fd(old_dirfd),
-            c_str(old_path),
-            borrowed_fd(new_dirfd),
-            c_str(new_path),
-        ))
+        // If we have `renameat`, use it.
+        if let Some(libc_renameat) = renameat.get() {
+            return ret(libc_renameat(
+                borrowed_fd(old_dirfd),
+                c_str(old_path),
+                borrowed_fd(new_dirfd),
+                c_str(new_path),
+            ));
+        }
+        // Otherwise, see if we can emulate the `AT_FDCWD` case.
+        if borrowed_fd(old_dirfd) != c::AT_FDCWD || borrowed_fd(new_dirfd) != c::AT_FDCWD {
+            return Err(io::Errno::NOSYS);
+        }
+        ret(c::rename(c_str(old_path), c_str(new_path)))
     }
 
     #[cfg(not(target_os = "macos"))]

--- a/tests/fs/chmodat.rs
+++ b/tests/fs/chmodat.rs
@@ -1,0 +1,54 @@
+#[cfg(not(target_os = "wasi"))]
+#[test]
+fn test_chmodat() {
+    use rustix::fs::{chmodat, cwd, openat, statat, AtFlags, Mode, OFlags};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::RWXU).unwrap();
+
+    let _ = openat(&dir, "foo", OFlags::CREATE | OFlags::WRONLY, Mode::RWXU).unwrap();
+
+    let before = statat(&dir, "foo", AtFlags::empty()).unwrap();
+    assert_ne!(before.st_mode as u64 & libc::S_IRWXU as u64, 0);
+
+    chmodat(&dir, "foo", Mode::empty()).unwrap();
+
+    let after = statat(&dir, "foo", AtFlags::empty()).unwrap();
+    assert_eq!(after.st_mode as u64 & libc::S_IRWXU as u64, 0);
+
+    chmodat(&dir, "foo", Mode::RWXU).unwrap();
+
+    let reverted = statat(&dir, "foo", AtFlags::empty()).unwrap();
+    assert_ne!(reverted.st_mode as u64 & libc::S_IRWXU as u64, 0);
+}
+
+#[cfg(not(target_os = "wasi"))]
+#[test]
+fn test_chmodat_with() {
+    use rustix::fs::{chmodat_with, cwd, openat, statat, symlinkat, AtFlags, Mode, OFlags};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::RWXU).unwrap();
+
+    let _ = openat(&dir, "foo", OFlags::CREATE | OFlags::WRONLY, Mode::RWXU).unwrap();
+    symlinkat("foo", &dir, "link").unwrap();
+
+    match chmodat_with(&dir, "link", Mode::empty(), AtFlags::SYMLINK_NOFOLLOW) {
+        Ok(()) => (),
+        Err(rustix::io::Errno::OPNOTSUPP) => return,
+        Err(e) => Err(e).unwrap(),
+    }
+
+    let before = statat(&dir, "foo", AtFlags::empty()).unwrap();
+    assert_ne!(before.st_mode as u64 & libc::S_IRWXU as u64, 0);
+
+    chmodat_with(&dir, "foo", Mode::empty(), AtFlags::empty()).unwrap();
+
+    let after = statat(&dir, "foo", AtFlags::empty()).unwrap();
+    assert_eq!(after.st_mode as u64 & libc::S_IRWXU as u64, 0);
+
+    chmodat_with(&dir, "foo", Mode::RWXU, AtFlags::empty()).unwrap();
+
+    let reverted = statat(&dir, "foo", AtFlags::empty()).unwrap();
+    assert_ne!(reverted.st_mode as u64 & libc::S_IRWXU as u64, 0);
+}

--- a/tests/fs/linkat.rs
+++ b/tests/fs/linkat.rs
@@ -1,0 +1,26 @@
+#[test]
+fn test_linkat() {
+    use rustix::fs::{cwd, linkat, openat, readlinkat, statat, AtFlags, Mode, OFlags};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+
+    let _ = openat(&dir, "foo", OFlags::CREATE | OFlags::WRONLY, Mode::RUSR).unwrap();
+
+    linkat(&dir, "foo", &dir, "link", AtFlags::empty()).unwrap();
+
+    readlinkat(&dir, "foo", Vec::new()).unwrap_err();
+    readlinkat(&dir, "link", Vec::new()).unwrap_err();
+
+    assert_eq!(
+        statat(&dir, "foo", AtFlags::empty()).unwrap().st_ino,
+        statat(&dir, "link", AtFlags::empty()).unwrap().st_ino
+    );
+
+    linkat(&dir, "link", &dir, "another", AtFlags::empty()).unwrap();
+
+    assert_eq!(
+        statat(&dir, "foo", AtFlags::empty()).unwrap().st_ino,
+        statat(&dir, "another", AtFlags::empty()).unwrap().st_ino
+    );
+}

--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -5,6 +5,7 @@
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 #![cfg_attr(core_c_str, feature(core_c_str))]
 
+mod chmodat;
 mod cwd;
 mod dir;
 mod fcntl;
@@ -20,6 +21,7 @@ mod file;
 mod flock;
 mod futimens;
 mod invalid_offset;
+mod linkat;
 mod long_paths;
 #[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 mod makedev;
@@ -31,11 +33,13 @@ mod openat;
 mod openat2;
 #[cfg(not(target_os = "redox"))]
 mod readdir;
+mod readlinkat;
 mod renameat;
 #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 mod statfs;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod statx;
+mod symlinkat;
 #[cfg(not(any(solarish, target_os = "redox", target_os = "wasi")))]
 mod sync;
 mod utimensat;

--- a/tests/fs/mkdirat.rs
+++ b/tests/fs/mkdirat.rs
@@ -1,7 +1,9 @@
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[test]
 fn test_mkdirat() {
-    use rustix::fs::{cwd, mkdirat, openat, statat, unlinkat, AtFlags, FileType, Mode, OFlags};
+    use rustix::fs::{
+        accessat, cwd, mkdirat, openat, statat, unlinkat, Access, AtFlags, FileType, Mode, OFlags,
+    };
 
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
@@ -9,13 +11,19 @@ fn test_mkdirat() {
     mkdirat(&dir, "foo", Mode::RWXU).unwrap();
     let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();
     assert_eq!(FileType::from_raw_mode(stat.st_mode), FileType::Directory);
+    accessat(&dir, "foo", Access::READ_OK, AtFlags::empty()).unwrap();
+    accessat(&dir, "foo", Access::WRITE_OK, AtFlags::empty()).unwrap();
+    accessat(&dir, "foo", Access::EXEC_OK, AtFlags::empty()).unwrap();
+    accessat(&dir, "foo", Access::EXISTS, AtFlags::empty()).unwrap();
     unlinkat(&dir, "foo", AtFlags::REMOVEDIR).unwrap();
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[test]
 fn test_mkdirat_with_o_path() {
-    use rustix::fs::{cwd, mkdirat, openat, statat, unlinkat, AtFlags, FileType, Mode, OFlags};
+    use rustix::fs::{
+        accessat, cwd, mkdirat, openat, statat, unlinkat, Access, AtFlags, FileType, Mode, OFlags,
+    };
 
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(
@@ -29,5 +37,6 @@ fn test_mkdirat_with_o_path() {
     mkdirat(&dir, "foo", Mode::RWXU).unwrap();
     let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();
     assert_eq!(FileType::from_raw_mode(stat.st_mode), FileType::Directory);
+    accessat(&dir, "foo", Access::EXISTS, AtFlags::empty()).unwrap();
     unlinkat(&dir, "foo", AtFlags::REMOVEDIR).unwrap();
 }

--- a/tests/fs/mknodat.rs
+++ b/tests/fs/mknodat.rs
@@ -1,7 +1,9 @@
 #[cfg(not(any(apple, target_os = "redox", target_os = "wasi")))]
 #[test]
 fn test_mknodat() {
-    use rustix::fs::{cwd, mknodat, openat, statat, unlinkat, AtFlags, FileType, Mode, OFlags};
+    use rustix::fs::{
+        accessat, cwd, mknodat, openat, statat, unlinkat, Access, AtFlags, FileType, Mode, OFlags,
+    };
 
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
@@ -18,5 +20,6 @@ fn test_mknodat() {
     mknodat(&dir, "foo", FileType::Fifo, Mode::empty(), 0).unwrap();
     let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();
     assert_eq!(FileType::from_raw_mode(stat.st_mode), FileType::Fifo);
+    accessat(&dir, "foo", Access::EXISTS, AtFlags::empty()).unwrap();
     unlinkat(&dir, "foo", AtFlags::empty()).unwrap();
 }

--- a/tests/fs/readlinkat.rs
+++ b/tests/fs/readlinkat.rs
@@ -1,0 +1,23 @@
+#[test]
+fn test_readlinkat() {
+    use rustix::fs::{cwd, openat, readlinkat, symlinkat, Mode, OFlags};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+
+    let _ = openat(&dir, "foo", OFlags::CREATE | OFlags::WRONLY, Mode::RUSR).unwrap();
+    symlinkat("foo", &dir, "link").unwrap();
+
+    readlinkat(&dir, "absent", Vec::new()).unwrap_err();
+    readlinkat(&dir, "foo", Vec::new()).unwrap_err();
+
+    let target = readlinkat(&dir, "link", Vec::new()).unwrap();
+    assert_eq!(target.to_string_lossy(), "foo");
+
+    symlinkat("link", &dir, "another").unwrap();
+
+    let target = readlinkat(&dir, "link", Vec::new()).unwrap();
+    assert_eq!(target.to_string_lossy(), "foo");
+    let target = readlinkat(&dir, "another", Vec::new()).unwrap();
+    assert_eq!(target.to_string_lossy(), "link");
+}

--- a/tests/fs/symlinkat.rs
+++ b/tests/fs/symlinkat.rs
@@ -1,0 +1,21 @@
+#[test]
+fn test_symlinkat() {
+    use rustix::fs::{cwd, openat, readlinkat, statat, symlinkat, AtFlags, Mode, OFlags};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = openat(cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+
+    let _ = openat(&dir, "foo", OFlags::CREATE | OFlags::WRONLY, Mode::RUSR).unwrap();
+    symlinkat("foo", &dir, "link").unwrap();
+
+    let target = readlinkat(&dir, "link", Vec::new()).unwrap();
+    assert_eq!(target.to_string_lossy(), "foo");
+
+    assert_eq!(
+        statat(&dir, "link", AtFlags::SYMLINK_NOFOLLOW)
+            .unwrap()
+            .st_mode as u64
+            & libc::S_IFMT as u64,
+        libc::S_IFLNK as u64
+    );
+}


### PR DESCRIPTION
macOS <= 10.9 lacks these functions, so use weak symbols for them.

Fixes #648.