### PR TITLE
Use `utils::{as_ptr, as_ptr_mut}` to reduce `as` casts.

### DIFF
--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -34,7 +34,7 @@ use libc_errno::errno;
 use {
     super::super::conv::syscall_ret_owned_fd,
     crate::io::{IoSliceRaw, ReadWriteFlags, SpliceFlags},
-    core::ptr,
+    crate::utils::optional_as_mut_ptr,
 };
 #[cfg(bsd)]
 use {crate::io::kqueue::Event, crate::utils::as_ptr, core::ptr::null};
@@ -586,13 +586,8 @@ pub fn splice(
     len: usize,
     flags: SpliceFlags,
 ) -> io::Result<usize> {
-    let off_in = off_in
-        .map(|off| (off as *mut u64).cast())
-        .unwrap_or(ptr::null_mut());
-
-    let off_out = off_out
-        .map(|off| (off as *mut u64).cast())
-        .unwrap_or(ptr::null_mut());
+    let off_in = optional_as_mut_ptr(off_in).cast();
+    let off_out = optional_as_mut_ptr(off_out).cast();
 
     unsafe {
         ret_usize(c::splice(

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -366,7 +366,7 @@ pub(crate) fn ext4_ioc_resize_fs(fd: BorrowedFd<'_>, blocks: u64) -> io::Result<
             __NR_ioctl,
             fd,
             c_uint(EXT4_IOC_RESIZE_FS),
-            &blocks as *const u64
+            by_ref(&blocks)
         ))
     }
 }

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -22,6 +22,7 @@ use crate::process::{
     Resource, Rlimit, Signal, Sysinfo, Uid, WaitId, WaitOptions, WaitStatus, WaitidOptions,
     WaitidStatus,
 };
+use crate::utils::as_mut_ptr;
 use core::convert::TryInto;
 use core::mem::MaybeUninit;
 use core::num::NonZeroU32;
@@ -224,7 +225,7 @@ pub(crate) fn sched_getaffinity(pid: Option<Pid>, cpuset: &mut RawCpuSet) -> io:
             size_of::<RawCpuSet, _>(),
             by_mut(&mut cpuset.bits)
         ))?;
-        let bytes = (cpuset as *mut RawCpuSet).cast::<u8>();
+        let bytes = as_mut_ptr(cpuset).cast::<u8>();
         let rest = bytes.wrapping_add(size);
         // Zero every byte in the cpuset not set by the kernel.
         rest.write_bytes(0, core::mem::size_of::<RawCpuSet>() - size);

--- a/src/process/prctl.rs
+++ b/src/process/prctl.rs
@@ -18,6 +18,7 @@ use crate::fd::{AsRawFd, BorrowedFd};
 use crate::ffi::CStr;
 use crate::io;
 use crate::process::{Pid, RawPid};
+use crate::utils::{as_mut_ptr, as_ptr};
 
 //
 // Helper functions.
@@ -58,7 +59,7 @@ where
     T: TryFrom<P, Error = io::Errno>,
 {
     let mut value: P = Default::default();
-    prctl_2args(option, ((&mut value) as *mut P).cast())?;
+    prctl_2args(option, as_mut_ptr(&mut value).cast())?;
     TryFrom::try_from(value)
 }
 
@@ -702,7 +703,7 @@ pub unsafe fn set_auxiliary_vector(auxv: &[*const c_void]) -> io::Result<()> {
 #[inline]
 pub fn virtual_memory_map_config_struct_size() -> io::Result<usize> {
     let mut value: c_uint = 0;
-    let value_ptr = (&mut value) as *mut c_uint;
+    let value_ptr = as_mut_ptr(&mut value);
     unsafe { prctl_3args(PR_SET_MM, PR_SET_MM_MAP_SIZE as *mut _, value_ptr.cast())? };
     Ok(value as usize)
 }
@@ -761,7 +762,7 @@ pub unsafe fn configure_virtual_memory_map(config: &PrctlMmMap) -> io::Result<()
     syscalls::prctl(
         PR_SET_MM,
         PR_SET_MM_MAP as *mut _,
-        config as *const PrctlMmMap as *mut _,
+        as_ptr(config) as *mut _,
         size_of::<PrctlMmMap>() as *mut _,
         null_mut(),
     )

--- a/src/thread/prctl.rs
+++ b/src/thread/prctl.rs
@@ -26,6 +26,7 @@ use crate::process::{
     prctl_1arg, prctl_2args, prctl_3args, prctl_get_at_arg2_optional, Pid,
     PointerAuthenticationKeys,
 };
+use crate::utils::as_ptr;
 
 //
 // PR_GET_KEEPCAPS/PR_SET_KEEPCAPS
@@ -854,7 +855,7 @@ pub unsafe fn enable_syscall_user_dispatch(
         PR_SYS_DISPATCH_ON as *mut _,
         always_allowed_region.as_ptr() as *mut _,
         always_allowed_region.len() as *mut _,
-        fast_switch_flag as *const AtomicU8 as *mut _,
+        as_ptr(fast_switch_flag) as *mut _,
     )
     .map(|_r| ())
 }


### PR DESCRIPTION
This reduces `as` casts, and is generally more concise.