### PR TITLE
Add pidfd_getfd syscall

### DIFF
--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -11,18 +11,18 @@ use crate::backend::c;
 #[cfg(feature = "fs")]
 use crate::backend::conv::slice_mut;
 use crate::backend::conv::{
-    by_mut, by_ref, c_int, c_uint, negative_pid, pass_usize, ret, ret_c_int, ret_c_int_infallible,
-    ret_c_uint, ret_infallible, ret_owned_fd, ret_usize, size_of, slice_just_addr,
-    slice_just_addr_mut, zero,
+    by_mut, by_ref, c_int, c_uint, negative_pid, pass_usize, raw_fd, ret, ret_c_int,
+    ret_c_int_infallible, ret_c_uint, ret_infallible, ret_owned_fd, ret_usize, size_of,
+    slice_just_addr, slice_just_addr_mut, zero,
 };
-use crate::fd::{AsRawFd, BorrowedFd, OwnedFd};
+use crate::fd::{AsRawFd, BorrowedFd, OwnedFd, RawFd};
 #[cfg(feature = "fs")]
 use crate::ffi::CStr;
 use crate::io;
 use crate::pid::{RawNonZeroPid, RawPid};
 use crate::process::{
-    Cpuid, Gid, MembarrierCommand, MembarrierQuery, Pid, PidfdFlags, Resource, Rlimit, Uid, WaitId,
-    WaitOptions, WaitStatus, WaitidOptions, WaitidStatus,
+    Cpuid, Gid, MembarrierCommand, MembarrierQuery, Pid, PidfdFlags, PidfdGetfdFlags, Resource,
+    Rlimit, Uid, WaitId, WaitOptions, WaitStatus, WaitidOptions, WaitidStatus,
 };
 use crate::signal::Signal;
 use crate::utils::as_mut_ptr;
@@ -598,6 +598,22 @@ pub(crate) fn test_kill_process_group(pid: Pid) -> io::Result<()> {
 #[inline]
 pub(crate) fn test_kill_current_process_group() -> io::Result<()> {
     unsafe { ret(syscall_readonly!(__NR_kill, pass_usize(0), pass_usize(0))) }
+}
+
+#[inline]
+pub(crate) fn pidfd_getfd(
+    pidfd: BorrowedFd<'_>,
+    targetfd: RawFd,
+    flags: PidfdGetfdFlags,
+) -> io::Result<OwnedFd> {
+    unsafe {
+        ret_owned_fd(syscall_readonly!(
+            __NR_pidfd_getfd,
+            pidfd,
+            raw_fd(targetfd),
+            c_int(flags.bits() as _)
+        ))
+    }
 }
 
 #[inline]

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -14,6 +14,8 @@ mod kill;
 mod membarrier;
 #[cfg(target_os = "linux")]
 mod pidfd;
+#[cfg(target_os = "linux")]
+mod pidfd_getfd;
 #[cfg(linux_kernel)]
 mod prctl;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))] // WASI doesn't have [gs]etpriority.
@@ -44,6 +46,8 @@ pub use kill::*;
 pub use membarrier::*;
 #[cfg(target_os = "linux")]
 pub use pidfd::*;
+#[cfg(target_os = "linux")]
+pub use pidfd_getfd::*;
 #[cfg(linux_kernel)]
 pub use prctl::*;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]

--- a/src/process/pidfd_getfd.rs
+++ b/src/process/pidfd_getfd.rs
@@ -1,0 +1,46 @@
+#![allow(unsafe_code)]
+use crate::fd::OwnedFd;
+use crate::{backend, io};
+use backend::fd::{AsFd, RawFd};
+
+/// Raw file descriptor in another process.
+///
+/// A distinct type alias is used here to inform the user that normal file descriptors from the
+/// calling process should not be used. The provided file descriptor is used by the kernel as the
+/// index into the file descriptor table of an entirely different process.
+pub type ForeignRawFd = RawFd;
+
+bitflags::bitflags! {
+    /// All flags are reserved for future use.
+    pub struct PidfdGetfdFlags: backend::c::c_uint {}
+}
+
+/// `syscall(SYS_pidfd_getfd, pidfd, flags)`—Obtain a duplicate of another
+/// process's file descriptor.
+///
+/// # References
+///  - [Linux]
+///
+/// # Warning
+///
+/// This function is generally safe for the calling process, but it can impact the target process
+/// in unexpected ways. If you want to ensure that Rust I/O safety assumptions continue to hold in
+/// the target process, then the target process must have communicated the file description number
+/// to the calling process from a value of a type that implements AsRawFd, and the target process
+/// must not drop that value until after the calling process has returned from `pidfd_getfd`.
+///
+/// When `pidfd_getfd` is used to debug the target, or the target is not a Rust aplication, or
+/// `pidfd_getfd` is used in any other way, then extra care should be taken to avoid unexpected
+/// behaviour or crashes.
+///
+/// For further details, see the references above.
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/pidfd_getfd.2.html
+#[inline]
+pub fn pidfd_getfd<Fd: AsFd>(
+    pidfd: Fd,
+    targetfd: ForeignRawFd,
+    flags: PidfdGetfdFlags,
+) -> io::Result<OwnedFd> {
+    backend::process::syscalls::pidfd_getfd(pidfd.as_fd(), targetfd, flags)
+}


### PR DESCRIPTION
Adding the `pidfd_getfd` syscall may require some discussion, but after doing some research, I think the approach used in this PR makes some sense. So, I sent this as a PR directly instead of creating an issue first.

The 3 main things that I think require some thought, are:
 - Is this even a desired feature to add to rustix?
 - How does pidfd_getfd measure up in the I/O safety concept?
 - Are the correct types used? (Especially for `targetfd`)

In this PR, I marked the function unsafe because it _can_ be used as a kind of `dup` from a RawFd to OwnedFd, when an application uses it on itself. That would still be memory safe, but violates I/O safety as I understand from the RFC.
The argument against marking this unsafe would be that using this does not impact the safety of the calling application directly, and the safety of other processes is outside of the bounds of the concepts of memory and I/O safety anyway. (Even when the target process could end up being the calling process in practice?) I'm curious what the thoughts are about this, and what safety considerations I may have missed.

For the `targetfd` arg: I think there is no other code that uses RawFd/AsRawFd for values that are not potential file descriptors of the current process. At least to me, it feels like a bit of a stretch to use it for `targetfd`. On the other hand, using `c_int` directly seems worse. Any thoughts on this?

And the flags: The syscall currently does not take any flags, but might in the future. I added an empty enum to represent this. Is this the correct approach?