### PR TITLE
Fix the fstat/statat/etc. fallback when statx fails with EPERM.

### DIFF
--- a/src/backend/linux_raw/runtime/syscalls.rs
+++ b/src/backend/linux_raw/runtime/syscalls.rs
@@ -193,6 +193,9 @@ pub(crate) fn sigtimedwait(set: &Sigset, timeout: Option<Timespec>) -> io::Resul
     let mut info = MaybeUninit::<Siginfo>::uninit();
     let timeout_ptr = optional_as_ptr(timeout.as_ref());
 
+    // `rt_sigtimedwait_time64` was introduced in Linux 5.1. The old
+    // `rt_sigtimedwait` syscall is not y2038-compatible on 32-bit
+    // architectures.
     #[cfg(target_pointer_width = "32")]
     unsafe {
         match ret_c_int(syscall!(

--- a/src/backend/linux_raw/time/syscalls.rs
+++ b/src/backend/linux_raw/time/syscalls.rs
@@ -63,6 +63,8 @@ unsafe fn clock_getres_old(which_clock: ClockId, result: &mut MaybeUninit<__kern
 #[cfg(feature = "time")]
 #[inline]
 pub(crate) fn clock_settime(which_clock: ClockId, timespec: __kernel_timespec) -> io::Result<()> {
+    // `clock_settime64` was introduced in Linux 5.1. The old `clock_settime`
+    // syscall is not y2038-compatible on 32-bit architectures.
     #[cfg(target_pointer_width = "32")]
     unsafe {
         match ret(syscall_readonly!(

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -263,6 +263,13 @@ pub fn statat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, flags: AtFlags) -> io:
 /// `faccessat(dirfd, path, access, flags)`—Tests permissions for a file or
 /// directory.
 ///
+/// On Linux before 5.8, this function uses the `faccessat` system call which
+/// doesn't support any flags. This function emulates support for the
+/// [`AtFlags::EACCESS`] flag by checking whether the uid and gid of the
+/// process match the effective uid and gid, in which case the `EACCESS` flag
+/// can be ignored. In Linux 5.8 and beyond `faccessat2` is used, which
+/// supports flags.
+///
 /// # References
 ///  - [POSIX]
 ///  - [Linux]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,8 @@
 //!    running under seccomp.
 //!
 //! Things they don't do include:
-//!  - Detecting whether functions are supported at runtime.
+//!  - Detecting whether functions are supported at runtime, except in specific
+//!    cases where new interfaces need to be detected to support y2038 and LFS.
 //!  - Hiding significant differences between platforms.
 //!  - Restricting ambient authorities.
 //!  - Imposing sandboxing features such as filesystem path or network address


### PR DESCRIPTION
On some old non-y2038-safe container runtimes, `statx` fails with `EPERM`, so use `crate::fs::statx` instead of calling the statx syscall directly. This includes code to check whether it was a "real" `EPERM` we should return to the user, or an `EPERM` which indicates that statx isn't supported, allowing rustix to fall back to the old non-y2038-safe syscalls.

Also, update the crate-level comment mentionintg that rustix does sometimes do dynamic feature detection in order to support y2038 and LFS.

And fix a copy and paste in a comment in `renameat2`.