### PR TITLE
process: Add aliaseses for `parent_process_death_signal`

### DIFF
--- a/src/process/prctl.rs
+++ b/src/process/prctl.rs
@@ -78,6 +78,7 @@ const PR_GET_PDEATHSIG: c_int = 2;
 /// [Linux: `prctl(PR_GET_PDEATHSIG,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 /// [FreeBSD: `procctl(PROC_PDEATHSIG_STATUS,...)`]: https://man.freebsd.org/cgi/man.cgi?query=procctl&sektion=2
 #[inline]
+#[doc(alias = "PR_GET_PDEATHSIG")]
 pub fn parent_process_death_signal() -> io::Result<Option<Signal>> {
     unsafe { prctl_get_at_arg2_optional::<c_int>(PR_GET_PDEATHSIG) }.map(Signal::from_raw)
 }
@@ -93,6 +94,7 @@ const PR_SET_PDEATHSIG: c_int = 1;
 /// [Linux: `prctl(PR_SET_PDEATHSIG,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 /// [FreeBSD: `procctl(PROC_PDEATHSIG_CTL,...)`]: https://man.freebsd.org/cgi/man.cgi?query=procctl&sektion=2
 #[inline]
+#[doc(alias = "PR_SET_PDEATHSIG")]
 pub fn set_parent_process_death_signal(signal: Option<Signal>) -> io::Result<()> {
     let signal = signal.map_or(0_usize, |signal| signal as usize);
     unsafe { prctl_2args(PR_SET_PDEATHSIG, signal as *mut _) }.map(|_r| ())


### PR DESCRIPTION
I went to search in the docs for `pdeathsig` bindings and almost didn't find it.  The wrapped naming is definitely better, but add aliases for the same reason as we do elsewhere.