### PR TITLE
Miscellaneous cleanups.

### DIFF
--- a/src/backend/libc/fs/inotify.rs
+++ b/src/backend/libc/fs/inotify.rs
@@ -113,7 +113,8 @@ pub fn inotify_add_watch<P: crate::path::Arg>(
 /// by [`inotify_add_watch`] and not previously have been removed.
 #[doc(alias = "inotify_rm_watch")]
 pub fn inotify_remove_watch(inot: BorrowedFd<'_>, wd: i32) -> io::Result<()> {
-    // Android's `inotify_rm_watch` takes u32 despite `inotify_add_watch` is i32.
+    // Android's `inotify_rm_watch` takes `u32` despite that
+    // `inotify_add_watch` expects a `i32`.
     #[cfg(target_os = "android")]
     let wd = wd as u32;
     // SAFETY: The fd is valid and closing an arbitrary wd is valid.

--- a/src/backend/libc/mod.rs
+++ b/src/backend/libc/mod.rs
@@ -93,8 +93,8 @@ pub(crate) mod time;
 #[cfg(all(unix, target_env = "gnu"))]
 pub(crate) fn if_glibc_is_less_than_2_25() -> bool {
     // This is also defined inside `weak_or_syscall!` in
-    // backend/libc/rand/syscalls.rs, but it's not convenient to re-export the weak
-    // symbol from that macro, so we duplicate it at a small cost here.
+    // backend/libc/rand/syscalls.rs, but it's not convenient to re-export the
+    // weak symbol from that macro, so we duplicate it at a small cost here.
     weak! { fn getrandom(*mut c::c_void, c::size_t, c::c_uint) -> c::ssize_t }
 
     // glibc 2.25 has `getrandom`, which is how we satisfy the API contract of

--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -97,8 +97,9 @@ impl SocketAddrUnix {
         if len != 0 && self.unix.sun_path[0] != b'\0' as c::c_char {
             let end = len as usize - offsetof_sun_path();
             let bytes = &self.unix.sun_path[..end];
-            // SAFETY: `from_raw_parts` to convert from `&[c_char]` to `&[u8]`. And
-            // `from_bytes_with_nul_unchecked` since the string is NUL-terminated.
+            // SAFETY: `from_raw_parts` to convert from `&[c_char]` to `&[u8]`.
+            // And `from_bytes_with_nul_unchecked` since the string is
+            // NUL-terminated.
             unsafe {
                 Some(CStr::from_bytes_with_nul_unchecked(slice::from_raw_parts(
                     bytes.as_ptr().cast(),

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -503,8 +503,8 @@ unsafe fn cvt_waitid_status(status: MaybeUninit<c::siginfo_t>) -> Option<WaitidS
     // `si_pid` is supposedly the better way to check that the struct has been
     // filled, e.g. the Linux manpage says about the `WNOHANG` case “zero out
     // the si_pid field before the call and check for a nonzero value”.
-    // But e.g. NetBSD/OpenBSD don't have it exposed in the libc crate for now, and
-    // some platforms don't have it at all. For simplicity, always check
+    // But e.g. NetBSD/OpenBSD don't have it exposed in the libc crate for now,
+    // and some platforms don't have it at all. For simplicity, always check
     // `si_signo`. We have zero-initialized the whole struct, and all kernels
     // should set `SIGCHLD` here.
     if status.si_signo == 0 {

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -50,8 +50,8 @@ pub(crate) fn clock_nanosleep_relative(id: ClockId, request: &Timespec) -> Nanos
     let mut remain = MaybeUninit::<LibcTimespec>::uninit();
     let flags = 0;
 
-    // 32-bit gnu version: libc has `clock_nanosleep` but it is not y2038 safe by
-    // default.
+    // 32-bit gnu version: libc has `clock_nanosleep` but it is not y2038 safe
+    // by default.
     #[cfg(all(
         any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
         target_env = "gnu",
@@ -142,8 +142,8 @@ unsafe fn clock_nanosleep_relative_old(id: ClockId, request: &Timespec) -> Nanos
 pub(crate) fn clock_nanosleep_absolute(id: ClockId, request: &Timespec) -> io::Result<()> {
     let flags = c::TIMER_ABSTIME;
 
-    // 32-bit gnu version: libc has `clock_nanosleep` but it is not y2038 safe by
-    // default.
+    // 32-bit gnu version: libc has `clock_nanosleep` but it is not y2038 safe
+    // by default.
     #[cfg(all(
         any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
         target_env = "gnu",

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -143,9 +143,9 @@ impl<'a, Num: ArgNumber> From<Option<&'a CStr>> for ArgReg<'a, Num> {
 impl<'a, Num: ArgNumber> From<BorrowedFd<'a>> for ArgReg<'a, Num> {
     #[inline]
     fn from(fd: BorrowedFd<'a>) -> Self {
-        // SAFETY: `BorrowedFd` ensures that the file descriptor is valid, and the
-        // lifetime parameter on the resulting `ArgReg` ensures that the result is
-        // bounded by the `BorrowedFd`'s lifetime.
+        // SAFETY: `BorrowedFd` ensures that the file descriptor is valid, and
+        // the lifetime parameter on the resulting `ArgReg` ensures that the
+        // result is bounded by the `BorrowedFd`'s lifetime.
         unsafe { raw_fd(fd.as_raw_fd()) }
     }
 }

--- a/src/backend/linux_raw/io/errno.rs
+++ b/src/backend/linux_raw/io/errno.rs
@@ -62,8 +62,8 @@ impl Errno {
 
     /// Convert from a C `errno` value (which is positive) to an `Errno`.
     const fn from_errno(raw: u32) -> Self {
-        // We store error values in negated form, so that we don't have to negate
-        // them after every syscall.
+        // We store error values in negated form, so that we don't have to
+        // negate them after every syscall.
         let encoded = raw.wrapping_neg() as u16;
 
         // TODO: Use Range::contains, once that's `const`.

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -74,8 +74,9 @@ impl SocketAddrUnix {
         if len != 0 && self.unix.sun_path[0] != b'\0' as c::c_char {
             let end = len as usize - offsetof_sun_path();
             let bytes = &self.unix.sun_path[..end];
-            // SAFETY: `from_raw_parts` to convert from `&[c_char]` to `&[u8]`. And
-            // `from_bytes_with_nul_unchecked` since the string is NUL-terminated.
+            // SAFETY: `from_raw_parts` to convert from `&[c_char]` to `&[u8]`.
+            // And `from_bytes_with_nul_unchecked` since the string is
+            // NUL-terminated.
             unsafe {
                 Some(CStr::from_bytes_with_nul_unchecked(slice::from_raw_parts(
                     bytes.as_ptr().cast(),

--- a/src/backend/linux_raw/vdso_wrappers.rs
+++ b/src/backend/linux_raw/vdso_wrappers.rs
@@ -376,8 +376,8 @@ fn init() {
             assert!(!ptr.is_null());
 
             // SAFETY: Store the computed function addresses in static storage
-            // so that we don't need to compute it again (but if we do, it doesn't
-            // hurt anything).
+            // so that we don't need to compute it again (but if we do, it
+            // doesn't hurt anything).
             unsafe {
                 CLOCK_GETTIME.store(ptr.cast(), Relaxed);
             }

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -40,9 +40,9 @@ macro_rules! cstr {
 
         #[allow(unsafe_code, unused_unsafe)]
         {
-            // Now that we know the string doesn't have embedded NULs, we can call
-            // `from_bytes_with_nul_unchecked`, which as of this writing is defined
-            // as `#[inline]` and completely optimizes away.
+            // Now that we know the string doesn't have embedded NULs, we can
+            // call `from_bytes_with_nul_unchecked`, which as of this writing
+            // is defined as `#[inline]` and completely optimizes away.
             //
             // SAFETY: We have manually checked that the string does not contain
             // embedded NULs above, and we append or own NUL terminator here.

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -3,7 +3,7 @@
 //! The `dirfd` argument to these functions may be a file descriptor for a
 //! directory, or the special value returned by [`cwd`].
 //!
-//! [`cwd`]: crate::fs::cwd
+//! [`cwd`]: crate::fs::cwd::cwd
 
 use crate::fd::OwnedFd;
 use crate::ffi::{CStr, CString};

--- a/src/fs/statx.rs
+++ b/src/fs/statx.rs
@@ -42,8 +42,8 @@ mod compat {
 
     use backend::fs::types::{Statx, StatxFlags};
 
-    // Linux kernel prior to 4.11 old versions of Docker don't support `statx`. We
-    // store the availability in a global to avoid unnecessary syscalls.
+    // Linux kernel prior to 4.11 old versions of Docker don't support `statx`.
+    // We store the availability in a global to avoid unnecessary syscalls.
     //
     // 0: Unknown
     // 1: Not available
@@ -92,9 +92,9 @@ mod compat {
     /// The first `statx` call failed with `PERM`.
     #[cold]
     fn statx_error_perm() -> io::Result<Statx> {
-        // Some old versions of Docker have `statx` fail with `PERM` when it isn't
-        // recognized. Check whether `statx` really is available, and if so, fail
-        // with `PERM`, and if not, treat it like `NOSYS`.
+        // Some old versions of Docker have `statx` fail with `PERM` when it
+        // isn't recognized. Check whether `statx` really is available, and if
+        // so, fail with `PERM`, and if not, treat it like `NOSYS`.
         if backend::fs::syscalls::is_statx_available() {
             STATX_STATE.store(2, Ordering::Relaxed);
             Err(io::Errno::PERM)

--- a/src/io/procfs.rs
+++ b/src/io/procfs.rs
@@ -78,14 +78,16 @@ fn check_proc_entry_with_stat(
 
     match kind {
         Kind::Fd => {
-            // Check that the "/proc/self/fd" directory doesn't have any extraneous
-            // links into it (which might include unexpected subdirectories).
+            // Check that the "/proc/self/fd" directory doesn't have any
+            // extraneous links into it (which might include unexpected
+            // subdirectories).
             if entry_stat.st_nlink != 2 {
                 return Err(io::Errno::NOTSUP);
             }
         }
         Kind::Pid | Kind::Proc => {
-            // Check that the "/proc" and "/proc/self" directories aren't empty.
+            // Check that the "/proc" and "/proc/self" directories aren't
+            // empty.
             if entry_stat.st_nlink <= 2 {
                 return Err(io::Errno::NOTSUP);
             }
@@ -246,8 +248,8 @@ fn proc_self() -> io::Result<(BorrowedFd<'static>, &'static Stat)> {
 
             let pid = getpid();
 
-            // Open "/proc/self". Use our pid to compute the name rather than literally
-            // using "self", as "self" is a symlink.
+            // Open "/proc/self". Use our pid to compute the name rather than
+            // literally using "self", as "self" is a symlink.
             let proc_self = proc_opendirat(proc, DecInt::new(pid.as_raw_nonzero().get()))?;
             let proc_self_stat = check_proc_entry(Kind::Pid, proc_self.as_fd(), Some(proc_stat))
                 .map_err(|_err| io::Errno::NOTSUP)?;

--- a/src/io/stdio.rs
+++ b/src/io/stdio.rs
@@ -49,8 +49,8 @@ use {crate::io, backend::fd::AsFd, core::mem::forget};
 #[doc(alias = "STDIN_FILENO")]
 #[inline]
 pub const fn stdin() -> BorrowedFd<'static> {
-    // SAFETY: When "std" is enabled, the standard library assumes that the stdio
-    // file descriptors are all valid.
+    // SAFETY: When "std" is enabled, the standard library assumes that the
+    // stdio file descriptors are all valid.
     unsafe { BorrowedFd::borrow_raw(backend::io::types::STDIN_FILENO as RawFd) }
 }
 
@@ -171,8 +171,8 @@ pub unsafe fn take_stdin() -> OwnedFd {
 #[doc(alias = "STDOUT_FILENO")]
 #[inline]
 pub const fn stdout() -> BorrowedFd<'static> {
-    // SAFETY: When "std" is enabled, the standard library assumes that the stdio
-    // file descriptors are all valid.
+    // SAFETY: When "std" is enabled, the standard library assumes that the
+    // stdio file descriptors are all valid.
     unsafe { BorrowedFd::borrow_raw(backend::io::types::STDOUT_FILENO as RawFd) }
 }
 
@@ -287,8 +287,8 @@ pub unsafe fn take_stdout() -> OwnedFd {
 #[doc(alias = "STDERR_FILENO")]
 #[inline]
 pub const fn stderr() -> BorrowedFd<'static> {
-    // SAFETY: When "std" is enabled, the standard library assumes that the stdio
-    // file descriptors are all valid.
+    // SAFETY: When "std" is enabled, the standard library assumes that the
+    // stdio file descriptors are all valid.
     unsafe { BorrowedFd::borrow_raw(backend::io::types::STDERR_FILENO as RawFd) }
 }
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -35,14 +35,3 @@ pub use {
     addr::{SocketAddr, SocketAddrV4, SocketAddrV6},
     ip::{IpAddr, Ipv4Addr, Ipv6Addr, Ipv6MulticastScope},
 };
-#[cfg(unix)]
-pub use {
-    send_recv::{sendmsg_unix, sendto_unix},
-    socket::{bind_unix, connect_unix, SocketAddrUnix},
-};
-
-#[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
-pub use send_recv::{
-    recvmsg, sendmsg_any, sendmsg_noaddr, sendmsg_v4, sendmsg_v6, RecvAncillaryBuffer,
-    RecvAncillaryMessage, RecvMsgReturn, SendAncillaryBuffer, SendAncillaryMessage, __cmsg_space,
-};

--- a/src/net/send_recv/mod.rs
+++ b/src/net/send_recv/mod.rs
@@ -12,13 +12,7 @@ pub use backend::net::send_recv::{RecvFlags, SendFlags};
 mod msg;
 
 #[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
-pub use msg::{
-    recvmsg, sendmsg_any, sendmsg_noaddr, sendmsg_v4, sendmsg_v6, RecvAncillaryBuffer,
-    RecvAncillaryMessage, RecvMsgReturn, SendAncillaryBuffer, SendAncillaryMessage, __cmsg_space,
-};
-
-#[cfg(unix)]
-pub use msg::sendmsg_unix;
+pub use msg::*;
 
 /// `recv(fd, buf, flags)`—Reads data from a socket.
 ///

--- a/src/net/send_recv/msg.rs
+++ b/src/net/send_recv/msg.rs
@@ -1,4 +1,4 @@
-//! [`recvmsg`] and [`sendmsg`] functions.
+//! [`recvmsg`], [`sendmsg_noaddr`], and related functions.
 
 #![allow(unsafe_code)]
 
@@ -739,7 +739,8 @@ mod messages {
 
         fn size_hint(&self) -> (usize, Option<usize>) {
             if self.header.is_some() {
-                // The remaining buffer *could* be filled with zero-length messages.
+                // The remaining buffer *could* be filled with zero-length
+                // messages.
                 let max_size = unsafe { c::CMSG_LEN(0) } as usize;
                 let remaining_count = self.msghdr.msg_controllen as usize / max_size;
                 (1, Some(remaining_count))

--- a/src/path/arg.rs
+++ b/src/path/arg.rs
@@ -953,8 +953,8 @@ where
     // This helps test our safety condition below.
     debug_assert!(bytes.len() + 1 <= SMALL_PATH_BUFFER_SIZE);
 
-    // SAFETY: `bytes.len() < SMALL_PATH_BUFFER_SIZE` which means we have space for
-    // `bytes.len() + 1` u8s:
+    // SAFETY: `bytes.len() < SMALL_PATH_BUFFER_SIZE` which means we have space
+    // for `bytes.len() + 1` u8s:
     unsafe {
         ptr::copy_nonoverlapping(bytes.as_ptr(), buf_ptr, bytes.len());
         buf_ptr.add(bytes.len()).write(0);

--- a/src/process/procctl.rs
+++ b/src/process/procctl.rs
@@ -5,7 +5,8 @@
 
 #![allow(unsafe_code)]
 
-use alloc::{vec, vec::Vec};
+use alloc::vec;
+use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 use core::ptr;
 
@@ -281,7 +282,8 @@ bitflags! {
         const VALID = 1;
         /// The pid field identifies a direct child of the reaper.
         const CHILD = 2;
-        /// The reported process is itself a reaper. Descendants of a subordinate reaper are not reported.
+        /// The reported process is itself a reaper. Descendants of a
+        /// subordinate reaper are not reported.
         const REAPER = 4;
         /// The reported process is in the zombie state.
         const ZOMBIE = 8;

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -230,8 +230,8 @@ impl WaitidStatus {
     #[cfg(not(any(target_os = "netbsd", target_os = "fuchsia", target_os = "emscripten")))]
     #[allow(unsafe_code)]
     fn si_status(&self) -> backend::c::c_int {
-        //  SAFETY: POSIX [specifies] that the `siginfo_t` returned by a `waitid`
-        //  call always has a valid `si_status` value.
+        // SAFETY: POSIX [specifies] that the `siginfo_t` returned by a
+        // `waitid` call always has a valid `si_status` value.
         //
         // [specifies]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/signal.h.html
         unsafe { self.0.si_status() }

--- a/src/thread/libcap.rs
+++ b/src/thread/libcap.rs
@@ -140,8 +140,8 @@ fn capget(pid: Option<Pid>) -> io::Result<CapabilitySets> {
         };
 
         backend::thread::syscalls::capget(&mut header, &mut data)?;
-        // SAFETY: v3 is a 64-bit implementation, so the kernel filled in both data
-        // structs.
+        // SAFETY: v3 is a 64-bit implementation, so the kernel filled in both
+        // data structs.
         unsafe { (data[0].assume_init(), data[1].assume_init()) }
     };
 
@@ -152,7 +152,8 @@ fn capget(pid: Option<Pid>) -> io::Result<CapabilitySets> {
         let permitted = u64::from(data.0.permitted) | (u64::from(data.1.permitted) << BITS);
         let inheritable = u64::from(data.0.inheritable) | (u64::from(data.1.inheritable) << BITS);
 
-        // SAFETY: the kernel returns a partitioned bitset that we just combined above
+        // SAFETY: The kernel returns a partitioned bitset that we just
+        // combined above.
         Ok(CapabilitySets {
             effective: unsafe { CapabilityFlags::from_bits_unchecked(effective) },
             permitted: unsafe { CapabilityFlags::from_bits_unchecked(permitted) },

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -1,6 +1,10 @@
 // Implementation derived from `weak` in Rust's
 // library/std/src/sys/unix/weak.rs at revision
 // fd0cb0cdc21dd9c06025277d772108f8d42cb25f.
+//
+// Ideally we should update to a newer version which doesn't need `dlsym`,
+// however that depends on the `extern_weak` feature which is currrently
+// unstable.
 
 #![cfg_attr(linux_raw, allow(unsafe_code))]
 

--- a/tests/fs/readdir.rs
+++ b/tests/fs/readdir.rs
@@ -113,8 +113,8 @@ fn test_raw_dir(buf: &mut [MaybeUninit<u8>]) {
 #[test]
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn raw_dir_entries_heap() {
-    // When we can depend on Rust 1.60, we can use the spare_capacity_mut version
-    // instead.
+    // When we can depend on Rust 1.60, we can use the spare_capacity_mut
+    // version instead.
     /*
     let mut buf = Vec::with_capacity(8192);
     test_raw_dir(buf.spare_capacity_mut());

--- a/tests/io/read_write.rs
+++ b/tests/io/read_write.rs
@@ -168,7 +168,8 @@ fn test_pwritev2() {
     // pwritev2 to append with a 0 offset: don't update the current position.
     match pwritev2(&foo, &[IoSlice::new(b"world")], 0, ReadWriteFlags::APPEND) {
         Ok(_) => {}
-        // Skip the rest of the test if we don't have `pwritev2` and `RWF_APPEND`.
+        // Skip the rest of the test if we don't have `pwritev2` and
+        // `RWF_APPEND`.
         Err(rustix::io::Errno::NOSYS) | Err(rustix::io::Errno::NOTSUP) => return,
         Err(err) => Err(err).unwrap(),
     }

--- a/tests/param/weak.rs
+++ b/tests/param/weak.rs
@@ -1,6 +1,10 @@
 // Implementation derived from `weak` in Rust's
 // library/std/src/sys/unix/weak.rs at revision
 // fd0cb0cdc21dd9c06025277d772108f8d42cb25f.
+//
+// Ideally we should update to a newer version which doesn't need `dlsym`,
+// however that depends on the `extern_weak` feature which is currrently
+// unstable.
 
 //! Support for "weak linkage" to symbols on Unix
 //!


### PR DESCRIPTION
 - Wrap some code comments at 79 columns, for consistency with the rest of the codebase.
 - Remove some redundant `use`s.
 - Fix some broken doc links.