### PR TITLE
Update to libc 0.2.144

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ once_cell = { version = "1.5.2", optional = true }
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64")))))'.dependencies]
 linux-raw-sys = { version = "0.3.6", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 libc_errno = { package = "errno", version = "0.3.1", default-features = false, optional = true }
-libc = { version = "0.2.142", features = ["extra_traits"], optional = true }
+libc = { version = "0.2.144", features = ["extra_traits"], optional = true }
 
 # Dependencies for platforms where only libc is supported:
 #
@@ -49,7 +49,7 @@ libc = { version = "0.2.142", features = ["extra_traits"], optional = true }
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64"))))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.1", default-features = false }
-libc = { version = "0.2.142", features = ["extra_traits"] }
+libc = { version = "0.2.144", features = ["extra_traits"] }
 
 # Additional dependencies for Linux with the libc backend:
 #
@@ -77,7 +77,7 @@ default-features = false
 
 [dev-dependencies]
 tempfile = "3.4.0"
-libc = "0.2.142"
+libc = "0.2.144"
 libc_errno = { package = "errno", version = "0.3.1", default-features = false }
 io-lifetimes = { version = "1.0.10", default-features = false, features = ["close"] }
 # Don't upgrade to serial_test 0.7 for now because it depends on a


### PR DESCRIPTION
### What does this PR try to resolve?

cargo cannot build successfully on LoongArch:

```
error[E0425]: cannot find value `FICLONE` in module `c`
   --> /home/hev/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustix-0.37.15/src/backend/libc/io/syscalls.rs:356:16
    |
356 |             c::FICLONE as _,
    |                ^^^^^^^ not found in `c`
```

This is caused by some constants are missing in libc and [fixed](https://github.com/rust-lang/libc/pull/3237) after `libc 0.2.143` release.