### PR TITLE
Update bitflags dependency to 2.2.1.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, nightly, 1.48]
+        build: [stable, nightly, 1.56]
         include:
           - build: stable
             os: ubuntu-latest
@@ -33,9 +33,9 @@ jobs:
           - build: nightly
             os: ubuntu-latest
             rust: nightly
-          - build: 1.48
+          - build: 1.56
             os: ubuntu-latest
-            rust: 1.48
+            rust: 1.56
 
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.
@@ -227,7 +227,7 @@ jobs:
       QEMU_BUILD_VERSION: 7.0.0
     strategy:
       matrix:
-        build: [ubuntu, ubuntu-20.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, ubuntu-1.48, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, mipsel-linux-stable, mips64el-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.48, i686-linux-1.48, aarch64-linux-1.48, riscv64-linux-1.48, s390x-linux-1.48, mipsel-linux-1.48, mips64el-linux-1.48, powerpc64le-linux-1.48, arm-linux-1.48, macos-latest, macos-11, windows, windows-2019]
+        build: [ubuntu, ubuntu-20.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, ubuntu-1.56, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, mipsel-linux-stable, mips64el-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.56, i686-linux-1.56, aarch64-linux-1.56, riscv64-linux-1.56, s390x-linux-1.56, mipsel-linux-1.56, mips64el-linux-1.56, powerpc64le-linux-1.56, arm-linux-1.56, macos-latest, macos-11, windows, windows-2019]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -378,73 +378,73 @@ jobs:
             qemu: qemu-arm
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
-          - build: ubuntu-1.48
+          - build: ubuntu-1.56
             os: ubuntu-latest
-            rust: 1.48
-          - build: i686-linux-1.48
+            rust: 1.56
+          - build: i686-linux-1.56
             os: ubuntu-latest
-            rust: 1.48
+            rust: 1.56
             target: i686-unknown-linux-gnu
             gcc_package: gcc-i686-linux-gnu
             gcc: i686-linux-gnu-gcc
             libc_package: libc-dev-i386-cross
-          - build: aarch64-linux-1.48
+          - build: aarch64-linux-1.56
             os: ubuntu-latest
-            rust: 1.48
+            rust: 1.56
             target: aarch64-unknown-linux-gnu
             gcc_package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
             qemu: qemu-aarch64
             qemu_args: -L /usr/aarch64-linux-gnu
             qemu_target: aarch64-linux-user
-          - build: riscv64-linux-1.48
+          - build: riscv64-linux-1.56
             os: ubuntu-latest
-            rust: 1.48
+            rust: 1.56
             target: riscv64gc-unknown-linux-gnu
             gcc_package: gcc-riscv64-linux-gnu
             gcc: riscv64-linux-gnu-gcc
             qemu: qemu-riscv64
             qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
-          - build: s390x-linux-1.48
+          - build: s390x-linux-1.56
             os: ubuntu-latest
-            rust: 1.48
+            rust: 1.56
             target: s390x-unknown-linux-gnu
             gcc_package: gcc-s390x-linux-gnu
             gcc: s390x-linux-gnu-gcc
             qemu: qemu-s390x
             qemu_args: -L /usr/s390x-linux-gnu
             qemu_target: s390x-linux-user
-          - build: powerpc64le-linux-1.48
+          - build: powerpc64le-linux-1.56
             os: ubuntu-latest
-            rust: 1.48
+            rust: 1.56
             target: powerpc64le-unknown-linux-gnu
             gcc_package: gcc-powerpc64le-linux-gnu
             gcc: powerpc64le-linux-gnu-gcc
             qemu: qemu-ppc64le
             qemu_args: -L /usr/powerpc64le-linux-gnu
             qemu_target: ppc64le-linux-user
-          - build: mips64el-linux-1.48
+          - build: mips64el-linux-1.56
             os: ubuntu-latest
-            rust: 1.48
+            rust: 1.56
             target: mips64el-unknown-linux-gnuabi64
             gcc_package: gcc-mips64el-linux-gnuabi64
             gcc: mips64el-linux-gnuabi64-gcc
             qemu: qemu-mips64el
             qemu_args: -L /usr/mips64el-linux-gnuabi64
             qemu_target: mips64el-linux-user
-          - build: mipsel-linux-1.48
+          - build: mipsel-linux-1.56
             os: ubuntu-latest
-            rust: 1.48
+            rust: 1.56
             target: mipsel-unknown-linux-gnu
             gcc_package: gcc-mipsel-linux-gnu
             gcc: mipsel-linux-gnu-gcc
             qemu: qemu-mipsel
             qemu_args: -L /usr/mipsel-linux-gnu
             qemu_target: mipsel-linux-user
-          - build: arm-linux-1.48
+          - build: arm-linux-1.56
             os: ubuntu-latest
-            rust: 1.48
+            rust: 1.56
             target: armv5te-unknown-linux-gnueabi
             gcc_package: gcc-arm-linux-gnueabi
             gcc: arm-linux-gnueabi-gcc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.48"
 cc = { version = "1.0.68", optional = true }
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "2.2.1"
 itoa = { version = "1.0.1", default-features = false, optional = true }
 io-lifetimes = { version = "1.0.10", default-features = false, features = ["close"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 keywords = ["api", "file", "network", "safe", "syscall"]
 categories = ["os::unix-apis", "date-and-time", "filesystem", "network-programming"]
 include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md", "benches"]
-rust-version = "1.48"
+rust-version = "1.56"
 
 [build-dependencies]
 cc = { version = "1.0.68", optional = true }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ portable APIs built on this functionality, see the [`cap-std`], [`memfd`],
 
  * linux_raw, which uses raw Linux system calls and vDSO calls, and is
    supported on Linux on x86-64, x86, aarch64, riscv64gc, powerpc64le,
-   arm (v5 onwards), mipsel, and mips64el, with stable, nightly, and 1.48 Rust.
+   arm (v5 onwards), mipsel, and mips64el, with stable, nightly, and 1.56 Rust.
     - By being implemented entirely in Rust, avoiding `libc`, `errno`, and pthread
       cancellation, and employing some specialized optimizations, most functions
       compile down to very efficient code, which can often be fully inlined into
@@ -111,7 +111,7 @@ features for `rustix`.
 
 `rustix` has its own code for making direct syscalls, similar to the [`sc`] and
 [`scall`] crates, though `rustix` can use either the Rust `asm!` macro or
-out-of-line `.s` files so it supports Rust versions from 1.48 through Nightly.
+out-of-line `.s` files so it supports Rust versions from 1.56 through Nightly.
 `rustix` can also use Linux's vDSO mechanism to optimize Linux `clock_gettime`
 on all architectures, and all Linux system calls on x86. And `rustix`'s
 syscalls report errors using an optimized `Errno` type.

--- a/src/backend/libc/fs/inotify.rs
+++ b/src/backend/libc/fs/inotify.rs
@@ -10,6 +10,8 @@ bitflags! {
     /// `IN_*` for use with [`inotify_init`].
     ///
     /// [`inotify_init`]: crate::fs::inotify::inotify_init
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct CreateFlags: c::c_int {
         /// `IN_CLOEXEC`
         const CLOEXEC = c::IN_CLOEXEC;
@@ -22,7 +24,8 @@ bitflags! {
     /// `IN*` for use with [`inotify_add_watch`].
     ///
     /// [`inotify_add_watch`]: crate::fs::inotify::inotify_add_watch
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct WatchFlags: u32 {
         /// `IN_ACCESS`
         const ACCESS = c::IN_ACCESS;

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -840,7 +840,7 @@ pub(crate) fn fcntl_setfl(fd: BorrowedFd<'_>, flags: OFlags) -> io::Result<()> {
 pub(crate) fn fcntl_get_seals(fd: BorrowedFd<'_>) -> io::Result<SealFlags> {
     unsafe {
         ret_c_int(c::fcntl(borrowed_fd(fd), c::F_GET_SEALS))
-            .map(|flags| SealFlags::from_bits_unchecked(flags))
+            .map(|flags| SealFlags::from_bits_retain(flags))
     }
 }
 
@@ -1054,7 +1054,7 @@ fn libc_statvfs_to_statvfs(from: libc_statvfs) -> StatVfs {
         f_ffree: from.f_ffree as u64,
         f_favail: from.f_ffree as u64,
         f_fsid: from.f_fsid as u64,
-        f_flag: unsafe { StatVfsMountFlags::from_bits_unchecked(from.f_flag as u64) },
+        f_flag: StatVfsMountFlags::from_bits_retain(from.f_flag as u64),
         f_namemax: from.f_namemax as u64,
     }
 }

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -5,6 +5,8 @@ bitflags! {
     /// `*_OK` constants for use with [`accessat`].
     ///
     /// [`accessat`]: fn.accessat.html
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct Access: c::c_int {
         /// `R_OK`
         const READ_OK = c::R_OK;
@@ -27,6 +29,8 @@ bitflags! {
     ///
     /// [`openat`]: crate::fs::openat
     /// [`statat`]: crate::fs::statat
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct AtFlags: c::c_int {
         /// `AT_REMOVEDIR`
         const REMOVEDIR = c::AT_REMOVEDIR;
@@ -74,6 +78,8 @@ bitflags! {
     /// [`openat`]: crate::fs::openat
     /// [`chmodat`]: crate::fs::chmodat
     /// [`fchmod`]: crate::fs::fchmod
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct Mode: RawMode {
         /// `S_IRWXU`
         #[cfg(not(target_os = "wasi"))] // WASI doesn't have Unix-style mode flags.
@@ -182,6 +188,8 @@ bitflags! {
     /// `O_*` constants for use with [`openat`].
     ///
     /// [`openat`]: crate::fs::openat
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct OFlags: c::c_int {
         /// `O_ACCMODE`
         const ACCMODE = c::O_ACCMODE;
@@ -312,6 +320,8 @@ bitflags! {
     /// `CLONE_*` constants for use with [`fclonefileat`].
     ///
     /// [`fclonefileat`]: crate::fs::fclonefileat
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct CloneFlags: c::c_int {
         /// `CLONE_NOFOLLOW`
         const NOFOLLOW = 1;
@@ -337,6 +347,8 @@ bitflags! {
     /// `COPYFILE_*` constants for use with [`fcopyfile`].
     ///
     /// [`fcopyfile`]: crate::fs::fcopyfile
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct CopyfileFlags: c::c_uint {
         /// `COPYFILE_ACL`
         const ACL = copyfile::ACL;
@@ -366,7 +378,8 @@ bitflags! {
     /// `RESOLVE_*` constants for use with [`openat2`].
     ///
     /// [`openat2`]: crate::fs::openat2
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct ResolveFlags: u64 {
         /// `RESOLVE_NO_XDEV`
         const NO_XDEV = 0x01;
@@ -393,6 +406,8 @@ bitflags! {
     /// `RENAME_*` constants for use with [`renameat_with`].
     ///
     /// [`renameat_with`]: crate::fs::renameat_with
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct RenameFlags: c::c_uint {
         /// `RENAME_EXCHANGE`
         const EXCHANGE = c::RENAME_EXCHANGE as _;
@@ -533,6 +548,8 @@ bitflags! {
     /// `MFD_*` constants for use with [`memfd_create`].
     ///
     /// [`memfd_create`]: crate::fs::memfd_create
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MemfdFlags: c::c_uint {
         /// `MFD_CLOEXEC`
         const CLOEXEC = c::MFD_CLOEXEC;
@@ -582,6 +599,8 @@ bitflags! {
     ///
     /// [`fcntl_add_seals`]: crate::fs::fcntl_add_seals
     /// [`fcntl_get_seals`]: crate::fs::fcntl_get_seals
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct SealFlags: i32 {
        /// `F_SEAL_SEAL`.
        const SEAL = c::F_SEAL_SEAL;
@@ -602,6 +621,8 @@ bitflags! {
     /// `STATX_*` constants for use with [`statx`].
     ///
     /// [`statx`]: crate::fs::statx
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct StatxFlags: u32 {
         /// `STATX_TYPE`
         const TYPE = c::STATX_TYPE;
@@ -658,6 +679,8 @@ bitflags! {
     /// `STATX_*` constants for use with [`statx`].
     ///
     /// [`statx`]: crate::fs::statx
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct StatxFlags: u32 {
         /// `STATX_TYPE`
         const TYPE = 0x0001;
@@ -711,6 +734,8 @@ bitflags! {
     /// `FALLOC_FL_*` constants for use with [`fallocate`].
     ///
     /// [`fallocate`]: crate::fs::fallocate
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct FallocateFlags: i32 {
         /// `FALLOC_FL_KEEP_SIZE`
         #[cfg(not(any(
@@ -781,6 +806,8 @@ bitflags! {
 #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 bitflags! {
     /// `ST_*` constants for use with [`StatVfs`].
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct StatVfsMountFlags: u64 {
         /// `ST_MANDLOCK`
         #[cfg(any(target_os = "android", target_os = "emscripten", target_os = "fuchsia", target_os = "linux"))]
@@ -1058,6 +1085,8 @@ bitflags! {
     /// `MS_*` constants for use with [`mount`].
     ///
     /// [`mount`]: crate::fs::mount
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MountFlags: c::c_ulong {
         /// `MS_BIND`
         const BIND = c::MS_BIND;
@@ -1112,6 +1141,8 @@ bitflags! {
     /// `MS_*` constants for use with [`change_mount`].
     ///
     /// [`change_mount`]: crate::fs::mount::change_mount
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MountPropagationFlags: c::c_ulong {
         /// `MS_SHARED`
         const SHARED = c::MS_SHARED;
@@ -1128,6 +1159,8 @@ bitflags! {
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 bitflags! {
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub(crate) struct InternalMountFlags: c::c_ulong {
         const REMOUNT = c::MS_REMOUNT;
         const MOVE = c::MS_MOVE;

--- a/src/backend/libc/io/epoll.rs
+++ b/src/backend/libc/io/epoll.rs
@@ -79,6 +79,8 @@ use core::ptr::null_mut;
 
 bitflags! {
     /// `EPOLL_*` for use with [`Epoll::new`].
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct CreateFlags: c::c_int {
         /// `EPOLL_CLOEXEC`
         const CLOEXEC = c::EPOLL_CLOEXEC;
@@ -87,7 +89,8 @@ bitflags! {
 
 bitflags! {
     /// `EPOLL*` for use with [`Epoll::add`].
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct EventFlags: u32 {
         /// `EPOLLIN`
         const IN = c::EPOLLIN as u32;

--- a/src/backend/libc/io/poll_fd.rs
+++ b/src/backend/libc/io/poll_fd.rs
@@ -12,6 +12,8 @@ bitflags! {
     /// `POLL*` flags for use with [`poll`].
     ///
     /// [`poll`]: crate::io::poll
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct PollFlags: c::c_short {
         /// `POLLIN`
         const IN = c::POLLIN;

--- a/src/backend/libc/io/types.rs
+++ b/src/backend/libc/io/types.rs
@@ -8,6 +8,8 @@ bitflags! {
     ///
     /// [`fcntl_getfd`]: crate::io::fcntl_getfd
     /// [`fcntl_setfd`]: crate::io::fcntl_setfd
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct FdFlags: c::c_int {
         /// `FD_CLOEXEC`
         const CLOEXEC = c::FD_CLOEXEC;
@@ -20,6 +22,8 @@ bitflags! {
     ///
     /// [`preadv2`]: crate::io::preadv2
     /// [`pwritev2`]: crate::io::pwritev
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct ReadWriteFlags: c::c_int {
         /// `RWF_DSYNC` (since Linux 4.7)
         const DSYNC = linux_raw_sys::general::RWF_DSYNC as c::c_int;
@@ -37,6 +41,8 @@ bitflags! {
 #[cfg(any(target_os = "android", target_os = "linux"))]
 bitflags! {
     /// `SPLICE_F_*` constants for use with [`splice`] and [`vmsplice`].
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct SpliceFlags: c::c_uint {
         /// `SPLICE_F_MOVE`
         const MOVE = c::SPLICE_F_MOVE;
@@ -54,6 +60,8 @@ bitflags! {
     /// `O_*` constants for use with [`dup2`].
     ///
     /// [`dup2`]: crate::io::dup2
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct DupFlags: c::c_int {
         /// `O_CLOEXEC`
         #[cfg(not(any(
@@ -71,6 +79,8 @@ bitflags! {
     /// `O_*` constants for use with [`pipe_with`].
     ///
     /// [`pipe_with`]: crate::io::pipe_with
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct PipeFlags: c::c_int {
         /// `O_CLOEXEC`
         const CLOEXEC = c::O_CLOEXEC;
@@ -97,6 +107,8 @@ bitflags! {
     /// `EFD_*` flags for use with [`eventfd`].
     ///
     /// [`eventfd`]: crate::io::eventfd
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct EventfdFlags: c::c_int {
         /// `EFD_CLOEXEC`
         const CLOEXEC = c::EFD_CLOEXEC;

--- a/src/backend/libc/mm/types.rs
+++ b/src/backend/libc/mm/types.rs
@@ -7,6 +7,8 @@ bitflags! {
     /// For `PROT_NONE`, use `ProtFlags::empty()`.
     ///
     /// [`mmap`]: crate::io::mmap
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct ProtFlags: c::c_int {
         /// `PROT_READ`
         const READ = c::PROT_READ;
@@ -23,6 +25,8 @@ bitflags! {
     /// For `PROT_NONE`, use `MprotectFlags::empty()`.
     ///
     /// [`mprotect`]: crate::io::mprotect
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MprotectFlags: c::c_int {
         /// `PROT_READ`
         const READ = c::PROT_READ;
@@ -46,6 +50,8 @@ bitflags! {
     ///
     /// [`mmap`]: crate::io::mmap
     /// [`mmap_anonymous`]: crates::io::mmap_anonymous
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MapFlags: c::c_int {
         /// `MAP_SHARED`
         const SHARED = c::MAP_SHARED;
@@ -188,6 +194,8 @@ bitflags! {
     ///
     /// [`mremap`]: crate::io::mremap
     /// [`mremap_fixed`]: crate::io::mremap_fixed
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MremapFlags: i32 {
         /// `MREMAP_MAYMOVE`
         const MAYMOVE = c::MREMAP_MAYMOVE;
@@ -198,6 +206,8 @@ bitflags! {
     /// `MS_*` flags for use with [`msync`].
     ///
     /// [`msync`]: crate::io::msync
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MsyncFlags: i32 {
         /// `MS_SYNC`—Requests an update and waits for it to complete.
         const SYNC = c::MS_SYNC;
@@ -216,6 +226,8 @@ bitflags! {
     /// `MLOCK_*` flags for use with [`mlock_with`].
     ///
     /// [`mlock_with`]: crate::io::mlock_with
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MlockFlags: i32 {
         /// `MLOCK_ONFAULT`
         const ONFAULT = c::MLOCK_ONFAULT as _;
@@ -357,6 +369,8 @@ bitflags! {
     /// `O_*` flags for use with [`userfaultfd`].
     ///
     /// [`userfaultfd`]: crate::io::userfaultfd
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct UserfaultfdFlags: c::c_int {
         /// `O_CLOEXEC`
         const CLOEXEC = c::O_CLOEXEC;

--- a/src/backend/libc/net/send_recv.rs
+++ b/src/backend/libc/net/send_recv.rs
@@ -6,6 +6,8 @@ bitflags! {
     ///
     /// [`send`]: crate::net::send
     /// [`sendto`]: crate::net::sendto
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct SendFlags: i32 {
         /// `MSG_CONFIRM`
         #[cfg(not(any(
@@ -44,6 +46,8 @@ bitflags! {
     ///
     /// [`recv`]: crate::net::recv
     /// [`recvfrom`]: crate::net::recvfrom
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct RecvFlags: i32 {
         #[cfg(not(any(apple, solarish, windows, target_os = "haiku")))]
         /// `MSG_CMSG_CLOEXEC`

--- a/src/backend/libc/net/types.rs
+++ b/src/backend/libc/net/types.rs
@@ -473,6 +473,8 @@ bitflags! {
     /// [`socket_with`]: crate::net::socket_with
     /// [`accept_with`]: crate::net::accept_with
     /// [`acceptfrom_with`]: crate::net::acceptfrom_with
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct SocketFlags: c::c_int {
         /// `SOCK_NONBLOCK`
         #[cfg(not(any(apple, windows, target_os = "haiku")))]

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -76,7 +76,7 @@ pub(crate) fn membarrier_query() -> MembarrierQuery {
     const MEMBARRIER_CMD_QUERY: u32 = 0;
     unsafe {
         match syscall_ret_u32(c::syscall(c::SYS_membarrier, MEMBARRIER_CMD_QUERY, 0)) {
-            Ok(query) => MembarrierQuery::from_bits_unchecked(query),
+            Ok(query) => MembarrierQuery::from_bits_retain(query),
             Err(_) => MembarrierQuery::empty(),
         }
     }

--- a/src/backend/libc/rand/types.rs
+++ b/src/backend/libc/rand/types.rs
@@ -8,6 +8,8 @@ bitflags! {
     /// `GRND_*` flags for use with [`getrandom`].
     ///
     /// [`getrandom`]: crate::rand::getrandom
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct GetRandomFlags: u32 {
         /// `GRND_RANDOM`
         const RANDOM = c::GRND_RANDOM;

--- a/src/backend/libc/time/types.rs
+++ b/src/backend/libc/time/types.rs
@@ -296,6 +296,8 @@ bitflags! {
     /// `TFD_*` flags for use with [`timerfd_create`].
     ///
     /// [`timerfd_create`]: crate::time::timerfd_create
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct TimerfdFlags: c::c_int {
         /// `TFD_NONBLOCK`
         const NONBLOCK = c::TFD_NONBLOCK;
@@ -310,6 +312,8 @@ bitflags! {
     /// `TFD_TIMER_*` flags for use with [`timerfd_settime`].
     ///
     /// [`timerfd_settime`]: crate::time::timerfd_settime
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct TimerfdTimerFlags: c::c_int {
         /// `TFD_TIMER_ABSTIME`
         const ABSTIME = c::TFD_TIMER_ABSTIME;

--- a/src/backend/linux_raw/fs/inotify.rs
+++ b/src/backend/linux_raw/fs/inotify.rs
@@ -10,6 +10,8 @@ bitflags! {
     /// `IN_*` for use with [`inotify_init`].
     ///
     /// [`inotify_init`]: crate::fs::inotify::inotify_init
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct CreateFlags: c::c_uint {
         /// `IN_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::IN_CLOEXEC;
@@ -22,7 +24,8 @@ bitflags! {
     /// `IN*` for use with [`inotify_add_watch`].
     ///
     /// [`inotify_add_watch`]: crate::fs::inotify::inotify_add_watch
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct WatchFlags: c::c_uint {
         /// `IN_ACCESS`
         const ACCESS = linux_raw_sys::general::IN_ACCESS;

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -884,7 +884,7 @@ fn statfs_to_statvfs(statfs: StatFs) -> StatVfs {
         f_ffree: statfs.f_ffree as u64,
         f_favail: statfs.f_ffree as u64,
         f_fsid: f_fsid_val0 as u32 as u64 | ((f_fsid_val1 as u32 as u64) << 32),
-        f_flag: unsafe { StatVfsMountFlags::from_bits_unchecked(statfs.f_flags as u64) },
+        f_flag: StatVfsMountFlags::from_bits_retain(statfs.f_flags as u64),
         f_namemax: statfs.f_namelen as u64,
     }
 }
@@ -1018,12 +1018,12 @@ pub(crate) fn fcntl_get_seals(fd: BorrowedFd<'_>) -> io::Result<SealFlags> {
     #[cfg(target_pointer_width = "32")]
     unsafe {
         ret_c_int(syscall_readonly!(__NR_fcntl64, fd, c_uint(F_GET_SEALS)))
-            .map(|seals| SealFlags::from_bits_unchecked(seals as u32))
+            .map(|seals| SealFlags::from_bits_retain(seals as u32))
     }
     #[cfg(target_pointer_width = "64")]
     unsafe {
         ret_c_int(syscall_readonly!(__NR_fcntl, fd, c_uint(F_GET_SEALS)))
-            .map(|seals| SealFlags::from_bits_unchecked(seals as u32))
+            .map(|seals| SealFlags::from_bits_retain(seals as u32))
     }
 }
 

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -5,6 +5,8 @@ bitflags! {
     /// `*_OK` constants for use with [`accessat`].
     ///
     /// [`accessat`]: fn.accessat.html
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct Access: c::c_uint {
         /// `R_OK`
         const READ_OK = linux_raw_sys::general::R_OK;
@@ -26,6 +28,8 @@ bitflags! {
     ///
     /// [`openat`]: crate::fs::openat
     /// [`statat`]: crate::fs::statat
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct AtFlags: c::c_uint {
         /// `AT_REMOVEDIR`
         const REMOVEDIR = linux_raw_sys::general::AT_REMOVEDIR;
@@ -59,6 +63,8 @@ bitflags! {
     /// [`openat`]: crate::fs::openat
     /// [`chmodat`]: crate::fs::chmodat
     /// [`fchmod`]: crate::fs::fchmod
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct Mode: RawMode {
         /// `S_IRWXU`
         const RWXU = linux_raw_sys::general::S_IRWXU;
@@ -152,6 +158,8 @@ bitflags! {
     /// `O_*` constants for use with [`openat`].
     ///
     /// [`openat`]: crate::fs::openat
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct OFlags: c::c_uint {
         /// `O_ACCMODE`
         const ACCMODE = linux_raw_sys::general::O_ACCMODE;
@@ -234,7 +242,8 @@ bitflags! {
     /// `RESOLVE_*` constants for use with [`openat2`].
     ///
     /// [`openat2`]: crate::fs::openat2
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct ResolveFlags: u64 {
         /// `RESOLVE_NO_XDEV`
         const NO_XDEV = linux_raw_sys::general::RESOLVE_NO_XDEV as u64;
@@ -260,6 +269,8 @@ bitflags! {
     /// `RENAME_*` constants for use with [`renameat_with`].
     ///
     /// [`renameat_with`]: crate::fs::renameat_with
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct RenameFlags: c::c_uint {
         /// `RENAME_EXCHANGE`
         const EXCHANGE = linux_raw_sys::general::RENAME_EXCHANGE;
@@ -382,6 +393,8 @@ bitflags! {
     /// `MFD_*` constants for use with [`memfd_create`].
     ///
     /// [`memfd_create`]: crate::fs::memfd_create
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MemfdFlags: c::c_uint {
         /// `MFD_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::MFD_CLOEXEC;
@@ -425,6 +438,8 @@ bitflags! {
     ///
     /// [`fcntl_add_seals`]: crate::fs::fcntl_add_seals
     /// [`fcntl_get_seals`]: crate::fs::fcntl_get_seals
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct SealFlags: u32 {
        /// `F_SEAL_SEAL`.
        const SEAL = linux_raw_sys::general::F_SEAL_SEAL;
@@ -443,6 +458,8 @@ bitflags! {
     /// `STATX_*` constants for use with [`statx`].
     ///
     /// [`statx`]: crate::fs::statx
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct StatxFlags: u32 {
         /// `STATX_TYPE`
         const TYPE = linux_raw_sys::general::STATX_TYPE;
@@ -495,6 +512,8 @@ bitflags! {
     /// `FALLOC_FL_*` constants for use with [`fallocate`].
     ///
     /// [`fallocate`]: crate::fs::fallocate
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct FallocateFlags: u32 {
         /// `FALLOC_FL_KEEP_SIZE`
         const KEEP_SIZE = linux_raw_sys::general::FALLOC_FL_KEEP_SIZE;
@@ -515,6 +534,8 @@ bitflags! {
 
 bitflags! {
     /// `ST_*` constants for use with [`StatVfs`].
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct StatVfsMountFlags: u64 {
         /// `ST_MANDLOCK`
         const MANDLOCK = linux_raw_sys::general::MS_MANDLOCK as u64;
@@ -673,6 +694,8 @@ bitflags! {
     /// `MS_*` constants for use with [`mount`].
     ///
     /// [`mount`]: crate::fs::mount
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MountFlags: c::c_uint {
         /// `MS_BIND`
         const BIND = linux_raw_sys::general::MS_BIND;
@@ -730,6 +753,8 @@ bitflags! {
     /// `MS_*` constants for use with [`change_mount`].
     ///
     /// [`change_mount`]: crate::fs::mount::change_mount
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MountPropagationFlags: c::c_uint {
         /// `MS_SHARED`
         const SHARED = linux_raw_sys::general::MS_SHARED;
@@ -746,6 +771,8 @@ bitflags! {
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 bitflags! {
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub(crate) struct InternalMountFlags: c::c_uint {
         const REMOUNT = linux_raw_sys::general::MS_REMOUNT;
         const MOVE = linux_raw_sys::general::MS_MOVE;
@@ -760,6 +787,8 @@ bitflags! {
     /// `MNT_*` constants for use with [`unmount`].
     ///
     /// [`unmount`]: crate::fs::mount::unmount
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct UnmountFlags: c::c_uint {
         /// `MNT_FORCE`
         const FORCE = linux_raw_sys::general::MNT_FORCE;

--- a/src/backend/linux_raw/io/epoll.rs
+++ b/src/backend/linux_raw/io/epoll.rs
@@ -79,6 +79,8 @@ use bitflags::bitflags;
 
 bitflags! {
     /// `EPOLL_*` for use with [`Epoll::new`].
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct CreateFlags: c::c_uint {
         /// `EPOLL_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::EPOLL_CLOEXEC;
@@ -87,7 +89,8 @@ bitflags! {
 
 bitflags! {
     /// `EPOLL*` for use with [`Epoll::add`].
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct EventFlags: u32 {
         /// `EPOLLIN`
         const IN = linux_raw_sys::general::EPOLLIN as u32;

--- a/src/backend/linux_raw/io/poll_fd.rs
+++ b/src/backend/linux_raw/io/poll_fd.rs
@@ -5,6 +5,8 @@ bitflags! {
     /// `POLL*` flags for use with [`poll`].
     ///
     /// [`poll`]: crate::io::poll
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct PollFlags: u16 {
         /// `POLLIN`
         const IN = linux_raw_sys::general::POLLIN as u16;

--- a/src/backend/linux_raw/io/types.rs
+++ b/src/backend/linux_raw/io/types.rs
@@ -7,6 +7,8 @@ bitflags! {
     ///
     /// [`fcntl_getfd`]: crate::io::fcntl_getfd
     /// [`fcntl_setfd`]: crate::io::fcntl_setfd
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct FdFlags: c::c_uint {
         /// `FD_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::FD_CLOEXEC;
@@ -18,6 +20,8 @@ bitflags! {
     ///
     /// [`preadv2`]: crate::io::preadv2
     /// [`pwritev2`]: crate::io::pwritev
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct ReadWriteFlags: c::c_uint {
         /// `RWF_DSYNC` (since Linux 4.7)
         const DSYNC = linux_raw_sys::general::RWF_DSYNC;
@@ -35,6 +39,8 @@ bitflags! {
 #[cfg(any(target_os = "android", target_os = "linux"))]
 bitflags! {
     /// `SPLICE_F_*` constants for use with [`splice`] and [`vmsplice`].
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct SpliceFlags: c::c_uint {
         /// `SPLICE_F_MOVE`
         const MOVE = linux_raw_sys::general::SPLICE_F_MOVE;
@@ -51,6 +57,8 @@ bitflags! {
     /// `O_*` constants for use with [`dup2`].
     ///
     /// [`dup2`]: crate::io::dup2
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct DupFlags: c::c_uint {
         /// `O_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::O_CLOEXEC;
@@ -61,6 +69,8 @@ bitflags! {
     /// `O_*` constants for use with [`pipe_with`].
     ///
     /// [`pipe_with`]: crate::io::pipe_with
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct PipeFlags: c::c_uint {
         /// `O_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::O_CLOEXEC;
@@ -75,6 +85,8 @@ bitflags! {
     /// `EFD_*` flags for use with [`eventfd`].
     ///
     /// [`eventfd`]: crate::io::eventfd
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct EventfdFlags: c::c_uint {
         /// `EFD_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::EFD_CLOEXEC;

--- a/src/backend/linux_raw/mm/types.rs
+++ b/src/backend/linux_raw/mm/types.rs
@@ -7,6 +7,8 @@ bitflags! {
     /// For `PROT_NONE`, use `ProtFlags::empty()`.
     ///
     /// [`mmap`]: crate::io::mmap
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct ProtFlags: u32 {
         /// `PROT_READ`
         const READ = linux_raw_sys::general::PROT_READ;
@@ -23,6 +25,8 @@ bitflags! {
     /// For `PROT_NONE`, use `MprotectFlags::empty()`.
     ///
     /// [`mprotect`]: crate::io::mprotect
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MprotectFlags: u32 {
         /// `PROT_READ`
         const READ = linux_raw_sys::general::PROT_READ;
@@ -44,6 +48,8 @@ bitflags! {
     ///
     /// [`mmap`]: crate::io::mmap
     /// [`mmap_anonymous`]: crates::io::mmap_anonymous
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MapFlags: u32 {
         /// `MAP_SHARED`
         const SHARED = linux_raw_sys::general::MAP_SHARED;
@@ -89,6 +95,8 @@ bitflags! {
     ///
     /// [`mremap`]: crate::io::mremap
     /// [`mremap_fixed`]: crate::io::mremap_fixed
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MremapFlags: u32 {
         /// `MREMAP_MAYMOVE`
         const MAYMOVE = linux_raw_sys::general::MREMAP_MAYMOVE;
@@ -101,6 +109,8 @@ bitflags! {
     /// `MLOCK_*` flags for use with [`mlock_with`].
     ///
     /// [`mlock_with`]: crate::io::mlock_with
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MlockFlags: u32 {
         /// `MLOCK_ONFAULT`
         const ONFAULT = linux_raw_sys::general::MLOCK_ONFAULT;
@@ -111,6 +121,8 @@ bitflags! {
     /// `MS_*` flags for use with [`msync`].
     ///
     /// [`msync`]: crate::io::msync
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MsyncFlags: u32 {
         /// `MS_SYNC`—Requests an update and waits for it to complete.
         const SYNC = linux_raw_sys::general::MS_SYNC;
@@ -128,6 +140,8 @@ bitflags! {
     /// `O_*` flags for use with [`userfaultfd`].
     ///
     /// [`userfaultfd`]: crate::io::userfaultfd
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct UserfaultfdFlags: c::c_uint {
         /// `O_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::O_CLOEXEC;

--- a/src/backend/linux_raw/net/send_recv.rs
+++ b/src/backend/linux_raw/net/send_recv.rs
@@ -6,6 +6,8 @@ bitflags! {
     ///
     /// [`send`]: crate::net::send
     /// [`sendto`]: crate::net::sendto
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct SendFlags: u32 {
         /// `MSG_CONFIRM`
         const CONFIRM = c::MSG_CONFIRM;
@@ -29,6 +31,8 @@ bitflags! {
     ///
     /// [`recv`]: crate::net::recv
     /// [`recvfrom`]: crate::net::recvfrom
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct RecvFlags: u32 {
         /// `MSG_CMSG_CLOEXEC`
         const CMSG_CLOEXEC = c::MSG_CMSG_CLOEXEC;

--- a/src/backend/linux_raw/net/types.rs
+++ b/src/backend/linux_raw/net/types.rs
@@ -250,6 +250,8 @@ bitflags! {
     /// [`socket_with`]: crate::net::socket_with
     /// [`accept_with`]: crate::net::accept_with
     /// [`acceptfrom_with`]: crate::net::acceptfrom_with
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct SocketFlags: c::c_uint {
         /// `SOCK_NONBLOCK`
         const NONBLOCK = c::O_NONBLOCK;

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -64,13 +64,10 @@ pub(crate) fn membarrier_query() -> MembarrierQuery {
             c_uint(0)
         )) {
             Ok(query) => {
-                // SAFETY: The safety of `from_bits_unchecked` is discussed
-                // [here]. Our "source of truth" is Linux, and here, the
-                // `query` value is coming from Linux, so we know it only
-                // contains "source of truth" valid bits.
-                //
-                // [here]: https://github.com/bitflags/bitflags/pull/207#issuecomment-671668662
-                MembarrierQuery::from_bits_unchecked(query)
+                // Our "source of truth" is Linux, and here, the `query` value
+                // is coming from Linux, so we know it only contains "source of
+                // truth" valid bits.
+                MembarrierQuery::from_bits_retain(query)
             }
             Err(_) => MembarrierQuery::empty(),
         }

--- a/src/backend/linux_raw/rand/types.rs
+++ b/src/backend/linux_raw/rand/types.rs
@@ -4,6 +4,8 @@ bitflags! {
     /// `GRND_*` flags for use with [`getrandom`].
     ///
     /// [`getrandom`]: crate::rand::getrandom
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct GetRandomFlags: u32 {
         /// `GRND_RANDOM`
         const RANDOM = linux_raw_sys::general::GRND_RANDOM;

--- a/src/backend/linux_raw/thread/futex.rs
+++ b/src/backend/linux_raw/thread/futex.rs
@@ -2,6 +2,8 @@ bitflags::bitflags! {
     /// Flags for use with [`futex`].
     ///
     /// [`futex`]: crate::thread::futex
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct FutexFlags: u32 {
         /// `FUTEX_PRIVATE_FLAG`
         const PRIVATE = linux_raw_sys::general::FUTEX_PRIVATE_FLAG;

--- a/src/backend/linux_raw/time/types.rs
+++ b/src/backend/linux_raw/time/types.rs
@@ -85,6 +85,8 @@ bitflags! {
     /// `TFD_*` flags for use with [`timerfd_create`].
     ///
     /// [`timerfd_create`]: crate::time::timerfd_create
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct TimerfdFlags: c::c_uint {
         /// `TFD_NONBLOCK`
         const NONBLOCK = linux_raw_sys::general::TFD_NONBLOCK;
@@ -98,6 +100,8 @@ bitflags! {
     /// `TFD_TIMER_*` flags for use with [`timerfd_settime`].
     ///
     /// [`timerfd_settime`]: crate::time::timerfd_settime
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct TimerfdTimerFlags: c::c_uint {
         /// `TFD_TIMER_ABSTIME`
         const ABSTIME = linux_raw_sys::general::TFD_TIMER_ABSTIME;

--- a/src/fs/xattr.rs
+++ b/src/fs/xattr.rs
@@ -6,6 +6,8 @@ use bitflags::bitflags;
 bitflags! {
     /// `XATTR_*` constants for use with [`setxattr`], and other `*setxattr`
     /// functions.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct XattrFlags: c::c_uint {
         /// `XATTR_CREATE`
         const CREATE = c::XATTR_CREATE as c::c_uint;

--- a/src/io/kqueue.rs
+++ b/src/io/kqueue.rs
@@ -233,6 +233,8 @@ pub enum EventFilter {
 
 bitflags::bitflags! {
     /// The flags for a `kqueue` event.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct EventFlags: u16 {
         /// Add the event to the `kqueue`.
         const ADD = c::EV_ADD as _;
@@ -265,6 +267,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// The flags for a virtual node event.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct VnodeEvents: u32 {
         /// The file was deleted.
         const DELETE = c::NOTE_DELETE;
@@ -292,6 +296,8 @@ bitflags::bitflags! {
 #[cfg(feature = "process")]
 bitflags::bitflags! {
     /// The flags for a process event.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct ProcessEvents: u32 {
         /// The process exited.
         const EXIT = c::NOTE_EXIT;
@@ -313,6 +319,8 @@ bitflags::bitflags! {
 #[cfg(any(apple, freebsdlike))]
 bitflags::bitflags! {
     /// The flags for a user event.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct UserFlags: u32 {
         /// Ignore the user input flags.
         const NOINPUT = c::NOTE_FFNOP;

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -96,7 +96,8 @@ pub unsafe fn io_uring_enter<Fd: AsFd>(
 
 bitflags::bitflags! {
     /// `IORING_ENTER_*` flags for use with [`io_uring_enter`].
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringEnterFlags: u32 {
         /// `IORING_ENTER_GETEVENTS`
         const GETEVENTS = sys::IORING_ENTER_GETEVENTS;
@@ -400,7 +401,8 @@ pub enum IoringMsgringCmds {
 
 bitflags::bitflags! {
     /// `IORING_SETUP_*` flags for use with [`io_uring_params`].
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringSetupFlags: u32 {
         /// `IORING_SETUP_ATTACH_WQ`
         const ATTACH_WQ = sys::IORING_SETUP_ATTACH_WQ;
@@ -448,7 +450,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IOSQE_*` flags for use with [`io_uring_sqe`].
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringSqeFlags: u8 {
         /// `1 << IOSQE_ASYNC_BIT`
         const ASYNC = 1 << sys::IOSQE_ASYNC_BIT as u8;
@@ -475,7 +478,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_CQE_F_*` flags for use with [`io_uring_cqe`].
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringCqeFlags: u32 {
         /// `IORING_CQE_F_BUFFER`
         const BUFFER = sys::IORING_CQE_F_BUFFER as _;
@@ -493,7 +497,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_FSYNC_*` flags for use with [`io_uring_sqe`].
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringFsyncFlags: u32 {
         /// `IORING_FSYNC_DATASYNC`
         const DATASYNC = sys::IORING_FSYNC_DATASYNC;
@@ -503,7 +508,8 @@ bitflags::bitflags! {
 bitflags::bitflags! {
     /// `IORING_TIMEOUT_*` and `IORING_LINK_TIMEOUT_UPDATE` flags for use with
     /// [`io_uring_sqe`].
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringTimeoutFlags: u32 {
         /// `IORING_TIMEOUT_ABS`
         const ABS = sys::IORING_TIMEOUT_ABS;
@@ -533,7 +539,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `SPLICE_F_*` flags for use with [`io_uring_sqe`].
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct SpliceFlags: u32 {
         /// `SPLICE_F_FD_IN_FIXED`
         const FD_IN_FIXED = sys::SPLICE_F_FD_IN_FIXED;
@@ -542,7 +549,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_MSG_RING_*` flags for use with [`io_uring_sqe`].
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringMsgringFlags: u32 {
         /// `IORING_MSG_RING_CQE_SKIP`
         const CQE_SKIP = sys::IORING_MSG_RING_CQE_SKIP;
@@ -551,7 +559,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_ASYNC_CANCEL_*` flags for use with [`io_uring_sqe`].
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringAsyncCancelFlags: u32 {
         /// `IORING_ASYNC_CANCEL_ALL`
         const ALL = sys::IORING_ASYNC_CANCEL_ALL;
@@ -569,7 +578,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_FEAT_*` flags for use with [`io_uring_params`].
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringFeatureFlags: u32 {
         /// `IORING_FEAT_CQE_SKIP`
         const CQE_SKIP = sys::IORING_FEAT_CQE_SKIP;
@@ -614,7 +624,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IO_URING_OP_*` flags for use with [`io_uring_probe_op`].
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringOpFlags: u16 {
         /// `IO_URING_OP_SUPPORTED`
         const SUPPORTED = sys::IO_URING_OP_SUPPORTED as _;
@@ -623,7 +634,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_RSRC_*` flags for use with [`io_uring_rsrc_register`].
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringRsrcFlags: u32 {
         /// `IORING_RSRC_REGISTER_SPARSE`
         const REGISTER_SPARSE = sys::IORING_RSRC_REGISTER_SPARSE as _;
@@ -632,7 +644,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_SQ_*` flags.
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringSqFlags: u32 {
         /// `IORING_SQ_NEED_WAKEUP`
         const NEED_WAKEUP = sys::IORING_SQ_NEED_WAKEUP;
@@ -647,7 +660,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_CQ_*` flags.
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringCqFlags: u32 {
         /// `IORING_CQ_EVENTFD_DISABLED`
         const EVENTFD_DISABLED = sys::IORING_CQ_EVENTFD_DISABLED;
@@ -656,7 +670,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_POLL_*` flags.
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringPollFlags: u32 {
         /// `IORING_POLL_ADD_MULTI`
         const ADD_MULTI = sys::IORING_POLL_ADD_MULTI;
@@ -674,7 +689,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// send/sendmsg flags (`sqe.ioprio`)
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringSendFlags: u16 {
         /// `IORING_RECVSEND_POLL_FIRST`.
         ///
@@ -693,7 +709,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// recv/recvmsg flags (`sqe.ioprio`)
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringRecvFlags: u16 {
         /// `IORING_RECVSEND_POLL_FIRST`
         ///
@@ -712,7 +729,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// accept flags (`sqe.ioprio`)
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct IoringAcceptFlags: u16 {
         /// `IORING_ACCEPT_MULTISHOT`
         const MULTISHOT = sys::IORING_ACCEPT_MULTISHOT as _;
@@ -721,7 +739,8 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// recvmsg out flags
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct RecvmsgOutFlags: u32 {
         /// `MSG_EOR`
         const EOR = sys::MSG_EOR;

--- a/src/process/membarrier.rs
+++ b/src/process/membarrier.rs
@@ -17,6 +17,8 @@ bitflags::bitflags! {
     ///
     /// These flags correspond to values of [`MembarrierCommand`] which are
     /// supported in the OS.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct MembarrierQuery: u32 {
        /// `MEMBARRIER_CMD_GLOBAL`
        #[doc(alias = "SHARED")]
@@ -46,9 +48,9 @@ impl MembarrierQuery {
     /// Test whether this query result contains the given command.
     #[inline]
     pub fn contains_command(self, cmd: MembarrierCommand) -> bool {
-        // SAFETY: `MembarrierCommand` is an enum that only contains values
-        // also valid in `MembarrierQuery`.
-        self.contains(unsafe { Self::from_bits_unchecked(cmd as _) })
+        // `MembarrierCommand` is an enum that only contains values also valid
+        // in `MembarrierQuery`.
+        self.contains(Self::from_bits_retain(cmd as _))
     }
 }
 

--- a/src/process/pidfd.rs
+++ b/src/process/pidfd.rs
@@ -6,6 +6,8 @@ bitflags::bitflags! {
     /// `PIDFD_*` flags for use with [`pidfd_open`].
     ///
     /// [`pidfd_open`]: crate::process::pidfd_open
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct PidfdFlags: backend::c::c_uint {
         /// `PIDFD_NONBLOCK`.
         const NONBLOCK = backend::c::PIDFD_NONBLOCK;

--- a/src/process/prctl.rs
+++ b/src/process/prctl.rs
@@ -172,6 +172,8 @@ const PR_GET_UNALIGN: c_int = 5;
 
 bitflags! {
     /// `PR_UNALIGN_*`.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct UnalignedAccessControl: u32 {
         /// Silently fix up unaligned user accesses.
         const NO_PRINT = 1;
@@ -213,6 +215,8 @@ const PR_GET_FPEMU: c_int = 9;
 
 bitflags! {
     /// `PR_FPEMU_*`.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct FloatingPointEmulationControl: u32 {
         /// Silently emulate floating point operations accesses.
         const NO_PRINT = 1;
@@ -257,6 +261,8 @@ const PR_GET_FPEXC: c_int = 11;
 
 bitflags! {
     /// Zero means floating point exceptions are disabled.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct FloatingPointExceptionMode: u32 {
         /// Async non-recoverable exception mode.
         const NONRECOV = 1;
@@ -933,6 +939,8 @@ impl TryFrom<u32> for SpeculationFeature {
 
 bitflags! {
     /// `PR_SPEC_*`.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct SpeculationFeatureControl: u32 {
         /// The speculation feature is enabled, mitigation is disabled.
         const ENABLE = 1_u32 << 1;
@@ -947,6 +955,8 @@ bitflags! {
 
 bitflags! {
     /// Zero means the processors are not vulnerable.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct SpeculationFeatureState: u32 {
         /// Mitigation can be controlled per thread by `PR_SET_SPECULATION_CTRL`.
         const PRCTL = 1_u32 << 0;
@@ -1032,6 +1042,8 @@ const PR_PAC_GET_ENABLED_KEYS: c_int = 61;
 
 bitflags! {
     /// `PR_PAC_AP*`.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct PointerAuthenticationKeys: u32 {
         /// Instruction authentication key `A`.
         const INSTRUCTION_AUTHENTICATION_KEY_A = 1_u32 << 0;

--- a/src/process/procctl.rs
+++ b/src/process/procctl.rs
@@ -219,6 +219,8 @@ const PROC_REAP_STATUS: c_int = 4;
 
 bitflags! {
     /// `REAPER_STATUS_*`.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct ReaperStatusFlags: c_uint {
         /// The process has acquired reaper status.
         const OWNED = 1;
@@ -276,6 +278,8 @@ const PROC_REAP_GETPIDS: c_int = 5;
 
 bitflags! {
     /// `REAPER_PIDINFO_*`.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct PidInfoFlags: c_uint {
         /// This structure was filled by the kernel.
         const VALID = 1;
@@ -362,6 +366,8 @@ const PROC_REAP_KILL: c_int = 6;
 
 bitflags! {
     /// `REAPER_KILL_*`.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     struct KillFlags: c_uint {
         const CHILDREN = 1;
         const SUBTREE = 2;

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -10,6 +10,8 @@ use crate::backend::process::wait::SiginfoExt;
 
 bitflags! {
     /// Options for modifying the behavior of wait/waitpid
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct WaitOptions: u32 {
         /// Return immediately if no child has exited.
         const NOHANG = backend::process::wait::WNOHANG as _;
@@ -26,6 +28,8 @@ bitflags! {
 #[cfg(not(any(target_os = "wasi", target_os = "redox", target_os = "openbsd")))]
 bitflags! {
     /// Options for modifying the behavior of waitid
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct WaitidOptions: u32 {
         /// Return immediately if no child has exited.
         const NOHANG = backend::process::wait::WNOHANG as _;

--- a/src/thread/libcap.rs
+++ b/src/thread/libcap.rs
@@ -17,6 +17,8 @@ pub struct CapabilitySets {
 
 bitflags! {
     /// `CAP_*` constants.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct CapabilityFlags: u64 {
         /// `CAP_CHOWN`
         const CHOWN = 1 << linux_raw_sys::general::CAP_CHOWN;
@@ -152,11 +154,10 @@ fn capget(pid: Option<Pid>) -> io::Result<CapabilitySets> {
         let permitted = u64::from(data.0.permitted) | (u64::from(data.1.permitted) << BITS);
         let inheritable = u64::from(data.0.inheritable) | (u64::from(data.1.inheritable) << BITS);
 
-        // SAFETY: the kernel returns a partitioned bitset that we just combined above
         Ok(CapabilitySets {
-            effective: unsafe { CapabilityFlags::from_bits_unchecked(effective) },
-            permitted: unsafe { CapabilityFlags::from_bits_unchecked(permitted) },
-            inheritable: unsafe { CapabilityFlags::from_bits_unchecked(inheritable) },
+            effective: CapabilityFlags::from_bits_retain(effective),
+            permitted: CapabilityFlags::from_bits_retain(permitted),
+            inheritable: CapabilityFlags::from_bits_retain(inheritable),
         })
     }
 }

--- a/src/thread/prctl.rs
+++ b/src/thread/prctl.rs
@@ -411,6 +411,8 @@ const PR_GET_SECUREBITS: c_int = 27;
 
 bitflags! {
     /// `SECBIT_*`.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct CapabilitiesSecureBits: u32 {
         /// If this bit is set, then the kernel does not grant capabilities when
         /// a `set-user-ID-root` program is executed, or when a process with an effective or real
@@ -732,6 +734,8 @@ const PR_MTE_TAG_MASK: u32 = 0xffff_u32 << PR_MTE_TAG_SHIFT;
 
 bitflags! {
     /// Zero means addresses that are passed for the purpose of being dereferenced by the kernel must be untagged.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct TaggedAddressMode: u32 {
         /// Addresses that are passed for the purpose of being dereferenced by the kernel may be tagged.
         const ENABLED = 1_u32 << 0;

--- a/src/thread/setns.rs
+++ b/src/thread/setns.rs
@@ -11,6 +11,8 @@ use crate::io;
 
 bitflags! {
     /// Thread name space type.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct ThreadNameSpaceType: u32 {
         /// Time name space.
         const TIME = CLONE_NEWTIME;
@@ -55,6 +57,8 @@ pub enum LinkNameSpaceType {
 
 bitflags! {
     /// `CLONE_*` for use with [`unshare`].
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
     pub struct UnshareFlags: u32 {
         /// `CLONE_FILES`.
         const FILES = CLONE_FILES;

--- a/tests/fs/statx.rs
+++ b/tests/fs/statx.rs
@@ -8,7 +8,7 @@ fn test_statx_unknown_flags() {
     // unknown bits. Exclude `STATX__RESERVED` here as that evokes an explicit
     // failure; that's tested separately below.
     let too_many_flags =
-        unsafe { StatxFlags::from_bits_unchecked(!0 & !linux_raw_sys::general::STATX__RESERVED) };
+        StatxFlags::from_bits_retain(!0 & !linux_raw_sys::general::STATX__RESERVED);
 
     // It's also ok to pass such flags to `statx`.
     let result = match rustix::fs::statx(&f, "Cargo.toml", AtFlags::empty(), too_many_flags) {
@@ -32,8 +32,7 @@ fn test_statx_reserved() {
 
     // It's ok (though still unwise) to construct a `STATX__RESERVED` flag
     // value but `statx` should reliably fail with `INVAL`.
-    let reserved =
-        unsafe { StatxFlags::from_bits_unchecked(linux_raw_sys::general::STATX__RESERVED) };
+    let reserved = StatxFlags::from_bits_retain(linux_raw_sys::general::STATX__RESERVED);
     match rustix::fs::statx(&f, "Cargo.toml", AtFlags::empty(), reserved) {
         Ok(_) => panic!("statx succeeded with `STATX__RESERVED`"),
         Err(err) => assert_eq!(err, rustix::io::Errno::INVAL),


### PR DESCRIPTION
This requires some minor code changes, mostly around deriving traits explicitly as they are no longer derived by default by the bitflags macro.