### PR TITLE
Clean up redundant Pid check

### DIFF
--- a/src/backend/linux_raw/pid/syscalls.rs
+++ b/src/backend/linux_raw/pid/syscalls.rs
@@ -13,7 +13,6 @@ use crate::pid::{Pid, RawPid};
 pub(crate) fn getpid() -> Pid {
     unsafe {
         let pid = ret_usize_infallible(syscall_readonly!(__NR_getpid)) as RawPid;
-        debug_assert!(pid > 0);
         Pid::from_raw_unchecked(pid)
     }
 }

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -545,7 +545,6 @@ unsafe fn cvt_waitid_status(status: MaybeUninit<c::siginfo_t>) -> Option<WaitidS
 pub(crate) fn getsid(pid: Option<Pid>) -> io::Result<Pid> {
     unsafe {
         let pid = ret_c_int(syscall_readonly!(__NR_getsid, c_int(Pid::as_raw(pid))))?;
-        debug_assert!(pid > 0);
         Ok(Pid::from_raw_unchecked(pid))
     }
 }
@@ -554,7 +553,6 @@ pub(crate) fn getsid(pid: Option<Pid>) -> io::Result<Pid> {
 pub(crate) fn setsid() -> io::Result<Pid> {
     unsafe {
         let pid = ret_c_int(syscall_readonly!(__NR_setsid))?;
-        debug_assert!(pid > 0);
         Ok(Pid::from_raw_unchecked(pid))
     }
 }

--- a/src/backend/linux_raw/runtime/syscalls.rs
+++ b/src/backend/linux_raw/runtime/syscalls.rs
@@ -100,7 +100,6 @@ pub(crate) mod tls {
     #[inline]
     pub(crate) unsafe fn set_tid_address(data: *mut c::c_void) -> Pid {
         let tid: i32 = ret_c_int_infallible(syscall_readonly!(__NR_set_tid_address, data));
-        debug_assert_ne!(tid, 0);
         Pid::from_raw_unchecked(tid)
     }
 

--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -74,7 +74,6 @@ pub(crate) fn tcgetpgrp(fd: BorrowedFd<'_>) -> io::Result<Pid> {
         let mut result = MaybeUninit::<c::pid_t>::uninit();
         ret(syscall!(__NR_ioctl, fd, c_uint(TIOCGPGRP), &mut result))?;
         let pid = result.assume_init();
-        debug_assert!(pid > 0);
         Ok(Pid::from_raw_unchecked(pid))
     }
 }
@@ -168,7 +167,6 @@ pub(crate) fn tcgetsid(fd: BorrowedFd) -> io::Result<Pid> {
         let mut result = MaybeUninit::<c::pid_t>::uninit();
         ret(syscall!(__NR_ioctl, fd, c_uint(TIOCGSID), &mut result))?;
         let pid = result.assume_init();
-        debug_assert!(pid > 0);
         Ok(Pid::from_raw_unchecked(pid))
     }
 }

--- a/src/backend/linux_raw/thread/syscalls.rs
+++ b/src/backend/linux_raw/thread/syscalls.rs
@@ -200,7 +200,6 @@ unsafe fn nanosleep_old(
 pub(crate) fn gettid() -> Pid {
     unsafe {
         let tid = ret_c_int_infallible(syscall_readonly!(__NR_gettid));
-        debug_assert_ne!(tid, 0);
         Pid::from_raw_unchecked(tid)
     }
 }


### PR DESCRIPTION
`Pid::from_raw_unchecked` already contains a positivity `debug_assert`.