### PR TITLE
Reconsider guarantees of Pid and refactor

### DIFF
--- a/src/backend/libc/pid/syscalls.rs
+++ b/src/backend/libc/pid/syscalls.rs
@@ -1,7 +1,7 @@
 //! libc syscalls for PIDs
 
 use crate::backend::c;
-use crate::pid::{Pid, RawNonZeroPid};
+use crate::pid::Pid;
 
 #[cfg(not(target_os = "wasi"))]
 #[inline]
@@ -9,7 +9,6 @@ use crate::pid::{Pid, RawNonZeroPid};
 pub(crate) fn getpid() -> Pid {
     unsafe {
         let pid = c::getpid();
-        debug_assert_ne!(pid, 0);
-        Pid::from_raw_nonzero(RawNonZeroPid::new_unchecked(pid))
+        Pid::from_raw_unchecked(pid)
     }
 }

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -14,7 +14,7 @@ use core::mem::MaybeUninit;
 #[cfg(not(target_os = "wasi"))]
 use {
     crate::io,
-    crate::pid::{Pid, RawNonZeroPid},
+    crate::pid::Pid,
     crate::termios::{Action, OptionalActions, QueueSelector, Speed, Termios, Winsize},
 };
 
@@ -52,8 +52,7 @@ pub(crate) fn tcgetattr2(fd: BorrowedFd<'_>) -> io::Result<crate::termios::Termi
 pub(crate) fn tcgetpgrp(fd: BorrowedFd<'_>) -> io::Result<Pid> {
     unsafe {
         let pid = ret_pid_t(c::tcgetpgrp(borrowed_fd(fd)))?;
-        debug_assert_ne!(pid, 0);
-        Ok(Pid::from_raw_nonzero(RawNonZeroPid::new_unchecked(pid)))
+        Ok(Pid::from_raw_unchecked(pid))
     }
 }
 
@@ -128,8 +127,7 @@ pub(crate) fn tcflow(fd: BorrowedFd, action: Action) -> io::Result<()> {
 pub(crate) fn tcgetsid(fd: BorrowedFd) -> io::Result<Pid> {
     unsafe {
         let pid = ret_pid_t(c::tcgetsid(borrowed_fd(fd)))?;
-        debug_assert_ne!(pid, 0);
-        Ok(Pid::from_raw_nonzero(RawNonZeroPid::new_unchecked(pid)))
+        Ok(Pid::from_raw_unchecked(pid))
     }
 }
 

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -15,7 +15,7 @@ use core::mem::MaybeUninit;
 use {
     crate::backend::conv::{borrowed_fd, ret_c_int, syscall_ret},
     crate::fd::BorrowedFd,
-    crate::pid::{Pid, RawNonZeroPid},
+    crate::pid::Pid,
     crate::utils::as_mut_ptr,
 };
 #[cfg(not(any(
@@ -285,8 +285,7 @@ pub(crate) fn gettid() -> Pid {
 
     unsafe {
         let tid = gettid();
-        debug_assert_ne!(tid, 0);
-        Pid::from_raw_nonzero(RawNonZeroPid::new_unchecked(tid))
+        Pid::from_raw_unchecked(tid)
     }
 }
 

--- a/src/backend/linux_raw/pid/syscalls.rs
+++ b/src/backend/linux_raw/pid/syscalls.rs
@@ -7,13 +7,13 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::conv::ret_usize_infallible;
-use crate::pid::{Pid, RawNonZeroPid, RawPid};
+use crate::pid::{Pid, RawPid};
 
 #[inline]
 pub(crate) fn getpid() -> Pid {
     unsafe {
         let pid = ret_usize_infallible(syscall_readonly!(__NR_getpid)) as RawPid;
         debug_assert!(pid > 0);
-        Pid::from_raw_nonzero(RawNonZeroPid::new_unchecked(pid as _))
+        Pid::from_raw_unchecked(pid)
     }
 }

--- a/src/backend/linux_raw/runtime/syscalls.rs
+++ b/src/backend/linux_raw/runtime/syscalls.rs
@@ -18,7 +18,7 @@ use crate::ffi::CStr;
 #[cfg(feature = "fs")]
 use crate::fs::AtFlags;
 use crate::io;
-use crate::pid::{Pid, RawNonZeroPid};
+use crate::pid::Pid;
 use crate::runtime::{How, Sigaction, Siginfo, Sigset, Stack};
 use crate::signal::Signal;
 use crate::timespec::Timespec;
@@ -101,7 +101,7 @@ pub(crate) mod tls {
     pub(crate) unsafe fn set_tid_address(data: *mut c::c_void) -> Pid {
         let tid: i32 = ret_c_int_infallible(syscall_readonly!(__NR_set_tid_address, data));
         debug_assert_ne!(tid, 0);
-        Pid::from_raw_nonzero(RawNonZeroPid::new_unchecked(tid))
+        Pid::from_raw_unchecked(tid)
     }
 
     #[inline]

--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -10,7 +10,7 @@ use crate::backend::c;
 use crate::backend::conv::{by_ref, c_uint, ret};
 use crate::fd::BorrowedFd;
 use crate::io;
-use crate::pid::{Pid, RawNonZeroPid};
+use crate::pid::Pid;
 #[cfg(feature = "procfs")]
 use crate::procfs;
 use crate::termios::{
@@ -75,7 +75,7 @@ pub(crate) fn tcgetpgrp(fd: BorrowedFd<'_>) -> io::Result<Pid> {
         ret(syscall!(__NR_ioctl, fd, c_uint(TIOCGPGRP), &mut result))?;
         let pid = result.assume_init();
         debug_assert!(pid > 0);
-        Ok(Pid::from_raw_nonzero(RawNonZeroPid::new_unchecked(pid)))
+        Ok(Pid::from_raw_unchecked(pid))
     }
 }
 
@@ -169,7 +169,7 @@ pub(crate) fn tcgetsid(fd: BorrowedFd) -> io::Result<Pid> {
         ret(syscall!(__NR_ioctl, fd, c_uint(TIOCGSID), &mut result))?;
         let pid = result.assume_init();
         debug_assert!(pid > 0);
-        Ok(Pid::from_raw_nonzero(RawNonZeroPid::new_unchecked(pid)))
+        Ok(Pid::from_raw_unchecked(pid))
     }
 }
 

--- a/src/backend/linux_raw/thread/syscalls.rs
+++ b/src/backend/linux_raw/thread/syscalls.rs
@@ -13,7 +13,7 @@ use crate::backend::conv::{
 };
 use crate::fd::BorrowedFd;
 use crate::io;
-use crate::pid::{Pid, RawNonZeroPid};
+use crate::pid::Pid;
 use crate::thread::{ClockId, FutexFlags, FutexOperation, NanosleepRelativeResult, Timespec};
 use core::mem::MaybeUninit;
 #[cfg(target_pointer_width = "32")]
@@ -201,7 +201,7 @@ pub(crate) fn gettid() -> Pid {
     unsafe {
         let tid = ret_c_int_infallible(syscall_readonly!(__NR_gettid));
         debug_assert_ne!(tid, 0);
-        Pid::from_raw_nonzero(RawNonZeroPid::new_unchecked(tid))
+        Pid::from_raw_unchecked(tid)
     }
 }
 

--- a/src/event/kqueue.rs
+++ b/src/event/kqueue.rs
@@ -113,7 +113,7 @@ impl Event {
                 flags: VnodeEvents::from_bits_truncate(self.inner.fflags),
             },
             c::EVFILT_PROC => EventFilter::Proc {
-                pid: unsafe { Pid::from_raw(self.inner.ident as _) }.unwrap(),
+                pid: Pid::from_raw(self.inner.ident as _).unwrap(),
                 flags: ProcessEvents::from_bits_truncate(self.inner.fflags),
             },
             c::EVFILT_SIGNAL => EventFilter::Signal {

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -32,14 +32,14 @@ impl Pid {
     /// This is always safe because a `Pid` is a number without any guarantees for the kernel.
     /// Non-child `Pid`s are always racy for any syscalls, but can only cause logic errors. If you
     /// want race-free access or control to non-child processes, please consider other mechanisms
-    /// like [`pidfd`] on Linux.
+    /// like [pidfd] on Linux.
+    ///
+    /// [pidfd]: https://man7.org/linux/man-pages/man2/pidfd_open.2.html
     #[inline]
     pub const fn from_raw(raw: RawPid) -> Option<Self> {
         if raw > 0 {
-            match RawNonZeroPid::new(raw) {
-                Some(pid) => Some(Self(pid)),
-                None => None,
-            }
+            // SAFETY: raw > 0.
+            unsafe { Some(Self::from_raw_unchecked(raw)) }
         } else {
             None
         }
@@ -78,7 +78,7 @@ impl Pid {
         pid.map_or(0, |pid| pid.0.get())
     }
 
-    /// Test whether this pid represents the init process (pid 0).
+    /// Test whether this pid represents the init process (pid 1).
     #[inline]
     pub const fn is_init(self) -> bool {
         self.0.get() == Self::INIT.0.get()

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -52,8 +52,7 @@ impl Pid {
     /// The caller must guarantee `raw` is strictly positive.
     #[inline]
     pub const unsafe fn from_raw_unchecked(raw: RawPid) -> Self {
-        // FIXME: `const_panic` is stabilized since Rust 1.57.
-        // debug_assert!(raw > 0);
+        debug_assert!(raw > 0);
         Self(RawNonZeroPid::new_unchecked(raw))
     }
 

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -1,11 +1,10 @@
 #![allow(unsafe_code)]
 
 use crate::backend::c;
+use core::num::NonZeroI32;
 
 /// A process identifier as a raw integer.
 pub type RawPid = c::pid_t;
-/// A non-zero process identifier as a raw non-zero integer.
-pub type RawNonZeroPid = core::num::NonZeroI32;
 
 /// `pid_t`—A non-zero Unix process ID.
 ///
@@ -14,13 +13,13 @@ pub type RawNonZeroPid = core::num::NonZeroI32;
 /// another, unrelated, process.
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
-pub struct Pid(RawNonZeroPid);
+pub struct Pid(NonZeroI32);
 
 impl Pid {
     /// A `Pid` corresponding to the init process (pid 1).
     pub const INIT: Self = Self(
         // SAFETY: One is non-zero.
-        unsafe { RawNonZeroPid::new_unchecked(1) },
+        unsafe { NonZeroI32::new_unchecked(1) },
     );
 
     /// Converts a `RawPid` into a `Pid`.
@@ -53,7 +52,7 @@ impl Pid {
     #[inline]
     pub const unsafe fn from_raw_unchecked(raw: RawPid) -> Self {
         debug_assert!(raw > 0);
-        Self(RawNonZeroPid::new_unchecked(raw))
+        Self(NonZeroI32::new_unchecked(raw))
     }
 
     /// Creates a `Pid` holding the ID of the given child process.
@@ -66,9 +65,9 @@ impl Pid {
         unsafe { Self::from_raw_unchecked(id as i32) }
     }
 
-    /// Converts a `Pid` into a `RawNonZeroPid`.
+    /// Converts a `Pid` into a `NonZeroI32`.
     #[inline]
-    pub const fn as_raw_nonzero(self) -> RawNonZeroPid {
+    pub const fn as_raw_nonzero(self) -> NonZeroI32 {
         self.0
     }
 
@@ -89,6 +88,6 @@ impl Pid {
 fn test_sizes() {
     use core::mem::size_of;
 
-    assert_eq!(size_of::<RawPid>(), size_of::<RawNonZeroPid>());
+    assert_eq!(size_of::<RawPid>(), size_of::<NonZeroI32>());
     assert_eq!(size_of::<RawPid>(), size_of::<Pid>());
 }

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -52,7 +52,8 @@ impl Pid {
     /// The caller must guarantee `raw` is strictly positive.
     #[inline]
     pub const unsafe fn from_raw_unchecked(raw: RawPid) -> Self {
-        debug_assert!(raw > 0);
+        // FIXME: `const_panic` is stabilized since Rust 1.57.
+        // debug_assert!(raw > 0);
         Self(RawNonZeroPid::new_unchecked(raw))
     }
 

--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -33,7 +33,7 @@ pub use crate::ugid::{Gid, Uid};
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub struct Cpuid(RawCpuid);
 
-#[cfg(linux_kernel)]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 impl Cpuid {
     /// Converts a `RawCpuid` into a `Cpuid`.
     ///

--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -21,9 +21,6 @@ pub use crate::ugid::RawGid;
 /// The raw integer value of a Unix process ID.
 pub use crate::pid::RawPid;
 
-/// The raw integer value of a Unix process ID.
-pub use crate::pid::RawNonZeroPid;
-
 pub use crate::pid::Pid;
 pub use crate::ugid::{Gid, Uid};
 

--- a/src/process/procctl.rs
+++ b/src/process/procctl.rs
@@ -254,7 +254,7 @@ pub struct ReaperStatus {
     /// The pid of the reaper for the specified process id.
     pub reaper: Pid,
     /// The pid of one reaper child if there are any descendants.
-    pub pid: Pid,
+    pub pid: Option<Pid>,
 }
 
 /// Get information about the reaper of the specified process (or the process
@@ -272,7 +272,11 @@ pub fn get_reaper_status(process: ProcSelector) -> io::Result<ReaperStatus> {
         children: raw.rs_children as _,
         descendants: raw.rs_descendants as _,
         reaper: Pid::from_raw(raw.rs_reaper).ok_or(io::Errno::RANGE)?,
-        pid: Pid::from_raw(raw.rs_pid).ok_or(io::Errno::RANGE)?,
+        pid: if raw.rs_pid == -1 {
+            None
+        } else {
+            Some(Pid::from_raw(raw.rs_pid).ok_or(io::Errno::RANGE)?)
+        },
     })
 }
 

--- a/src/process/procctl.rs
+++ b/src/process/procctl.rs
@@ -184,7 +184,7 @@ pub fn trace_status(process: ProcSelector) -> io::Result<TracingStatus> {
         -1 => Ok(TracingStatus::NotTraceble),
         0 => Ok(TracingStatus::Tracable),
         pid => {
-            let pid = unsafe { Pid::from_raw(pid as RawPid) }.ok_or(io::Errno::RANGE)?;
+            let pid = Pid::from_raw(pid as RawPid).ok_or(io::Errno::RANGE)?;
             Ok(TracingStatus::BeingTraced(pid))
         }
     }
@@ -271,8 +271,8 @@ pub fn get_reaper_status(process: ProcSelector) -> io::Result<ReaperStatus> {
         flags: ReaperStatusFlags::from_bits_truncate(raw.rs_flags),
         children: raw.rs_children as _,
         descendants: raw.rs_descendants as _,
-        reaper: unsafe { Pid::from_raw(raw.rs_reaper) }.ok_or(io::Errno::RANGE)?,
-        pid: unsafe { Pid::from_raw(raw.rs_pid) }.ok_or(io::Errno::RANGE)?,
+        reaper: Pid::from_raw(raw.rs_reaper).ok_or(io::Errno::RANGE)?,
+        pid: Pid::from_raw(raw.rs_pid).ok_or(io::Errno::RANGE)?,
     })
 }
 
@@ -351,8 +351,8 @@ pub fn get_reaper_pids(process: ProcSelector) -> io::Result<Vec<PidInfo>> {
         }
         result.push(PidInfo {
             flags,
-            subtree: unsafe { Pid::from_raw(raw.pi_subtree) }.ok_or(io::Errno::RANGE)?,
-            pid: unsafe { Pid::from_raw(raw.pi_pid) }.ok_or(io::Errno::RANGE)?,
+            subtree: Pid::from_raw(raw.pi_subtree).ok_or(io::Errno::RANGE)?,
+            pid: Pid::from_raw(raw.pi_pid).ok_or(io::Errno::RANGE)?,
         });
     }
     Ok(result)
@@ -414,11 +414,7 @@ pub fn reaper_kill(
     unsafe { procctl(PROC_REAP_KILL, process, as_mut_ptr(&mut req).cast())? };
     Ok(KillResult {
         killed: req.rk_killed as _,
-        first_failed: if req.rk_fpid == -1 {
-            None
-        } else {
-            unsafe { Pid::from_raw(req.rk_fpid) }
-        },
+        first_failed: Pid::from_raw(req.rk_fpid),
     })
 }
 

--- a/tests/process/pidfd.rs
+++ b/tests/process/pidfd.rs
@@ -19,7 +19,7 @@ fn test_pidfd_waitid() {
         .expect("failed to execute child");
 
     // Create a pidfd for the child process.
-    let pid = unsafe { process::Pid::from_raw(child.id() as _) }.unwrap();
+    let pid = process::Pid::from_child(&child);
     let pidfd = match process::pidfd_open(pid, process::PidfdFlags::empty()) {
         Ok(pidfd) => pidfd,
         Err(e) if e == io::Errno::NOSYS => {
@@ -56,7 +56,7 @@ fn test_pidfd_poll() {
         .expect("failed to execute child");
 
     // Create a pidfd for the child process.
-    let pid = unsafe { process::Pid::from_raw(child.id() as _) }.unwrap();
+    let pid = process::Pid::from_child(&child);
     let pidfd = match process::pidfd_open(pid, process::PidfdFlags::NONBLOCK) {
         Ok(pidfd) => pidfd,
         Err(e) if e == io::Errno::NOSYS || e == io::Errno::INVAL => {


### PR DESCRIPTION
Fixes #604.

## Summary

```rust
mod backend {
    mod linux_raw {
        pub type RawPid = i32;
        pub type RawNonZeroPid = core::num::NonZeroI32;
    }
}

pub mod process {
    impl Pid {
        pub const fn from_raw(raw: RawPid) -> Option<Self>;
        pub const unsafe fn from_raw_unchecked(raw: RawPid) -> Self;

        // Removed.
        // pub const unsafe fn from_raw_nonzero(raw: RawNonZeroPid) -> Self;
    }
}
```

## Things done & Rationales

1.  `Pid` and `RawPid` use `NonZeroI32` and `i32` now. `Pid` are guaranteed to be in range `1..=i32::MAX`.

    Notice that pid range should be enforced for all APIs, and negative values are exploited by Linux for different functionalities (eg, kill(2) a process group instead of a process). We should validate that range to prevent accidental misfunction, no matter for `i32` or `u32`.

    So here we consistently use a wrapped `i32` for both linux_raw and libc backend. Two constructor `Pid::from_raw{,_unchecked}` are provided to either do or bypass the check. These APIs also simplify code a lot.

2.  `Pid::from_raw_nonzero` is removed.

    As mentioned in (1), the range guarantee is stricter now and only the nonzero property cannot help much.

    **This is a breaking change.**

3.  `Pid::from_raw` is safe now.

    We are not possible to make any guarantee for an arbitrary non-children pid at all, and an invalid pid causes nothing more than a logic error.



## Unresolved

With the changes made, `Pid` (range checked) and `RawPid` (no restriction) covers almost all usages. `RawNonZeroPid` is under-checked for syscalls since `i32::MAX as u32 + 1` is type-valid but will malfunction. Is `RawNonZeroPid` still useful after this PR? If no, should we make it private as a implementation detail?