### PR TITLE
Add a `linux_kernel` cfg, to simplify a common platform set.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -140,6 +140,12 @@ fn main() {
     {
         use_feature("bsd");
     }
+
+    // Add some additional common target combinations.
+    if target_os == "android" || target_os == "linux" {
+        use_feature("linux_kernel");
+    }
+
     if target_os == "wasi" {
         use_feature_or_nothing("wasi_ext");
     }

--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -1,9 +1,9 @@
 pub(crate) use libc::*;
 
 /// `PROC_SUPER_MAGIC`—The magic number for the procfs filesystem.
-#[cfg(all(any(target_os = "android", target_os = "linux"), target_env = "musl"))]
+#[cfg(all(linux_kernel, target_env = "musl"))]
 pub(crate) const PROC_SUPER_MAGIC: u32 = 0x0000_9fa0;
 
 /// `NFS_SUPER_MAGIC`—The magic number for the NFS filesystem.
-#[cfg(all(any(target_os = "android", target_os = "linux"), target_env = "musl"))]
+#[cfg(all(linux_kernel, target_env = "musl"))]
 pub(crate) const NFS_SUPER_MAGIC: u32 = 0x0000_6969;

--- a/src/backend/libc/conv.rs
+++ b/src/backend/libc/conv.rs
@@ -107,7 +107,7 @@ pub(super) fn syscall_ret_usize(raw: c::c_long) -> io::Result<usize> {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub(super) fn syscall_ret_u32(raw: c::c_long) -> io::Result<u32> {
     if raw == -1 {

--- a/src/backend/libc/fs/mod.rs
+++ b/src/backend/libc/fs/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(not(target_os = "redox"))]
 pub(crate) mod dir;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub mod inotify;
 #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 pub(crate) mod makedev;

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -361,7 +361,7 @@ bitflags! {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags! {
     /// `RESOLVE_*` constants for use with [`openat2`].
     ///
@@ -388,7 +388,7 @@ bitflags! {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags! {
     /// `RENAME_*` constants for use with [`renameat_with`].
     ///
@@ -592,7 +592,7 @@ bitflags! {
        /// `F_SEAL_WRITE`.
        const WRITE = c::F_SEAL_WRITE;
        /// `F_SEAL_FUTURE_WRITE` (since Linux 5.1)
-       #[cfg(any(target_os = "android", target_os = "linux"))]
+       #[cfg(linux_kernel)]
        const FUTURE_WRITE = c::F_SEAL_FUTURE_WRITE;
     }
 }
@@ -852,10 +852,7 @@ pub type Stat = c::stat;
 /// [`statat`]: crate::fs::statat
 /// [`fstat`]: crate::fs::fstat
 #[cfg(any(
-    all(
-        any(target_os = "android", target_os = "linux"),
-        target_pointer_width = "64",
-    ),
+    all(linux_kernel, target_pointer_width = "64"),
     target_os = "emscripten",
     target_os = "l4re",
 ))]
@@ -868,10 +865,7 @@ pub type Stat = c::stat64;
 // On 32-bit, Linux's `struct stat64` has a 32-bit `st_mtime` and friends, so
 // we use our own struct, populated from `statx` where possible, to avoid the
 // y2038 bug.
-#[cfg(all(
-    any(target_os = "android", target_os = "linux"),
-    target_pointer_width = "32",
-))]
+#[cfg(all(linux_kernel, target_pointer_width = "32"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 #[allow(missing_docs)]
@@ -1053,7 +1047,7 @@ pub type FsWord = u32;
 #[derive(Copy, Clone)]
 pub struct copyfile_state_t(pub(crate) *mut c::c_void);
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags! {
     /// `MS_*` constants for use with [`mount`].
     ///
@@ -1107,7 +1101,7 @@ bitflags! {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags! {
     /// `MS_*` constants for use with [`change_mount`].
     ///
@@ -1126,7 +1120,7 @@ bitflags! {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags! {
     pub(crate) struct InternalMountFlags: c::c_ulong {
         const REMOUNT = c::MS_REMOUNT;
@@ -1134,10 +1128,10 @@ bitflags! {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub(crate) struct MountFlagsArg(pub(crate) c::c_ulong);
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags! {
     /// `MNT_*` constants for use with [`unmount`].
     ///

--- a/src/backend/libc/io/mod.rs
+++ b/src/backend/libc/io/mod.rs
@@ -9,5 +9,5 @@ pub(crate) mod types;
 #[cfg_attr(windows, path = "windows_syscalls.rs")]
 pub(crate) mod syscalls;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub mod epoll;

--- a/src/backend/libc/io/poll_fd.rs
+++ b/src/backend/libc/io/poll_fd.rs
@@ -38,7 +38,7 @@ bitflags! {
         const NVAL = c::POLLNVAL;
         /// `POLLRDHUP`
         #[cfg(all(
-            any(target_os = "android", target_os = "linux"),
+            linux_kernel,
             not(any(target_arch = "sparc", target_arch = "sparc64"))),
         )]
         const RDHUP = c::POLLRDHUP;

--- a/src/backend/libc/io/types.rs
+++ b/src/backend/libc/io/types.rs
@@ -1,6 +1,6 @@
 use super::super::c;
 use bitflags::bitflags;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 use core::marker::PhantomData;
 
 bitflags! {
@@ -14,7 +14,7 @@ bitflags! {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags! {
     /// `RWF_*` constants for use with [`preadv2`] and [`pwritev2`].
     ///
@@ -34,7 +34,7 @@ bitflags! {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags! {
     /// `SPLICE_F_*` constants for use with [`splice`] and [`vmsplice`].
     pub struct SpliceFlags: c::c_uint {
@@ -87,12 +87,7 @@ bitflags! {
     }
 }
 
-#[cfg(any(
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "illumos",
-    target_os = "linux"
-))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "illumos"))]
 bitflags! {
     /// `EFD_*` flags for use with [`eventfd`].
     ///
@@ -125,14 +120,14 @@ pub(crate) const STDERR_FILENO: c::c_int = c::STDERR_FILENO;
 /// and `WSABUF` on Windows. Unlike `IoSlice` and `IoSliceMut` it is
 /// semantically like a raw pointer, and therefore can be shared or mutated as
 /// needed.
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[repr(transparent)]
 pub struct IoSliceRaw<'a> {
     _buf: c::iovec,
     _lifetime: PhantomData<&'a ()>,
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 impl<'a> IoSliceRaw<'a> {
     /// Creates a new `IoSlice` wrapping a byte slice.
     pub fn from_slice(buf: &'a [u8]) -> Self {

--- a/src/backend/libc/mm/syscalls.rs
+++ b/src/backend/libc/mm/syscalls.rs
@@ -1,7 +1,7 @@
 //! libc syscalls supporting `rustix::mm`.
 
 use super::super::c;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 use super::super::conv::syscall_ret_owned_fd;
 use super::super::conv::{borrowed_fd, no_fd, ret};
 use super::super::offset::libc_mmap;
@@ -10,10 +10,10 @@ use super::types::Advice;
 #[cfg(any(target_os = "emscripten", target_os = "linux"))]
 use super::types::MremapFlags;
 use super::types::{MapFlags, MprotectFlags, MsyncFlags, ProtFlags};
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 use super::types::{MlockFlags, UserfaultfdFlags};
 use crate::fd::BorrowedFd;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 use crate::fd::OwnedFd;
 use crate::io;
 
@@ -185,7 +185,7 @@ pub(crate) unsafe fn mlock(addr: *mut c::c_void, length: usize) -> io::Result<()
 ///
 /// `mlock_with` operates on raw pointers and may round out to the nearest page
 /// boundaries.
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub(crate) unsafe fn mlock_with(
     addr: *mut c::c_void,
@@ -212,7 +212,7 @@ pub(crate) unsafe fn munlock(addr: *mut c::c_void, length: usize) -> io::Result<
     ret(c::munlock(addr, length))
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub(crate) unsafe fn userfaultfd(flags: UserfaultfdFlags) -> io::Result<OwnedFd> {
     syscall_ret_owned_fd(c::syscall(c::SYS_userfaultfd, flags.bits()))
 }

--- a/src/backend/libc/mm/types.rs
+++ b/src/backend/libc/mm/types.rs
@@ -31,10 +31,10 @@ bitflags! {
         /// `PROT_EXEC`
         const EXEC = c::PROT_EXEC;
         /// `PROT_GROWSUP`
-        #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg(linux_kernel)]
         const GROWSUP = c::PROT_GROWSUP;
         /// `PROT_GROWSDOWN`
-        #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg(linux_kernel)]
         const GROWSDOWN = c::PROT_GROWSDOWN;
     }
 }
@@ -169,7 +169,7 @@ bitflags! {
             target_os = "haiku",
             target_os = "redox",
             all(
-                any(target_os = "android", target_os = "linux"),
+                linux_kernel,
                 any(target_arch = "mips", target_arch = "mips64"),
             )
         )))]
@@ -211,7 +211,7 @@ bitflags! {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags! {
     /// `MLOCK_*` flags for use with [`mlock_with`].
     ///
@@ -281,64 +281,61 @@ pub enum Advice {
     #[cfg(target_os = "android")]
     LinuxDontNeed = c::MADV_DONTNEED,
     /// `MADV_FREE`
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxFree = c::MADV_FREE,
     /// `MADV_REMOVE`
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxRemove = c::MADV_REMOVE,
     /// `MADV_DONTFORK`
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxDontFork = c::MADV_DONTFORK,
     /// `MADV_DOFORK`
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxDoFork = c::MADV_DOFORK,
     /// `MADV_HWPOISON`
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxHwPoison = c::MADV_HWPOISON,
     /// `MADV_SOFT_OFFLINE`
-    #[cfg(all(
-        any(target_os = "android", target_os = "linux"),
-        not(any(target_arch = "mips", target_arch = "mips64")),
-    ))]
+    #[cfg(all(linux_kernel, not(any(target_arch = "mips", target_arch = "mips64"))))]
     LinuxSoftOffline = c::MADV_SOFT_OFFLINE,
     /// `MADV_MERGEABLE`
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxMergeable = c::MADV_MERGEABLE,
     /// `MADV_UNMERGEABLE`
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxUnmergeable = c::MADV_UNMERGEABLE,
     /// `MADV_HUGEPAGE` (since Linux 2.6.38)
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxHugepage = c::MADV_HUGEPAGE,
     /// `MADV_NOHUGEPAGE` (since Linux 2.6.38)
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxNoHugepage = c::MADV_NOHUGEPAGE,
     /// `MADV_DONTDUMP` (since Linux 3.4)
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxDontDump = c::MADV_DONTDUMP,
     /// `MADV_DODUMP` (since Linux 3.4)
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxDoDump = c::MADV_DODUMP,
     /// `MADV_WIPEONFORK` (since Linux 4.14)
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxWipeOnFork = libc::MADV_WIPEONFORK as i32,
     /// `MADV_KEEPONFORK` (since Linux 4.14)
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxKeepOnFork = libc::MADV_KEEPONFORK as i32,
     /// `MADV_COLD` (since Linux 5.4)
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxCold = libc::MADV_COLD as i32,
     /// `MADV_PAGEOUT` (since Linux 5.4)
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxPageOut = libc::MADV_PAGEOUT as i32,
     /// `MADV_POPULATE_READ` (since Linux 5.14)
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxPopulateRead = libc::MADV_POPULATE_READ as i32,
     /// `MADV_POPULATE_WRITE` (since Linux 5.14)
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxPopulateWrite = libc::MADV_POPULATE_WRITE as i32,
     /// `MADV_DONTNEED_LOCKED` (since Linux 5.18)
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     LinuxDontneedLocked = libc::MADV_DONTNEED_LOCKED as i32,
 }
 
@@ -349,7 +346,7 @@ impl Advice {
     pub const DontNeed: Self = Self::Normal;
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags! {
     /// `O_*` flags for use with [`userfaultfd`].
     ///

--- a/src/backend/libc/mod.rs
+++ b/src/backend/libc/mod.rs
@@ -52,7 +52,7 @@ pub(crate) mod c;
 #[cfg(feature = "fs")]
 pub(crate) mod fs;
 pub(crate) mod io;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[cfg(feature = "io_uring")]
 pub(crate) mod io_uring;
 #[cfg(not(any(windows, target_os = "wasi")))]

--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -56,7 +56,7 @@ impl SocketAddrUnix {
     }
 
     /// Construct a new abstract Unix-domain address from a byte slice.
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     #[inline]
     pub fn new_abstract_name(name: &[u8]) -> io::Result<Self> {
         let mut unix = Self::init();
@@ -112,7 +112,7 @@ impl SocketAddrUnix {
     }
 
     /// For an abstract address, return the identifier.
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     #[inline]
     pub fn abstract_name(&self) -> Option<&[u8]> {
         let len = self.len();
@@ -192,7 +192,7 @@ impl fmt::Debug for SocketAddrUnix {
         if let Some(path) = self.path() {
             path.fmt(fmt)
         } else {
-            #[cfg(any(target_os = "android", target_os = "linux"))]
+            #[cfg(linux_kernel)]
             if let Some(name) = self.abstract_name() {
                 return name.fmt(fmt);
             }

--- a/src/backend/libc/net/read_sockaddr.rs
+++ b/src/backend/libc/net/read_sockaddr.rs
@@ -98,7 +98,7 @@ pub(crate) unsafe fn read_sockaddr(
                 // On Linux check for Linux's [abstract namespace].
                 //
                 // [abstract namespace]: https://man7.org/linux/man-pages/man7/unix.7.html
-                #[cfg(any(target_os = "android", target_os = "linux"))]
+                #[cfg(linux_kernel)]
                 if decode.sun_path[0] == 0 {
                     return SocketAddrUnix::new_abstract_name(core::mem::transmute::<
                         &[c::c_char],
@@ -207,7 +207,7 @@ unsafe fn inner_read_sockaddr_os(
                 // On Linux check for Linux's [abstract namespace].
                 //
                 // [abstract namespace]: https://man7.org/linux/man-pages/man7/unix.7.html
-                #[cfg(any(target_os = "android", target_os = "linux"))]
+                #[cfg(linux_kernel)]
                 if decode.sun_path[0] == 0 {
                     return SocketAddrAny::Unix(
                         SocketAddrUnix::new_abstract_name(core::mem::transmute::<

--- a/src/backend/libc/net/syscalls.rs
+++ b/src/backend/libc/net/syscalls.rs
@@ -600,13 +600,13 @@ pub(crate) mod sockopt {
         })
     }
 
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     #[inline]
     pub(crate) fn set_socket_passcred(fd: BorrowedFd<'_>, passcred: bool) -> io::Result<()> {
         setsockopt(fd, c::SOL_SOCKET as _, c::SO_PASSCRED, from_bool(passcred))
     }
 
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     #[inline]
     pub(crate) fn get_socket_passcred(fd: BorrowedFd<'_>) -> io::Result<bool> {
         getsockopt(fd, c::SOL_SOCKET as _, c::SO_PASSCRED).map(to_bool)

--- a/src/backend/libc/offset.rs
+++ b/src/backend/libc/offset.rs
@@ -112,7 +112,7 @@ pub(super) use c::openat64 as libc_openat;
 #[cfg(target_os = "fuchsia")]
 #[cfg(feature = "fs")]
 pub(super) use c::fallocate as libc_fallocate;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[cfg(feature = "fs")]
 pub(super) use c::fallocate64 as libc_fallocate;
 #[cfg(not(any(
@@ -131,22 +131,16 @@ pub(super) use c::posix_fadvise as libc_posix_fadvise;
 #[cfg(feature = "fs")]
 pub(super) use c::posix_fadvise64 as libc_posix_fadvise;
 
-#[cfg(all(not(any(
-    windows,
-    target_os = "android",
-    target_os = "linux",
-    target_os = "emscripten",
-))))]
+#[cfg(all(not(any(linux_kernel, windows, target_os = "emscripten"))))]
 pub(super) use c::{pread as libc_pread, pwrite as libc_pwrite};
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "emscripten"))]
+#[cfg(any(linux_kernel, target_os = "emscripten"))]
 pub(super) use c::{pread64 as libc_pread, pwrite64 as libc_pwrite};
 #[cfg(not(any(
     apple,
+    linux_kernel,
     windows,
-    target_os = "android",
     target_os = "emscripten",
     target_os = "haiku",
-    target_os = "linux",
     target_os = "redox",
     target_os = "solaris",
 )))]
@@ -365,14 +359,13 @@ pub(super) use readwrite_pv64v2::{preadv64v2 as libc_preadv2, pwritev64v2 as lib
 
 #[cfg(not(any(
     apple,
+    linux_kernel,
     netbsdlike,
     solarish,
     windows,
     target_os = "aix",
-    target_os = "android",
     target_os = "dragonfly",
     target_os = "fuchsia",
-    target_os = "linux",
     target_os = "l4re",
     target_os = "redox",
 )))]

--- a/src/backend/libc/process/cpu_set.rs
+++ b/src/backend/libc/process/cpu_set.rs
@@ -43,7 +43,7 @@ pub(crate) fn CPU_ISSET(cpu: usize, cpuset: &RawCpuSet) -> bool {
     unsafe { c::CPU_ISSET(cpu, cpuset) }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub(crate) fn CPU_COUNT(cpuset: &RawCpuSet) -> u32 {
     use core::convert::TryInto;

--- a/src/backend/libc/process/mod.rs
+++ b/src/backend/libc/process/mod.rs
@@ -1,9 +1,4 @@
-#[cfg(any(
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "fuchsia",
-    target_os = "linux",
-))]
+#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
 pub(crate) mod cpu_set;
 #[cfg(not(windows))]
 pub(crate) mod syscalls;

--- a/src/backend/libc/process/types.rs
+++ b/src/backend/libc/process/types.rs
@@ -1,7 +1,7 @@
 use super::super::c;
 
 /// `sysinfo`
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub type Sysinfo = c::sysinfo;
 
 /// A command for use with [`membarrier`] and [`membarrier_cpu`].
@@ -11,7 +11,7 @@ pub type Sysinfo = c::sysinfo;
 /// [`membarrier`]: crate::process::membarrier
 /// [`membarrier_cpu`]: crate::process::membarrier_cpu
 /// [`membarrier_query`]: crate::process::membarrier_query
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[repr(u32)]
 pub enum MembarrierCommand {
@@ -157,7 +157,7 @@ pub enum Signal {
         target_os = "aix",
         target_os = "haiku",
         all(
-            any(target_os = "android", target_os = "linux"),
+            linux_kernel,
             any(
                 target_arch = "mips",
                 target_arch = "mips64",
@@ -205,11 +205,11 @@ pub enum Signal {
     #[doc(alias = "Unused")]
     Sys = c::SIGSYS,
     /// `SIGEMT`
-    #[cfg(any(bsd, solarish, target_os = "aix", target_os = "hermit",))]
+    #[cfg(any(bsd, solarish, target_os = "aix", target_os = "hermit"))]
     Emt = c::SIGEMT,
     /// `SIGEMT`
     #[cfg(all(
-        any(target_os = "android", target_os = "linux"),
+        linux_kernel,
         any(
             target_arch = "mips",
             target_arch = "mips64",
@@ -256,7 +256,7 @@ impl Signal {
                 target_os = "aix",
                 target_os = "haiku",
                 all(
-                    any(target_os = "android", target_os = "linux"),
+                    linux_kernel,
                     any(
                         target_arch = "mips",
                         target_arch = "mips64",
@@ -314,7 +314,7 @@ pub type RawGid = c::gid_t;
 #[cfg(not(target_os = "wasi"))]
 pub type RawUid = c::uid_t;
 /// A CPU identifier as a raw integer.
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub type RawCpuid = u32;
 #[cfg(target_os = "freebsd")]
 pub type RawId = c::id_t;
@@ -322,20 +322,10 @@ pub type RawId = c::id_t;
 #[cfg(not(target_os = "wasi"))]
 pub(crate) type RawUname = c::utsname;
 
-#[cfg(any(
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "fuchsia",
-    target_os = "linux",
-))]
+#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
 pub(crate) type RawCpuSet = c::cpu_set_t;
 
-#[cfg(any(
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "fuchsia",
-    target_os = "linux",
-))]
+#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
 #[inline]
 pub(crate) fn raw_cpu_set_new() -> RawCpuSet {
     let mut set = unsafe { core::mem::zeroed() };
@@ -343,7 +333,7 @@ pub(crate) fn raw_cpu_set_new() -> RawCpuSet {
     set
 }
 
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 pub(crate) const CPU_SETSIZE: usize = c::CPU_SETSIZE as usize;
 #[cfg(target_os = "dragonfly")]
 pub(crate) const CPU_SETSIZE: usize = 256;

--- a/src/backend/libc/pty/syscalls.rs
+++ b/src/backend/libc/pty/syscalls.rs
@@ -14,7 +14,7 @@ use {
     alloc::vec::Vec,
 };
 
-#[cfg(not(any(target_os = "android", target_os = "linux")))]
+#[cfg(not(linux_kernel))]
 #[inline]
 pub(crate) fn openpt(flags: OpenptFlags) -> io::Result<OwnedFd> {
     unsafe { ret_owned_fd(c::posix_openpt(flags.bits() as _)) }
@@ -74,7 +74,7 @@ pub(crate) fn unlockpt(fd: BorrowedFd) -> io::Result<()> {
     unsafe { ret(c::unlockpt(borrowed_fd(fd))) }
 }
 
-#[cfg(not(any(target_os = "android", target_os = "linux")))]
+#[cfg(not(linux_kernel))]
 #[inline]
 pub(crate) fn grantpt(fd: BorrowedFd) -> io::Result<()> {
     unsafe { ret(c::grantpt(borrowed_fd(fd))) }

--- a/src/backend/libc/rand/syscalls.rs
+++ b/src/backend/libc/rand/syscalls.rs
@@ -1,9 +1,9 @@
 //! libc syscalls supporting `rustix::rand`.
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 use {super::super::c, super::super::conv::ret_usize, crate::io, crate::rand::GetRandomFlags};
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub(crate) fn getrandom(buf: &mut [u8], flags: GetRandomFlags) -> io::Result<usize> {
     // `getrandom` wasn't supported in glibc until 2.25.
     weak_or_syscall! {

--- a/src/backend/libc/rand/types.rs
+++ b/src/backend/libc/rand/types.rs
@@ -1,9 +1,9 @@
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 use super::super::c;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 use bitflags::bitflags;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags! {
     /// `GRND_*` flags for use with [`getrandom`].
     ///

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -28,7 +28,7 @@ pub(crate) fn tcgetattr(fd: BorrowedFd<'_>) -> io::Result<Termios> {
 }
 
 #[cfg(all(
-    any(target_os = "android", target_os = "linux"),
+    linux_kernel,
     any(
         target_arch = "x86",
         target_arch = "x86_64",
@@ -78,7 +78,7 @@ pub(crate) fn tcsetattr(
 }
 
 #[cfg(all(
-    any(target_os = "android", target_os = "linux"),
+    linux_kernel,
     any(
         target_arch = "x86",
         target_arch = "x86_64",

--- a/src/backend/libc/termios/types.rs
+++ b/src/backend/libc/termios/types.rs
@@ -74,7 +74,7 @@ pub type Termios = c::termios;
 /// [`tcgetattr2`]: crate::termios::tcgetattr2
 /// [`tcsetattr2`]: crate::termios::tcsetattr2
 #[cfg(all(
-    any(target_os = "android", target_os = "linux"),
+    linux_kernel,
     any(
         target_arch = "x86",
         target_arch = "x86_64",
@@ -557,7 +557,7 @@ pub const B3500000: Speed = c::B3500000;
 pub const B4000000: Speed = c::B4000000;
 
 /// `BOTHER`
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub const BOTHER: Speed = c::BOTHER;
 
 /// `CSIZE`

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -7,7 +7,7 @@ use crate::io;
 #[cfg(not(target_os = "redox"))]
 use crate::thread::{NanosleepRelativeResult, Timespec};
 use core::mem::MaybeUninit;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 use {
     super::super::conv::{borrowed_fd, ret_c_int, syscall_ret},
     crate::fd::BorrowedFd,
@@ -266,7 +266,7 @@ unsafe fn nanosleep_old(request: &Timespec) -> NanosleepRelativeResult {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 #[must_use]
 pub(crate) fn gettid() -> Pid {
@@ -284,7 +284,7 @@ pub(crate) fn gettid() -> Pid {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub(crate) fn setns(fd: BorrowedFd, nstype: c::c_int) -> io::Result<c::c_int> {
     // `setns` wasn't supported in glibc until 2.14, and musl until 0.9.5,
@@ -296,13 +296,13 @@ pub(crate) fn setns(fd: BorrowedFd, nstype: c::c_int) -> io::Result<c::c_int> {
     unsafe { ret_c_int(setns(borrowed_fd(fd), nstype)) }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub(crate) fn unshare(flags: crate::thread::UnshareFlags) -> io::Result<()> {
     unsafe { ret(c::unshare(flags.bits() as i32)) }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub(crate) fn capget(
     header: &mut linux_raw_sys::general::__user_cap_header_struct,
@@ -312,7 +312,7 @@ pub(crate) fn capget(
     unsafe { syscall_ret(c::syscall(c::SYS_capget, header, data.as_mut_ptr())) }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub(crate) fn capset(
     header: &mut linux_raw_sys::general::__user_cap_header_struct,
@@ -322,13 +322,13 @@ pub(crate) fn capset(
     unsafe { syscall_ret(c::syscall(c::SYS_capset, header, data.as_ptr())) }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub(crate) fn setuid_thread(uid: crate::process::Uid) -> io::Result<()> {
     unsafe { syscall_ret(c::syscall(c::SYS_setuid, uid.as_raw())) }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub(crate) fn setresuid_thread(
     ruid: crate::process::Uid,
@@ -342,13 +342,13 @@ pub(crate) fn setresuid_thread(
     unsafe { syscall_ret(c::syscall(SYS, ruid.as_raw(), euid.as_raw(), suid.as_raw())) }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub(crate) fn setgid_thread(gid: crate::process::Gid) -> io::Result<()> {
     unsafe { syscall_ret(c::syscall(c::SYS_setgid, gid.as_raw())) }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub(crate) fn setresgid_thread(
     rgid: crate::process::Gid,

--- a/src/backend/libc/time/types.rs
+++ b/src/backend/libc/time/types.rs
@@ -1,7 +1,7 @@
 use super::super::c;
 #[cfg(not(target_os = "wasi"))]
 use crate::fd::BorrowedFd;
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 use bitflags::bitflags;
 
 /// `struct timespec`
@@ -139,15 +139,15 @@ pub enum ClockId {
     ThreadCPUTime = c::CLOCK_THREAD_CPUTIME_ID,
 
     /// `CLOCK_REALTIME_COARSE`
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "freebsd"))]
+    #[cfg(any(linux_kernel, target_os = "freebsd"))]
     RealtimeCoarse = c::CLOCK_REALTIME_COARSE,
 
     /// `CLOCK_MONOTONIC_COARSE`
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "freebsd"))]
+    #[cfg(any(linux_kernel, target_os = "freebsd"))]
     MonotonicCoarse = c::CLOCK_MONOTONIC_COARSE,
 
     /// `CLOCK_MONOTONIC_RAW`
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     MonotonicRaw = c::CLOCK_MONOTONIC_RAW,
 }
 
@@ -193,19 +193,19 @@ pub enum DynamicClockId<'a> {
     Dynamic(BorrowedFd<'a>),
 
     /// `CLOCK_REALTIME_ALARM`, available on Linux >= 3.0
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     RealtimeAlarm,
 
     /// `CLOCK_TAI`, available on Linux >= 3.10
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     Tai,
 
     /// `CLOCK_BOOTTIME`, available on Linux >= 2.6.39
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "openbsd"))]
+    #[cfg(any(linux_kernel, target_os = "openbsd"))]
     Boottime,
 
     /// `CLOCK_BOOTTIME_ALARM`, available on Linux >= 2.6.39
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     BoottimeAlarm,
 }
 
@@ -214,7 +214,7 @@ pub enum DynamicClockId<'a> {
 ///
 /// [`timerfd_gettime`]: crate::time::timerfd_gettime
 /// [`timerfd_settime`]: crate::time::timerfd_settime
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(not(all(
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
@@ -226,7 +226,7 @@ pub type Itimerspec = c::itimerspec;
 ///
 /// [`timerfd_gettime`]: crate::time::timerfd_gettime
 /// [`timerfd_settime`]: crate::time::timerfd_settime
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(all(
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
@@ -240,7 +240,7 @@ pub struct Itimerspec {
 }
 
 /// On most platforms, `LibcItimerspec` is just `Itimerspec`.
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(not(all(
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
@@ -249,7 +249,7 @@ pub(crate) type LibcItimerspec = Itimerspec;
 
 /// On 32-bit glibc platforms, `LibcTimespec` differs from `Timespec`, so we
 /// define our own struct, with bidirectional `From` impls.
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(all(
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
@@ -261,7 +261,7 @@ pub(crate) struct LibcItimerspec {
     pub it_value: LibcTimespec,
 }
 
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(all(
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
@@ -276,7 +276,7 @@ impl From<LibcItimerspec> for Itimerspec {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(all(
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
@@ -291,7 +291,7 @@ impl From<Itimerspec> for LibcItimerspec {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 bitflags! {
     /// `TFD_*` flags for use with [`timerfd_create`].
     ///
@@ -305,7 +305,7 @@ bitflags! {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 bitflags! {
     /// `TFD_TIMER_*` flags for use with [`timerfd_settime`].
     ///
@@ -315,7 +315,7 @@ bitflags! {
         const ABSTIME = c::TFD_TIMER_ABSTIME;
 
         /// `TFD_TIMER_CANCEL_ON_SET`
-        #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg(linux_kernel)]
         const CANCEL_ON_SET = c::TFD_TIMER_CANCEL_ON_SET;
     }
 }
@@ -323,7 +323,7 @@ bitflags! {
 /// `CLOCK_*` constants for use with [`timerfd_create`].
 ///
 /// [`timerfd_create`]: crate::time::timerfd_create
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[repr(i32)]
 #[non_exhaustive]

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -702,7 +702,7 @@ impl<'a, Num: ArgNumber, T> From<&'a mut [MaybeUninit<T>]> for ArgReg<'a, Num> {
 }
 
 #[cfg(feature = "fs")]
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 impl<'a, Num: ArgNumber> From<crate::backend::fs::types::MountFlagsArg> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::backend::fs::types::MountFlagsArg) -> Self {
@@ -711,7 +711,7 @@ impl<'a, Num: ArgNumber> From<crate::backend::fs::types::MountFlagsArg> for ArgR
 }
 
 #[cfg(feature = "fs")]
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 impl<'a, Num: ArgNumber> From<crate::backend::fs::types::UnmountFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::backend::fs::types::UnmountFlags) -> Self {

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -1500,7 +1500,7 @@ pub(crate) fn sendfile(
 }
 
 #[inline]
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub(crate) fn mount(
     source: Option<&CStr>,
     target: &CStr,
@@ -1521,7 +1521,7 @@ pub(crate) fn mount(
 }
 
 #[inline]
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub(crate) fn unmount(target: &CStr, flags: super::types::UnmountFlags) -> io::Result<()> {
     unsafe { ret(syscall_readonly!(__NR_umount2, target, flags)) }
 }

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -668,7 +668,7 @@ pub type FsWord = linux_raw_sys::general::__fsword_t;
 #[cfg(target_arch = "mips64")]
 pub type FsWord = i64;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags! {
     /// `MS_*` constants for use with [`mount`].
     ///
@@ -725,7 +725,7 @@ bitflags! {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags! {
     /// `MS_*` constants for use with [`change_mount`].
     ///
@@ -744,7 +744,7 @@ bitflags! {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags! {
     pub(crate) struct InternalMountFlags: c::c_uint {
         const REMOUNT = linux_raw_sys::general::MS_REMOUNT;
@@ -752,10 +752,10 @@ bitflags! {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub(crate) struct MountFlagsArg(pub(crate) c::c_uint);
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags! {
     /// `MNT_*` constants for use with [`unmount`].
     ///

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -16,7 +16,7 @@ use super::super::conv::{
 #[cfg(target_pointer_width = "32")]
 use super::super::conv::{hi, lo};
 use crate::fd::{AsFd, BorrowedFd, OwnedFd, RawFd};
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 use crate::io::SpliceFlags;
 use crate::io::{
     self, epoll, DupFlags, EventfdFlags, FdFlags, IoSlice, IoSliceMut, IoSliceRaw, PipeFlags,
@@ -654,7 +654,7 @@ pub(crate) fn epoll_wait(
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub fn splice(
     fd_in: BorrowedFd,
@@ -677,7 +677,7 @@ pub fn splice(
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub unsafe fn vmsplice(
     fd: BorrowedFd,

--- a/src/backend/linux_raw/io/types.rs
+++ b/src/backend/linux_raw/io/types.rs
@@ -32,7 +32,7 @@ bitflags! {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags! {
     /// `SPLICE_F_*` constants for use with [`splice`] and [`vmsplice`].
     pub struct SpliceFlags: c::c_uint {

--- a/src/backend/linux_raw/net/read_sockaddr.rs
+++ b/src/backend/linux_raw/net/read_sockaddr.rs
@@ -92,7 +92,7 @@ pub(crate) unsafe fn read_sockaddr(
                 // On Linux check for Linux's [abstract namespace].
                 //
                 // [abstract namespace]: https://man7.org/linux/man-pages/man7/unix.7.html
-                #[cfg(any(target_os = "android", target_os = "linux"))]
+                #[cfg(linux_kernel)]
                 if decode.sun_path[0] == 0 {
                     return SocketAddrUnix::new_abstract_name(
                         &decode.sun_path[1..len - offsetof_sun_path],
@@ -165,7 +165,7 @@ pub(crate) unsafe fn read_sockaddr_os(storage: *const c::sockaddr, len: usize) -
                 // On Linux check for Linux's [abstract namespace].
                 //
                 // [abstract namespace]: https://man7.org/linux/man-pages/man7/unix.7.html
-                #[cfg(any(target_os = "android", target_os = "linux"))]
+                #[cfg(linux_kernel)]
                 if decode.sun_path[0] == 0 {
                     return SocketAddrAny::Unix(
                         SocketAddrUnix::new_abstract_name(

--- a/src/backend/linux_raw/thread/syscalls.rs
+++ b/src/backend/linux_raw/thread/syscalls.rs
@@ -275,19 +275,19 @@ unsafe fn futex_old(
     ))
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub(crate) fn setns(fd: BorrowedFd, nstype: c::c_int) -> io::Result<c::c_int> {
     unsafe { ret_c_int(syscall_readonly!(__NR_setns, fd, c_int(nstype))) }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub(crate) fn unshare(flags: crate::thread::UnshareFlags) -> io::Result<()> {
     unsafe { ret(syscall_readonly!(__NR_unshare, c_uint(flags.bits()))) }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub(crate) fn capget(
     header: &mut linux_raw_sys::general::__user_cap_header_struct,
@@ -297,7 +297,7 @@ pub(crate) fn capget(
     unsafe { ret(syscall!(__NR_capget, header, data)) }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub(crate) fn capset(
     header: &mut linux_raw_sys::general::__user_cap_header_struct,

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -11,7 +11,7 @@ use crate::ffi::{CStr, CString};
 use crate::fs::CloneFlags;
 #[cfg(not(any(apple, target_os = "wasi")))]
 use crate::fs::FileType;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 use crate::fs::RenameFlags;
 use crate::fs::{Access, AtFlags, Mode, OFlags, Stat, Timestamps};
 use crate::path::SMALL_PATH_BUFFER_SIZE;
@@ -197,7 +197,7 @@ pub fn renameat<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/renameat2.2.html
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 #[doc(alias = "renameat2")]
 pub fn renameat_with<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -11,7 +11,7 @@ pub use backend::fs::types::AtFlags;
 #[cfg(apple)]
 pub use backend::fs::types::{CloneFlags, CopyfileFlags};
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use backend::fs::types::*;
 
 pub use backend::time::types::{Nsecs, Secs, Timespec};

--- a/src/fs/fcntl.rs
+++ b/src/fs/fcntl.rs
@@ -55,24 +55,14 @@ pub fn fcntl_setfl<Fd: AsFd>(fd: Fd, flags: OFlags) -> io::Result<()> {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/fcntl.2.html
-#[cfg(any(
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "linux",
-))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
 #[inline]
 #[doc(alias = "F_GET_SEALS")]
 pub fn fcntl_get_seals<Fd: AsFd>(fd: Fd) -> io::Result<SealFlags> {
     backend::fs::syscalls::fcntl_get_seals(fd.as_fd())
 }
 
-#[cfg(any(
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "linux",
-))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
 pub use backend::fs::types::SealFlags;
 
 /// `fcntl(fd, F_ADD_SEALS)`
@@ -81,12 +71,7 @@ pub use backend::fs::types::SealFlags;
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/fcntl.2.html
-#[cfg(any(
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "linux",
-))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
 #[inline]
 #[doc(alias = "F_ADD_SEALS")]
 pub fn fcntl_add_seals<Fd: AsFd>(fd: Fd, seals: SealFlags) -> io::Result<()> {

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -4,7 +4,7 @@ mod abs;
 #[cfg(not(target_os = "redox"))]
 mod at;
 mod constants;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod copy_file_range;
 #[cfg(not(target_os = "redox"))]
 mod cwd;
@@ -30,30 +30,30 @@ mod file_type;
 mod getpath;
 #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 mod makedev;
-#[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "freebsd"))]
 mod memfd_create;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod mount;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod openat2;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod raw_dir;
 #[cfg(target_os = "linux")]
 mod sendfile;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod statx;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 mod sync;
-#[cfg(any(apple, target_os = "android", target_os = "linux"))]
+#[cfg(any(apple, linux_kernel))]
 mod xattr;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use crate::backend::fs::inotify;
 pub use abs::*;
 #[cfg(not(target_os = "redox"))]
 pub use at::*;
 pub use constants::*;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use copy_file_range::copy_file_range;
 #[cfg(not(target_os = "redox"))]
 pub use cwd::cwd;
@@ -79,21 +79,21 @@ pub use file_type::FileType;
 pub use getpath::getpath;
 #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 pub use makedev::*;
-#[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "freebsd"))]
 pub use memfd_create::{memfd_create, MemfdFlags};
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use mount::*;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use openat2::openat2;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use raw_dir::{RawDir, RawDirEntry};
 #[cfg(target_os = "linux")]
 pub use sendfile::sendfile;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use statx::{statx, Statx, StatxFlags, StatxTimestamp};
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub use sync::sync;
-#[cfg(any(apple, target_os = "android", target_os = "linux"))]
+#[cfg(any(apple, linux_kernel))]
 pub use xattr::*;
 
 /// Re-export types common to POSIX-ish platforms.

--- a/src/fs/sendfile.rs
+++ b/src/fs/sendfile.rs
@@ -7,7 +7,7 @@ use backend::fd::AsFd;
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/sendfile.2.html
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub fn sendfile<OutFd: AsFd, InFd: AsFd>(
     out_fd: OutFd,

--- a/src/io/ioctl.rs
+++ b/src/io/ioctl.rs
@@ -109,7 +109,7 @@ pub fn ioctl_fionread<Fd: AsFd>(fd: Fd) -> io::Result<u64> {
 /// This is mentioned in the [Linux `openat` manual page].
 ///
 /// [Linux `openat` manual page]: https://man7.org/linux/man-pages/man2/openat.2.html
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 #[doc(alias = "BLKSSZGET")]
 pub fn ioctl_blksszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
@@ -117,7 +117,7 @@ pub fn ioctl_blksszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
 }
 
 /// `ioctl(fd, BLKPBSZGET)`—Returns the physical block size of a block device.
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 #[doc(alias = "BLKPBSZGET")]
 pub fn ioctl_blkpbszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
@@ -132,10 +132,7 @@ pub fn ioctl_blkpbszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/ioctl_ficlone.2.html
-#[cfg(all(
-    not(any(target_arch = "sparc", target_arch = "sparc64")),
-    any(target_os = "android", target_os = "linux"),
-))]
+#[cfg(all(linux_kernel, not(any(target_arch = "sparc", target_arch = "sparc64"))))]
 #[inline]
 #[doc(alias = "FICLONE")]
 pub fn ioctl_ficlone<Fd: AsFd, SrcFd: AsFd>(fd: Fd, src_fd: SrcFd) -> io::Result<()> {
@@ -143,7 +140,7 @@ pub fn ioctl_ficlone<Fd: AsFd, SrcFd: AsFd>(fd: Fd, src_fd: SrcFd) -> io::Result
 }
 
 /// `ioctl(fd, EXT4_IOC_RESIZE_FS, blocks)`—Resize ext4 filesystem on fd.
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 #[doc(alias = "EXT4_IOC_RESIZE_FS")]
 pub fn ext4_ioc_resize_fs<Fd: AsFd>(fd: Fd, blocks: u64) -> io::Result<()> {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -4,12 +4,7 @@ mod close;
 #[cfg(not(windows))]
 mod dup;
 mod errno;
-#[cfg(any(
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "illumos",
-    target_os = "linux"
-))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "illumos"))]
 mod eventfd;
 #[cfg(not(windows))]
 mod fcntl;
@@ -25,7 +20,7 @@ mod pipe;
 mod poll;
 #[cfg(solarish)]
 pub mod port;
-#[cfg(all(feature = "procfs", any(target_os = "android", target_os = "linux")))]
+#[cfg(all(feature = "procfs", linux_kernel))]
 mod procfs;
 #[cfg(not(windows))]
 mod read_write;
@@ -33,18 +28,13 @@ mod seek_from;
 #[cfg(not(windows))]
 mod stdio;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use crate::backend::io::epoll;
 pub use close::close;
 #[cfg(not(windows))]
 pub use dup::*;
 pub use errno::{retry_on_intr, Errno, Result};
-#[cfg(any(
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "illumos",
-    target_os = "linux"
-))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "illumos"))]
 pub use eventfd::{eventfd, EventfdFlags};
 #[cfg(not(windows))]
 pub use fcntl::*;
@@ -55,7 +45,7 @@ pub use is_read_write::is_read_write;
 #[cfg(not(any(windows, target_os = "wasi")))]
 pub use pipe::*;
 pub use poll::{poll, PollFd, PollFlags};
-#[cfg(all(feature = "procfs", any(target_os = "android", target_os = "linux")))]
+#[cfg(all(feature = "procfs", linux_kernel))]
 pub use procfs::*;
 #[cfg(not(windows))]
 pub use read_write::*;

--- a/src/io/pipe.rs
+++ b/src/io/pipe.rs
@@ -8,13 +8,13 @@
 
 use crate::fd::OwnedFd;
 use crate::{backend, io};
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 use backend::fd::AsFd;
 
 #[cfg(not(apple))]
 pub use backend::io::types::PipeFlags;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use backend::io::types::{IoSliceRaw, SpliceFlags};
 
 /// `PIPE_BUF`—The maximum length at which writes to a pipe are atomic.
@@ -109,7 +109,7 @@ pub fn pipe_with(flags: PipeFlags) -> io::Result<(OwnedFd, OwnedFd)> {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/splice.2.html
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub fn splice<FdIn: AsFd, FdOut: AsFd>(
     fd_in: FdIn,
@@ -145,7 +145,7 @@ pub fn splice<FdIn: AsFd, FdOut: AsFd>(
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/vmsplice.2.html
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub unsafe fn vmsplice<PipeFd: AsFd>(
     fd: PipeFd,

--- a/src/io/read_write.rs
+++ b/src/io/read_write.rs
@@ -11,7 +11,7 @@ pub use backend::io::io_slice::{IoSlice, IoSliceMut};
 #[cfg(feature = "std")]
 pub use std::io::{IoSlice, IoSliceMut};
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use backend::io::types::ReadWriteFlags;
 
 /// `read(fd, buf)`—Reads from a stream.
@@ -230,7 +230,7 @@ pub fn pwritev<Fd: AsFd>(fd: Fd, bufs: &[IoSlice<'_>], offset: u64) -> io::Resul
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/preadv2.2.html
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub fn preadv2<Fd: AsFd>(
     fd: Fd,
@@ -249,7 +249,7 @@ pub fn preadv2<Fd: AsFd>(
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/pwritev2.2.html
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub fn pwritev2<Fd: AsFd>(
     fd: Fd,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ pub mod ffi;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
 pub mod fs;
 pub mod io;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[cfg(feature = "io_uring")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "io_uring")))]
 pub mod io_uring;

--- a/src/mm/mmap.rs
+++ b/src/mm/mmap.rs
@@ -10,7 +10,7 @@ use crate::{backend, io};
 use backend::fd::AsFd;
 use core::ffi::c_void;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use backend::mm::types::MlockFlags;
 #[cfg(any(target_os = "emscripten", target_os = "linux"))]
 pub use backend::mm::types::MremapFlags;
@@ -270,7 +270,7 @@ pub unsafe fn mlock(ptr: *mut c_void, len: usize) -> io::Result<()> {
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/mlock2.2.html
 /// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Page-Lock-Functions.html#index-mlock2
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 #[doc(alias = "mlock2")]
 pub unsafe fn mlock_with(ptr: *mut c_void, len: usize, flags: MlockFlags) -> io::Result<()> {

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -4,12 +4,12 @@
 mod madvise;
 mod mmap;
 mod msync;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod userfaultfd;
 
 #[cfg(not(target_os = "redox"))]
 pub use madvise::{madvise, Advice};
 pub use mmap::*;
 pub use msync::{msync, MsyncFlags};
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use userfaultfd::{userfaultfd, UserfaultfdFlags};

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -249,7 +249,7 @@ pub fn get_socket_linger<Fd: AsFd>(fd: Fd) -> io::Result<Option<Duration>> {
 ///
 /// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
 /// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 #[doc(alias = "SO_PASSCRED")]
 pub fn set_socket_passcred<Fd: AsFd>(fd: Fd, passcred: bool) -> io::Result<()> {
@@ -264,7 +264,7 @@ pub fn set_socket_passcred<Fd: AsFd>(fd: Fd, passcred: bool) -> io::Result<()> {
 ///
 /// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
 /// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 #[doc(alias = "SO_PASSCRED")]
 pub fn get_socket_passcred<Fd: AsFd>(fd: Fd) -> io::Result<bool> {

--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -9,7 +9,7 @@
 
 use crate::{backend, io};
 use alloc::vec::Vec;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 use backend::process::types::RawCpuid;
 
 /// The raw integer value of a Unix user ID.
@@ -44,7 +44,7 @@ pub struct Gid(RawGid);
 pub struct Pid(RawNonZeroPid);
 
 /// A Linux CPU ID.
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub struct Cpuid(RawCpuid);
@@ -165,7 +165,7 @@ impl Pid {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 impl Cpuid {
     /// Converts a `RawCpuid` into a `Cpuid`.
     ///

--- a/src/process/membarrier.rs
+++ b/src/process/membarrier.rs
@@ -11,7 +11,7 @@ use crate::{backend, io};
 
 pub use backend::process::types::MembarrierCommand;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 bitflags::bitflags! {
     /// A result from [`membarrier_query`].
     ///
@@ -41,7 +41,7 @@ bitflags::bitflags! {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 impl MembarrierQuery {
     /// Test whether this query result contains the given command.
     #[inline]

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -10,11 +10,11 @@ mod id;
 mod ioctl;
 #[cfg(not(target_os = "wasi"))]
 mod kill;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod membarrier;
 #[cfg(target_os = "linux")]
 mod pidfd;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod prctl;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))] // WASI doesn't have [gs]etpriority.
 mod priority;
@@ -22,12 +22,7 @@ mod priority;
 mod procctl;
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 mod rlimit;
-#[cfg(any(
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "fuchsia",
-    target_os = "linux",
-))]
+#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
 mod sched;
 mod sched_yield;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have uname.
@@ -47,11 +42,11 @@ pub use id::*;
 pub use ioctl::*;
 #[cfg(not(target_os = "wasi"))]
 pub use kill::*;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use membarrier::*;
 #[cfg(target_os = "linux")]
 pub use pidfd::*;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use prctl::*;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 pub use priority::*;
@@ -59,12 +54,7 @@ pub use priority::*;
 pub use procctl::*;
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 pub use rlimit::*;
-#[cfg(any(
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "fuchsia",
-    target_os = "linux",
-))]
+#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
 pub use sched::*;
 pub use sched_yield::sched_yield;
 #[cfg(not(target_os = "wasi"))]

--- a/src/process/rlimit.rs
+++ b/src/process/rlimit.rs
@@ -1,4 +1,4 @@
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 use crate::process::Pid;
 use crate::{backend, io};
 
@@ -46,7 +46,7 @@ pub fn setrlimit(resource: Resource, new: Rlimit) -> io::Result<()> {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/prlimit.2.html
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub fn prlimit(pid: Option<Pid>, resource: Resource, new: Rlimit) -> io::Result<Rlimit> {
     backend::process::syscalls::prlimit(pid, resource, new)

--- a/src/process/sched.rs
+++ b/src/process/sched.rs
@@ -55,7 +55,7 @@ impl CpuSet {
     }
 
     /// Count the number of CPUs set in the `CpuSet`.
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     #[inline]
     pub fn count(&self) -> u32 {
         backend::process::cpu_set::CPU_COUNT(&self.cpu_set)

--- a/src/process/system.rs
+++ b/src/process/system.rs
@@ -12,7 +12,7 @@ use crate::ffi::CStr;
 use crate::io;
 use core::fmt;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use backend::process::types::Sysinfo;
 
 /// `uname()`—Returns high-level information about the runtime OS and
@@ -69,7 +69,7 @@ impl Uname {
     }
 
     /// `domainname`—NIS or YP domain identifier
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     #[inline]
     pub fn domainname(&self) -> &CStr {
         Self::to_cstr(self.0.domainname.as_ptr().cast())
@@ -84,7 +84,7 @@ impl Uname {
 
 impl fmt::Debug for Uname {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        #[cfg(not(any(target_os = "android", target_os = "linux")))]
+        #[cfg(not(linux_kernel))]
         {
             write!(
                 fmt,
@@ -96,7 +96,7 @@ impl fmt::Debug for Uname {
                 self.machine().to_string_lossy(),
             )
         }
-        #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg(linux_kernel)]
         {
             write!(
                 fmt,
@@ -118,7 +118,7 @@ impl fmt::Debug for Uname {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/uname.2.html
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub fn sysinfo() -> Sysinfo {
     backend::process::syscalls::sysinfo()

--- a/src/rand/mod.rs
+++ b/src/rand/mod.rs
@@ -1,7 +1,7 @@
 //! Random-related operations.
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod getrandom;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use getrandom::{getrandom, GetRandomFlags};

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -181,7 +181,7 @@ pub fn startup_tls_info() -> StartupTlsInfo {
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man3/getauxval.3.html
 #[cfg(linux_raw)]
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[inline]
 pub fn exe_phdrs() -> (*const c_void, usize) {
     backend::param::auxv::exe_phdrs()

--- a/src/termios/tc.rs
+++ b/src/termios/tc.rs
@@ -3,7 +3,7 @@ use crate::process::Pid;
 use crate::{backend, io};
 
 #[cfg(all(
-    any(target_os = "android", target_os = "linux"),
+    linux_kernel,
     any(
         target_arch = "x86",
         target_arch = "x86_64",
@@ -54,7 +54,7 @@ pub fn tcgetattr<Fd: AsFd>(fd: Fd) -> io::Result<Termios> {
 #[inline]
 #[doc(alias = "TCGETS2")]
 #[cfg(all(
-    any(target_os = "android", target_os = "linux"),
+    linux_kernel,
     any(
         target_arch = "x86",
         target_arch = "x86_64",
@@ -156,7 +156,7 @@ pub fn tcsetattr<Fd: AsFd>(
 #[inline]
 #[doc(alias = "TCSETS2")]
 #[cfg(all(
-    any(target_os = "android", target_os = "linux"),
+    linux_kernel,
     any(
         target_arch = "x86",
         target_arch = "x86_64",

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -4,24 +4,24 @@
 mod clock;
 #[cfg(linux_raw)]
 mod futex;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod id;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod libcap;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod prctl;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod setns;
 
 #[cfg(not(target_os = "redox"))]
 pub use clock::*;
 #[cfg(linux_raw)]
 pub use futex::{futex, FutexFlags, FutexOperation};
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use id::{gettid, set_thread_gid, set_thread_res_gid, set_thread_res_uid, set_thread_uid};
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use libcap::{capabilities, set_capabilities, CapabilityFlags, CapabilitySets};
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use prctl::*;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 pub use setns::*;

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -1,13 +1,13 @@
 //! Time-related operations.
 
 mod clock;
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(feature = "time")]
 mod timerfd;
 
 // TODO: Convert WASI'S clock APIs to use handles rather than ambient clock
 // identifiers, update `wasi-libc`, and then add support in `rustix`.
 pub use clock::*;
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(feature = "time")]
 pub use timerfd::*;

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -120,7 +120,7 @@ unsafe fn fetch(name: &str) -> *mut c_void {
     libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr())
 }
 
-#[cfg(not(any(target_os = "android", target_os = "linux")))]
+#[cfg(not(linux_kernel))]
 macro_rules! syscall {
     (fn $name:ident($($arg_name:ident: $t:ty),*) via $_sys_name:ident -> $ret:ty) => (
         unsafe fn $name($($arg_name: $t),*) -> $ret {
@@ -136,7 +136,7 @@ macro_rules! syscall {
     )
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 macro_rules! syscall {
     (fn $name:ident($($arg_name:ident: $t:ty),*) via $sys_name:ident -> $ret:ty) => (
         unsafe fn $name($($arg_name:$t),*) -> $ret {

--- a/tests/fs/invalid_offset.rs
+++ b/tests/fs/invalid_offset.rs
@@ -130,7 +130,7 @@ fn invalid_offset_pwrite() {
     pwrite(&file, &buf, i64::MAX as u64 + 1).unwrap_err();
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn invalid_offset_copy_file_range() {
     use rustix::fs::{copy_file_range, cwd, openat, Mode, OFlags};

--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -27,9 +27,9 @@ mod long_paths;
 mod makedev;
 mod mkdirat;
 mod mknodat;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod openat;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod openat2;
 #[cfg(not(target_os = "redox"))]
 mod readdir;
@@ -37,12 +37,12 @@ mod readlinkat;
 mod renameat;
 #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 mod statfs;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod statx;
 mod symlinkat;
 #[cfg(not(any(solarish, target_os = "redox", target_os = "wasi")))]
 mod sync;
 mod utimensat;
-#[cfg(any(apple, target_os = "android", target_os = "linux"))]
+#[cfg(any(apple, linux_kernel))]
 mod xattr;
 mod y2038;

--- a/tests/fs/mkdirat.rs
+++ b/tests/fs/mkdirat.rs
@@ -18,7 +18,7 @@ fn test_mkdirat() {
     unlinkat(&dir, "foo", AtFlags::REMOVEDIR).unwrap();
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_mkdirat_with_o_path() {
     use rustix::fs::{

--- a/tests/fs/readdir.rs
+++ b/tests/fs/readdir.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs::File;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 use std::mem::MaybeUninit;
 
 use rustix::fs::{Dir, DirEntry};
@@ -52,7 +52,7 @@ fn read_entries(dir: &mut Dir) -> HashMap<String, DirEntry> {
     out
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 fn test_raw_dir(buf: &mut [MaybeUninit<u8>]) {
     use std::collections::HashSet;
     use std::io::{Seek, SeekFrom};
@@ -111,7 +111,7 @@ fn test_raw_dir(buf: &mut [MaybeUninit<u8>]) {
 }
 
 #[test]
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 fn raw_dir_entries_heap() {
     // When we can depend on Rust 1.60, we can use the spare_capacity_mut
     // version instead.
@@ -124,14 +124,14 @@ fn raw_dir_entries_heap() {
 }
 
 #[test]
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 fn raw_dir_entries_stack() {
     let mut buf = [MaybeUninit::uninit(); 2048];
     test_raw_dir(&mut buf);
 }
 
 #[test]
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 fn raw_dir_entries_unaligned() {
     let mut buf = [MaybeUninit::uninit(); 2048];
     let buf = &mut buf[1..];

--- a/tests/fs/renameat.rs
+++ b/tests/fs/renameat.rs
@@ -1,12 +1,12 @@
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 use rustix::fs::Stat;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 fn same(a: &Stat, b: &Stat) -> bool {
     a.st_ino == b.st_ino && a.st_dev == b.st_dev
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_renameat() {
     use rustix::fs::{accessat, cwd, openat, renameat, statat, Access, AtFlags, Mode, OFlags};
@@ -36,7 +36,7 @@ fn test_renameat() {
 
 /// Like `test_renameat` but the file already exists, so `renameat`
 /// overwrites it.
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_renameat_overwrite() {
     use rustix::fs::{cwd, openat, renameat, statat, AtFlags, Mode, OFlags};
@@ -58,7 +58,7 @@ fn test_renameat_overwrite() {
     assert!(same(&before, &renamed));
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_renameat_with() {
     use rustix::fs::{cwd, openat, renameat_with, statat, AtFlags, Mode, OFlags, RenameFlags};

--- a/tests/fs/statfs.rs
+++ b/tests/fs/statfs.rs
@@ -1,4 +1,4 @@
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_statfs_abi() {
     use rustix::fs::{FsWord, StatFs, NFS_SUPER_MAGIC, PROC_SUPER_MAGIC};
@@ -61,7 +61,7 @@ fn test_fstatfs() {
 }
 
 /// Test that files in procfs are in a filesystem with `PROC_SUPER_MAGIC`.
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_statfs_procfs() {
     let statfs = rustix::fs::statfs("/proc/self/maps").unwrap();

--- a/tests/fs/sync.rs
+++ b/tests/fs/sync.rs
@@ -3,7 +3,7 @@ fn test_sync() {
     rustix::fs::sync();
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_syncfs() {
     let f = std::fs::File::open("Cargo.toml").unwrap();

--- a/tests/io/eventfd.rs
+++ b/tests/io/eventfd.rs
@@ -1,9 +1,4 @@
-#[cfg(any(
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "illumos",
-    target_os = "linux"
-))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "illumos"))]
 #[test]
 fn test_eventfd() {
     use rustix::io::{eventfd, read, write, EventfdFlags};

--- a/tests/io/ioctl.rs
+++ b/tests/io/ioctl.rs
@@ -15,10 +15,7 @@ fn test_ioctls() {
 }
 
 // Sparc lacks `FICLONE`.
-#[cfg(all(
-    not(any(target_arch = "sparc", target_arch = "sparc64")),
-    any(target_os = "android", target_os = "linux"),
-))]
+#[cfg(all(linux_kernel, not(any(target_arch = "sparc", target_arch = "sparc64"))))]
 #[test]
 fn test_ioctl_ficlone() {
     use rustix::io;

--- a/tests/io/main.rs
+++ b/tests/io/main.rs
@@ -8,7 +8,7 @@
 mod dup2_to_replace_stdio;
 #[cfg(not(feature = "rustc-dep-of-std"))] // TODO
 #[cfg(feature = "net")]
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod epoll;
 mod error;
 #[cfg(not(windows))]
@@ -20,11 +20,11 @@ mod from_into;
 mod ioctl;
 mod pipe;
 mod poll;
-#[cfg(all(feature = "procfs", any(target_os = "android", target_os = "linux")))]
+#[cfg(all(feature = "procfs", linux_kernel))]
 mod procfs;
 #[cfg(not(windows))]
 #[cfg(not(target_os = "redox"))] // redox doesn't have cwd/openat
 #[cfg(not(target_os = "wasi"))] // wasi support for `S_IRUSR` etc. submitted to libc in #2264
 mod read_write;
-#[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "freebsd"))]
 mod seals;

--- a/tests/io/pipe.rs
+++ b/tests/io/pipe.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "fs")]
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_splice_cursor() {
     use rustix::io::{pipe, splice, SpliceFlags};
@@ -25,7 +25,7 @@ fn test_splice_cursor() {
 }
 
 #[cfg(feature = "fs")]
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_splice_offset() {
     use rustix::io::{pipe, splice, SpliceFlags};
@@ -66,7 +66,7 @@ fn test_splice_offset() {
 }
 
 #[cfg(feature = "fs")]
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_splice_pipe2pipe() {
     use rustix::io::{pipe, read, splice, write, SpliceFlags};
@@ -83,7 +83,7 @@ fn test_splice_pipe2pipe() {
 }
 
 #[cfg(feature = "fs")]
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_vmsplice_write() {
     use rustix::io::{pipe, read, vmsplice, IoSliceRaw, SpliceFlags};
@@ -103,7 +103,7 @@ fn test_vmsplice_write() {
 }
 
 #[cfg(feature = "fs")]
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_vmsplice_read() {
     use rustix::io::{pipe, vmsplice, write, IoSliceRaw, SpliceFlags};

--- a/tests/io/read_write.rs
+++ b/tests/io/read_write.rs
@@ -145,7 +145,7 @@ fn test_rwf_values() {
     );
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[cfg(feature = "fs")]
 #[test]
 fn test_pwritev2() {

--- a/tests/mm/mlock.rs
+++ b/tests/mm/mlock.rs
@@ -20,7 +20,7 @@ fn test_mlock() {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_mlock_with() {
     let mut buf = vec![0_u8; 4096];
@@ -42,7 +42,7 @@ fn test_mlock_with() {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_mlock_with_onfault() {
     // With glibc, `mlock2` with `MLOCK_ONFAULT` returns `EINVAL` if the

--- a/tests/mm/mmap.rs
+++ b/tests/mm/mmap.rs
@@ -93,7 +93,7 @@ fn test_mprotect() {
 #[test]
 fn test_mlock() {
     use rustix::mm::{mlock, mmap_anonymous, munlock, munmap, MapFlags, ProtFlags};
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     use rustix::mm::{mlock_with, MlockFlags};
     use std::ptr::null_mut;
 
@@ -103,7 +103,7 @@ fn test_mlock() {
         mlock(addr, 8192).unwrap();
         munlock(addr, 8192).unwrap();
 
-        #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg(linux_kernel)]
         {
             match mlock_with(addr, 8192, MlockFlags::empty()) {
                 Err(rustix::io::Errno::NOSYS) => (),
@@ -139,7 +139,7 @@ fn test_madvise() {
         madvise(addr, 8192, Advice::Normal).unwrap();
         madvise(addr, 8192, Advice::DontNeed).unwrap();
 
-        #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg(linux_kernel)]
         madvise(addr, 8192, Advice::LinuxDontNeed).unwrap();
 
         munmap(addr, 8192).unwrap();

--- a/tests/net/addr.rs
+++ b/tests/net/addr.rs
@@ -55,7 +55,7 @@ fn test_unix_addr() {
     SocketAddrUnix::new("/foo\0/bar").unwrap_err();
     assert!(SocketAddrUnix::new("").unwrap().path().is_none());
 
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     {
         assert!(SocketAddrUnix::new("foo")
             .unwrap()

--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -22,7 +22,7 @@ fn test_sockopts_ipv4() {
     assert!(rustix::net::sockopt::get_socket_linger(&s)
         .unwrap()
         .is_none());
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     assert!(!rustix::net::sockopt::get_socket_passcred(&s).unwrap());
     assert_ne!(rustix::net::sockopt::get_ip_ttl(&s).unwrap(), 0);
     assert_ne!(rustix::net::sockopt::get_ip_ttl(&s).unwrap(), 77);
@@ -97,7 +97,7 @@ fn test_sockopts_ipv4() {
             >= Duration::new(1, 1)
     );
 
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     {
         // Set the passcred flag;
         rustix::net::sockopt::set_socket_passcred(&s, true).unwrap();

--- a/tests/net/unix.rs
+++ b/tests/net/unix.rs
@@ -295,7 +295,7 @@ fn test_unix_msg() {
     unlinkat(cwd(), path, AtFlags::empty()).unwrap();
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_abstract_unix_msg() {
     use std::os::unix::ffi::OsStrExt;

--- a/tests/param/weak.rs
+++ b/tests/param/weak.rs
@@ -118,7 +118,7 @@ unsafe fn fetch(name: &str) -> *mut c_void {
     libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr())
 }
 
-#[cfg(not(any(target_os = "android", target_os = "linux")))]
+#[cfg(not(linux_kernel))]
 macro_rules! syscall {
     (fn $name:ident($($arg_name:ident: $t:ty),*) via $_sys_name:ident -> $ret:ty) => (
         unsafe fn $name($($arg_name: $t),*) -> $ret {
@@ -134,7 +134,7 @@ macro_rules! syscall {
     )
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 macro_rules! syscall {
     (fn $name:ident($($arg_name:ident: $t:ty),*) via $sys_name:ident -> $ret:ty) => (
         unsafe fn $name($($arg_name:$t),*) -> $ret {

--- a/tests/process/cpu_set.rs
+++ b/tests/process/cpu_set.rs
@@ -1,4 +1,4 @@
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_cpu_set() {
     let set = rustix::process::sched_getaffinity(None).unwrap();

--- a/tests/process/main.rs
+++ b/tests/process/main.rs
@@ -8,11 +8,11 @@
 mod cpu_set;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have get[gpu]id.
 mod id;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod membarrier;
 #[cfg(target_os = "linux")]
 mod pidfd;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod prctl;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))] // WASI doesn't have [gs]etpriority.
 mod priority;

--- a/tests/process/rlimit.rs
+++ b/tests/process/rlimit.rs
@@ -23,7 +23,7 @@ fn test_setrlimit() {
     let lim = rustix::process::getrlimit(Resource::Core);
     assert_eq!(lim, new);
 
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     {
         let new = Rlimit {
             current: Some(0),

--- a/tests/process/uname.rs
+++ b/tests/process/uname.rs
@@ -8,6 +8,6 @@ fn test_uname() {
     assert!(!name.version().to_bytes().is_empty());
     assert!(!name.machine().to_bytes().is_empty());
 
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(linux_kernel)]
     assert!(!name.domainname().to_bytes().is_empty());
 }

--- a/tests/pty/openpty.rs
+++ b/tests/pty/openpty.rs
@@ -7,19 +7,9 @@ use std::io::{Read, Write};
 #[test]
 fn openpty_basic() -> io::Result<()> {
     // Use `CLOEXEC` if we can.
-    #[cfg(any(
-        target_os = "android",
-        target_os = "freebsd",
-        target_os = "linux",
-        target_os = "netbsd"
-    ))]
+    #[cfg(any(linux_kernel, target_os = "freebsd", target_os = "netbsd"))]
     let flags = OpenptFlags::RDWR | OpenptFlags::NOCTTY | OpenptFlags::CLOEXEC;
-    #[cfg(not(any(
-        target_os = "android",
-        target_os = "freebsd",
-        target_os = "linux",
-        target_os = "netbsd"
-    )))]
+    #[cfg(not(any(linux_kernel, target_os = "freebsd", target_os = "netbsd")))]
     let flags = OpenptFlags::RDWR | OpenptFlags::NOCTTY;
 
     let controller = openpt(flags)?;
@@ -53,19 +43,9 @@ fn openpty_basic() -> io::Result<()> {
 #[test]
 fn openpty_get_peer() -> io::Result<()> {
     // Use `CLOEXEC` if we can.
-    #[cfg(any(
-        target_os = "android",
-        target_os = "freebsd",
-        target_os = "linux",
-        target_os = "netbsd"
-    ))]
+    #[cfg(any(linux_kernel, target_os = "freebsd", target_os = "netbsd"))]
     let flags = OpenptFlags::RDWR | OpenptFlags::NOCTTY | OpenptFlags::CLOEXEC;
-    #[cfg(not(any(
-        target_os = "android",
-        target_os = "freebsd",
-        target_os = "linux",
-        target_os = "netbsd"
-    )))]
+    #[cfg(not(any(linux_kernel, target_os = "freebsd", target_os = "netbsd")))]
     let flags = OpenptFlags::RDWR | OpenptFlags::NOCTTY;
 
     let controller = openpt(flags)?;

--- a/tests/rand/main.rs
+++ b/tests/rand/main.rs
@@ -4,5 +4,5 @@
 #![cfg(not(windows))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod getrandom;

--- a/tests/thread/main.rs
+++ b/tests/thread/main.rs
@@ -5,11 +5,11 @@
 
 #[cfg(not(target_os = "redox"))]
 mod clocks;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod id;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod libcap;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod prctl;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod setns;

--- a/tests/time/dynamic_clocks.rs
+++ b/tests/time/dynamic_clocks.rs
@@ -13,7 +13,7 @@ fn test_dynamic_clocks() {
     clock_gettime_dynamic(DynamicClockId::Dynamic(file.as_fd())).unwrap_err();
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 #[test]
 fn test_conditional_clocks() {
     let _ = clock_gettime_dynamic(DynamicClockId::Tai);

--- a/tests/time/main.rs
+++ b/tests/time/main.rs
@@ -14,7 +14,7 @@ mod monotonic;
     all(apple, not(target_os = "macos"))
 )))]
 mod settime;
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(linux_kernel)]
 mod timerfd;
 mod timespec;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]

--- a/tests/time/y2038.rs
+++ b/tests/time/y2038.rs
@@ -23,7 +23,7 @@ fn test_y2038() {
     let _ = Timespec { tv_sec, tv_nsec: 0 };
     let _: Secs = tv_sec;
 
-    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg(any(linux_kernel, target_os = "fuchsia"))]
     {
         use rustix::time::Itimerspec;
 
@@ -34,7 +34,7 @@ fn test_y2038() {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[test]
 fn test_y2038_with_timerfd() {
     use rustix::time::{


### PR DESCRIPTION
"android" and "linux" share much in common, so add a `linux_kernel` config to factor out `any(target_os = "android", target_os = "linux")`.