### PR TITLE
Miscellaneous cleanups

### DIFF
--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -336,11 +336,11 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 #[cfg(not(windows))]
 fn key(b: u8) -> String {
     if b == 0 {
-        format!("<undef>")
+        "<undef>".to_string()
     } else if b < 0x20 {
         format!("^{}", (b + 0x40) as char)
     } else if b == 0x7f {
-        format!("^?")
+        "^?".to_string()
     } else {
         format!("{}", b as char)
     }

--- a/src/backend/libc/io/epoll.rs
+++ b/src/backend/libc/io/epoll.rs
@@ -152,12 +152,12 @@ pub fn epoll_create(flags: CreateFlags) -> io::Result<OwnedFd> {
 /// `epoll_ctl(self, EPOLL_CTL_ADD, data, event)`—Adds an element to an
 /// `Epoll`.
 ///
-/// Note that if `epoll_del` is not called on the I/O source passed into
-/// this function before the I/O source is `close`d, then the `epoll` will
-/// act as if the I/O source is still registered with it. This can lead to
-/// spurious events being returned from `epoll_wait`. If a file descriptor
-/// is an `Arc<dyn SystemResource>`, then `epoll` can be thought to maintain
-/// a `Weak<dyn SystemResource>` to the file descriptor.
+/// If `epoll_del` is not called on the I/O source passed into this function
+/// before the I/O source is `close`d, then the `epoll` will act as if the I/O
+/// source is still registered with it. This can lead to spurious events being
+/// returned from `epoll_wait`. If a file descriptor is an
+/// `Arc<dyn SystemResource>`, then `epoll` can be thought to maintain a
+/// `Weak<dyn SystemResource>` to the file descriptor.
 #[doc(alias = "epoll_ctl")]
 pub fn epoll_add(
     epoll: impl AsFd,

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -12,6 +12,7 @@ use {
     super::super::conv::{borrowed_fd, ret_c_int, syscall_ret},
     crate::fd::BorrowedFd,
     crate::process::{Pid, RawNonZeroPid},
+    crate::utils::as_mut_ptr,
 };
 #[cfg(not(any(
     apple,
@@ -308,8 +309,13 @@ pub(crate) fn capget(
     header: &mut linux_raw_sys::general::__user_cap_header_struct,
     data: &mut [MaybeUninit<linux_raw_sys::general::__user_cap_data_struct>],
 ) -> io::Result<()> {
-    let header: *mut _ = header;
-    unsafe { syscall_ret(c::syscall(c::SYS_capget, header, data.as_mut_ptr())) }
+    unsafe {
+        syscall_ret(c::syscall(
+            c::SYS_capget,
+            as_mut_ptr(header),
+            data.as_mut_ptr(),
+        ))
+    }
 }
 
 #[cfg(linux_kernel)]
@@ -318,8 +324,7 @@ pub(crate) fn capset(
     header: &mut linux_raw_sys::general::__user_cap_header_struct,
     data: &[linux_raw_sys::general::__user_cap_data_struct],
 ) -> io::Result<()> {
-    let header: *mut _ = header;
-    unsafe { syscall_ret(c::syscall(c::SYS_capset, header, data.as_ptr())) }
+    unsafe { syscall_ret(c::syscall(c::SYS_capset, as_mut_ptr(header), data.as_ptr())) }
 }
 
 #[cfg(linux_kernel)]

--- a/src/backend/libc/time/syscalls.rs
+++ b/src/backend/libc/time/syscalls.rs
@@ -277,7 +277,6 @@ pub(crate) fn clock_settime(id: ClockId, timespec: Timespec) -> io::Result<()> {
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
-#[must_use]
 unsafe fn clock_settime_old(id: ClockId, timespec: Timespec) -> io::Result<()> {
     use core::convert::TryInto;
     let old_timespec = c::timespec {

--- a/src/backend/linux_raw/arch/inline/x86.rs
+++ b/src/backend/linux_raw/arch/inline/x86.rs
@@ -113,7 +113,7 @@ pub(in crate::backend) unsafe fn indirect_syscall4(
 ) -> RetReg<R0> {
     let r0;
     // a3 should go in esi, but `asm!` won't let us use it as an operand.
-    // temporarily swap it into place, and then swap it back afterward.
+    // Temporarily swap it into place, and then swap it back afterward.
     //
     // We hard-code the callee operand to use edi instead of `in(reg)` because
     // even though we can't name esi as an operand, the compiler can use esi to

--- a/src/backend/linux_raw/elf.rs
+++ b/src/backend/linux_raw/elf.rs
@@ -1,4 +1,4 @@
-//! The ELF ABI.
+//! The ELF ABI. 🧝
 
 #![allow(non_snake_case)]
 #![cfg_attr(

--- a/src/backend/linux_raw/fs/inotify.rs
+++ b/src/backend/linux_raw/fs/inotify.rs
@@ -76,6 +76,7 @@ bitflags! {
 /// Use the [`CreateFlags::CLOEXEC`] flag to prevent the resulting file
 /// descriptor from being implicitly passed across `exec` boundaries.
 #[doc(alias = "inotify_init1")]
+#[inline]
 pub fn inotify_init(flags: CreateFlags) -> io::Result<OwnedFd> {
     syscalls::inotify_init1(flags)
 }
@@ -89,6 +90,7 @@ pub fn inotify_init(flags: CreateFlags) -> io::Result<OwnedFd> {
 /// different paths to this method may result in it returning
 /// the same watch descriptor. An application should keep track of this
 /// externally to avoid logic errors.
+#[inline]
 pub fn inotify_add_watch<P: crate::path::Arg>(
     inot: BorrowedFd<'_>,
     path: P,
@@ -103,6 +105,7 @@ pub fn inotify_add_watch<P: crate::path::Arg>(
 /// The watch descriptor provided should have previously been returned
 /// by [`inotify_add_watch`] and not previously have been removed.
 #[doc(alias = "inotify_rm_watch")]
+#[inline]
 pub fn inotify_remove_watch(inot: BorrowedFd<'_>, wd: i32) -> io::Result<()> {
     syscalls::inotify_rm_watch(inot, wd)
 }

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -1667,15 +1667,15 @@ pub(crate) fn flistxattr(fd: BorrowedFd<'_>, list: &mut [c::c_char]) -> io::Resu
 
 #[inline]
 pub(crate) fn removexattr(path: &CStr, name: &CStr) -> io::Result<()> {
-    unsafe { ret(syscall!(__NR_removexattr, path, name)) }
+    unsafe { ret(syscall_readonly!(__NR_removexattr, path, name)) }
 }
 
 #[inline]
 pub(crate) fn lremovexattr(path: &CStr, name: &CStr) -> io::Result<()> {
-    unsafe { ret(syscall!(__NR_lremovexattr, path, name)) }
+    unsafe { ret(syscall_readonly!(__NR_lremovexattr, path, name)) }
 }
 
 #[inline]
 pub(crate) fn fremovexattr(fd: BorrowedFd<'_>, name: &CStr) -> io::Result<()> {
-    unsafe { ret(syscall!(__NR_fremovexattr, fd, name)) }
+    unsafe { ret(syscall_readonly!(__NR_fremovexattr, fd, name)) }
 }

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -136,7 +136,7 @@ impl From<RawMode> for Mode {
 }
 
 impl From<Mode> for RawMode {
-    /// Support conversions from `Mode to raw mode values.
+    /// Support conversions from `Mode` to raw mode values.
     ///
     /// ```
     /// use rustix::fs::{Mode, RawMode};

--- a/src/backend/linux_raw/io/epoll.rs
+++ b/src/backend/linux_raw/io/epoll.rs
@@ -153,12 +153,12 @@ pub fn epoll_create(flags: CreateFlags) -> io::Result<OwnedFd> {
 /// This registers interest in any of the events set in `events` occurring
 /// on the file descriptor associated with `data`.
 ///
-/// Note that if `epoll_del` is not called on the I/O source passed into
-/// this function before the I/O source is `close`d, then the `epoll` will
-/// act as if the I/O source is still registered with it. This can lead to
-/// spurious events being returned from `epoll_wait`. If a file descriptor
-/// is an `Arc<dyn SystemResource>`, then `epoll` can be thought to maintain
-/// a `Weak<dyn SystemResource>` to the file descriptor.
+/// If `epoll_del` is not called on the I/O source passed into this function
+/// before the I/O source is `close`d, then the `epoll` will act as if the I/O
+/// source is still registered with it. This can lead to spurious events being
+/// returned from `epoll_wait`. If a file descriptor is an
+/// `Arc<dyn SystemResource>`, then `epoll` can be thought to maintain a
+/// `Weak<dyn SystemResource>` to the file descriptor.
 #[doc(alias = "epoll_ctl")]
 #[inline]
 pub fn epoll_add(

--- a/src/backend/linux_raw/io/epoll.rs
+++ b/src/backend/linux_raw/io/epoll.rs
@@ -160,6 +160,7 @@ pub fn epoll_create(flags: CreateFlags) -> io::Result<OwnedFd> {
 /// is an `Arc<dyn SystemResource>`, then `epoll` can be thought to maintain
 /// a `Weak<dyn SystemResource>` to the file descriptor.
 #[doc(alias = "epoll_ctl")]
+#[inline]
 pub fn epoll_add(
     epoll: impl AsFd,
     source: impl AsFd,
@@ -185,6 +186,7 @@ pub fn epoll_add(
 ///
 /// This sets the events of interest with `target` to `events`.
 #[doc(alias = "epoll_ctl")]
+#[inline]
 pub fn epoll_mod(
     epoll: impl AsFd,
     source: impl AsFd,
@@ -211,6 +213,7 @@ pub fn epoll_mod(
 ///
 /// This also returns the owning `Data`.
 #[doc(alias = "epoll_ctl")]
+#[inline]
 pub fn epoll_del(epoll: impl AsFd, source: impl AsFd) -> io::Result<()> {
     // SAFETY: We're calling `epoll_ctl` via FFI and we know how it
     // behaves.
@@ -225,6 +228,7 @@ pub fn epoll_del(epoll: impl AsFd, source: impl AsFd) -> io::Result<()> {
 ///
 /// For each event of interest, an element is written to `events`. On
 /// success, this returns the number of written elements.
+#[inline]
 pub fn epoll_wait(
     epoll: impl AsFd,
     event_list: &mut EventVec,
@@ -254,6 +258,7 @@ pub struct Iter<'a> {
 impl<'a> Iterator for Iter<'a> {
     type Item = (EventFlags, u64);
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.iter
             .next()

--- a/src/backend/linux_raw/io/types.rs
+++ b/src/backend/linux_raw/io/types.rs
@@ -109,7 +109,7 @@ impl<'a> IoSliceRaw<'a> {
     pub fn from_slice(buf: &'a [u8]) -> Self {
         IoSliceRaw {
             _buf: c::iovec {
-                iov_base: buf.as_ptr() as *mut u8 as *mut c::c_void,
+                iov_base: (buf.as_ptr() as *mut u8).cast::<c::c_void>(),
                 iov_len: buf.len() as _,
             },
             _lifetime: PhantomData,
@@ -120,7 +120,7 @@ impl<'a> IoSliceRaw<'a> {
     pub fn from_slice_mut(buf: &'a mut [u8]) -> Self {
         IoSliceRaw {
             _buf: c::iovec {
-                iov_base: buf.as_mut_ptr() as *mut c::c_void,
+                iov_base: buf.as_mut_ptr().cast::<c::c_void>(),
                 iov_len: buf.len() as _,
             },
             _lifetime: PhantomData,

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -59,7 +59,7 @@ impl SocketAddrUnix {
         }
     }
 
-    fn init() -> c::sockaddr_un {
+    const fn init() -> c::sockaddr_un {
         c::sockaddr_un {
             sun_family: c::AF_UNIX as _,
             sun_path: [0; 108],

--- a/src/backend/linux_raw/net/syscalls.rs
+++ b/src/backend/linux_raw/net/syscalls.rs
@@ -1440,7 +1440,7 @@ pub(crate) mod sockopt {
     #[inline]
     pub(crate) fn set_ipv6_unicast_hops(fd: BorrowedFd<'_>, hops: Option<u8>) -> io::Result<()> {
         let hops = match hops {
-            Some(hops) => hops as c::c_int,
+            Some(hops) => hops.into(),
             None => -1,
         };
         setsockopt(fd, c::IPPROTO_IPV6 as _, c::IPV6_UNICAST_HOPS, hops)

--- a/src/backend/linux_raw/thread/futex.rs
+++ b/src/backend/linux_raw/thread/futex.rs
@@ -1,5 +1,5 @@
 bitflags::bitflags! {
-    /// Flags for use with [`futex`].
+    /// `FUTEX_*` flags for use with [`futex`].
     ///
     /// [`futex`]: crate::thread::futex
     pub struct FutexFlags: u32 {
@@ -10,7 +10,7 @@ bitflags::bitflags! {
     }
 }
 
-/// Operations for use with [`futex`].
+/// `FUTEX_*` operations for use with [`futex`].
 ///
 /// [`futex`]: crate::thread::futex
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/src/backend/linux_raw/thread/syscalls.rs
+++ b/src/backend/linux_raw/thread/syscalls.rs
@@ -8,7 +8,8 @@
 
 use super::super::c;
 use super::super::conv::{
-    by_ref, c_int, c_uint, ret, ret_c_int, ret_usize, ret_usize_infallible, zero,
+    by_mut, by_ref, c_int, c_uint, ret, ret_c_int, ret_usize, ret_usize_infallible,
+    slice_just_addr, slice_just_addr_mut, zero,
 };
 use crate::fd::BorrowedFd;
 use crate::io;
@@ -293,8 +294,13 @@ pub(crate) fn capget(
     header: &mut linux_raw_sys::general::__user_cap_header_struct,
     data: &mut [MaybeUninit<linux_raw_sys::general::__user_cap_data_struct>],
 ) -> io::Result<()> {
-    let header: *mut _ = header;
-    unsafe { ret(syscall!(__NR_capget, header, data)) }
+    unsafe {
+        ret(syscall!(
+            __NR_capget,
+            by_mut(header),
+            slice_just_addr_mut(data)
+        ))
+    }
 }
 
 #[cfg(linux_kernel)]
@@ -303,8 +309,7 @@ pub(crate) fn capset(
     header: &mut linux_raw_sys::general::__user_cap_header_struct,
     data: &[linux_raw_sys::general::__user_cap_data_struct],
 ) -> io::Result<()> {
-    let header: *mut _ = header;
-    unsafe { ret(syscall!(__NR_capset, header, data.as_ptr())) }
+    unsafe { ret(syscall!(__NR_capset, by_mut(header), slice_just_addr(data))) }
 }
 
 #[inline]

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -49,7 +49,7 @@ pub const UTIME_OMIT: Nsecs = backend::c::UTIME_OMIT as Nsecs;
 ///  - [Linux]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/openat.html
-/// [Linux]: https://man7.org/linux/man-pages/man2/open.2.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/openat.2.html
 #[inline]
 pub fn openat<P: path::Arg, Fd: AsFd>(
     dirfd: Fd,

--- a/src/fs/raw_dir.rs
+++ b/src/fs/raw_dir.rs
@@ -139,8 +139,7 @@ impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
 
 /// A raw directory entry, similar to `std::fs::DirEntry`.
 ///
-/// Note that unlike the std version, this may represent the `.` or `..`
-/// entries.
+/// Unlike the std version, this may represent the `.` or `..` entries.
 pub struct RawDirEntry<'a> {
     file_name: &'a CStr,
     file_type: u8,

--- a/src/fs/raw_dir.rs
+++ b/src/fs/raw_dir.rs
@@ -188,8 +188,8 @@ impl<'a> RawDirEntry<'a> {
 }
 
 impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
-    /// Identical to [Iterator::next] except that [Iterator::Item] borrows from
-    /// self.
+    /// Identical to [`Iterator::next`] except that [`Iterator::Item`] borrows
+    /// from self.
     ///
     /// Note: this interface will be broken to implement a stdlib iterator API
     /// with GAT support once one becomes available.

--- a/src/io/is_read_write.rs
+++ b/src/io/is_read_write.rs
@@ -2,9 +2,7 @@
 //!
 //! [`is_read_write`]: https://docs.rs/rustix/*/rustix/io/fn.is_read_write.html
 
-#[cfg(all(feature = "fs", feature = "net"))]
 use crate::{backend, io};
-#[cfg(all(feature = "fs", feature = "net"))]
 use backend::fd::AsFd;
 
 /// Returns a pair of booleans indicating whether the file descriptor is
@@ -15,7 +13,6 @@ use backend::fd::AsFd;
 ///
 /// [`is_file_read_write`]: crate::fs::is_file_read_write
 #[inline]
-#[cfg(all(feature = "fs", feature = "net"))]
 #[cfg_attr(doc_cfg, doc(cfg(all(feature = "fs", feature = "net"))))]
 pub fn is_read_write<Fd: AsFd>(fd: Fd) -> io::Result<(bool, bool)> {
     backend::io::syscalls::is_read_write(fd.as_fd())

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -12,6 +12,7 @@ mod fcntl;
 pub(crate) mod fd;
 mod ioctl;
 #[cfg(not(any(windows, target_os = "redox")))]
+#[cfg(all(feature = "fs", feature = "net"))]
 mod is_read_write;
 #[cfg(bsd)]
 pub mod kqueue;
@@ -41,7 +42,7 @@ pub use fcntl::*;
 pub use ioctl::*;
 #[cfg(not(any(windows, target_os = "redox")))]
 #[cfg(all(feature = "fs", feature = "net"))]
-pub use is_read_write::is_read_write;
+pub use is_read_write::*;
 #[cfg(not(any(windows, target_os = "wasi")))]
 pub use pipe::*;
 pub use poll::{poll, PollFd, PollFlags};

--- a/src/net/send_recv/msg.rs
+++ b/src/net/send_recv/msg.rs
@@ -325,43 +325,43 @@ impl<'buf> Iterator for AncillaryDrain<'buf> {
         (0, max)
     }
 
-    fn fold<B, F>(mut self, init: B, f: F) -> B
+    fn fold<B, F>(self, init: B, f: F) -> B
     where
         Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
-        let read = &mut self.read;
-        let length = &mut self.length;
+        let read = self.read;
+        let length = self.length;
         self.messages
             .filter_map(|ev| Self::cvt_msg(read, length, ev))
             .fold(init, f)
     }
 
-    fn count(mut self) -> usize {
-        let read = &mut self.read;
-        let length = &mut self.length;
+    fn count(self) -> usize {
+        let read = self.read;
+        let length = self.length;
         self.messages
             .filter_map(|ev| Self::cvt_msg(read, length, ev))
             .count()
     }
 
-    fn last(mut self) -> Option<Self::Item>
+    fn last(self) -> Option<Self::Item>
     where
         Self: Sized,
     {
-        let read = &mut self.read;
-        let length = &mut self.length;
+        let read = self.read;
+        let length = self.length;
         self.messages
             .filter_map(|ev| Self::cvt_msg(read, length, ev))
             .last()
     }
 
-    fn collect<B: FromIterator<Self::Item>>(mut self) -> B
+    fn collect<B: FromIterator<Self::Item>>(self) -> B
     where
         Self: Sized,
     {
-        let read = &mut self.read;
-        let length = &mut self.length;
+        let read = self.read;
+        let length = self.length;
         self.messages
             .filter_map(|ev| Self::cvt_msg(read, length, ev))
             .collect()

--- a/src/path/arg.rs
+++ b/src/path/arg.rs
@@ -948,7 +948,7 @@ where
     // Taken from
     // <https://github.com/rust-lang/rust/blob/a00f8ba7fcac1b27341679c51bf5a3271fa82df3/library/std/src/sys/common/small_c_string.rs>
     let mut buf = MaybeUninit::<[u8; SMALL_PATH_BUFFER_SIZE]>::uninit();
-    let buf_ptr = buf.as_mut_ptr() as *mut u8;
+    let buf_ptr = buf.as_mut_ptr().cast::<u8>();
 
     // This helps test our safety condition below.
     debug_assert!(bytes.len() + 1 <= SMALL_PATH_BUFFER_SIZE);

--- a/src/path/dec_int.rs
+++ b/src/path/dec_int.rs
@@ -25,10 +25,10 @@ use {core::fmt, std::ffi::OsStr, std::path::Path};
 /// # Example
 ///
 /// ```
-/// # #[cfg(feature = "path")]
+/// # #[cfg(any(feature = "fs", feature = "net"))]
 /// use rustix::path::DecInt;
 ///
-/// # #[cfg(feature = "path")]
+/// # #[cfg(any(feature = "fs", feature = "net"))]
 /// assert_eq!(
 ///     format!("hello {}", DecInt::new(9876).as_ref().display()),
 ///     "hello 9876"

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -6,6 +6,7 @@ mod dec_int;
 
 pub use arg::Arg;
 #[cfg(feature = "itoa")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "itoa")))]
 pub use dec_int::DecInt;
 
 pub(crate) const SMALL_PATH_BUFFER_SIZE: usize = 256;

--- a/src/process/membarrier.rs
+++ b/src/process/membarrier.rs
@@ -18,7 +18,7 @@ bitflags::bitflags! {
     /// These flags correspond to values of [`MembarrierCommand`] which are
     /// supported in the OS.
     pub struct MembarrierQuery: u32 {
-       /// `MEMBARRIER_CMD_GLOBAL`
+       /// `MEMBARRIER_CMD_GLOBAL` (also known as `MEMBARRIER_CMD_SHARED`)
        #[doc(alias = "SHARED")]
        #[doc(alias = "MEMBARRIER_CMD_SHARED")]
        const GLOBAL = MembarrierCommand::Global as _;

--- a/src/process/prctl.rs
+++ b/src/process/prctl.rs
@@ -110,15 +110,19 @@ const SUID_DUMP_DISABLE: i32 = 0;
 const SUID_DUMP_USER: i32 = 1;
 const SUID_DUMP_ROOT: i32 = 2;
 
-/// `SUID_DUMP_*`.
+/// `SUID_DUMP_*` values for use with [`dumpable_behavior`] and
+/// [`set_dumpable_behavior`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(i32)]
 pub enum DumpableBehavior {
     /// Not dumpable.
+    #[doc(alias = "SUID_DUMP_DISABLE")]
     NotDumpable = SUID_DUMP_DISABLE,
     /// Dumpable.
+    #[doc(alias = "SUID_DUMP_USER")]
     Dumpable = SUID_DUMP_USER,
     /// Dumpable but only readable by root.
+    #[doc(alias = "SUID_DUMP_ROOT")]
     DumpableReadableOnlyByRoot = SUID_DUMP_ROOT,
 }
 
@@ -142,6 +146,7 @@ impl TryFrom<i32> for DumpableBehavior {
 ///
 /// [`prctl(PR_GET_DUMPABLE,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_GET_DUMPABLE")]
 pub fn dumpable_behavior() -> io::Result<DumpableBehavior> {
     unsafe { prctl_1arg(PR_GET_DUMPABLE) }.and_then(TryInto::try_into)
 }
@@ -162,6 +167,7 @@ const PR_SET_DUMPABLE: c_int = 4;
 ///
 /// [`prctl(PR_SET_DUMPABLE,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_SET_DUMPABLE")]
 pub fn set_dumpable_behavior(config: DumpableBehavior) -> io::Result<()> {
     unsafe { prctl_2args(PR_SET_DUMPABLE, config as usize as *mut _) }.map(|_r| ())
 }
@@ -173,11 +179,14 @@ pub fn set_dumpable_behavior(config: DumpableBehavior) -> io::Result<()> {
 const PR_GET_UNALIGN: c_int = 5;
 
 bitflags! {
-    /// `PR_UNALIGN_*`.
+    /// `PR_UNALIGN_*` flags for use with [`unaligned_access_control`] and
     pub struct UnalignedAccessControl: u32 {
         /// Silently fix up unaligned user accesses.
+        #[doc(alias = "NOPRINT")]
+        #[doc(alias = "PR_UNALIGN_NOPRINT")]
         const NO_PRINT = 1;
         /// Generate a [`Signal::Bus`] signal on unaligned user access.
+        #[doc(alias = "PR_UNALIGN_SIGBUS")]
         const SIGBUS = 2;
     }
 }
@@ -189,6 +198,7 @@ bitflags! {
 ///
 /// [`prctl(PR_GET_UNALIGN,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_GET_UNALIGN")]
 pub fn unaligned_access_control() -> io::Result<UnalignedAccessControl> {
     let r = unsafe { prctl_get_at_arg2_optional::<c_uint>(PR_GET_UNALIGN)? };
     UnalignedAccessControl::from_bits(r).ok_or(io::Errno::RANGE)
@@ -203,6 +213,7 @@ const PR_SET_UNALIGN: c_int = 6;
 ///
 /// [`prctl(PR_SET_UNALIGN,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_SET_UNALIGN")]
 pub fn set_unaligned_access_control(config: UnalignedAccessControl) -> io::Result<()> {
     unsafe { prctl_2args(PR_SET_UNALIGN, config.bits() as usize as *mut _) }.map(|_r| ())
 }
@@ -214,12 +225,15 @@ pub fn set_unaligned_access_control(config: UnalignedAccessControl) -> io::Resul
 const PR_GET_FPEMU: c_int = 9;
 
 bitflags! {
-    /// `PR_FPEMU_*`.
+    /// `PR_FPEMU_*` flags for use with [`floating_point_emulation_control`]
+    /// and [`set_floating_point_emulation_control`].
     pub struct FloatingPointEmulationControl: u32 {
         /// Silently emulate floating point operations accesses.
+        #[doc(alias = "PR_UNALIGN_NOPRINT")]
         const NO_PRINT = 1;
         /// Don't emulate floating point operations, send a [`Signal::Fpe`]
         /// signal instead.
+        #[doc(alias = "PR_UNALIGN_SIGFPE")]
         const SIGFPE = 2;
     }
 }
@@ -231,6 +245,7 @@ bitflags! {
 ///
 /// [`prctl(PR_GET_FPEMU,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_GET_FPEMU")]
 pub fn floating_point_emulation_control() -> io::Result<FloatingPointEmulationControl> {
     let r = unsafe { prctl_get_at_arg2_optional::<c_uint>(PR_GET_FPEMU)? };
     FloatingPointEmulationControl::from_bits(r).ok_or(io::Errno::RANGE)
@@ -245,6 +260,7 @@ const PR_SET_FPEMU: c_int = 10;
 ///
 /// [`prctl(PR_SET_FPEMU,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_SET_FPEMU")]
 pub fn set_floating_point_emulation_control(
     config: FloatingPointEmulationControl,
 ) -> io::Result<()> {
@@ -289,6 +305,7 @@ bitflags! {
 ///
 /// [`prctl(PR_GET_FPEXC,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_GET_FPEXEC")]
 pub fn floating_point_exception_mode() -> io::Result<Option<FloatingPointExceptionMode>> {
     unsafe { prctl_get_at_arg2_optional::<c_uint>(PR_GET_FPEXC) }
         .map(FloatingPointExceptionMode::from_bits)
@@ -303,6 +320,7 @@ const PR_SET_FPEXC: c_int = 12;
 ///
 /// [`prctl(PR_SET_FPEXC,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_SET_FPEXEC")]
 pub fn set_floating_point_exception_mode(
     config: Option<FloatingPointExceptionMode>,
 ) -> io::Result<()> {
@@ -319,7 +337,8 @@ const PR_GET_TIMING: c_int = 13;
 const PR_TIMING_STATISTICAL: i32 = 0;
 const PR_TIMING_TIMESTAMP: i32 = 1;
 
-/// `PR_TIMING_*`.
+/// `PR_TIMING_*` values for use with [`timing_method`] and
+/// [`set_timing_method`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(i32)]
 pub enum TimingMethod {
@@ -348,6 +367,7 @@ impl TryFrom<i32> for TimingMethod {
 ///
 /// [`prctl(PR_GET_TIMING,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_GET_TIMING")]
 pub fn timing_method() -> io::Result<TimingMethod> {
     unsafe { prctl_1arg(PR_GET_TIMING) }.and_then(TryInto::try_into)
 }
@@ -362,6 +382,7 @@ const PR_SET_TIMING: c_int = 14;
 ///
 /// [`prctl(PR_SET_TIMING,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_SET_TIMING")]
 pub fn set_timing_method(method: TimingMethod) -> io::Result<()> {
     unsafe { prctl_2args(PR_SET_TIMING, method as usize as *mut _) }.map(|_r| ())
 }
@@ -376,7 +397,7 @@ const PR_ENDIAN_BIG: u32 = 0;
 const PR_ENDIAN_LITTLE: u32 = 1;
 const PR_ENDIAN_PPC_LITTLE: u32 = 2;
 
-/// `PR_ENDIAN_*`.
+/// `PR_ENDIAN_*` values for use with [`endian_mode`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum EndianMode {
@@ -408,6 +429,7 @@ impl TryFrom<u32> for EndianMode {
 ///
 /// [`prctl(PR_GET_ENDIAN,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_GET_ENDIAN")]
 pub fn endian_mode() -> io::Result<EndianMode> {
     unsafe { prctl_get_at_arg2::<c_uint, _>(PR_GET_ENDIAN) }
 }
@@ -426,6 +448,7 @@ const PR_SET_ENDIAN: c_int = 20;
 ///
 /// [`prctl(PR_SET_ENDIAN,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_SET_ENDIAN")]
 pub unsafe fn set_endian_mode(mode: EndianMode) -> io::Result<()> {
     prctl_2args(PR_SET_ENDIAN, mode as usize as *mut _).map(|_r| ())
 }
@@ -439,7 +462,8 @@ const PR_GET_TSC: c_int = 25;
 const PR_TSC_ENABLE: u32 = 1;
 const PR_TSC_SIGSEGV: u32 = 2;
 
-/// `PR_TSC_*`.
+/// `PR_TSC_*` values for use with [`time_stamp_counter_readability`] and
+/// [`set_time_stamp_counter_readability`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum TimeStampCounterReadability {
@@ -468,6 +492,7 @@ impl TryFrom<u32> for TimeStampCounterReadability {
 ///
 /// [`prctl(PR_GET_TSC,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_GET_TSC")]
 pub fn time_stamp_counter_readability() -> io::Result<TimeStampCounterReadability> {
     unsafe { prctl_get_at_arg2::<c_uint, _>(PR_GET_TSC) }
 }
@@ -482,6 +507,7 @@ const PR_SET_TSC: c_int = 26;
 ///
 /// [`prctl(PR_SET_TSC,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_SET_TSC")]
 pub fn set_time_stamp_counter_readability(
     readability: TimeStampCounterReadability,
 ) -> io::Result<()> {
@@ -504,6 +530,8 @@ const PR_TASK_PERF_EVENTS_ENABLE: c_int = 32;
 /// [`prctl(PR_TASK_PERF_EVENTS_ENABLE,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 /// [`prctl(PR_TASK_PERF_EVENTS_DISABLE,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_TASK_PERF_EVENTS_ENABLE")]
+#[doc(alias = "PR_TASK_PERF_EVENTS_DISABLE")]
 pub fn configure_performance_counters(enable: bool) -> io::Result<()> {
     let option = if enable {
         PR_TASK_PERF_EVENTS_ENABLE
@@ -524,15 +552,20 @@ const PR_MCE_KILL_LATE: u32 = 0;
 const PR_MCE_KILL_EARLY: u32 = 1;
 const PR_MCE_KILL_DEFAULT: u32 = 2;
 
-/// `PR_MCE_KILL_*`.
+/// `PR_MCE_KILL_*` values for use with
+/// [`machine_check_memory_corruption_kill_policy`] and
+/// [`set_machine_check_memory_corruption_kill_policy`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum MachineCheckMemoryCorruptionKillPolicy {
     /// Late kill policy.
+    #[doc(alias = "PR_MCE_KILL_LATE")]
     Late = PR_MCE_KILL_LATE,
     /// Early kill policy.
+    #[doc(alias = "PR_MCE_KILL_EARLY")]
     Early = PR_MCE_KILL_EARLY,
     /// System-wide default policy.
+    #[doc(alias = "PR_MCE_KILL_DEFAULT")]
     Default = PR_MCE_KILL_DEFAULT,
 }
 
@@ -556,6 +589,7 @@ impl TryFrom<u32> for MachineCheckMemoryCorruptionKillPolicy {
 ///
 /// [`prctl(PR_MCE_KILL_GET,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_MCE_KILL_GET")]
 pub fn machine_check_memory_corruption_kill_policy(
 ) -> io::Result<MachineCheckMemoryCorruptionKillPolicy> {
     let r = unsafe { prctl_1arg(PR_MCE_KILL_GET)? } as c_uint;
@@ -574,6 +608,7 @@ const PR_MCE_KILL_SET: usize = 1;
 ///
 /// [`prctl(PR_MCE_KILL,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_MCE_KILL")]
 pub fn set_machine_check_memory_corruption_kill_policy(
     policy: Option<MachineCheckMemoryCorruptionKillPolicy>,
 ) -> io::Result<()> {
@@ -608,7 +643,7 @@ const PR_SET_MM_EXE_FILE: usize = 13;
 const PR_SET_MM_MAP: usize = 14;
 const PR_SET_MM_MAP_SIZE: usize = 15;
 
-/// `PR_SET_MM_*`.
+/// `PR_SET_MM_*` values for use with [`set_virtual_memory_map_address`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum VirtualMemoryMapAddress {
@@ -652,6 +687,7 @@ pub enum VirtualMemoryMapAddress {
 ///
 /// [`prctl(PR_SET_MM,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_SET_MM")]
 pub unsafe fn set_virtual_memory_map_address(
     option: VirtualMemoryMapAddress,
     address: Option<NonNull<c_void>>,
@@ -668,6 +704,8 @@ pub unsafe fn set_virtual_memory_map_address(
 ///
 /// [`prctl(PR_SET_MM,PR_SET_MM_EXE_FILE,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_SET_MM")]
+#[doc(alias = "PR_SET_MM_EXE_FILE")]
 pub fn set_executable_file(fd: BorrowedFd) -> io::Result<()> {
     let fd = usize::try_from(fd.as_raw_fd()).map_err(|_r| io::Errno::RANGE)?;
     unsafe { prctl_3args(PR_SET_MM, PR_SET_MM_EXE_FILE as *mut _, fd as *mut _) }.map(|_r| ())
@@ -685,6 +723,8 @@ pub fn set_executable_file(fd: BorrowedFd) -> io::Result<()> {
 ///
 /// [`prctl(PR_SET_MM,PR_SET_MM_AUXV,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_SET_MM")]
+#[doc(alias = "PR_SET_MM_AUXV")]
 pub unsafe fn set_auxiliary_vector(auxv: &[*const c_void]) -> io::Result<()> {
     syscalls::prctl(
         PR_SET_MM,
@@ -703,6 +743,8 @@ pub unsafe fn set_auxiliary_vector(auxv: &[*const c_void]) -> io::Result<()> {
 ///
 /// [`prctl(PR_SET_MM,PR_SET_MM_MAP_SIZE,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_SET_MM")]
+#[doc(alias = "PR_SET_MM_MAP_SIZE")]
 pub fn virtual_memory_map_config_struct_size() -> io::Result<usize> {
     let mut value: c_uint = 0;
     let value_ptr = as_mut_ptr(&mut value);
@@ -760,6 +802,8 @@ pub struct PrctlMmMap {
 ///
 /// [`prctl(PR_SET_MM,PR_SET_MM_MAP,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_SET_MM")]
+#[doc(alias = "PR_SET_MM_MAP")]
 pub unsafe fn configure_virtual_memory_map(config: &PrctlMmMap) -> io::Result<()> {
     syscalls::prctl(
         PR_SET_MM,
@@ -798,6 +842,7 @@ pub enum PTracer {
 ///
 /// [`prctl(PR_SET_PTRACER,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_SET_PTRACER")]
 pub fn set_ptracer(tracer: PTracer) -> io::Result<()> {
     let pid = match tracer {
         PTracer::None => null_mut(),
@@ -821,6 +866,7 @@ const PR_GET_CHILD_SUBREAPER: c_int = 37;
 ///
 /// [`prctl(PR_GET_CHILD_SUBREAPER,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_GET_CHILD_SUBREAPER")]
 pub fn child_subreaper() -> io::Result<Option<Pid>> {
     unsafe {
         let r = prctl_get_at_arg2_optional::<c_uint>(PR_GET_CHILD_SUBREAPER)?;
@@ -837,6 +883,7 @@ const PR_SET_CHILD_SUBREAPER: c_int = 36;
 ///
 /// [`prctl(PR_SET_CHILD_SUBREAPER,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_SET_CHILD_SUBREAPER")]
 pub fn set_child_subreaper(pid: Option<Pid>) -> io::Result<()> {
     let pid = pid.map_or(0_usize, |pid| pid.as_raw_nonzero().get() as usize);
     unsafe { prctl_2args(PR_SET_CHILD_SUBREAPER, pid as *mut _) }.map(|_r| ())
@@ -851,7 +898,8 @@ const PR_GET_FP_MODE: c_int = 46;
 const PR_FP_MODE_FR: u32 = 1_u32 << 0;
 const PR_FP_MODE_FRE: u32 = 1_u32 << 1;
 
-/// `PR_FP_MODE_*`.
+/// `PR_FP_MODE_*` values for use with [`floating_point_mode`] and
+/// [`set_floating_point_mode`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum FloatingPointMode {
@@ -880,6 +928,7 @@ impl TryFrom<u32> for FloatingPointMode {
 ///
 /// [`prctl(PR_GET_FP_MODE,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_GET_FP_MODE")]
 pub fn floating_point_mode() -> io::Result<FloatingPointMode> {
     let r = unsafe { prctl_1arg(PR_GET_FP_MODE)? } as c_uint;
     FloatingPointMode::try_from(r)
@@ -894,6 +943,7 @@ const PR_SET_FP_MODE: c_int = 45;
 ///
 /// [`prctl(PR_SET_FP_MODE,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_SET_FP_MODE")]
 pub fn set_floating_point_mode(mode: FloatingPointMode) -> io::Result<()> {
     unsafe { prctl_2args(PR_SET_FP_MODE, mode as usize as *mut _) }.map(|_r| ())
 }
@@ -908,7 +958,8 @@ const PR_SPEC_STORE_BYPASS: u32 = 0;
 const PR_SPEC_INDIRECT_BRANCH: u32 = 1;
 const PR_SPEC_L1D_FLUSH: u32 = 2;
 
-/// `PR_SPEC_*`.
+/// `PR_SPEC_*` values for use with [`speculative_feature_state`] and
+/// [`control_speculative_feature`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum SpeculationFeature {
@@ -934,7 +985,7 @@ impl TryFrom<u32> for SpeculationFeature {
 }
 
 bitflags! {
-    /// `PR_SPEC_*`.
+    /// `PR_SPEC_*` flags for use with [`control_speculative_feature`].
     pub struct SpeculationFeatureControl: u32 {
         /// The speculation feature is enabled, mitigation is disabled.
         const ENABLE = 1_u32 << 1;
@@ -970,6 +1021,7 @@ bitflags! {
 ///
 /// [`prctl(PR_GET_SPECULATION_CTRL,...)`]: https://www.kernel.org/doc/html/v5.18/userspace-api/spec_ctrl.html
 #[inline]
+#[doc(alias = "PR_GET_SPECULATION_CTRL")]
 pub fn speculative_feature_state(
     feature: SpeculationFeature,
 ) -> io::Result<Option<SpeculationFeatureState>> {
@@ -986,6 +1038,7 @@ const PR_SET_SPECULATION_CTRL: c_int = 53;
 ///
 /// [`prctl(PR_SET_SPECULATION_CTRL,...)`]: https://www.kernel.org/doc/html/v5.18/userspace-api/spec_ctrl.html
 #[inline]
+#[doc(alias = "PR_SET_SPECULATION_CTRL")]
 pub fn control_speculative_feature(
     feature: SpeculationFeature,
     config: SpeculationFeatureControl,
@@ -1008,6 +1061,7 @@ const PR_GET_IO_FLUSHER: c_int = 58;
 ///
 /// [`prctl(PR_GET_IO_FLUSHER,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_GET_IO_FLUSHER")]
 pub fn is_io_flusher() -> io::Result<bool> {
     unsafe { prctl_1arg(PR_GET_IO_FLUSHER) }.map(|r| r != 0)
 }
@@ -1022,6 +1076,7 @@ const PR_SET_IO_FLUSHER: c_int = 57;
 ///
 /// [`prctl(PR_SET_IO_FLUSHER,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[doc(alias = "PR_SET_IO_FLUSHER")]
 pub fn configure_io_flusher_behavior(enable: bool) -> io::Result<()> {
     unsafe { prctl_2args(PR_SET_IO_FLUSHER, usize::from(enable) as *mut _) }.map(|_r| ())
 }
@@ -1055,6 +1110,7 @@ bitflags! {
 ///
 /// [`prctl(PR_PAC_GET_ENABLED_KEYS,...)`]: https://www.kernel.org/doc/html/v5.18/arm64/pointer-authentication.html
 #[inline]
+#[doc(alias = "PR_PAC_GET_ENABLED_KEYS")]
 pub fn enabled_pointer_authentication_keys() -> io::Result<PointerAuthenticationKeys> {
     let r = unsafe { prctl_1arg(PR_PAC_GET_ENABLED_KEYS)? } as c_uint;
     PointerAuthenticationKeys::from_bits(r).ok_or(io::Errno::RANGE)
@@ -1074,6 +1130,7 @@ const PR_PAC_SET_ENABLED_KEYS: c_int = 60;
 ///
 /// [`prctl(PR_PAC_SET_ENABLED_KEYS,...)`]: https://www.kernel.org/doc/html/v5.18/arm64/pointer-authentication.html
 #[inline]
+#[doc(alias = "PR_PAC_SET_ENABLED_KEYS")]
 pub unsafe fn configure_pointer_authentication_keys(
     config: impl Iterator<Item = (PointerAuthenticationKeys, bool)>,
 ) -> io::Result<()> {
@@ -1118,6 +1175,8 @@ const PR_SET_VMA_ANON_NAME: usize = 0;
 ///
 /// [`prctl(PR_SET_VMA,PR_SET_VMA_ANON_NAME,...)`]: https://lwn.net/Articles/867818/
 #[inline]
+#[doc(alias = "PR_SET_VMA")]
+#[doc(alias = "PR_SET_VMA_ANON_NAME")]
 pub fn set_virtual_memory_region_name(region: &[u8], name: Option<&CStr>) -> io::Result<()> {
     unsafe {
         syscalls::prctl(

--- a/src/process/prctl.rs
+++ b/src/process/prctl.rs
@@ -1023,7 +1023,7 @@ const PR_SET_IO_FLUSHER: c_int = 57;
 /// [`prctl(PR_SET_IO_FLUSHER,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
 pub fn configure_io_flusher_behavior(enable: bool) -> io::Result<()> {
-    unsafe { prctl_2args(PR_SET_IO_FLUSHER, enable as usize as *mut _) }.map(|_r| ())
+    unsafe { prctl_2args(PR_SET_IO_FLUSHER, usize::from(enable) as *mut _) }.map(|_r| ())
 }
 
 //

--- a/src/process/system.rs
+++ b/src/process/system.rs
@@ -124,7 +124,7 @@ pub fn sysinfo() -> Sysinfo {
     backend::process::syscalls::sysinfo()
 }
 
-/// `sethostname(name)—Sets the system host name.
+/// `sethostname(name)`—Sets the system host name.
 ///
 /// # References
 ///  - [Linux]

--- a/src/process/umask.rs
+++ b/src/process/umask.rs
@@ -13,9 +13,9 @@ use crate::fs::Mode;
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/umask.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/umask.2.html
-#[inline]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
 #[cfg(feature = "fs")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
+#[inline]
 pub fn umask(mask: Mode) -> Mode {
     backend::process::syscalls::umask(mask)
 }

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -13,7 +13,7 @@ use crate::{backend, io};
 use {crate::ffi::CString, alloc::vec::Vec};
 
 bitflags::bitflags! {
-    /// Flags for use with [`openpt`] and [`ioctl_tiocgptpeer`].
+    /// `O_*` flags for use with [`openpt`] and [`ioctl_tiocgptpeer`].
     ///
     /// [`ioctl_tiocgtpeer`]: https://docs.rs/rustix/*/x86_64-unknown-linux-gnu/rustix/pty/fn.ioctl_tiocgtpeer.html
     pub struct OpenptFlags: u32 {
@@ -70,7 +70,7 @@ impl From<OpenptFlags> for OFlags {
 /// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=posix_openpt&sektion=2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=posix_openpt&section=3
 /// [NetBSD]: https://man.netbsd.org/posix_openpt.3
-/// [OpenBSD]: http://man.openbsd.org/posix_openpt
+/// [OpenBSD]: https://man.openbsd.org/posix_openpt
 /// [illumos]: https://illumos.org/man/3C/posix_openpt
 #[inline]
 #[doc(alias = "posix_openpt")]

--- a/src/thread/prctl.rs
+++ b/src/thread/prctl.rs
@@ -55,7 +55,7 @@ const PR_SET_KEEPCAPS: c_int = 8;
 /// [`prctl(PR_SET_KEEPCAPS,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
 pub fn set_keep_capabilities(enable: bool) -> io::Result<()> {
-    unsafe { prctl_2args(PR_SET_KEEPCAPS, enable as usize as *mut _) }.map(|_r| ())
+    unsafe { prctl_2args(PR_SET_KEEPCAPS, usize::from(enable) as *mut _) }.map(|_r| ())
 }
 
 //
@@ -521,7 +521,7 @@ const PR_SET_NO_NEW_PRIVS: c_int = 38;
 /// [`prctl(PR_SET_NO_NEW_PRIVS,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
 pub fn set_no_new_privs(no_new_privs: bool) -> io::Result<()> {
-    unsafe { prctl_2args(PR_SET_NO_NEW_PRIVS, no_new_privs as usize as *mut _) }.map(|_r| ())
+    unsafe { prctl_2args(PR_SET_NO_NEW_PRIVS, usize::from(no_new_privs) as *mut _) }.map(|_r| ())
 }
 
 //
@@ -569,7 +569,7 @@ const PR_SET_THP_DISABLE: c_int = 41;
 /// [`prctl(PR_SET_THP_DISABLE,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
 pub fn disable_transparent_huge_pages(thp_disable: bool) -> io::Result<()> {
-    unsafe { prctl_2args(PR_SET_THP_DISABLE, thp_disable as usize as *mut _) }.map(|_r| ())
+    unsafe { prctl_2args(PR_SET_THP_DISABLE, usize::from(thp_disable) as *mut _) }.map(|_r| ())
 }
 
 //

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -2,12 +2,10 @@
 
 mod clock;
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[cfg(feature = "time")]
 mod timerfd;
 
 // TODO: Convert WASI'S clock APIs to use handles rather than ambient clock
 // identifiers, update `wasi-libc`, and then add support in `rustix`.
 pub use clock::*;
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[cfg(feature = "time")]
 pub use timerfd::*;

--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -35,6 +35,8 @@ mod openat2;
 mod readdir;
 mod readlinkat;
 mod renameat;
+#[cfg(any(linux_kernel, target_os = "freebsd"))]
+mod seals;
 #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 mod statfs;
 #[cfg(linux_kernel)]

--- a/tests/fs/seals.rs
+++ b/tests/fs/seals.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "fs")]
 #[test]
 fn test_seals() {
     use rustix::fs::{

--- a/tests/fs/statx.rs
+++ b/tests/fs/statx.rs
@@ -8,7 +8,7 @@ fn test_statx_unknown_flags() {
     // unknown bits. Exclude `STATX__RESERVED` here as that evokes an explicit
     // failure; that's tested separately below.
     let too_many_flags =
-        unsafe { StatxFlags::from_bits_unchecked(!0 & !linux_raw_sys::general::STATX__RESERVED) };
+        unsafe { StatxFlags::from_bits_unchecked(!linux_raw_sys::general::STATX__RESERVED) };
 
     // It's also ok to pass such flags to `statx`.
     let result = match rustix::fs::statx(&f, "Cargo.toml", AtFlags::empty(), too_many_flags) {

--- a/tests/fs/y2038.rs
+++ b/tests/fs/y2038.rs
@@ -46,26 +46,23 @@ fn test_y2038_with_utimensat() {
     // Use `statat` to read back the timestamp.
     let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();
 
-    assert_eq!(
-        TryInto::<u64>::try_into(stat.st_mtime).unwrap() as u64,
-        m_sec
-    );
+    assert_eq!(TryInto::<u64>::try_into(stat.st_mtime).unwrap(), m_sec);
 
     #[cfg(not(target_os = "netbsd"))]
     assert_eq!(stat.st_mtime_nsec as u32, m_nsec);
     #[cfg(target_os = "netbsd")]
     assert_eq!(stat.st_mtimensec as u32, m_nsec);
 
-    assert!(TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 >= a_sec);
+    assert!(TryInto::<u64>::try_into(stat.st_atime).unwrap() >= a_sec);
 
     #[cfg(not(target_os = "netbsd"))]
     assert!(
-        TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 > a_sec
+        TryInto::<u64>::try_into(stat.st_atime).unwrap() > a_sec
             || stat.st_atime_nsec as u32 >= a_nsec
     );
     #[cfg(target_os = "netbsd")]
     assert!(
-        TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 > a_sec
+        TryInto::<u64>::try_into(stat.st_atime).unwrap() > a_sec
             || stat.st_atimensec as u32 >= a_nsec
     );
 
@@ -73,26 +70,23 @@ fn test_y2038_with_utimensat() {
     let file = openat(&dir, "foo", OFlags::RDONLY, Mode::empty()).unwrap();
     let stat = fstat(&file).unwrap();
 
-    assert_eq!(
-        TryInto::<u64>::try_into(stat.st_mtime).unwrap() as u64,
-        m_sec
-    );
+    assert_eq!(TryInto::<u64>::try_into(stat.st_mtime).unwrap(), m_sec);
 
     #[cfg(not(target_os = "netbsd"))]
     assert_eq!(stat.st_mtime_nsec as u32, m_nsec);
     #[cfg(target_os = "netbsd")]
     assert_eq!(stat.st_mtimensec as u32, m_nsec);
 
-    assert!(TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 >= a_sec);
+    assert!(TryInto::<u64>::try_into(stat.st_atime).unwrap() >= a_sec);
 
     #[cfg(not(target_os = "netbsd"))]
     assert!(
-        TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 > a_sec
+        TryInto::<u64>::try_into(stat.st_atime).unwrap() > a_sec
             || stat.st_atime_nsec as u32 >= a_nsec
     );
     #[cfg(target_os = "netbsd")]
     assert!(
-        TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 > a_sec
+        TryInto::<u64>::try_into(stat.st_atime).unwrap() > a_sec
             || stat.st_atimensec as u32 >= a_nsec
     );
 }
@@ -169,26 +163,23 @@ fn test_y2038_with_futimens() {
     let file = openat(&dir, "foo", OFlags::RDONLY, Mode::empty()).unwrap();
     let stat = fstat(&file).unwrap();
 
-    assert_eq!(
-        TryInto::<u64>::try_into(stat.st_mtime).unwrap() as u64,
-        m_sec
-    );
+    assert_eq!(TryInto::<u64>::try_into(stat.st_mtime).unwrap(), m_sec);
 
     #[cfg(not(target_os = "netbsd"))]
     assert_eq!(stat.st_mtime_nsec as u32, m_nsec);
     #[cfg(target_os = "netbsd")]
     assert_eq!(stat.st_mtimensec as u32, m_nsec);
 
-    assert!(TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 >= a_sec);
+    assert!(TryInto::<u64>::try_into(stat.st_atime).unwrap() >= a_sec);
 
     #[cfg(not(target_os = "netbsd"))]
     assert!(
-        TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 > a_sec
+        TryInto::<u64>::try_into(stat.st_atime).unwrap() > a_sec
             || stat.st_atime_nsec as u32 >= a_nsec
     );
     #[cfg(target_os = "netbsd")]
     assert!(
-        TryInto::<u64>::try_into(stat.st_atime).unwrap() as u64 > a_sec
+        TryInto::<u64>::try_into(stat.st_atime).unwrap() > a_sec
             || stat.st_atimensec as u32 >= a_nsec
     );
 }

--- a/tests/io/main.rs
+++ b/tests/io/main.rs
@@ -26,5 +26,3 @@ mod procfs;
 #[cfg(not(target_os = "redox"))] // redox doesn't have cwd/openat
 #[cfg(not(target_os = "wasi"))] // wasi support for `S_IRUSR` etc. submitted to libc in #2264
 mod read_write;
-#[cfg(any(linux_kernel, target_os = "freebsd"))]
-mod seals;

--- a/tests/process/prctl.rs
+++ b/tests/process/prctl.rs
@@ -158,7 +158,7 @@ pub(crate) fn thread_has_capability(capability: Capability) -> io::Result<bool> 
         libc::syscall(
             libc::SYS_capget,
             &header as *const cap_user_header_t,
-            data.as_mut_ptr() as *mut cap_user_data_t,
+            data.as_mut_ptr(),
         )
     };
 

--- a/tests/process/priority.rs
+++ b/tests/process/priority.rs
@@ -44,7 +44,7 @@ fn test_priorities() {
         setpriority_process(None, get + 10000).unwrap();
         let now = getpriority_process(None).unwrap();
         // Linux's max is 19; Darwin's max is 20.
-        assert!(now >= 19 && now <= 20);
+        assert!((19..=20).contains(&now));
         // Darwin appears to return `EPERM` on an out of range `nice`.
         if let Ok(again) = nice(1) {
             assert_eq!(now, again);


### PR DESCRIPTION
 - Mark the `removeattr` syscalls as readonly
 - Various minor documentation and code cleanups