### PR TITLE
Enable several features enabled by libc 0.2.144.

### DIFF
--- a/src/backend/libc/fs/makedev.rs
+++ b/src/backend/libc/fs/makedev.rs
@@ -4,6 +4,7 @@ use crate::fs::Dev;
 
 #[cfg(not(any(
     apple,
+    solarish,
     target_os = "aix",
     target_os = "android",
     target_os = "emscripten",
@@ -11,6 +12,13 @@ use crate::fs::Dev;
 #[inline]
 pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
     c::makedev(maj, min)
+}
+
+#[cfg(solarish)]
+pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
+    // SAFETY: Solarish's `makedev` is marked unsafe but it isn't doing
+    // anything unsafe.
+    unsafe { c::makedev(maj, min) }
 }
 
 #[cfg(all(target_os = "android", not(target_pointer_width = "32")))]
@@ -54,19 +62,24 @@ pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
 #[cfg(not(any(
     apple,
     freebsdlike,
-    netbsdlike,
     target_os = "android",
     target_os = "emscripten",
+    target_os = "netbsd"
 )))]
 #[inline]
 pub(crate) fn major(dev: Dev) -> u32 {
     unsafe { c::major(dev) }
 }
 
-#[cfg(all(target_os = "android", not(target_pointer_width = "32")))]
+#[cfg(any(
+    apple,
+    freebsdlike,
+    target_os = "netbsd",
+    all(target_os = "android", not(target_pointer_width = "32")),
+))]
 #[inline]
 pub(crate) fn major(dev: Dev) -> u32 {
-    // Android's `major` oddly has signed return types.
+    // On some platforms `major` oddly has signed return types.
     (unsafe { c::major(dev) }) as u32
 }
 
@@ -88,19 +101,24 @@ pub(crate) fn major(dev: Dev) -> u32 {
 #[cfg(not(any(
     apple,
     freebsdlike,
-    netbsdlike,
     target_os = "android",
     target_os = "emscripten",
+    target_os = "netbsd"
 )))]
 #[inline]
 pub(crate) fn minor(dev: Dev) -> u32 {
     unsafe { c::minor(dev) }
 }
 
-#[cfg(all(target_os = "android", not(target_pointer_width = "32")))]
+#[cfg(any(
+    apple,
+    freebsdlike,
+    target_os = "netbsd",
+    all(target_os = "android", not(target_pointer_width = "32"))
+))]
 #[inline]
 pub(crate) fn minor(dev: Dev) -> u32 {
-    // Android's `minor` oddly has signed return types.
+    // On some platforms, `minor` oddly has signed return types.
     (unsafe { c::minor(dev) }) as u32
 }
 

--- a/src/backend/libc/fs/mod.rs
+++ b/src/backend/libc/fs/mod.rs
@@ -2,7 +2,7 @@
 pub(crate) mod dir;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub mod inotify;
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 pub(crate) mod makedev;
 #[cfg(not(windows))]
 pub(crate) mod syscalls;

--- a/src/backend/libc/io/poll_fd.rs
+++ b/src/backend/libc/io/poll_fd.rs
@@ -21,16 +21,14 @@ bitflags! {
         /// `POLLOUT`
         const OUT = c::POLLOUT;
         /// `POLLRDNORM`
-        #[cfg(not(target_os = "redox"))]
         const RDNORM = c::POLLRDNORM;
         /// `POLLWRNORM`
-        #[cfg(not(target_os = "redox"))]
         const WRNORM = c::POLLWRNORM;
         /// `POLLRDBAND`
-        #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+        #[cfg(not(target_os = "wasi"))]
         const RDBAND = c::POLLRDBAND;
         /// `POLLWRBAND`
-        #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+        #[cfg(not(target_os = "wasi"))]
         const WRBAND = c::POLLWRBAND;
         /// `POLLERR`
         const ERR = c::POLLERR;

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -339,37 +339,18 @@ pub(crate) fn ioctl_fionbio(fd: BorrowedFd<'_>, value: bool) -> io::Result<()> {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+// Sparc lacks `FICLONE`.
+#[cfg(all(
+    not(any(target_arch = "sparc", target_arch = "sparc64")),
+    any(target_os = "android", target_os = "linux"),
+))]
 pub(crate) fn ioctl_ficlone(fd: BorrowedFd<'_>, src_fd: BorrowedFd<'_>) -> io::Result<()> {
-    // TODO: Enable this on mips and power once libc is updated.
-    #[cfg(not(any(
-        target_arch = "mips",
-        target_arch = "mips64",
-        target_arch = "powerpc",
-        target_arch = "powerpc64",
-        target_arch = "sparc",
-        target_arch = "sparc64"
-    )))]
     unsafe {
         ret(c::ioctl(
             borrowed_fd(fd),
             c::FICLONE as _,
             borrowed_fd(src_fd),
         ))
-    }
-
-    #[cfg(any(
-        target_arch = "mips",
-        target_arch = "mips64",
-        target_arch = "powerpc",
-        target_arch = "powerpc64",
-        target_arch = "sparc",
-        target_arch = "sparc64"
-    ))]
-    {
-        let _ = fd;
-        let _ = src_fd;
-        Err(io::Errno::NOSYS)
     }
 }
 

--- a/src/backend/libc/mm/types.rs
+++ b/src/backend/libc/mm/types.rs
@@ -321,28 +321,25 @@ pub enum Advice {
     LinuxDoDump = c::MADV_DODUMP,
     /// `MADV_WIPEONFORK` (since Linux 4.14)
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg(feature = "mm")]
-    LinuxWipeOnFork = linux_raw_sys::general::MADV_WIPEONFORK as i32,
+    LinuxWipeOnFork = libc::MADV_WIPEONFORK as i32,
     /// `MADV_KEEPONFORK` (since Linux 4.14)
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg(feature = "mm")]
-    LinuxKeepOnFork = linux_raw_sys::general::MADV_KEEPONFORK as i32,
+    LinuxKeepOnFork = libc::MADV_KEEPONFORK as i32,
     /// `MADV_COLD` (since Linux 5.4)
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg(feature = "mm")]
-    LinuxCold = linux_raw_sys::general::MADV_COLD as i32,
+    LinuxCold = libc::MADV_COLD as i32,
     /// `MADV_PAGEOUT` (since Linux 5.4)
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg(feature = "mm")]
-    LinuxPageOut = linux_raw_sys::general::MADV_PAGEOUT as i32,
+    LinuxPageOut = libc::MADV_PAGEOUT as i32,
     /// `MADV_POPULATE_READ` (since Linux 5.14)
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg(feature = "mm")]
-    LinuxPopulateRead = linux_raw_sys::general::MADV_POPULATE_READ as i32,
+    LinuxPopulateRead = libc::MADV_POPULATE_READ as i32,
     /// `MADV_POPULATE_WRITE` (since Linux 5.14)
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg(feature = "mm")]
-    LinuxPopulateWrite = linux_raw_sys::general::MADV_POPULATE_WRITE as i32,
+    LinuxPopulateWrite = libc::MADV_POPULATE_WRITE as i32,
+    /// `MADV_DONTNEED_LOCKED` (since Linux 5.18)
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    LinuxDontneedLocked = libc::MADV_DONTNEED_LOCKED as i32,
 }
 
 #[cfg(target_os = "emscripten")]

--- a/src/backend/libc/net/types.rs
+++ b/src/backend/libc/net/types.rs
@@ -414,7 +414,6 @@ impl Protocol {
         bsd,
         solarish,
         windows,
-        target_os = "android",
         target_os = "emscripten",
         target_os = "fuchsia",
         target_os = "haiku",

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -259,7 +259,7 @@ pub(crate) fn nice(inc: i32) -> io::Result<i32> {
     }
 }
 
-#[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 #[inline]
 pub(crate) fn getpriority_user(uid: Uid) -> io::Result<i32> {
     libc_errno::set_errno(libc_errno::Errno(0));
@@ -271,7 +271,7 @@ pub(crate) fn getpriority_user(uid: Uid) -> io::Result<i32> {
     }
 }
 
-#[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 #[inline]
 pub(crate) fn getpriority_pgrp(pgid: Option<Pid>) -> io::Result<i32> {
     libc_errno::set_errno(libc_errno::Errno(0));
@@ -283,7 +283,7 @@ pub(crate) fn getpriority_pgrp(pgid: Option<Pid>) -> io::Result<i32> {
     }
 }
 
-#[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 #[inline]
 pub(crate) fn getpriority_process(pid: Option<Pid>) -> io::Result<i32> {
     libc_errno::set_errno(libc_errno::Errno(0));
@@ -295,13 +295,13 @@ pub(crate) fn getpriority_process(pid: Option<Pid>) -> io::Result<i32> {
     }
 }
 
-#[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 #[inline]
 pub(crate) fn setpriority_user(uid: Uid, priority: i32) -> io::Result<()> {
     unsafe { ret(c::setpriority(c::PRIO_USER, uid.as_raw() as _, priority)) }
 }
 
-#[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 #[inline]
 pub(crate) fn setpriority_pgrp(pgid: Option<Pid>, priority: i32) -> io::Result<()> {
     unsafe {
@@ -313,7 +313,7 @@ pub(crate) fn setpriority_pgrp(pgid: Option<Pid>, priority: i32) -> io::Result<(
     }
 }
 
-#[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 #[inline]
 pub(crate) fn setpriority_process(pid: Option<Pid>, priority: i32) -> io::Result<()> {
     unsafe {

--- a/src/backend/libc/time/syscalls.rs
+++ b/src/backend/libc/time/syscalls.rs
@@ -181,7 +181,7 @@ pub(crate) fn clock_gettime_dynamic(id: DynamicClockId<'_>) -> io::Result<Timesp
             #[cfg(any(target_os = "android", target_os = "linux"))]
             DynamicClockId::Tai => c::CLOCK_TAI,
 
-            #[cfg(any(target_os = "android", target_os = "linux"))]
+            #[cfg(any(target_os = "android", target_os = "linux", target_os = "openbsd"))]
             DynamicClockId::Boottime => c::CLOCK_BOOTTIME,
 
             #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/backend/libc/time/types.rs
+++ b/src/backend/libc/time/types.rs
@@ -127,15 +127,15 @@ pub enum ClockId {
     Monotonic = c::CLOCK_MONOTONIC,
 
     /// `CLOCK_UPTIME`
-    #[cfg(any(freebsdlike))]
+    #[cfg(any(freebsdlike, target_os = "openbsd"))]
     Uptime = c::CLOCK_UPTIME,
 
     /// `CLOCK_PROCESS_CPUTIME_ID`
-    #[cfg(not(any(netbsdlike, solarish, target_os = "redox")))]
+    #[cfg(not(any(solarish, target_os = "netbsd", target_os = "redox")))]
     ProcessCPUTime = c::CLOCK_PROCESS_CPUTIME_ID,
 
     /// `CLOCK_THREAD_CPUTIME_ID`
-    #[cfg(not(any(netbsdlike, solarish, target_os = "redox")))]
+    #[cfg(not(any(solarish, target_os = "netbsd", target_os = "redox")))]
     ThreadCPUTime = c::CLOCK_THREAD_CPUTIME_ID,
 
     /// `CLOCK_REALTIME_COARSE`
@@ -201,7 +201,7 @@ pub enum DynamicClockId<'a> {
     Tai,
 
     /// `CLOCK_BOOTTIME`, available on Linux >= 2.6.39
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "openbsd"))]
     Boottime,
 
     /// `CLOCK_BOOTTIME_ALARM`, available on Linux >= 2.6.39

--- a/src/backend/libc/winsock_c.rs
+++ b/src/backend/libc/winsock_c.rs
@@ -33,16 +33,12 @@ pub(crate) const AF_UNSPEC: i32 = WinSock::AF_UNSPEC as _;
 // `WSAECANCELLED` will be removed in the future.
 // <https://docs.microsoft.com/en-us/windows/win32/api/ws2spi/nc-ws2spi-lpnsplookupserviceend#remarks>
 pub(crate) use WinSock::{
-    closesocket as close, ioctlsocket as ioctl, socklen_t, WSAPoll as poll,
-    ADDRESS_FAMILY as sa_family_t, ADDRINFOA as addrinfo, IN6_ADDR as in6_addr, IN_ADDR as in_addr,
-    IPV6_ADD_MEMBERSHIP, IPV6_DROP_MEMBERSHIP, IPV6_MREQ as ipv6_mreq, IPV6_MULTICAST_LOOP,
-    IPV6_V6ONLY, IP_ADD_MEMBERSHIP, IP_DROP_MEMBERSHIP, IP_MREQ as ip_mreq, IP_MULTICAST_LOOP,
-    IP_MULTICAST_TTL, IP_TTL, LINGER as linger, POLLERR, POLLHUP, POLLIN, POLLNVAL, POLLOUT,
-    POLLPRI, POLLRDBAND, POLLRDNORM, POLLWRBAND, POLLWRNORM, SD_BOTH as SHUT_RDWR,
-    SD_RECEIVE as SHUT_RD, SD_SEND as SHUT_WR, SOCKADDR as sockaddr, SOCKADDR_IN as sockaddr_in,
-    SOCKADDR_IN6 as sockaddr_in6, SOCKADDR_STORAGE as sockaddr_storage, SOL_SOCKET, SO_BROADCAST,
-    SO_ERROR, SO_LINGER, SO_RCVTIMEO, SO_REUSEADDR, SO_SNDTIMEO, SO_TYPE, TCP_NODELAY,
-    WSAEACCES as EACCES, WSAEADDRINUSE as EADDRINUSE, WSAEADDRNOTAVAIL as EADDRNOTAVAIL,
+    closesocket as close, ioctlsocket as ioctl, WSAPoll as poll, ADDRESS_FAMILY as sa_family_t,
+    ADDRINFOA as addrinfo, IN6_ADDR as in6_addr, IN_ADDR as in_addr, IPV6_MREQ as ipv6_mreq,
+    IP_MREQ as ip_mreq, LINGER as linger, SD_BOTH as SHUT_RDWR, SD_RECEIVE as SHUT_RD,
+    SD_SEND as SHUT_WR, SOCKADDR as sockaddr, SOCKADDR_IN as sockaddr_in,
+    SOCKADDR_IN6 as sockaddr_in6, SOCKADDR_STORAGE as sockaddr_storage, WSAEACCES as EACCES,
+    WSAEADDRINUSE as EADDRINUSE, WSAEADDRNOTAVAIL as EADDRNOTAVAIL,
     WSAEAFNOSUPPORT as EAFNOSUPPORT, WSAEALREADY as EALREADY, WSAEBADF as EBADF,
     WSAECONNABORTED as ECONNABORTED, WSAECONNREFUSED as ECONNREFUSED, WSAECONNRESET as ECONNRESET,
     WSAEDESTADDRREQ as EDESTADDRREQ, WSAEDISCON as EDISCON, WSAEDQUOT as EDQUOT,

--- a/src/backend/linux_raw/mm/types.rs
+++ b/src/backend/linux_raw/mm/types.rs
@@ -195,6 +195,8 @@ pub enum Advice {
     LinuxPopulateRead = linux_raw_sys::general::MADV_POPULATE_READ,
     /// `MADV_POPULATE_WRITE` (since Linux 5.14)
     LinuxPopulateWrite = linux_raw_sys::general::MADV_POPULATE_WRITE,
+    /// `MADV_DONTNEED_LOCKED` (since Linux 5.18)
+    LinuxDontneedLocked = linux_raw_sys::general::MADV_DONTNEED_LOCKED,
 }
 
 #[allow(non_upper_case_globals)]

--- a/src/fs/makedev.rs
+++ b/src/fs/makedev.rs
@@ -18,7 +18,6 @@ pub fn makedev(maj: u32, min: u32) -> Dev {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man3/minor.3.html
-#[cfg(not(bsd))]
 #[inline]
 pub fn minor(dev: Dev) -> u32 {
     backend::fs::makedev::minor(dev)
@@ -30,7 +29,6 @@ pub fn minor(dev: Dev) -> u32 {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man3/major.3.html
-#[cfg(not(bsd))]
 #[inline]
 pub fn major(dev: Dev) -> u32 {
     backend::fs::makedev::major(dev)

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -28,7 +28,7 @@ pub(crate) mod fd;
 mod file_type;
 #[cfg(apple)]
 mod getpath;
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 mod makedev;
 #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 mod memfd_create;
@@ -77,7 +77,7 @@ pub use fd::*;
 pub use file_type::FileType;
 #[cfg(apple)]
 pub use getpath::getpath;
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 pub use makedev::*;
 #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 pub use memfd_create::{memfd_create, MemfdFlags};

--- a/src/io/ioctl.rs
+++ b/src/io/ioctl.rs
@@ -126,11 +126,16 @@ pub fn ioctl_blkpbszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
 
 /// `ioctl(fd, FICLONE, src_fd)`—Share data between open files.
 ///
+/// This ioctl is not available on Sparc platforms
+///
 /// # References
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/ioctl_ficlone.2.html
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(all(
+    not(any(target_arch = "sparc", target_arch = "sparc64")),
+    any(target_os = "android", target_os = "linux"),
+))]
 #[inline]
 #[doc(alias = "FICLONE")]
 pub fn ioctl_ficlone<Fd: AsFd, SrcFd: AsFd>(fd: Fd, src_fd: SrcFd) -> io::Result<()> {

--- a/src/process/priority.rs
+++ b/src/process/priority.rs
@@ -25,7 +25,6 @@ pub fn nice(inc: i32) -> io::Result<i32> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpriority.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getpriority.2.html
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/setpriority.2.html
-#[cfg(not(target_os = "redox"))]
 #[inline]
 #[doc(alias = "getpriority")]
 pub fn getpriority_user(uid: Uid) -> io::Result<i32> {
@@ -45,7 +44,6 @@ pub fn getpriority_user(uid: Uid) -> io::Result<i32> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpriority.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getpriority.2.html
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/setpriority.2.html
-#[cfg(not(target_os = "redox"))]
 #[inline]
 #[doc(alias = "getpriority")]
 pub fn getpriority_pgrp(pgid: Option<Pid>) -> io::Result<i32> {
@@ -65,7 +63,6 @@ pub fn getpriority_pgrp(pgid: Option<Pid>) -> io::Result<i32> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpriority.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getpriority.2.html
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/setpriority.2.html
-#[cfg(not(target_os = "redox"))]
 #[inline]
 #[doc(alias = "getpriority")]
 pub fn getpriority_process(pid: Option<Pid>) -> io::Result<i32> {
@@ -83,7 +80,6 @@ pub fn getpriority_process(pid: Option<Pid>) -> io::Result<i32> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setpriority.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/setpriority.2.html
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/setpriority.2.html
-#[cfg(not(target_os = "redox"))]
 #[inline]
 #[doc(alias = "setpriority")]
 pub fn setpriority_user(uid: Uid, priority: i32) -> io::Result<()> {
@@ -103,7 +99,6 @@ pub fn setpriority_user(uid: Uid, priority: i32) -> io::Result<()> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setpriority.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/setpriority.2.html
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/setpriority.2.html
-#[cfg(not(target_os = "redox"))]
 #[inline]
 #[doc(alias = "setpriority")]
 pub fn setpriority_pgrp(pgid: Option<Pid>, priority: i32) -> io::Result<()> {
@@ -123,7 +118,6 @@ pub fn setpriority_pgrp(pgid: Option<Pid>, priority: i32) -> io::Result<()> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setpriority.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/setpriority.2.html
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/setpriority.2.html
-#[cfg(not(target_os = "redox"))]
 #[inline]
 #[doc(alias = "setpriority")]
 pub fn setpriority_process(pid: Option<Pid>, priority: i32) -> io::Result<()> {

--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -23,7 +23,7 @@ mod futimens;
 mod invalid_offset;
 mod linkat;
 mod long_paths;
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 mod makedev;
 mod mkdirat;
 mod mknodat;

--- a/tests/fs/makedev.rs
+++ b/tests/fs/makedev.rs
@@ -1,17 +1,17 @@
-use rustix::fs::makedev;
-#[cfg(not(bsd))]
-use rustix::fs::{major, minor};
+use rustix::fs::{major, makedev, minor};
 
 #[test]
 fn makedev_roundtrip() {
-    let maj = 0x2324_2526;
-    let min = 0x6564_6361;
+    // Apple's, FreeBSD 11's, and Dragonfly's `makedev` doesn't handle extra
+    // bits set.
+    #[cfg(freebsdlike)]
+    let (maj, min) = (0x0000_0026, 0x6564_0061);
+    #[cfg(not(any(apple, freebsdlike)))]
+    let (maj, min) = (0x2324_2526, 0x6564_6361);
+    #[cfg(apple)]
+    let (maj, min) = (0x0000_0026, 0x0064_6361);
+
     let dev = makedev(maj, min);
-    #[cfg(not(bsd))]
-    {
-        assert_eq!(maj, major(dev));
-        assert_eq!(min, minor(dev));
-    }
-    #[cfg(bsd)]
-    let _ = dev;
+    assert_eq!(maj, major(dev));
+    assert_eq!(min, minor(dev));
 }

--- a/tests/io/ioctl.rs
+++ b/tests/io/ioctl.rs
@@ -14,16 +14,11 @@ fn test_ioctls() {
     );
 }
 
-// TODO: Enable this on mips and power once libc is updated.
-#[cfg(any(target_os = "android", target_os = "linux"))]
-#[cfg(not(any(
-    target_arch = "mips",
-    target_arch = "mips64",
-    target_arch = "powerpc",
-    target_arch = "powerpc64",
-    target_arch = "sparc",
-    target_arch = "sparc64"
-)))]
+// Sparc lacks `FICLONE`.
+#[cfg(all(
+    not(any(target_arch = "sparc", target_arch = "sparc64")),
+    any(target_os = "android", target_os = "linux"),
+))]
 #[test]
 fn test_ioctl_ficlone() {
     use rustix::io;


### PR DESCRIPTION
 - enable `makedev`/`major`/`minor` on solarish and bsd
 - enable more poll constants on redox
 - enable `ioctl_ficlone` on mips, power, and sparc
 - add new Linux `MADV_` constants
 - enable `IPPROTO_MPTCP` on android
 - enable `getpriority`/`setpriority` on redox