### PR TITLE
Remove some rerun-if-env-changed lines from build.rs. (#576)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -232,13 +232,13 @@ jobs:
       QEMU_BUILD_VERSION: 7.0.0
     strategy:
       matrix:
-        build: [ubuntu, ubuntu-18.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, ubuntu-1.48, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, mipsel-linux-stable, mips64el-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.48, i686-linux-1.48, aarch64-linux-1.48, riscv64-linux-1.48, s390x-linux-1.48, mipsel-linux-1.48, mips64el-linux-1.48, powerpc64le-linux-1.48, arm-linux-1.48, macos-latest, macos-10.15, windows, windows-2019]
+        build: [ubuntu, ubuntu-20.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, ubuntu-1.48, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, mipsel-linux-stable, mips64el-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.48, i686-linux-1.48, aarch64-linux-1.48, riscv64-linux-1.48, s390x-linux-1.48, mipsel-linux-1.48, mips64el-linux-1.48, powerpc64le-linux-1.48, arm-linux-1.48, macos-latest, macos-11, windows, windows-2019]
         include:
           - build: ubuntu
             os: ubuntu-20.04 # TODO: remove pin when fixed (#483)
             rust: nightly
-          - build: ubuntu-18.04
-            os: ubuntu-18.04
+          - build: ubuntu-20.04
+            os: ubuntu-20.04
             rust: nightly
           - build: i686-linux
             os: ubuntu-20.04 # TODO: remove pin when fixed (#483)
@@ -459,8 +459,8 @@ jobs:
           - build: macos-latest
             os: macos-latest
             rust: stable
-          - build: macos-10.15
-            os: macos-10.15
+          - build: macos-11
+            os: macos-11
             rust: stable
           - build: windows
             os: windows-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,6 +93,7 @@ jobs:
         cargo update --package=once_cell --precise 1.14.0
         cargo update --package=tempfile --precise=3.4.0
         cargo update --package=io-lifetimes --precise 1.0.6
+        cargo update --package=flate2 --precise=1.0.25
         for crate in test-crates/*; do
             cd $crate
             cargo update --package=io-lifetimes --precise 1.0.6
@@ -535,6 +536,7 @@ jobs:
         cargo update --package=once_cell --precise 1.14.0
         cargo update --package=tempfile --precise=3.4.0
         cargo update --package=io-lifetimes --precise 1.0.6
+        cargo update --package=flate2 --precise=1.0.25
         for crate in test-crates/*; do
             cd $crate
             cargo update --package=io-lifetimes --precise 1.0.6

--- a/build.rs
+++ b/build.rs
@@ -117,11 +117,6 @@ fn main() {
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_USE_LIBC");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_RUSTC_DEP_OF_STD");
     println!("cargo:rerun-if-env-changed=CARGO_CFG_MIRI");
-    println!("cargo:rerun-if-env-changed=CARGO_ENCODED_RUSTFLAGS");
-    println!("cargo:rerun-if-env-changed=RUSTC");
-    println!("cargo:rerun-if-env-changed=TARGET");
-    println!("cargo:rerun-if-env-changed=RUSTC_WRAPPER");
-    println!("cargo:rerun-if-env-changed=PROFILE");
 }
 
 /// Link in the desired version of librustix_outline_{arch}.a, containing the


### PR DESCRIPTION
Now that we appear to have a known-working fix for #526, we can investigate relaxing the fix. If #526 reappears, we now have a known-working state we can quickly revert to.

Reports in #562 and #575 are that having rerun-if-env-changed=RUSTC and rerun-if-env-changed=RUSTC_WRAPPER are triggering spurious rebuilds in some situations, so remove these. In theory, cargo should already be aware of these environment variables. In practice, there were reports of build failures which had the appearance of using an older version of rustc with build.rs output from a newer version of rustc, and it wasn't clear what was happening. But, it's possible that #563 fixes the issue properly. So let's try removing these rerun-if-env-changed lines, and see if the problem resurfaces.

And, rerun-if-env-changed=TARGET is explicitly documented as being unnecessary [here].

[here]: https://doc.rust-lang.org/cargo/reference/build-scripts.html