### PR TITLE
Fix panic on dropping `RecvAncillaryBuffer` after failed `recvmsg`

### DIFF
--- a/src/backend/libc/net/msghdr.rs
+++ b/src/backend/libc/net/msghdr.rs
@@ -7,7 +7,7 @@ use super::super::c;
 use super::super::conv::{msg_control_len, msg_iov_len};
 use super::super::net::write_sockaddr::{encode_sockaddr_v4, encode_sockaddr_v6};
 
-use crate::io::{IoSlice, IoSliceMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::{RecvAncillaryBuffer, SendAncillaryBuffer, SocketAddrV4, SocketAddrV6};
 use crate::utils::as_ptr;
 
@@ -19,8 +19,8 @@ pub(crate) fn with_recv_msghdr<R>(
     name: &mut MaybeUninit<c::sockaddr_storage>,
     iov: &mut [IoSliceMut<'_>],
     control: &mut RecvAncillaryBuffer<'_>,
-    f: impl FnOnce(&mut c::msghdr) -> R,
-) -> R {
+    f: impl FnOnce(&mut c::msghdr) -> io::Result<R>,
+) -> io::Result<R> {
     let namelen = size_of::<c::sockaddr_storage>() as c::socklen_t;
     let mut msghdr = {
         let mut h: c::msghdr = unsafe { zeroed() };
@@ -36,8 +36,10 @@ pub(crate) fn with_recv_msghdr<R>(
     let res = f(&mut msghdr);
 
     // Reset the control length.
-    unsafe {
-        control.set_control_len(msghdr.msg_controllen.try_into().unwrap_or(usize::MAX));
+    if res.is_ok() {
+        unsafe {
+            control.set_control_len(msghdr.msg_controllen.try_into().unwrap_or(usize::MAX));
+        }
     }
 
     res

--- a/src/backend/libc/net/msghdr.rs
+++ b/src/backend/libc/net/msghdr.rs
@@ -21,6 +21,8 @@ pub(crate) fn with_recv_msghdr<R>(
     control: &mut RecvAncillaryBuffer<'_>,
     f: impl FnOnce(&mut c::msghdr) -> io::Result<R>,
 ) -> io::Result<R> {
+    control.clear();
+
     let namelen = size_of::<c::sockaddr_storage>() as c::socklen_t;
     let mut msghdr = {
         let mut h: c::msghdr = unsafe { zeroed() };

--- a/src/backend/linux_raw/net/msghdr.rs
+++ b/src/backend/linux_raw/net/msghdr.rs
@@ -33,6 +33,8 @@ pub(crate) fn with_recv_msghdr<R>(
     control: &mut RecvAncillaryBuffer<'_>,
     f: impl FnOnce(&mut c::msghdr) -> io::Result<R>,
 ) -> io::Result<R> {
+    control.clear();
+
     let namelen = size_of::<c::sockaddr_storage>() as c::c_int;
     let mut msghdr = c::msghdr {
         msg_name: name.as_mut_ptr().cast(),

--- a/src/backend/linux_raw/net/msghdr.rs
+++ b/src/backend/linux_raw/net/msghdr.rs
@@ -8,7 +8,7 @@
 use super::super::c;
 use super::super::net::write_sockaddr::{encode_sockaddr_v4, encode_sockaddr_v6};
 
-use crate::io::{IoSlice, IoSliceMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::{RecvAncillaryBuffer, SendAncillaryBuffer, SocketAddrV4, SocketAddrV6};
 use crate::utils::as_ptr;
 
@@ -31,8 +31,8 @@ pub(crate) fn with_recv_msghdr<R>(
     name: &mut MaybeUninit<c::sockaddr_storage>,
     iov: &mut [IoSliceMut<'_>],
     control: &mut RecvAncillaryBuffer<'_>,
-    f: impl FnOnce(&mut c::msghdr) -> R,
-) -> R {
+    f: impl FnOnce(&mut c::msghdr) -> io::Result<R>,
+) -> io::Result<R> {
     let namelen = size_of::<c::sockaddr_storage>() as c::c_int;
     let mut msghdr = c::msghdr {
         msg_name: name.as_mut_ptr().cast(),
@@ -49,8 +49,10 @@ pub(crate) fn with_recv_msghdr<R>(
     let res = f(&mut msghdr);
 
     // Reset the control length.
-    unsafe {
-        control.set_control_len(msghdr.msg_controllen.try_into().unwrap_or(usize::MAX));
+    if res.is_ok() {
+        unsafe {
+            control.set_control_len(msghdr.msg_controllen.try_into().unwrap_or(usize::MAX));
+        }
     }
 
     res

--- a/src/net/send_recv/msg.rs
+++ b/src/net/send_recv/msg.rs
@@ -248,6 +248,11 @@ impl<'buf> RecvAncillaryBuffer<'buf> {
         self.read = 0;
     }
 
+    /// Delete all messages from the buffer.
+    pub(crate) fn clear(&mut self) {
+        self.drain().for_each(drop);
+    }
+
     /// Drain all messages from the buffer.
     pub fn drain(&mut self) -> AncillaryDrain<'_> {
         AncillaryDrain {
@@ -260,7 +265,7 @@ impl<'buf> RecvAncillaryBuffer<'buf> {
 
 impl Drop for RecvAncillaryBuffer<'_> {
     fn drop(&mut self) {
-        self.drain().for_each(drop);
+        self.clear();
     }
 }
 


### PR DESCRIPTION
Calling drain on `RecvAncillaryBuffer`, including in its `Drop` implementation was failing, with an "attempted to subtract with overflow" error in `cvt_msg`.

If `recvmsg` returns `-1`, `msg_controllen` will not be updated by the call. So it had a non-zero value as passed into the function, despite there not being any control messages to parse.