### PR TITLE
Use `u32` to represent most flags and enum types.

### DIFF
--- a/src/backend/libc/event/epoll.rs
+++ b/src/backend/libc/event/epoll.rs
@@ -87,62 +87,64 @@ use core::slice;
 
 bitflags! {
     /// `EPOLL_*` for use with [`new`].
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct CreateFlags: c::c_int {
+    pub struct CreateFlags: u32 {
         /// `EPOLL_CLOEXEC`
-        const CLOEXEC = c::EPOLL_CLOEXEC;
+        const CLOEXEC = bitcast!(c::EPOLL_CLOEXEC);
     }
 }
 
 bitflags! {
     /// `EPOLL*` for use with [`add`].
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct EventFlags: u32 {
         /// `EPOLLIN`
-        const IN = c::EPOLLIN as u32;
+        const IN = bitcast!(c::EPOLLIN);
 
         /// `EPOLLOUT`
-        const OUT = c::EPOLLOUT as u32;
+        const OUT = bitcast!(c::EPOLLOUT);
 
         /// `EPOLLPRI`
-        const PRI = c::EPOLLPRI as u32;
+        const PRI = bitcast!(c::EPOLLPRI);
 
         /// `EPOLLERR`
-        const ERR = c::EPOLLERR as u32;
+        const ERR = bitcast!(c::EPOLLERR);
 
         /// `EPOLLHUP`
-        const HUP = c::EPOLLHUP as u32;
+        const HUP = bitcast!(c::EPOLLHUP);
 
         /// `EPOLLRDNORM`
-        const RDNORM = c::EPOLLRDNORM as u32;
+        const RDNORM = bitcast!(c::EPOLLRDNORM);
 
         /// `EPOLLRDBAND`
-        const RDBAND = c::EPOLLRDBAND as u32;
+        const RDBAND = bitcast!(c::EPOLLRDBAND);
 
         /// `EPOLLWRNORM`
-        const WRNORM = c::EPOLLWRNORM as u32;
+        const WRNORM = bitcast!(c::EPOLLWRNORM);
 
         /// `EPOLLWRBAND`
-        const WRBAND = c::EPOLLWRBAND as u32;
+        const WRBAND = bitcast!(c::EPOLLWRBAND);
 
         /// `EPOLLMSG`
-        const MSG = c::EPOLLMSG as u32;
+        const MSG = bitcast!(c::EPOLLMSG);
 
         /// `EPOLLRDHUP`
-        const RDHUP = c::EPOLLRDHUP as u32;
+        const RDHUP = bitcast!(c::EPOLLRDHUP);
 
         /// `EPOLLET`
-        const ET = c::EPOLLET as u32;
+        const ET = bitcast!(c::EPOLLET);
 
         /// `EPOLLONESHOT`
-        const ONESHOT = c::EPOLLONESHOT as u32;
+        const ONESHOT = bitcast!(c::EPOLLONESHOT);
 
         /// `EPOLLWAKEUP`
-        const WAKEUP = c::EPOLLWAKEUP as u32;
+        const WAKEUP = bitcast!(c::EPOLLWAKEUP);
 
         /// `EPOLLEXCLUSIVE`
         #[cfg(not(target_os = "android"))]
-        const EXCLUSIVE = c::EPOLLEXCLUSIVE as u32;
+        const EXCLUSIVE = bitcast!(c::EPOLLEXCLUSIVE);
     }
 }
 
@@ -155,7 +157,7 @@ bitflags! {
 pub fn create(flags: CreateFlags) -> io::Result<OwnedFd> {
     // SAFETY: We're calling `epoll_create1` via FFI and we know how it
     // behaves.
-    unsafe { ret_owned_fd(c::epoll_create1(flags.bits())) }
+    unsafe { ret_owned_fd(c::epoll_create1(bitflags_bits!(flags))) }
 }
 
 /// `epoll_ctl(self, EPOLL_CTL_ADD, data, event)`—Adds an element to an

--- a/src/backend/libc/event/poll_fd.rs
+++ b/src/backend/libc/event/poll_fd.rs
@@ -13,6 +13,7 @@ bitflags! {
     /// `POLL*` flags for use with [`poll`].
     ///
     /// [`poll`]: crate::io::poll
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct PollFlags: c::c_short {
         /// `POLLIN`

--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -31,7 +31,7 @@ pub(crate) fn eventfd(initval: u32, flags: EventfdFlags) -> io::Result<OwnedFd> 
 
     #[cfg(any(target_os = "freebsd", target_os = "illumos"))]
     unsafe {
-        ret_owned_fd(c::eventfd(initval, flags.bits()))
+        ret_owned_fd(c::eventfd(initval, bitflags_bits!(flags)))
     }
 }
 

--- a/src/backend/libc/event/types.rs
+++ b/src/backend/libc/event/types.rs
@@ -6,13 +6,14 @@ bitflags! {
     /// `EFD_*` flags for use with [`eventfd`].
     ///
     /// [`eventfd`]: crate::io::eventfd
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct EventfdFlags: c::c_int {
+    pub struct EventfdFlags: u32 {
         /// `EFD_CLOEXEC`
-        const CLOEXEC = c::EFD_CLOEXEC;
+        const CLOEXEC = bitcast!(c::EFD_CLOEXEC);
         /// `EFD_NONBLOCK`
-        const NONBLOCK = c::EFD_NONBLOCK;
+        const NONBLOCK = bitcast!(c::EFD_NONBLOCK);
         /// `EFD_SEMAPHORE`
-        const SEMAPHORE = c::EFD_SEMAPHORE;
+        const SEMAPHORE = bitcast!(c::EFD_SEMAPHORE);
     }
 }

--- a/src/backend/libc/fs/inotify.rs
+++ b/src/backend/libc/fs/inotify.rs
@@ -10,12 +10,13 @@ bitflags! {
     /// `IN_*` for use with [`inotify_init`].
     ///
     /// [`inotify_init`]: crate::fs::inotify::inotify_init
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct CreateFlags: c::c_int {
+    pub struct CreateFlags: u32 {
         /// `IN_CLOEXEC`
-        const CLOEXEC = c::IN_CLOEXEC;
+        const CLOEXEC = bitcast!(c::IN_CLOEXEC);
         /// `IN_NONBLOCK`
-        const NONBLOCK = c::IN_NONBLOCK;
+        const NONBLOCK = bitcast!(c::IN_NONBLOCK);
     }
 }
 
@@ -23,6 +24,7 @@ bitflags! {
     /// `IN*` for use with [`inotify_add_watch`].
     ///
     /// [`inotify_add_watch`]: crate::fs::inotify::inotify_add_watch
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct WatchFlags: u32 {
         /// `IN_ACCESS`
@@ -79,7 +81,7 @@ bitflags! {
 #[doc(alias = "inotify_init1")]
 pub fn inotify_init(flags: CreateFlags) -> io::Result<OwnedFd> {
     // SAFETY: `inotify_init1` has no safety preconditions.
-    unsafe { ret_owned_fd(c::inotify_init1(flags.bits())) }
+    unsafe { ret_owned_fd(c::inotify_init1(bitflags_bits!(flags))) }
 }
 
 /// `inotify_add_watch(self, path, flags)`—Adds a watch to inotify

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -5,6 +5,7 @@ bitflags! {
     /// `*_OK` constants for use with [`accessat`].
     ///
     /// [`accessat`]: fn.accessat.html
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct Access: c::c_int {
         /// `R_OK`
@@ -28,24 +29,25 @@ bitflags! {
     ///
     /// [`openat`]: crate::fs::openat
     /// [`statat`]: crate::fs::statat
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct AtFlags: c::c_int {
+    pub struct AtFlags: u32 {
         /// `AT_SYMLINK_NOFOLLOW`
-        const SYMLINK_NOFOLLOW = c::AT_SYMLINK_NOFOLLOW;
+        const SYMLINK_NOFOLLOW = bitcast!(c::AT_SYMLINK_NOFOLLOW);
 
         /// `AT_EACCESS`
         #[cfg(not(any(target_os = "emscripten", target_os = "android")))]
-        const EACCESS = c::AT_EACCESS;
+        const EACCESS = bitcast!(c::AT_EACCESS);
 
         /// `AT_REMOVEDIR`
-        const REMOVEDIR = c::AT_REMOVEDIR;
+        const REMOVEDIR = bitcast!(c::AT_REMOVEDIR);
 
         /// `AT_SYMLINK_FOLLOW`
-        const SYMLINK_FOLLOW = c::AT_SYMLINK_FOLLOW;
+        const SYMLINK_FOLLOW = bitcast!(c::AT_SYMLINK_FOLLOW);
 
         /// `AT_NO_AUTOMOUNT`
         #[cfg(any(linux_like, target_os = "fuchsia"))]
-        const NO_AUTOMOUNT = c::AT_NO_AUTOMOUNT;
+        const NO_AUTOMOUNT = bitcast!(c::AT_NO_AUTOMOUNT);
 
         /// `AT_EMPTY_PATH`
         #[cfg(any(
@@ -53,23 +55,23 @@ bitflags! {
             target_os = "freebsd",
             target_os = "fuchsia",
         ))]
-        const EMPTY_PATH = c::AT_EMPTY_PATH;
+        const EMPTY_PATH = bitcast!(c::AT_EMPTY_PATH);
 
         /// `AT_RESOLVE_BENEATH`
         #[cfg(target_os = "freebsd")]
-        const RESOLVE_BENEATH = c::AT_RESOLVE_BENEATH;
+        const RESOLVE_BENEATH = bitcast!(c::AT_RESOLVE_BENEATH);
 
         /// `AT_STATX_SYNC_AS_STAT`
         #[cfg(all(target_os = "linux", target_env = "gnu"))]
-        const STATX_SYNC_AS_STAT = c::AT_STATX_SYNC_AS_STAT;
+        const STATX_SYNC_AS_STAT = bitcast!(c::AT_STATX_SYNC_AS_STAT);
 
         /// `AT_STATX_FORCE_SYNC`
         #[cfg(all(target_os = "linux", target_env = "gnu"))]
-        const STATX_FORCE_SYNC = c::AT_STATX_FORCE_SYNC;
+        const STATX_FORCE_SYNC = bitcast!(c::AT_STATX_FORCE_SYNC);
 
         /// `AT_STATX_DONT_SYNC`
         #[cfg(all(target_os = "linux", target_env = "gnu"))]
-        const STATX_DONT_SYNC = c::AT_STATX_DONT_SYNC;
+        const STATX_DONT_SYNC = bitcast!(c::AT_STATX_DONT_SYNC);
     }
 }
 
@@ -79,6 +81,7 @@ bitflags! {
     /// [`openat`]: crate::fs::openat
     /// [`chmodat`]: crate::fs::chmodat
     /// [`fchmod`]: crate::fs::fchmod
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct Mode: RawMode {
         /// `S_IRWXU`
@@ -188,10 +191,11 @@ bitflags! {
     /// `O_*` constants for use with [`openat`].
     ///
     /// [`openat`]: crate::fs::openat
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct OFlags: c::c_int {
+    pub struct OFlags: u32 {
         /// `O_ACCMODE`
-        const ACCMODE = c::O_ACCMODE;
+        const ACCMODE = bitcast!(c::O_ACCMODE);
 
         /// Similar to `ACCMODE`, but just includes the read/write flags, and
         /// no other flags.
@@ -200,50 +204,50 @@ bitflags! {
         /// sometimes we really just want the read/write bits. Caution is
         /// indicated, as the presence of `O_PATH` may mean that the read/write
         /// bits don't have their usual meaning.
-        const RWMODE = c::O_RDONLY | c::O_WRONLY | c::O_RDWR;
+        const RWMODE = bitcast!(c::O_RDONLY | c::O_WRONLY | c::O_RDWR);
 
         /// `O_APPEND`
-        const APPEND = c::O_APPEND;
+        const APPEND = bitcast!(c::O_APPEND);
 
         /// `O_CREAT`
         #[doc(alias = "CREAT")]
-        const CREATE = c::O_CREAT;
+        const CREATE = bitcast!(c::O_CREAT);
 
         /// `O_DIRECTORY`
-        const DIRECTORY = c::O_DIRECTORY;
+        const DIRECTORY = bitcast!(c::O_DIRECTORY);
 
         /// `O_DSYNC`
         #[cfg(not(any(target_os = "dragonfly", target_os = "redox")))]
-        const DSYNC = c::O_DSYNC;
+        const DSYNC = bitcast!(c::O_DSYNC);
 
         /// `O_EXCL`
-        const EXCL = c::O_EXCL;
+        const EXCL = bitcast!(c::O_EXCL);
 
         /// `O_FSYNC`
         #[cfg(any(
             bsd,
             all(target_os = "linux", not(target_env = "musl")),
         ))]
-        const FSYNC = c::O_FSYNC;
+        const FSYNC = bitcast!(c::O_FSYNC);
 
         /// `O_NOFOLLOW`
-        const NOFOLLOW = c::O_NOFOLLOW;
+        const NOFOLLOW = bitcast!(c::O_NOFOLLOW);
 
         /// `O_NONBLOCK`
-        const NONBLOCK = c::O_NONBLOCK;
+        const NONBLOCK = bitcast!(c::O_NONBLOCK);
 
         /// `O_RDONLY`
-        const RDONLY = c::O_RDONLY;
+        const RDONLY = bitcast!(c::O_RDONLY);
 
         /// `O_WRONLY`
-        const WRONLY = c::O_WRONLY;
+        const WRONLY = bitcast!(c::O_WRONLY);
 
         /// `O_RDWR`
-        const RDWR = c::O_RDWR;
+        const RDWR = bitcast!(c::O_RDWR);
 
         /// `O_NOCTTY`
         #[cfg(not(target_os = "redox"))]
-        const NOCTTY = c::O_NOCTTY;
+        const NOCTTY = bitcast!(c::O_NOCTTY);
 
         /// `O_RSYNC`
         #[cfg(any(
@@ -252,14 +256,14 @@ bitflags! {
             target_os = "emscripten",
             target_os = "wasi",
         ))]
-        const RSYNC = c::O_RSYNC;
+        const RSYNC = bitcast!(c::O_RSYNC);
 
         /// `O_SYNC`
         #[cfg(not(target_os = "redox"))]
-        const SYNC = c::O_SYNC;
+        const SYNC = bitcast!(c::O_SYNC);
 
         /// `O_TRUNC`
-        const TRUNC = c::O_TRUNC;
+        const TRUNC = bitcast!(c::O_TRUNC);
 
         /// `O_PATH`
         #[cfg(any(
@@ -269,10 +273,10 @@ bitflags! {
             target_os = "fuchsia",
             target_os = "redox",
         ))]
-        const PATH = c::O_PATH;
+        const PATH = bitcast!(c::O_PATH);
 
         /// `O_CLOEXEC`
-        const CLOEXEC = c::O_CLOEXEC;
+        const CLOEXEC = bitcast!(c::O_CLOEXEC);
 
         /// `O_TMPFILE`
         #[cfg(any(
@@ -280,14 +284,14 @@ bitflags! {
             target_os = "emscripten",
             target_os = "fuchsia",
         ))]
-        const TMPFILE = c::O_TMPFILE;
+        const TMPFILE = bitcast!(c::O_TMPFILE);
 
         /// `O_NOATIME`
         #[cfg(any(
             linux_kernel,
             target_os = "fuchsia",
         ))]
-        const NOATIME = c::O_NOATIME;
+        const NOATIME = bitcast!(c::O_NOATIME);
 
         /// `O_DIRECT`
         #[cfg(any(
@@ -297,15 +301,15 @@ bitflags! {
             target_os = "fuchsia",
             target_os = "netbsd",
         ))]
-        const DIRECT = c::O_DIRECT;
+        const DIRECT = bitcast!(c::O_DIRECT);
 
         /// `O_RESOLVE_BENEATH`
         #[cfg(target_os = "freebsd")]
-        const RESOLVE_BENEATH = c::O_RESOLVE_BENEATH;
+        const RESOLVE_BENEATH = bitcast!(c::O_RESOLVE_BENEATH);
 
         /// `O_EMPTY_PATH`
         #[cfg(target_os = "freebsd")]
-        const EMPTY_PATH = c::O_EMPTY_PATH;
+        const EMPTY_PATH = bitcast!(c::O_EMPTY_PATH);
     }
 }
 
@@ -314,8 +318,9 @@ bitflags! {
     /// `CLONE_*` constants for use with [`fclonefileat`].
     ///
     /// [`fclonefileat`]: crate::fs::fclonefileat
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct CloneFlags: c::c_int {
+    pub struct CloneFlags: u32 {
         /// `CLONE_NOFOLLOW`
         const NOFOLLOW = 1;
 
@@ -340,6 +345,7 @@ bitflags! {
     /// `COPYFILE_*` constants for use with [`fcopyfile`].
     ///
     /// [`fcopyfile`]: crate::fs::fcopyfile
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct CopyfileFlags: c::c_uint {
         /// `COPYFILE_ACL`
@@ -370,6 +376,7 @@ bitflags! {
     /// `RESOLVE_*` constants for use with [`openat2`].
     ///
     /// [`openat2`]: crate::fs::openat2
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct ResolveFlags: u64 {
         /// `RESOLVE_NO_XDEV`
@@ -397,16 +404,17 @@ bitflags! {
     /// `RENAME_*` constants for use with [`renameat_with`].
     ///
     /// [`renameat_with`]: crate::fs::renameat_with
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct RenameFlags: c::c_uint {
         /// `RENAME_EXCHANGE`
-        const EXCHANGE = c::RENAME_EXCHANGE as _;
+        const EXCHANGE = bitcast!(c::RENAME_EXCHANGE);
 
         /// `RENAME_NOREPLACE`
-        const NOREPLACE = c::RENAME_NOREPLACE as _;
+        const NOREPLACE = bitcast!(c::RENAME_NOREPLACE);
 
         /// `RENAME_WHITEOUT`
-        const WHITEOUT = c::RENAME_WHITEOUT as _;
+        const WHITEOUT = bitcast!(c::RENAME_WHITEOUT);
     }
 }
 
@@ -538,6 +546,7 @@ bitflags! {
     /// `MFD_*` constants for use with [`memfd_create`].
     ///
     /// [`memfd_create`]: crate::fs::memfd_create
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MemfdFlags: c::c_uint {
         /// `MFD_CLOEXEC`
@@ -583,19 +592,20 @@ bitflags! {
     ///
     /// [`fcntl_add_seals`]: crate::fs::fcntl_add_seals
     /// [`fcntl_get_seals`]: crate::fs::fcntl_get_seals
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct SealFlags: i32 {
+    pub struct SealFlags: u32 {
        /// `F_SEAL_SEAL`.
-       const SEAL = c::F_SEAL_SEAL;
+       const SEAL = bitcast!(c::F_SEAL_SEAL);
        /// `F_SEAL_SHRINK`.
-       const SHRINK = c::F_SEAL_SHRINK;
+       const SHRINK = bitcast!(c::F_SEAL_SHRINK);
        /// `F_SEAL_GROW`.
-       const GROW = c::F_SEAL_GROW;
+       const GROW = bitcast!(c::F_SEAL_GROW);
        /// `F_SEAL_WRITE`.
-       const WRITE = c::F_SEAL_WRITE;
+       const WRITE = bitcast!(c::F_SEAL_WRITE);
        /// `F_SEAL_FUTURE_WRITE` (since Linux 5.1)
        #[cfg(linux_kernel)]
-       const FUTURE_WRITE = c::F_SEAL_FUTURE_WRITE;
+       const FUTURE_WRITE = bitcast!(c::F_SEAL_FUTURE_WRITE);
     }
 }
 
@@ -604,6 +614,7 @@ bitflags! {
     /// `STATX_*` constants for use with [`statx`].
     ///
     /// [`statx`]: crate::fs::statx
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct StatxFlags: u32 {
         /// `STATX_TYPE`
@@ -664,6 +675,7 @@ bitflags! {
     /// `STATX_*` constants for use with [`statx`].
     ///
     /// [`statx`]: crate::fs::statx
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct StatxFlags: u32 {
         /// `STATX_TYPE`
@@ -718,8 +730,9 @@ bitflags! {
     /// `FALLOC_FL_*` constants for use with [`fallocate`].
     ///
     /// [`fallocate`]: crate::fs::fallocate
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct FallocateFlags: i32 {
+    pub struct FallocateFlags: u32 {
         /// `FALLOC_FL_KEEP_SIZE`
         #[cfg(not(any(
             bsd,
@@ -727,7 +740,7 @@ bitflags! {
             target_os = "haiku",
             target_os = "wasi",
         )))]
-        const KEEP_SIZE = c::FALLOC_FL_KEEP_SIZE;
+        const KEEP_SIZE = bitcast!(c::FALLOC_FL_KEEP_SIZE);
         /// `FALLOC_FL_PUNCH_HOLE`
         #[cfg(not(any(
             bsd,
@@ -735,7 +748,7 @@ bitflags! {
             target_os = "haiku",
             target_os = "wasi",
         )))]
-        const PUNCH_HOLE = c::FALLOC_FL_PUNCH_HOLE;
+        const PUNCH_HOLE = bitcast!(c::FALLOC_FL_PUNCH_HOLE);
         /// `FALLOC_FL_NO_HIDE_STALE`
         #[cfg(not(any(
             bsd,
@@ -746,7 +759,7 @@ bitflags! {
             target_os = "fuchsia",
             target_os = "wasi",
         )))]
-        const NO_HIDE_STALE = c::FALLOC_FL_NO_HIDE_STALE;
+        const NO_HIDE_STALE = bitcast!(c::FALLOC_FL_NO_HIDE_STALE);
         /// `FALLOC_FL_COLLAPSE_RANGE`
         #[cfg(not(any(
             bsd,
@@ -755,7 +768,7 @@ bitflags! {
             target_os = "emscripten",
             target_os = "wasi",
         )))]
-        const COLLAPSE_RANGE = c::FALLOC_FL_COLLAPSE_RANGE;
+        const COLLAPSE_RANGE = bitcast!(c::FALLOC_FL_COLLAPSE_RANGE);
         /// `FALLOC_FL_ZERO_RANGE`
         #[cfg(not(any(
             bsd,
@@ -764,7 +777,7 @@ bitflags! {
             target_os = "emscripten",
             target_os = "wasi",
         )))]
-        const ZERO_RANGE = c::FALLOC_FL_ZERO_RANGE;
+        const ZERO_RANGE = bitcast!(c::FALLOC_FL_ZERO_RANGE);
         /// `FALLOC_FL_INSERT_RANGE`
         #[cfg(not(any(
             bsd,
@@ -773,7 +786,7 @@ bitflags! {
             target_os = "emscripten",
             target_os = "wasi",
         )))]
-        const INSERT_RANGE = c::FALLOC_FL_INSERT_RANGE;
+        const INSERT_RANGE = bitcast!(c::FALLOC_FL_INSERT_RANGE);
         /// `FALLOC_FL_UNSHARE_RANGE`
         #[cfg(not(any(
             bsd,
@@ -782,13 +795,14 @@ bitflags! {
             target_os = "emscripten",
             target_os = "wasi",
         )))]
-        const UNSHARE_RANGE = c::FALLOC_FL_UNSHARE_RANGE;
+        const UNSHARE_RANGE = bitcast!(c::FALLOC_FL_UNSHARE_RANGE);
     }
 }
 
 #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 bitflags! {
     /// `ST_*` constants for use with [`StatVfs`].
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct StatVfsMountFlags: u64 {
         /// `ST_MANDLOCK`
@@ -838,20 +852,20 @@ bitflags! {
 /// [`fcntl_lock`]: crate::fs::fcntl_lock
 #[cfg(not(target_os = "wasi"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(i32)]
+#[repr(u32)]
 pub enum FlockOperation {
     /// `LOCK_SH`
-    LockShared = c::LOCK_SH,
+    LockShared = bitcast!(c::LOCK_SH),
     /// `LOCK_EX`
-    LockExclusive = c::LOCK_EX,
+    LockExclusive = bitcast!(c::LOCK_EX),
     /// `LOCK_UN`
-    Unlock = c::LOCK_UN,
+    Unlock = bitcast!(c::LOCK_UN),
     /// `LOCK_SH | LOCK_NB`
-    NonBlockingLockShared = c::LOCK_SH | c::LOCK_NB,
+    NonBlockingLockShared = bitcast!(c::LOCK_SH | c::LOCK_NB),
     /// `LOCK_EX | LOCK_NB`
-    NonBlockingLockExclusive = c::LOCK_EX | c::LOCK_NB,
+    NonBlockingLockExclusive = bitcast!(c::LOCK_EX | c::LOCK_NB),
     /// `LOCK_UN | LOCK_NB`
-    NonBlockingUnlock = c::LOCK_UN | c::LOCK_NB,
+    NonBlockingUnlock = bitcast!(c::LOCK_UN | c::LOCK_NB),
 }
 
 /// `struct stat` for use with [`statat`] and [`fstat`].
@@ -1066,6 +1080,7 @@ bitflags! {
     /// `MS_*` constants for use with [`mount`].
     ///
     /// [`mount`]: crate::fs::mount
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MountFlags: c::c_ulong {
         /// `MS_BIND`
@@ -1121,6 +1136,7 @@ bitflags! {
     /// `MS_*` constants for use with [`change_mount`].
     ///
     /// [`change_mount`]: crate::fs::mount::change_mount
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MountPropagationFlags: c::c_ulong {
         /// `MS_SHARED`
@@ -1138,6 +1154,8 @@ bitflags! {
 
 #[cfg(linux_kernel)]
 bitflags! {
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub(crate) struct InternalMountFlags: c::c_ulong {
         const REMOUNT = c::MS_REMOUNT;
         const MOVE = c::MS_MOVE;
@@ -1152,15 +1170,16 @@ bitflags! {
     /// `MNT_*` constants for use with [`unmount`].
     ///
     /// [`unmount`]: crate::fs::mount::unmount
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct UnmountFlags: c::c_int {
+    pub struct UnmountFlags: u32 {
         /// `MNT_FORCE`
-        const FORCE = c::MNT_FORCE;
+        const FORCE = bitcast!(c::MNT_FORCE);
         /// `MNT_DETACH`
-        const DETACH = c::MNT_DETACH;
+        const DETACH = bitcast!(c::MNT_DETACH);
         /// `MNT_EXPIRE`
-        const EXPIRE = c::MNT_EXPIRE;
+        const EXPIRE = bitcast!(c::MNT_EXPIRE);
         /// `UMOUNT_NOFOLLOW`
-        const NOFOLLOW = c::UMOUNT_NOFOLLOW;
+        const NOFOLLOW = bitcast!(c::UMOUNT_NOFOLLOW);
     }
 }

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -132,7 +132,7 @@ pub(crate) fn preadv2(
             bufs.as_ptr().cast::<c::iovec>(),
             min(bufs.len(), MAX_IOV) as c::c_int,
             offset,
-            flags.bits(),
+            bitflags_bits!(flags),
         ))
     }
 }
@@ -179,7 +179,7 @@ pub(crate) fn pwritev2(
             bufs.as_ptr().cast::<c::iovec>(),
             min(bufs.len(), MAX_IOV) as c::c_int,
             offset,
-            flags.bits(),
+            bitflags_bits!(flags),
         ))
     }
 }
@@ -302,7 +302,8 @@ pub(crate) fn is_read_write(_fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
 }
 
 pub(crate) fn fcntl_getfd(fd: BorrowedFd<'_>) -> io::Result<FdFlags> {
-    unsafe { ret_c_int(c::fcntl(borrowed_fd(fd), c::F_GETFD)).map(FdFlags::from_bits_truncate) }
+    let flags = unsafe { ret_c_int(c::fcntl(borrowed_fd(fd), c::F_GETFD))? };
+    Ok(FdFlags::from_bits_retain(bitcast!(flags)))
 }
 
 pub(crate) fn fcntl_setfd(fd: BorrowedFd<'_>, flags: FdFlags) -> io::Result<()> {
@@ -338,7 +339,7 @@ pub(crate) fn dup3(fd: BorrowedFd<'_>, new: &mut OwnedFd, flags: DupFlags) -> io
         ret_discarded_fd(c::dup3(
             borrowed_fd(fd),
             borrowed_fd(new.as_fd()),
-            flags.bits(),
+            bitflags_bits!(flags),
         ))
     }
 }

--- a/src/backend/libc/io/types.rs
+++ b/src/backend/libc/io/types.rs
@@ -6,10 +6,11 @@ bitflags! {
     ///
     /// [`fcntl_getfd`]: crate::io::fcntl_getfd
     /// [`fcntl_setfd`]: crate::io::fcntl_setfd
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct FdFlags: c::c_int {
+    pub struct FdFlags: u32 {
         /// `FD_CLOEXEC`
-        const CLOEXEC = c::FD_CLOEXEC;
+        const CLOEXEC = bitcast!(c::FD_CLOEXEC);
     }
 }
 
@@ -19,18 +20,19 @@ bitflags! {
     ///
     /// [`preadv2`]: crate::io::preadv2
     /// [`pwritev2`]: crate::io::pwritev
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct ReadWriteFlags: c::c_int {
+    pub struct ReadWriteFlags: u32 {
         /// `RWF_DSYNC` (since Linux 4.7)
-        const DSYNC = linux_raw_sys::general::RWF_DSYNC as c::c_int;
+        const DSYNC = linux_raw_sys::general::RWF_DSYNC;
         /// `RWF_HIPRI` (since Linux 4.6)
-        const HIPRI = linux_raw_sys::general::RWF_HIPRI as c::c_int;
+        const HIPRI = linux_raw_sys::general::RWF_HIPRI;
         /// `RWF_SYNC` (since Linux 4.7)
-        const SYNC = linux_raw_sys::general::RWF_SYNC as c::c_int;
+        const SYNC = linux_raw_sys::general::RWF_SYNC;
         /// `RWF_NOWAIT` (since Linux 4.14)
-        const NOWAIT = linux_raw_sys::general::RWF_NOWAIT as c::c_int;
+        const NOWAIT = linux_raw_sys::general::RWF_NOWAIT;
         /// `RWF_APPEND` (since Linux 4.16)
-        const APPEND = linux_raw_sys::general::RWF_APPEND as c::c_int;
+        const APPEND = linux_raw_sys::general::RWF_APPEND;
     }
 }
 
@@ -39,8 +41,9 @@ bitflags! {
     /// `O_*` constants for use with [`dup2`].
     ///
     /// [`dup2`]: crate::io::dup2
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct DupFlags: c::c_int {
+    pub struct DupFlags: u32 {
         /// `O_CLOEXEC`
         #[cfg(not(any(
             apple,
@@ -48,6 +51,6 @@ bitflags! {
             target_os = "android",
             target_os = "redox",
         )))] // Android 5.0 has dup3, but libc doesn't have bindings
-        const CLOEXEC = c::O_CLOEXEC;
+        const CLOEXEC = bitcast!(c::O_CLOEXEC);
     }
 }

--- a/src/backend/libc/mm/syscalls.rs
+++ b/src/backend/libc/mm/syscalls.rs
@@ -51,7 +51,7 @@ pub(crate) fn madvise(addr: *mut c::c_void, len: usize, advice: Advice) -> io::R
 }
 
 pub(crate) unsafe fn msync(addr: *mut c::c_void, len: usize, flags: MsyncFlags) -> io::Result<()> {
-    let err = c::msync(addr, len, flags.bits());
+    let err = c::msync(addr, len, bitflags_bits!(flags));
 
     // `msync` returns its error status rather than using `errno`.
     if err == 0 {
@@ -76,8 +76,8 @@ pub(crate) unsafe fn mmap(
     let res = c::mmap(
         ptr,
         len,
-        prot.bits(),
-        flags.bits(),
+        bitflags_bits!(prot),
+        bitflags_bits!(flags),
         borrowed_fd(fd),
         offset as i64,
     );
@@ -101,8 +101,8 @@ pub(crate) unsafe fn mmap_anonymous(
     let res = c::mmap(
         ptr,
         len,
-        prot.bits(),
-        flags.bits() | c::MAP_ANONYMOUS,
+        bitflags_bits!(prot),
+        bitflags_bits!(flags | MapFlags::from_bits_retain(bitcast!(c::MAP_ANONYMOUS))),
         no_fd(),
         0,
     );
@@ -118,7 +118,7 @@ pub(crate) unsafe fn mprotect(
     len: usize,
     flags: MprotectFlags,
 ) -> io::Result<()> {
-    ret(c::mprotect(ptr, len, flags.bits()))
+    ret(c::mprotect(ptr, len, bitflags_bits!(flags)))
 }
 
 pub(crate) unsafe fn munmap(ptr: *mut c::c_void, len: usize) -> io::Result<()> {
@@ -136,7 +136,7 @@ pub(crate) unsafe fn mremap(
     new_size: usize,
     flags: MremapFlags,
 ) -> io::Result<*mut c::c_void> {
-    let res = c::mremap(old_address, old_size, new_size, flags.bits());
+    let res = c::mremap(old_address, old_size, new_size, bitflags_bits!(flags));
     if res == c::MAP_FAILED {
         Err(io::Errno::last_os_error())
     } else {
@@ -161,7 +161,7 @@ pub(crate) unsafe fn mremap_fixed(
         old_address,
         old_size,
         new_size,
-        flags.bits() | c::MAP_FIXED,
+        bitflags_bits!(flags | MremapFlags::from_bits_retain(bitcast!(c::MAP_FIXED))),
         new_address,
     );
     if res == c::MAP_FAILED {
@@ -199,7 +199,7 @@ pub(crate) unsafe fn mlock_with(
         ) via SYS_mlock2 -> c::c_int
     }
 
-    ret(mlock2(addr, length, flags.bits()))
+    ret(mlock2(addr, length, bitflags_bits!(flags)))
 }
 
 /// # Safety

--- a/src/backend/libc/mm/types.rs
+++ b/src/backend/libc/mm/types.rs
@@ -7,14 +7,15 @@ bitflags! {
     /// For `PROT_NONE`, use `ProtFlags::empty()`.
     ///
     /// [`mmap`]: crate::io::mmap
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct ProtFlags: c::c_int {
+    pub struct ProtFlags: u32 {
         /// `PROT_READ`
-        const READ = c::PROT_READ;
+        const READ = bitcast!(c::PROT_READ);
         /// `PROT_WRITE`
-        const WRITE = c::PROT_WRITE;
+        const WRITE = bitcast!(c::PROT_WRITE);
         /// `PROT_EXEC`
-        const EXEC = c::PROT_EXEC;
+        const EXEC = bitcast!(c::PROT_EXEC);
     }
 }
 
@@ -24,20 +25,21 @@ bitflags! {
     /// For `PROT_NONE`, use `MprotectFlags::empty()`.
     ///
     /// [`mprotect`]: crate::io::mprotect
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct MprotectFlags: c::c_int {
+    pub struct MprotectFlags: u32 {
         /// `PROT_READ`
-        const READ = c::PROT_READ;
+        const READ = bitcast!(c::PROT_READ);
         /// `PROT_WRITE`
-        const WRITE = c::PROT_WRITE;
+        const WRITE = bitcast!(c::PROT_WRITE);
         /// `PROT_EXEC`
-        const EXEC = c::PROT_EXEC;
+        const EXEC = bitcast!(c::PROT_EXEC);
         /// `PROT_GROWSUP`
         #[cfg(linux_kernel)]
-        const GROWSUP = c::PROT_GROWSUP;
+        const GROWSUP = bitcast!(c::PROT_GROWSUP);
         /// `PROT_GROWSDOWN`
         #[cfg(linux_kernel)]
-        const GROWSDOWN = c::PROT_GROWSDOWN;
+        const GROWSDOWN = bitcast!(c::PROT_GROWSDOWN);
     }
 }
 
@@ -48,10 +50,11 @@ bitflags! {
     ///
     /// [`mmap`]: crate::io::mmap
     /// [`mmap_anonymous`]: crates::io::mmap_anonymous
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct MapFlags: c::c_int {
+    pub struct MapFlags: u32 {
         /// `MAP_SHARED`
-        const SHARED = c::MAP_SHARED;
+        const SHARED = bitcast!(c::MAP_SHARED);
         /// `MAP_SHARED_VALIDATE`
         #[cfg(not(any(
             bsd,
@@ -62,9 +65,9 @@ bitflags! {
             target_os = "haiku",
             target_os = "redox",
         )))]
-        const SHARED_VALIDATE = c::MAP_SHARED_VALIDATE;
+        const SHARED_VALIDATE = bitcast!(c::MAP_SHARED_VALIDATE);
         /// `MAP_PRIVATE`
-        const PRIVATE = c::MAP_PRIVATE;
+        const PRIVATE = bitcast!(c::MAP_PRIVATE);
         /// `MAP_DENYWRITE`
         #[cfg(not(any(
             bsd,
@@ -72,9 +75,9 @@ bitflags! {
             target_os = "haiku",
             target_os = "redox",
         )))]
-        const DENYWRITE = c::MAP_DENYWRITE;
+        const DENYWRITE = bitcast!(c::MAP_DENYWRITE);
         /// `MAP_FIXED`
-        const FIXED = c::MAP_FIXED;
+        const FIXED = bitcast!(c::MAP_FIXED);
         /// `MAP_FIXED_NOREPLACE`
         #[cfg(not(any(
             bsd,
@@ -85,7 +88,7 @@ bitflags! {
             target_os = "haiku",
             target_os = "redox",
         )))]
-        const FIXED_NOREPLACE = c::MAP_FIXED_NOREPLACE;
+        const FIXED_NOREPLACE = bitcast!(c::MAP_FIXED_NOREPLACE);
         /// `MAP_GROWSDOWN`
         #[cfg(not(any(
             bsd,
@@ -93,7 +96,7 @@ bitflags! {
             target_os = "haiku",
             target_os = "redox",
         )))]
-        const GROWSDOWN = c::MAP_GROWSDOWN;
+        const GROWSDOWN = bitcast!(c::MAP_GROWSDOWN);
         /// `MAP_HUGETLB`
         #[cfg(not(any(
             bsd,
@@ -101,7 +104,7 @@ bitflags! {
             target_os = "haiku",
             target_os = "redox",
         )))]
-        const HUGETLB = c::MAP_HUGETLB;
+        const HUGETLB = bitcast!(c::MAP_HUGETLB);
         /// `MAP_HUGE_2MB`
         #[cfg(not(any(
             bsd,
@@ -112,7 +115,7 @@ bitflags! {
             target_os = "haiku",
             target_os = "redox",
         )))]
-        const HUGE_2MB = c::MAP_HUGE_2MB;
+        const HUGE_2MB = bitcast!(c::MAP_HUGE_2MB);
         /// `MAP_HUGE_1GB`
         #[cfg(not(any(
             bsd,
@@ -123,7 +126,7 @@ bitflags! {
             target_os = "haiku",
             target_os = "redox",
         )))]
-        const HUGE_1GB = c::MAP_HUGE_1GB;
+        const HUGE_1GB = bitcast!(c::MAP_HUGE_1GB);
         /// `MAP_LOCKED`
         #[cfg(not(any(
             bsd,
@@ -131,16 +134,16 @@ bitflags! {
             target_os = "haiku",
             target_os = "redox",
         )))]
-        const LOCKED = c::MAP_LOCKED;
+        const LOCKED = bitcast!(c::MAP_LOCKED);
         /// `MAP_NOCORE`
         #[cfg(freebsdlike)]
-        const NOCORE = c::MAP_NOCORE;
+        const NOCORE = bitcast!(c::MAP_NOCORE);
         /// `MAP_NORESERVE`
         #[cfg(not(any(freebsdlike, target_os = "redox")))]
-        const NORESERVE = c::MAP_NORESERVE;
+        const NORESERVE = bitcast!(c::MAP_NORESERVE);
         /// `MAP_NOSYNC`
         #[cfg(freebsdlike)]
-        const NOSYNC = c::MAP_NOSYNC;
+        const NOSYNC = bitcast!(c::MAP_NOSYNC);
         /// `MAP_POPULATE`
         #[cfg(not(any(
             bsd,
@@ -148,7 +151,7 @@ bitflags! {
             target_os = "haiku",
             target_os = "redox",
         )))]
-        const POPULATE = c::MAP_POPULATE;
+        const POPULATE = bitcast!(c::MAP_POPULATE);
         /// `MAP_STACK`
         #[cfg(not(any(
             apple,
@@ -158,10 +161,10 @@ bitflags! {
             target_os = "netbsd",
             target_os = "redox",
         )))]
-        const STACK = c::MAP_STACK;
+        const STACK = bitcast!(c::MAP_STACK);
         /// `MAP_PREFAULT_READ`
         #[cfg(target_os = "freebsd")]
-        const PREFAULT_READ = c::MAP_PREFAULT_READ;
+        const PREFAULT_READ = bitcast!(c::MAP_PREFAULT_READ);
         /// `MAP_SYNC`
         #[cfg(not(any(
             bsd,
@@ -176,10 +179,10 @@ bitflags! {
                 any(target_arch = "mips", target_arch = "mips64"),
             )
         )))]
-        const SYNC = c::MAP_SYNC;
+        const SYNC = bitcast!(c::MAP_SYNC);
         /// `MAP_UNINITIALIZED`
         #[cfg(any())]
-        const UNINITIALIZED = c::MAP_UNINITIALIZED;
+        const UNINITIALIZED = bitcast!(c::MAP_UNINITIALIZED);
     }
 }
 
@@ -191,10 +194,11 @@ bitflags! {
     ///
     /// [`mremap`]: crate::io::mremap
     /// [`mremap_fixed`]: crate::io::mremap_fixed
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct MremapFlags: i32 {
+    pub struct MremapFlags: u32 {
         /// `MREMAP_MAYMOVE`
-        const MAYMOVE = c::MREMAP_MAYMOVE;
+        const MAYMOVE = bitcast!(c::MREMAP_MAYMOVE);
     }
 }
 
@@ -202,17 +206,18 @@ bitflags! {
     /// `MS_*` flags for use with [`msync`].
     ///
     /// [`msync`]: crate::io::msync
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct MsyncFlags: i32 {
+    pub struct MsyncFlags: u32 {
         /// `MS_SYNC`—Requests an update and waits for it to complete.
-        const SYNC = c::MS_SYNC;
+        const SYNC = bitcast!(c::MS_SYNC);
         /// `MS_ASYNC`—Specifies that an update be scheduled, but the call
         /// returns immediately.
-        const ASYNC = c::MS_ASYNC;
+        const ASYNC = bitcast!(c::MS_ASYNC);
         /// `MS_INVALIDATE`—Asks to invalidate other mappings of the same
         /// file (so that they can be updated with the fresh values just
         /// written).
-        const INVALIDATE = c::MS_INVALIDATE;
+        const INVALIDATE = bitcast!(c::MS_INVALIDATE);
     }
 }
 
@@ -221,10 +226,11 @@ bitflags! {
     /// `MLOCK_*` flags for use with [`mlock_with`].
     ///
     /// [`mlock_with`]: crate::io::mlock_with
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct MlockFlags: i32 {
+    pub struct MlockFlags: u32 {
         /// `MLOCK_ONFAULT`
-        const ONFAULT = c::MLOCK_ONFAULT as _;
+        const ONFAULT = bitcast!(c::MLOCK_ONFAULT);
     }
 }
 
@@ -233,116 +239,116 @@ bitflags! {
 /// [`madvise`]: crate::mm::madvise
 #[cfg(not(target_os = "redox"))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[repr(i32)]
+#[repr(u32)]
 #[non_exhaustive]
 pub enum Advice {
     /// `POSIX_MADV_NORMAL`
     #[cfg(not(any(target_os = "android", target_os = "haiku")))]
-    Normal = c::POSIX_MADV_NORMAL,
+    Normal = bitcast!(c::POSIX_MADV_NORMAL),
 
     /// `POSIX_MADV_NORMAL`
     #[cfg(any(target_os = "android", target_os = "haiku"))]
-    Normal = c::MADV_NORMAL,
+    Normal = bitcast!(c::MADV_NORMAL),
 
     /// `POSIX_MADV_SEQUENTIAL`
     #[cfg(not(any(target_os = "android", target_os = "haiku")))]
-    Sequential = c::POSIX_MADV_SEQUENTIAL,
+    Sequential = bitcast!(c::POSIX_MADV_SEQUENTIAL),
 
     /// `POSIX_MADV_SEQUENTIAL`
     #[cfg(any(target_os = "android", target_os = "haiku"))]
-    Sequential = c::MADV_SEQUENTIAL,
+    Sequential = bitcast!(c::MADV_SEQUENTIAL),
 
     /// `POSIX_MADV_RANDOM`
     #[cfg(not(any(target_os = "android", target_os = "haiku")))]
-    Random = c::POSIX_MADV_RANDOM,
+    Random = bitcast!(c::POSIX_MADV_RANDOM),
 
     /// `POSIX_MADV_RANDOM`
     #[cfg(any(target_os = "android", target_os = "haiku"))]
-    Random = c::MADV_RANDOM,
+    Random = bitcast!(c::MADV_RANDOM),
 
     /// `POSIX_MADV_WILLNEED`
     #[cfg(not(any(target_os = "android", target_os = "haiku")))]
-    WillNeed = c::POSIX_MADV_WILLNEED,
+    WillNeed = bitcast!(c::POSIX_MADV_WILLNEED),
 
     /// `POSIX_MADV_WILLNEED`
     #[cfg(any(target_os = "android", target_os = "haiku"))]
-    WillNeed = c::MADV_WILLNEED,
+    WillNeed = bitcast!(c::MADV_WILLNEED),
 
     /// `POSIX_MADV_DONTNEED`
     #[cfg(not(any(target_os = "android", target_os = "emscripten", target_os = "haiku")))]
-    DontNeed = c::POSIX_MADV_DONTNEED,
+    DontNeed = bitcast!(c::POSIX_MADV_DONTNEED),
 
     /// `POSIX_MADV_DONTNEED`
     #[cfg(any(target_os = "android", target_os = "haiku"))]
-    DontNeed = i32::MAX - 1,
+    DontNeed = bitcast!(i32::MAX - 1),
 
     /// `MADV_DONTNEED`
     // `MADV_DONTNEED` has the same value as `POSIX_MADV_DONTNEED`. We don't
     // have a separate `posix_madvise` from `madvise`, so we expose a special
     // value which we special-case.
     #[cfg(target_os = "linux")]
-    LinuxDontNeed = i32::MAX,
+    LinuxDontNeed = bitcast!(i32::MAX),
 
     /// `MADV_DONTNEED`
     #[cfg(target_os = "android")]
-    LinuxDontNeed = c::MADV_DONTNEED,
+    LinuxDontNeed = bitcast!(c::MADV_DONTNEED),
     /// `MADV_FREE`
     #[cfg(linux_kernel)]
-    LinuxFree = c::MADV_FREE,
+    LinuxFree = bitcast!(c::MADV_FREE),
     /// `MADV_REMOVE`
     #[cfg(linux_kernel)]
-    LinuxRemove = c::MADV_REMOVE,
+    LinuxRemove = bitcast!(c::MADV_REMOVE),
     /// `MADV_DONTFORK`
     #[cfg(linux_kernel)]
-    LinuxDontFork = c::MADV_DONTFORK,
+    LinuxDontFork = bitcast!(c::MADV_DONTFORK),
     /// `MADV_DOFORK`
     #[cfg(linux_kernel)]
-    LinuxDoFork = c::MADV_DOFORK,
+    LinuxDoFork = bitcast!(c::MADV_DOFORK),
     /// `MADV_HWPOISON`
     #[cfg(linux_kernel)]
-    LinuxHwPoison = c::MADV_HWPOISON,
+    LinuxHwPoison = bitcast!(c::MADV_HWPOISON),
     /// `MADV_SOFT_OFFLINE`
     #[cfg(all(linux_kernel, not(any(target_arch = "mips", target_arch = "mips64"))))]
-    LinuxSoftOffline = c::MADV_SOFT_OFFLINE,
+    LinuxSoftOffline = bitcast!(c::MADV_SOFT_OFFLINE),
     /// `MADV_MERGEABLE`
     #[cfg(linux_kernel)]
-    LinuxMergeable = c::MADV_MERGEABLE,
+    LinuxMergeable = bitcast!(c::MADV_MERGEABLE),
     /// `MADV_UNMERGEABLE`
     #[cfg(linux_kernel)]
-    LinuxUnmergeable = c::MADV_UNMERGEABLE,
+    LinuxUnmergeable = bitcast!(c::MADV_UNMERGEABLE),
     /// `MADV_HUGEPAGE` (since Linux 2.6.38)
     #[cfg(linux_kernel)]
-    LinuxHugepage = c::MADV_HUGEPAGE,
+    LinuxHugepage = bitcast!(c::MADV_HUGEPAGE),
     /// `MADV_NOHUGEPAGE` (since Linux 2.6.38)
     #[cfg(linux_kernel)]
-    LinuxNoHugepage = c::MADV_NOHUGEPAGE,
+    LinuxNoHugepage = bitcast!(c::MADV_NOHUGEPAGE),
     /// `MADV_DONTDUMP` (since Linux 3.4)
     #[cfg(linux_kernel)]
-    LinuxDontDump = c::MADV_DONTDUMP,
+    LinuxDontDump = bitcast!(c::MADV_DONTDUMP),
     /// `MADV_DODUMP` (since Linux 3.4)
     #[cfg(linux_kernel)]
-    LinuxDoDump = c::MADV_DODUMP,
+    LinuxDoDump = bitcast!(c::MADV_DODUMP),
     /// `MADV_WIPEONFORK` (since Linux 4.14)
     #[cfg(linux_kernel)]
-    LinuxWipeOnFork = libc::MADV_WIPEONFORK as i32,
+    LinuxWipeOnFork = bitcast!(c::MADV_WIPEONFORK),
     /// `MADV_KEEPONFORK` (since Linux 4.14)
     #[cfg(linux_kernel)]
-    LinuxKeepOnFork = libc::MADV_KEEPONFORK as i32,
+    LinuxKeepOnFork = bitcast!(c::MADV_KEEPONFORK),
     /// `MADV_COLD` (since Linux 5.4)
     #[cfg(linux_kernel)]
-    LinuxCold = libc::MADV_COLD as i32,
+    LinuxCold = bitcast!(c::MADV_COLD),
     /// `MADV_PAGEOUT` (since Linux 5.4)
     #[cfg(linux_kernel)]
-    LinuxPageOut = libc::MADV_PAGEOUT as i32,
+    LinuxPageOut = bitcast!(c::MADV_PAGEOUT),
     /// `MADV_POPULATE_READ` (since Linux 5.14)
     #[cfg(linux_kernel)]
-    LinuxPopulateRead = libc::MADV_POPULATE_READ as i32,
+    LinuxPopulateRead = bitcast!(c::MADV_POPULATE_READ),
     /// `MADV_POPULATE_WRITE` (since Linux 5.14)
     #[cfg(linux_kernel)]
-    LinuxPopulateWrite = libc::MADV_POPULATE_WRITE as i32,
+    LinuxPopulateWrite = bitcast!(c::MADV_POPULATE_WRITE),
     /// `MADV_DONTNEED_LOCKED` (since Linux 5.18)
     #[cfg(linux_kernel)]
-    LinuxDontneedLocked = libc::MADV_DONTNEED_LOCKED as i32,
+    LinuxDontneedLocked = bitcast!(c::MADV_DONTNEED_LOCKED),
 }
 
 #[cfg(target_os = "emscripten")]
@@ -357,11 +363,12 @@ bitflags! {
     /// `O_*` flags for use with [`userfaultfd`].
     ///
     /// [`userfaultfd`]: crate::io::userfaultfd
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct UserfaultfdFlags: c::c_int {
+    pub struct UserfaultfdFlags: u32 {
         /// `O_CLOEXEC`
-        const CLOEXEC = c::O_CLOEXEC;
+        const CLOEXEC = bitcast!(c::O_CLOEXEC);
         /// `O_NONBLOCK`
-        const NONBLOCK = c::O_NONBLOCK;
+        const NONBLOCK = bitcast!(c::O_NONBLOCK);
     }
 }

--- a/src/backend/libc/net/send_recv.rs
+++ b/src/backend/libc/net/send_recv.rs
@@ -6,8 +6,9 @@ bitflags! {
     ///
     /// [`send`]: crate::net::send
     /// [`sendto`]: crate::net::sendto
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct SendFlags: i32 {
+    pub struct SendFlags: u32 {
         /// `MSG_CONFIRM`
         #[cfg(not(any(
             bsd,
@@ -15,15 +16,15 @@ bitflags! {
             windows,
             target_os = "haiku",
         )))]
-        const CONFIRM = c::MSG_CONFIRM;
+        const CONFIRM = bitcast!(c::MSG_CONFIRM);
         /// `MSG_DONTROUTE`
-        const DONTROUTE = c::MSG_DONTROUTE;
+        const DONTROUTE = bitcast!(c::MSG_DONTROUTE);
         /// `MSG_DONTWAIT`
         #[cfg(not(windows))]
-        const DONTWAIT = c::MSG_DONTWAIT;
+        const DONTWAIT = bitcast!(c::MSG_DONTWAIT);
         /// `MSG_EOR`
         #[cfg(not(windows))]
-        const EOT = c::MSG_EOR;
+        const EOT = bitcast!(c::MSG_EOR);
         /// `MSG_MORE`
         #[cfg(not(any(
             bsd,
@@ -31,12 +32,12 @@ bitflags! {
             windows,
             target_os = "haiku",
         )))]
-        const MORE = c::MSG_MORE;
+        const MORE = bitcast!(c::MSG_MORE);
         #[cfg(not(any(apple, windows)))]
         /// `MSG_NOSIGNAL`
-        const NOSIGNAL = c::MSG_NOSIGNAL;
+        const NOSIGNAL = bitcast!(c::MSG_NOSIGNAL);
         /// `MSG_OOB`
-        const OOB = c::MSG_OOB;
+        const OOB = bitcast!(c::MSG_OOB);
     }
 }
 
@@ -45,14 +46,15 @@ bitflags! {
     ///
     /// [`recv`]: crate::net::recv
     /// [`recvfrom`]: crate::net::recvfrom
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct RecvFlags: i32 {
+    pub struct RecvFlags: u32 {
         #[cfg(not(any(apple, solarish, windows, target_os = "haiku")))]
         /// `MSG_CMSG_CLOEXEC`
-        const CMSG_CLOEXEC = c::MSG_CMSG_CLOEXEC;
+        const CMSG_CLOEXEC = bitcast!(c::MSG_CMSG_CLOEXEC);
         /// `MSG_DONTWAIT`
         #[cfg(not(windows))]
-        const DONTWAIT = c::MSG_DONTWAIT;
+        const DONTWAIT = bitcast!(c::MSG_DONTWAIT);
         /// `MSG_ERRQUEUE`
         #[cfg(not(any(
             bsd,
@@ -60,14 +62,14 @@ bitflags! {
             windows,
             target_os = "haiku",
         )))]
-        const ERRQUEUE = c::MSG_ERRQUEUE;
+        const ERRQUEUE = bitcast!(c::MSG_ERRQUEUE);
         /// `MSG_OOB`
-        const OOB = c::MSG_OOB;
+        const OOB = bitcast!(c::MSG_OOB);
         /// `MSG_PEEK`
-        const PEEK = c::MSG_PEEK;
+        const PEEK = bitcast!(c::MSG_PEEK);
         /// `MSG_TRUNC`
-        const TRUNC = c::MSG_TRUNC as c::c_int;
+        const TRUNC = bitcast!(c::MSG_TRUNC);
         /// `MSG_WAITALL`
-        const WAITALL = c::MSG_WAITALL;
+        const WAITALL = bitcast!(c::MSG_WAITALL);
     }
 }

--- a/src/backend/libc/pipe/syscalls.rs
+++ b/src/backend/libc/pipe/syscalls.rs
@@ -29,7 +29,10 @@ pub(crate) fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
 pub(crate) fn pipe_with(flags: PipeFlags) -> io::Result<(OwnedFd, OwnedFd)> {
     unsafe {
         let mut result = MaybeUninit::<[OwnedFd; 2]>::uninit();
-        ret(c::pipe2(result.as_mut_ptr().cast::<i32>(), flags.bits()))?;
+        ret(c::pipe2(
+            result.as_mut_ptr().cast::<i32>(),
+            bitflags_bits!(flags),
+        ))?;
         let [p0, p1] = result.assume_init();
         Ok((p0, p1))
     }

--- a/src/backend/libc/pipe/types.rs
+++ b/src/backend/libc/pipe/types.rs
@@ -8,10 +8,11 @@ bitflags! {
     /// `O_*` constants for use with [`pipe_with`].
     ///
     /// [`pipe_with`]: crate::io::pipe_with
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct PipeFlags: c::c_int {
+    pub struct PipeFlags: u32 {
         /// `O_CLOEXEC`
-        const CLOEXEC = c::O_CLOEXEC;
+        const CLOEXEC = bitcast!(c::O_CLOEXEC);
         /// `O_DIRECT`
         #[cfg(not(any(
             solarish,
@@ -19,9 +20,9 @@ bitflags! {
             target_os = "openbsd",
             target_os = "redox",
         )))]
-        const DIRECT = c::O_DIRECT;
+        const DIRECT = bitcast!(c::O_DIRECT);
         /// `O_NONBLOCK`
-        const NONBLOCK = c::O_NONBLOCK;
+        const NONBLOCK = bitcast!(c::O_NONBLOCK);
     }
 }
 
@@ -29,6 +30,7 @@ bitflags! {
 bitflags! {
     /// `SPLICE_F_*` constants for use with [`splice`], [`vmsplice`],
     /// and [`tee`].
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct SpliceFlags: c::c_uint {
         /// `SPLICE_F_MOVE`
@@ -78,4 +80,14 @@ impl<'a> IoSliceRaw<'a> {
             _lifetime: PhantomData,
         }
     }
+}
+
+#[cfg(not(any(apple, target_os = "wasi")))]
+#[test]
+fn test_types() {
+    use core::mem::size_of;
+    assert_eq!(size_of::<PipeFlags>(), size_of::<c::c_int>());
+
+    #[cfg(linux_kernel)]
+    assert_eq!(size_of::<SpliceFlags>(), size_of::<c::c_int>());
 }

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -164,8 +164,7 @@ pub(crate) fn sched_yield() {
 #[cfg(feature = "fs")]
 #[inline]
 pub(crate) fn umask(mask: Mode) -> Mode {
-    // TODO: Use `from_bits_retain` when we switch to bitflags 2.0.
-    unsafe { Mode::from_bits_truncate(c::umask(mask.bits() as _) as _) }
+    unsafe { Mode::from_bits_retain(c::umask(mask.bits() as c::mode_t).into()) }
 }
 
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]

--- a/src/backend/libc/process/types.rs
+++ b/src/backend/libc/process/types.rs
@@ -42,48 +42,48 @@ pub enum MembarrierCommand {
 /// [`prlimit`]: crate::process::prlimit
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[repr(i32)]
+#[repr(u32)]
 pub enum Resource {
     /// `RLIMIT_CPU`
-    Cpu = c::RLIMIT_CPU as c::c_int,
+    Cpu = bitcast!(c::RLIMIT_CPU),
     /// `RLIMIT_FSIZE`
-    Fsize = c::RLIMIT_FSIZE as c::c_int,
+    Fsize = bitcast!(c::RLIMIT_FSIZE),
     /// `RLIMIT_DATA`
-    Data = c::RLIMIT_DATA as c::c_int,
+    Data = bitcast!(c::RLIMIT_DATA),
     /// `RLIMIT_STACK`
-    Stack = c::RLIMIT_STACK as c::c_int,
+    Stack = bitcast!(c::RLIMIT_STACK),
     /// `RLIMIT_CORE`
     #[cfg(not(target_os = "haiku"))]
-    Core = c::RLIMIT_CORE as c::c_int,
+    Core = bitcast!(c::RLIMIT_CORE),
     /// `RLIMIT_RSS`
     #[cfg(not(any(apple, solarish, target_os = "haiku")))]
-    Rss = c::RLIMIT_RSS as c::c_int,
+    Rss = bitcast!(c::RLIMIT_RSS),
     /// `RLIMIT_NPROC`
     #[cfg(not(any(solarish, target_os = "haiku")))]
-    Nproc = c::RLIMIT_NPROC as c::c_int,
+    Nproc = bitcast!(c::RLIMIT_NPROC),
     /// `RLIMIT_NOFILE`
-    Nofile = c::RLIMIT_NOFILE as c::c_int,
+    Nofile = bitcast!(c::RLIMIT_NOFILE),
     /// `RLIMIT_MEMLOCK`
     #[cfg(not(any(solarish, target_os = "aix", target_os = "haiku")))]
-    Memlock = c::RLIMIT_MEMLOCK as c::c_int,
+    Memlock = bitcast!(c::RLIMIT_MEMLOCK),
     /// `RLIMIT_AS`
     #[cfg(not(target_os = "openbsd"))]
-    As = c::RLIMIT_AS as c::c_int,
+    As = bitcast!(c::RLIMIT_AS),
     /// `RLIMIT_LOCKS`
     #[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
-    Locks = c::RLIMIT_LOCKS as c::c_int,
+    Locks = bitcast!(c::RLIMIT_LOCKS),
     /// `RLIMIT_SIGPENDING`
     #[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
-    Sigpending = c::RLIMIT_SIGPENDING as c::c_int,
+    Sigpending = bitcast!(c::RLIMIT_SIGPENDING),
     /// `RLIMIT_MSGQUEUE`
     #[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
-    Msgqueue = c::RLIMIT_MSGQUEUE as c::c_int,
+    Msgqueue = bitcast!(c::RLIMIT_MSGQUEUE),
     /// `RLIMIT_NICE`
     #[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
-    Nice = c::RLIMIT_NICE as c::c_int,
+    Nice = bitcast!(c::RLIMIT_NICE),
     /// `RLIMIT_RTPRIO`
     #[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
-    Rtprio = c::RLIMIT_RTPRIO as c::c_int,
+    Rtprio = bitcast!(c::RLIMIT_RTPRIO),
     /// `RLIMIT_RTTIME`
     #[cfg(not(any(
         bsd,
@@ -93,7 +93,7 @@ pub enum Resource {
         target_os = "emscripten",
         target_os = "haiku",
     )))]
-    Rttime = c::RLIMIT_RTTIME as c::c_int,
+    Rttime = bitcast!(c::RLIMIT_RTTIME),
 }
 
 #[cfg(apple)]

--- a/src/backend/libc/rand/types.rs
+++ b/src/backend/libc/rand/types.rs
@@ -8,6 +8,7 @@ bitflags! {
     /// `GRND_*` flags for use with [`getrandom`].
     ///
     /// [`getrandom`]: crate::rand::getrandom
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct GetRandomFlags: u32 {
         /// `GRND_RANDOM`

--- a/src/backend/libc/time/syscalls.rs
+++ b/src/backend/libc/time/syscalls.rs
@@ -298,7 +298,7 @@ unsafe fn clock_settime_old(id: ClockId, timespec: Timespec) -> io::Result<()> {
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(feature = "time")]
 pub(crate) fn timerfd_create(id: TimerfdClockId, flags: TimerfdFlags) -> io::Result<OwnedFd> {
-    unsafe { ret_owned_fd(c::timerfd_create(id as c::clockid_t, flags.bits())) }
+    unsafe { ret_owned_fd(c::timerfd_create(id as c::clockid_t, bitflags_bits!(flags))) }
 }
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
@@ -318,7 +318,7 @@ pub(crate) fn timerfd_settime(
         if let Some(libc_timerfd_settime) = __timerfd_settime64.get() {
             ret(libc_timerfd_settime(
                 borrowed_fd(fd),
-                flags.bits(),
+                bitflags_bits!(flags),
                 &new_value.clone().into(),
                 result.as_mut_ptr(),
             ))?;
@@ -335,7 +335,7 @@ pub(crate) fn timerfd_settime(
     unsafe {
         ret(c::timerfd_settime(
             borrowed_fd(fd),
-            flags.bits(),
+            bitflags_bits!(flags),
             new_value,
             result.as_mut_ptr(),
         ))?;
@@ -386,7 +386,7 @@ unsafe fn timerfd_settime_old(
 
     ret(c::timerfd_settime(
         borrowed_fd(fd),
-        flags.bits(),
+        bitflags_bits!(flags),
         &old_new_value,
         old_result.as_mut_ptr(),
     ))?;

--- a/src/backend/libc/time/types.rs
+++ b/src/backend/libc/time/types.rs
@@ -101,13 +101,14 @@ bitflags! {
     /// `TFD_*` flags for use with [`timerfd_create`].
     ///
     /// [`timerfd_create`]: crate::time::timerfd_create
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct TimerfdFlags: c::c_int {
+    pub struct TimerfdFlags: u32 {
         /// `TFD_NONBLOCK`
-        const NONBLOCK = c::TFD_NONBLOCK;
+        const NONBLOCK = bitcast!(c::TFD_NONBLOCK);
 
         /// `TFD_CLOEXEC`
-        const CLOEXEC = c::TFD_CLOEXEC;
+        const CLOEXEC = bitcast!(c::TFD_CLOEXEC);
     }
 }
 
@@ -116,14 +117,15 @@ bitflags! {
     /// `TFD_TIMER_*` flags for use with [`timerfd_settime`].
     ///
     /// [`timerfd_settime`]: crate::time::timerfd_settime
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct TimerfdTimerFlags: c::c_int {
+    pub struct TimerfdTimerFlags: u32 {
         /// `TFD_TIMER_ABSTIME`
-        const ABSTIME = c::TFD_TIMER_ABSTIME;
+        const ABSTIME = bitcast!(c::TFD_TIMER_ABSTIME);
 
         /// `TFD_TIMER_CANCEL_ON_SET`
         #[cfg(linux_kernel)]
-        const CANCEL_ON_SET = c::TFD_TIMER_CANCEL_ON_SET;
+        const CANCEL_ON_SET = bitcast!(c::TFD_TIMER_CANCEL_ON_SET);
     }
 }
 
@@ -132,7 +134,7 @@ bitflags! {
 /// [`timerfd_create`]: crate::time::timerfd_create
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-#[repr(i32)]
+#[repr(u32)]
 #[non_exhaustive]
 pub enum TimerfdClockId {
     /// `CLOCK_REALTIME`—A clock that tells the “real” time.
@@ -141,7 +143,7 @@ pub enum TimerfdClockId {
     /// Unix epoch, 1970-01-01T00:00:00Z. The clock is externally settable, so
     /// it is not monotonic. Successive reads may see decreasing times, so it
     /// isn't reliable for measuring durations.
-    Realtime = c::CLOCK_REALTIME,
+    Realtime = bitcast!(c::CLOCK_REALTIME),
 
     /// `CLOCK_MONOTONIC`—A clock that tells an abstract time.
     ///
@@ -151,25 +153,33 @@ pub enum TimerfdClockId {
     ///
     /// This clock does not advance while the system is suspended; see
     /// `Boottime` for a clock that does.
-    Monotonic = c::CLOCK_MONOTONIC,
+    Monotonic = bitcast!(c::CLOCK_MONOTONIC),
 
     /// `CLOCK_BOOTTIME`—Like `Monotonic`, but advances while suspended.
     ///
     /// This clock is similar to `Monotonic`, but does advance while the system
     /// is suspended.
-    Boottime = c::CLOCK_BOOTTIME,
+    Boottime = bitcast!(c::CLOCK_BOOTTIME),
 
     /// `CLOCK_REALTIME_ALARM`—Like `Realtime`, but wakes a suspended system.
     ///
     /// This clock is like `Realtime`, but can wake up a suspended system.
     ///
     /// Use of this clock requires the `CAP_WAKE_ALARM` Linux capability.
-    RealtimeAlarm = c::CLOCK_REALTIME_ALARM,
+    RealtimeAlarm = bitcast!(c::CLOCK_REALTIME_ALARM),
 
     /// `CLOCK_BOOTTIME_ALARM`—Like `Boottime`, but wakes a suspended system.
     ///
     /// This clock is like `Boottime`, but can wake up a suspended system.
     ///
     /// Use of this clock requires the `CAP_WAKE_ALARM` Linux capability.
-    BoottimeAlarm = c::CLOCK_BOOTTIME_ALARM,
+    BoottimeAlarm = bitcast!(c::CLOCK_BOOTTIME_ALARM),
+}
+
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
+#[test]
+fn test_types() {
+    use core::mem::size_of;
+    assert_eq!(size_of::<TimerfdFlags>(), size_of::<c::c_int>());
+    assert_eq!(size_of::<TimerfdTimerFlags>(), size_of::<c::c_int>());
 }

--- a/src/backend/linux_raw/event/epoll.rs
+++ b/src/backend/linux_raw/event/epoll.rs
@@ -87,6 +87,7 @@ use core::slice;
 
 bitflags! {
     /// `EPOLL_*` for use with [`new`].
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct CreateFlags: c::c_uint {
         /// `EPOLL_CLOEXEC`
@@ -96,6 +97,7 @@ bitflags! {
 
 bitflags! {
     /// `EPOLL*` for use with [`add`].
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct EventFlags: u32 {
         /// `EPOLLIN`

--- a/src/backend/linux_raw/event/poll_fd.rs
+++ b/src/backend/linux_raw/event/poll_fd.rs
@@ -5,6 +5,7 @@ bitflags! {
     /// `POLL*` flags for use with [`poll`].
     ///
     /// [`poll`]: crate::io::poll
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct PollFlags: u16 {
         /// `POLLIN`

--- a/src/backend/linux_raw/event/types.rs
+++ b/src/backend/linux_raw/event/types.rs
@@ -5,6 +5,7 @@ bitflags! {
     /// `EFD_*` flags for use with [`eventfd`].
     ///
     /// [`eventfd`]: crate::io::eventfd
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct EventfdFlags: c::c_uint {
         /// `EFD_CLOEXEC`

--- a/src/backend/linux_raw/fs/inotify.rs
+++ b/src/backend/linux_raw/fs/inotify.rs
@@ -10,6 +10,7 @@ bitflags! {
     /// `IN_*` for use with [`inotify_init`].
     ///
     /// [`inotify_init`]: crate::fs::inotify::inotify_init
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct CreateFlags: c::c_uint {
         /// `IN_CLOEXEC`
@@ -23,6 +24,7 @@ bitflags! {
     /// `IN*` for use with [`inotify_add_watch`].
     ///
     /// [`inotify_add_watch`]: crate::fs::inotify::inotify_add_watch
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct WatchFlags: c::c_uint {
         /// `IN_ACCESS`

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -5,6 +5,7 @@ bitflags! {
     /// `*_OK` constants for use with [`accessat`].
     ///
     /// [`accessat`]: fn.accessat.html
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct Access: c::c_uint {
         /// `R_OK`
@@ -27,6 +28,7 @@ bitflags! {
     ///
     /// [`openat`]: crate::fs::openat
     /// [`statat`]: crate::fs::statat
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct AtFlags: c::c_uint {
         /// `AT_SYMLINK_NOFOLLOW`
@@ -64,6 +66,7 @@ bitflags! {
     /// [`openat`]: crate::fs::openat
     /// [`chmodat`]: crate::fs::chmodat
     /// [`fchmod`]: crate::fs::fchmod
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct Mode: RawMode {
         /// `S_IRWXU`
@@ -158,6 +161,7 @@ bitflags! {
     /// `O_*` constants for use with [`openat`].
     ///
     /// [`openat`]: crate::fs::openat
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct OFlags: c::c_uint {
         /// `O_ACCMODE`
@@ -241,6 +245,7 @@ bitflags! {
     /// `RESOLVE_*` constants for use with [`openat2`].
     ///
     /// [`openat2`]: crate::fs::openat2
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct ResolveFlags: u64 {
         /// `RESOLVE_NO_XDEV`
@@ -267,6 +272,7 @@ bitflags! {
     /// `RENAME_*` constants for use with [`renameat_with`].
     ///
     /// [`renameat_with`]: crate::fs::renameat_with
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct RenameFlags: c::c_uint {
         /// `RENAME_EXCHANGE`
@@ -390,6 +396,7 @@ bitflags! {
     /// `MFD_*` constants for use with [`memfd_create`].
     ///
     /// [`memfd_create`]: crate::fs::memfd_create
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MemfdFlags: c::c_uint {
         /// `MFD_CLOEXEC`
@@ -434,6 +441,7 @@ bitflags! {
     ///
     /// [`fcntl_add_seals`]: crate::fs::fcntl_add_seals
     /// [`fcntl_get_seals`]: crate::fs::fcntl_get_seals
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct SealFlags: u32 {
        /// `F_SEAL_SEAL`.
@@ -453,6 +461,7 @@ bitflags! {
     /// `STATX_*` constants for use with [`statx`].
     ///
     /// [`statx`]: crate::fs::statx
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct StatxFlags: u32 {
         /// `STATX_TYPE`
@@ -509,6 +518,7 @@ bitflags! {
     /// `FALLOC_FL_*` constants for use with [`fallocate`].
     ///
     /// [`fallocate`]: crate::fs::fallocate
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct FallocateFlags: u32 {
         /// `FALLOC_FL_KEEP_SIZE`
@@ -530,6 +540,7 @@ bitflags! {
 
 bitflags! {
     /// `ST_*` constants for use with [`StatVfs`].
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct StatVfsMountFlags: u64 {
         /// `ST_MANDLOCK`
@@ -688,6 +699,7 @@ bitflags! {
     /// `MS_*` constants for use with [`mount`].
     ///
     /// [`mount`]: crate::fs::mount
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MountFlags: c::c_uint {
         /// `MS_BIND`
@@ -745,6 +757,7 @@ bitflags! {
     /// `MS_*` constants for use with [`change_mount`].
     ///
     /// [`change_mount`]: crate::fs::mount::change_mount
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MountPropagationFlags: c::c_uint {
         /// `MS_SHARED`
@@ -761,18 +774,22 @@ bitflags! {
 }
 
 bitflags! {
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub(crate) struct InternalMountFlags: c::c_uint {
         const REMOUNT = linux_raw_sys::general::MS_REMOUNT;
         const MOVE = linux_raw_sys::general::MS_MOVE;
     }
 }
 
+#[repr(transparent)]
 pub(crate) struct MountFlagsArg(pub(crate) c::c_uint);
 
 bitflags! {
     /// `MNT_*` constants for use with [`unmount`].
     ///
     /// [`unmount`]: crate::fs::mount::unmount
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct UnmountFlags: c::c_uint {
         /// `MNT_FORCE`

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -382,12 +382,12 @@ pub(crate) fn fcntl_getfd(fd: BorrowedFd<'_>) -> io::Result<FdFlags> {
     #[cfg(target_pointer_width = "32")]
     unsafe {
         ret_c_uint(syscall_readonly!(__NR_fcntl64, fd, c_uint(F_GETFD)))
-            .map(FdFlags::from_bits_truncate)
+            .map(FdFlags::from_bits_retain)
     }
     #[cfg(target_pointer_width = "64")]
     unsafe {
         ret_c_uint(syscall_readonly!(__NR_fcntl, fd, c_uint(F_GETFD)))
-            .map(FdFlags::from_bits_truncate)
+            .map(FdFlags::from_bits_retain)
     }
 }
 

--- a/src/backend/linux_raw/io/types.rs
+++ b/src/backend/linux_raw/io/types.rs
@@ -6,6 +6,7 @@ bitflags! {
     ///
     /// [`fcntl_getfd`]: crate::io::fcntl_getfd
     /// [`fcntl_setfd`]: crate::io::fcntl_setfd
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct FdFlags: c::c_uint {
         /// `FD_CLOEXEC`
@@ -18,6 +19,7 @@ bitflags! {
     ///
     /// [`preadv2`]: crate::io::preadv2
     /// [`pwritev2`]: crate::io::pwritev
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct ReadWriteFlags: c::c_uint {
         /// `RWF_DSYNC` (since Linux 4.7)
@@ -37,6 +39,7 @@ bitflags! {
     /// `O_*` constants for use with [`dup2`].
     ///
     /// [`dup2`]: crate::io::dup2
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct DupFlags: c::c_uint {
         /// `O_CLOEXEC`

--- a/src/backend/linux_raw/mm/types.rs
+++ b/src/backend/linux_raw/mm/types.rs
@@ -7,6 +7,7 @@ bitflags! {
     /// For `PROT_NONE`, use `ProtFlags::empty()`.
     ///
     /// [`mmap`]: crate::io::mmap
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct ProtFlags: u32 {
         /// `PROT_READ`
@@ -24,6 +25,7 @@ bitflags! {
     /// For `PROT_NONE`, use `MprotectFlags::empty()`.
     ///
     /// [`mprotect`]: crate::io::mprotect
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MprotectFlags: u32 {
         /// `PROT_READ`
@@ -46,6 +48,7 @@ bitflags! {
     ///
     /// [`mmap`]: crate::io::mmap
     /// [`mmap_anonymous`]: crates::io::mmap_anonymous
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MapFlags: u32 {
         /// `MAP_SHARED`
@@ -92,6 +95,7 @@ bitflags! {
     ///
     /// [`mremap`]: crate::io::mremap
     /// [`mremap_fixed`]: crate::io::mremap_fixed
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MremapFlags: u32 {
         /// `MREMAP_MAYMOVE`
@@ -105,6 +109,7 @@ bitflags! {
     /// `MLOCK_*` flags for use with [`mlock_with`].
     ///
     /// [`mlock_with`]: crate::io::mlock_with
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MlockFlags: u32 {
         /// `MLOCK_ONFAULT`
@@ -116,6 +121,7 @@ bitflags! {
     /// `MS_*` flags for use with [`msync`].
     ///
     /// [`msync`]: crate::io::msync
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MsyncFlags: u32 {
         /// `MS_SYNC`—Requests an update and waits for it to complete.
@@ -134,6 +140,7 @@ bitflags! {
     /// `O_*` flags for use with [`userfaultfd`].
     ///
     /// [`userfaultfd`]: crate::io::userfaultfd
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct UserfaultfdFlags: c::c_uint {
         /// `O_CLOEXEC`

--- a/src/backend/linux_raw/net/send_recv.rs
+++ b/src/backend/linux_raw/net/send_recv.rs
@@ -6,6 +6,7 @@ bitflags! {
     ///
     /// [`send`]: crate::net::send
     /// [`sendto`]: crate::net::sendto
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct SendFlags: u32 {
         /// `MSG_CONFIRM`
@@ -30,6 +31,7 @@ bitflags! {
     ///
     /// [`recv`]: crate::net::recv
     /// [`recvfrom`]: crate::net::recvfrom
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct RecvFlags: u32 {
         /// `MSG_CMSG_CLOEXEC`

--- a/src/backend/linux_raw/net/syscalls.rs
+++ b/src/backend/linux_raw/net/syscalls.rs
@@ -278,7 +278,7 @@ pub(crate) fn recvmsg(
             RecvMsgReturn {
                 bytes,
                 address: addr,
-                flags: RecvFlags::from_bits_truncate(msghdr.msg_flags),
+                flags: RecvFlags::from_bits_retain(msghdr.msg_flags),
             }
         })
     })

--- a/src/backend/linux_raw/pipe/types.rs
+++ b/src/backend/linux_raw/pipe/types.rs
@@ -6,6 +6,7 @@ bitflags! {
     /// `O_*` constants for use with [`pipe_with`].
     ///
     /// [`pipe_with`]: crate::io::pipe_with
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct PipeFlags: c::c_uint {
         /// `O_CLOEXEC`
@@ -20,6 +21,7 @@ bitflags! {
 bitflags! {
     /// `SPLICE_F_*` constants for use with [`splice`] [`vmsplice`], and
     /// [`tee`].
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct SpliceFlags: c::c_uint {
         /// `SPLICE_F_MOVE`

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -183,10 +183,7 @@ pub(crate) fn sched_yield() {
 #[cfg(feature = "fs")]
 #[inline]
 pub(crate) fn umask(mode: Mode) -> Mode {
-    unsafe {
-        // TODO: Use `from_bits_retain` when we switch to bitflags 2.0.
-        Mode::from_bits_truncate(ret_c_uint_infallible(syscall_readonly!(__NR_umask, mode)))
-    }
+    unsafe { Mode::from_bits_retain(ret_c_uint_infallible(syscall_readonly!(__NR_umask, mode))) }
 }
 
 #[inline]

--- a/src/backend/linux_raw/rand/types.rs
+++ b/src/backend/linux_raw/rand/types.rs
@@ -4,6 +4,7 @@ bitflags! {
     /// `GRND_*` flags for use with [`getrandom`].
     ///
     /// [`getrandom`]: crate::rand::getrandom
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct GetRandomFlags: u32 {
         /// `GRND_RANDOM`

--- a/src/backend/linux_raw/thread/futex.rs
+++ b/src/backend/linux_raw/thread/futex.rs
@@ -2,6 +2,7 @@ bitflags::bitflags! {
     /// `FUTEX_*` flags for use with [`futex`].
     ///
     /// [`futex`]: crate::thread::futex
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct FutexFlags: u32 {
         /// `FUTEX_PRIVATE_FLAG`

--- a/src/backend/linux_raw/time/types.rs
+++ b/src/backend/linux_raw/time/types.rs
@@ -12,6 +12,7 @@ bitflags! {
     /// `TFD_*` flags for use with [`timerfd_create`].
     ///
     /// [`timerfd_create`]: crate::time::timerfd_create
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct TimerfdFlags: c::c_uint {
         /// `TFD_NONBLOCK`
@@ -26,6 +27,7 @@ bitflags! {
     /// `TFD_TIMER_*` flags for use with [`timerfd_settime`].
     ///
     /// [`timerfd_settime`]: crate::time::timerfd_settime
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct TimerfdTimerFlags: c::c_uint {
         /// `TFD_TIMER_ABSTIME`

--- a/src/bitcast.rs
+++ b/src/bitcast.rs
@@ -1,0 +1,32 @@
+// Ensure that the source and destination types are both primitive integer
+// types and the same size, and then bitcast.
+#[allow(unused_macros)]
+macro_rules! bitcast {
+    ($x:expr) => {{
+        if false {
+            // Ensure the source and destinations are primitive integer types.
+            let _ = !$x;
+            let _ = $x as u8;
+            0
+        } else if false {
+            // Ensure that the source and destinations are the same size.
+            // SAFETY: This code is under an `if false`.
+            #[allow(unsafe_code, unused_unsafe, clippy::useless_transmute)]
+            unsafe {
+                ::core::mem::transmute($x)
+            }
+        } else {
+            // Do the conversion.
+            $x as _
+        }
+    }};
+}
+
+/// Return a [`bitcast`] of the value of `$x.bits()`, where `$x` is a
+/// `bitflags` type.
+#[allow(unused_macros)]
+macro_rules! bitflags_bits {
+    ($x:expr) => {{
+        bitcast!($x.bits())
+    }};
+}

--- a/src/event/kqueue.rs
+++ b/src/event/kqueue.rs
@@ -90,7 +90,7 @@ impl Event {
 
     /// Get the event flags for this event.
     pub fn flags(&self) -> EventFlags {
-        EventFlags::from_bits_truncate(self.inner.flags as _)
+        EventFlags::from_bits_retain(self.inner.flags as _)
     }
 
     /// Get the user data for this event.
@@ -110,11 +110,11 @@ impl Event {
             c::EVFILT_EMPTY => EventFilter::Empty(self.inner.ident as _),
             c::EVFILT_VNODE => EventFilter::Vnode {
                 vnode: self.inner.ident as _,
-                flags: VnodeEvents::from_bits_truncate(self.inner.fflags),
+                flags: VnodeEvents::from_bits_retain(self.inner.fflags),
             },
             c::EVFILT_PROC => EventFilter::Proc {
                 pid: Pid::from_raw(self.inner.ident as _).unwrap(),
-                flags: ProcessEvents::from_bits_truncate(self.inner.fflags),
+                flags: ProcessEvents::from_bits_retain(self.inner.fflags),
             },
             c::EVFILT_SIGNAL => EventFilter::Signal {
                 signal: Signal::from_raw(self.inner.ident as _).unwrap(),
@@ -143,7 +143,7 @@ impl Event {
             #[cfg(any(apple, freebsdlike))]
             c::EVFILT_USER => EventFilter::User {
                 ident: self.inner.ident as _,
-                flags: UserFlags::from_bits_truncate(self.inner.fflags),
+                flags: UserFlags::from_bits_retain(self.inner.fflags),
                 user_flags: UserDefinedFlags(self.inner.fflags & EVFILT_USER_FLAGS),
             },
             _ => EventFilter::Unknown,
@@ -229,6 +229,7 @@ pub enum EventFilter {
 
 bitflags::bitflags! {
     /// The flags for a `kqueue` event specifying actions to perform.
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct EventFlags: u16 {
         /// Add the event to the `kqueue`.
@@ -262,6 +263,7 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// The flags for a virtual node event.
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct VnodeEvents: u32 {
         /// The file was deleted.
@@ -289,6 +291,7 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// The flags for a process event.
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct ProcessEvents: u32 {
         /// The process exited.
@@ -311,6 +314,7 @@ bitflags::bitflags! {
 #[cfg(any(apple, freebsdlike))]
 bitflags::bitflags! {
     /// The flags for a user event.
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct UserFlags: u32 {
         /// Ignore the user input flags.

--- a/src/fs/xattr.rs
+++ b/src/fs/xattr.rs
@@ -6,6 +6,7 @@ use bitflags::bitflags;
 bitflags! {
     /// `XATTR_*` constants for use with [`setxattr`], and other `*setxattr`
     /// functions.
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct XattrFlags: c::c_uint {
         /// `XATTR_CREATE`

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -106,6 +106,7 @@ pub unsafe fn io_uring_enter<Fd: AsFd>(
 
 bitflags::bitflags! {
     /// `IORING_ENTER_*` flags for use with [`io_uring_enter`].
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringEnterFlags: u32 {
         /// `IORING_ENTER_GETEVENTS`
@@ -410,6 +411,7 @@ pub enum IoringMsgringCmds {
 
 bitflags::bitflags! {
     /// `IORING_SETUP_*` flags for use with [`io_uring_params`].
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringSetupFlags: u32 {
         /// `IORING_SETUP_ATTACH_WQ`
@@ -458,6 +460,7 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IOSQE_*` flags for use with [`io_uring_sqe`].
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringSqeFlags: u8 {
         /// `1 << IOSQE_ASYNC_BIT`
@@ -485,24 +488,26 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_CQE_F_*` flags for use with [`io_uring_cqe`].
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringCqeFlags: u32 {
         /// `IORING_CQE_F_BUFFER`
-        const BUFFER = sys::IORING_CQE_F_BUFFER as _;
+        const BUFFER = bitcast!(sys::IORING_CQE_F_BUFFER);
 
         /// `IORING_CQE_F_MORE`
-        const MORE = sys::IORING_CQE_F_MORE as _;
+        const MORE = bitcast!(sys::IORING_CQE_F_MORE);
 
         /// `IORING_CQE_F_SOCK_NONEMPTY`
-        const SOCK_NONEMPTY = sys::IORING_CQE_F_SOCK_NONEMPTY as _;
+        const SOCK_NONEMPTY = bitcast!(sys::IORING_CQE_F_SOCK_NONEMPTY);
 
         /// `IORING_CQE_F_NOTIF`
-        const NOTIF = sys::IORING_CQE_F_NOTIF as _;
+        const NOTIF = bitcast!(sys::IORING_CQE_F_NOTIF);
     }
 }
 
 bitflags::bitflags! {
     /// `IORING_FSYNC_*` flags for use with [`io_uring_sqe`].
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringFsyncFlags: u32 {
         /// `IORING_FSYNC_DATASYNC`
@@ -513,6 +518,7 @@ bitflags::bitflags! {
 bitflags::bitflags! {
     /// `IORING_TIMEOUT_*` and `IORING_LINK_TIMEOUT_UPDATE` flags for use with
     /// [`io_uring_sqe`].
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringTimeoutFlags: u32 {
         /// `IORING_TIMEOUT_ABS`
@@ -543,6 +549,7 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `SPLICE_F_*` flags for use with [`io_uring_sqe`].
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct SpliceFlags: u32 {
         /// `SPLICE_F_FD_IN_FIXED`
@@ -552,6 +559,7 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_MSG_RING_*` flags for use with [`io_uring_sqe`].
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringMsgringFlags: u32 {
         /// `IORING_MSG_RING_CQE_SKIP`
@@ -561,6 +569,7 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_ASYNC_CANCEL_*` flags for use with [`io_uring_sqe`].
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringAsyncCancelFlags: u32 {
         /// `IORING_ASYNC_CANCEL_ALL`
@@ -579,6 +588,7 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_FEAT_*` flags for use with [`io_uring_params`].
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringFeatureFlags: u32 {
         /// `IORING_FEAT_CQE_SKIP`
@@ -624,6 +634,7 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IO_URING_OP_*` flags for use with [`io_uring_probe_op`].
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringOpFlags: u16 {
         /// `IO_URING_OP_SUPPORTED`
@@ -633,6 +644,7 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_RSRC_*` flags for use with [`io_uring_rsrc_register`].
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringRsrcFlags: u32 {
         /// `IORING_RSRC_REGISTER_SPARSE`
@@ -642,6 +654,7 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_SQ_*` flags.
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringSqFlags: u32 {
         /// `IORING_SQ_NEED_WAKEUP`
@@ -657,6 +670,7 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_CQ_*` flags.
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringCqFlags: u32 {
         /// `IORING_CQ_EVENTFD_DISABLED`
@@ -666,6 +680,7 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// `IORING_POLL_*` flags.
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringPollFlags: u32 {
         /// `IORING_POLL_ADD_MULTI`
@@ -684,6 +699,7 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// send/sendmsg flags (`sqe.ioprio`)
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringSendFlags: u16 {
         /// `IORING_RECVSEND_POLL_FIRST`.
@@ -703,6 +719,7 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// recv/recvmsg flags (`sqe.ioprio`)
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringRecvFlags: u16 {
         /// `IORING_RECVSEND_POLL_FIRST`
@@ -722,6 +739,7 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// accept flags (`sqe.ioprio`)
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IoringAcceptFlags: u16 {
         /// `IORING_ACCEPT_MULTISHOT`
@@ -731,6 +749,7 @@ bitflags::bitflags! {
 
 bitflags::bitflags! {
     /// recvmsg out flags
+    #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct RecvmsgOutFlags: u32 {
         /// `MSG_EOR`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,8 @@ pub(crate) mod maybe_polyfill;
 #[cfg(test)]
 #[macro_use]
 pub(crate) mod check_types;
+#[macro_use]
+pub(crate) mod bitcast;
 
 // linux_raw: Weak symbols are used by the use-libc-auxv feature for
 // glibc 2.15 support.

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1270,15 +1270,16 @@ bitflags! {
     /// [`socket_with`]: crate::net::socket_with
     /// [`accept_with`]: crate::net::accept_with
     /// [`acceptfrom_with`]: crate::net::acceptfrom_with
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct SocketFlags: c::c_uint {
         /// `SOCK_NONBLOCK`
         #[cfg(not(any(apple, windows, target_os = "haiku")))]
-        const NONBLOCK = c::SOCK_NONBLOCK as _;
+        const NONBLOCK = bitcast!(c::SOCK_NONBLOCK);
 
         /// `SOCK_CLOEXEC`
         #[cfg(not(any(apple, windows, target_os = "haiku")))]
-        const CLOEXEC = c::SOCK_CLOEXEC as _;
+        const CLOEXEC = bitcast!(c::SOCK_CLOEXEC);
     }
 }
 

--- a/src/prctl.rs
+++ b/src/prctl.rs
@@ -12,6 +12,7 @@ use core::ptr::null_mut;
 
 bitflags! {
     /// `PR_PAC_AP*`.
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct PointerAuthenticationKeys: u32 {
         /// `PR_PAC_APIAKEY`—Instruction authentication key `A`.

--- a/src/process/membarrier.rs
+++ b/src/process/membarrier.rs
@@ -11,6 +11,7 @@ bitflags::bitflags! {
     ///
     /// These flags correspond to values of [`MembarrierCommand`] which are
     /// supported in the OS.
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MembarrierQuery: u32 {
        /// `MEMBARRIER_CMD_GLOBAL` (also known as `MEMBARRIER_CMD_SHARED`)

--- a/src/process/pidfd.rs
+++ b/src/process/pidfd.rs
@@ -6,6 +6,7 @@ bitflags::bitflags! {
     /// `PIDFD_*` flags for use with [`pidfd_open`].
     ///
     /// [`pidfd_open`]: crate::process::pidfd_open
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct PidfdFlags: backend::c::c_uint {
         /// `PIDFD_NONBLOCK`.

--- a/src/process/pidfd_getfd.rs
+++ b/src/process/pidfd_getfd.rs
@@ -13,6 +13,8 @@ pub type ForeignRawFd = RawFd;
 
 bitflags::bitflags! {
     /// All flags are reserved for future use.
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct PidfdGetfdFlags: backend::c::c_uint {}
 }
 

--- a/src/process/prctl.rs
+++ b/src/process/prctl.rs
@@ -138,6 +138,7 @@ const PR_GET_UNALIGN: c_int = 5;
 bitflags! {
     /// `PR_UNALIGN_*` flags for use with [`unaligned_access_control`] and
     /// [`set_unaligned_access_control`].
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct UnalignedAccessControl: u32 {
         /// Silently fix up unaligned user accesses.
@@ -186,6 +187,7 @@ const PR_GET_FPEMU: c_int = 9;
 bitflags! {
     /// `PR_FPEMU_*` flags for use with [`floating_point_emulation_control`]
     /// and [`set_floating_point_emulation_control`].
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct FloatingPointEmulationControl: u32 {
         /// Silently emulate floating point operations accesses.
@@ -235,6 +237,7 @@ const PR_GET_FPEXC: c_int = 11;
 
 bitflags! {
     /// Zero means floating point exceptions are disabled.
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct FloatingPointExceptionMode: u32 {
         /// Async non-recoverable exception mode.
@@ -947,6 +950,7 @@ impl TryFrom<u32> for SpeculationFeature {
 
 bitflags! {
     /// `PR_SPEC_*` flags for use with [`control_speculative_feature`].
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct SpeculationFeatureControl: u32 {
         /// The speculation feature is enabled, mitigation is disabled.
@@ -962,6 +966,7 @@ bitflags! {
 
 bitflags! {
     /// Zero means the processors are not vulnerable.
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct SpeculationFeatureState: u32 {
         /// Mitigation can be controlled per thread by `PR_SET_SPECULATION_CTRL`.

--- a/src/process/procctl.rs
+++ b/src/process/procctl.rs
@@ -222,6 +222,7 @@ const PROC_REAP_STATUS: c_int = 4;
 
 bitflags! {
     /// `REAPER_STATUS_*`.
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct ReaperStatusFlags: c_uint {
         /// The process has acquired reaper status.
@@ -268,7 +269,7 @@ pub struct ReaperStatus {
 pub fn get_reaper_status(process: ProcSelector) -> io::Result<ReaperStatus> {
     let raw = unsafe { procctl_get_optional::<procctl_reaper_status>(PROC_REAP_STATUS, process) }?;
     Ok(ReaperStatus {
-        flags: ReaperStatusFlags::from_bits_truncate(raw.rs_flags),
+        flags: ReaperStatusFlags::from_bits_retain(raw.rs_flags),
         children: raw.rs_children as _,
         descendants: raw.rs_descendants as _,
         reaper: Pid::from_raw(raw.rs_reaper).ok_or(io::Errno::RANGE)?,
@@ -284,6 +285,7 @@ const PROC_REAP_GETPIDS: c_int = 5;
 
 bitflags! {
     /// `REAPER_PIDINFO_*`.
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct PidInfoFlags: c_uint {
         /// This structure was filled by the kernel.
@@ -349,7 +351,7 @@ pub fn get_reaper_pids(process: ProcSelector) -> io::Result<Vec<PidInfo>> {
     unsafe { procctl(PROC_REAP_GETPIDS, process, as_mut_ptr(&mut pinfo).cast())? };
     let mut result = Vec::new();
     for raw in pids.into_iter() {
-        let flags = PidInfoFlags::from_bits_truncate(raw.pi_flags);
+        let flags = PidInfoFlags::from_bits_retain(raw.pi_flags);
         if !flags.contains(PidInfoFlags::VALID) {
             break;
         }
@@ -366,6 +368,7 @@ const PROC_REAP_KILL: c_int = 6;
 
 bitflags! {
     /// `REAPER_KILL_*`.
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     struct KillFlags: c_uint {
         const CHILDREN = 1;

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -10,36 +10,38 @@ use crate::backend::process::wait::SiginfoExt;
 
 bitflags! {
     /// Options for modifying the behavior of wait/waitpid
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct WaitOptions: u32 {
         /// Return immediately if no child has exited.
-        const NOHANG = backend::process::wait::WNOHANG as _;
+        const NOHANG = bitcast!(backend::process::wait::WNOHANG);
         /// Return if a child has stopped (but not traced via [`ptrace`])
         ///
         /// [`ptrace`]: https://man7.org/linux/man-pages/man2/ptrace.2.html
-        const UNTRACED = backend::process::wait::WUNTRACED as _;
+        const UNTRACED = bitcast!(backend::process::wait::WUNTRACED);
         /// Return if a stopped child has been resumed by delivery of
         /// [`Signal::Cont`].
-        const CONTINUED = backend::process::wait::WCONTINUED as _;
+        const CONTINUED = bitcast!(backend::process::wait::WCONTINUED);
     }
 }
 
 #[cfg(not(any(target_os = "wasi", target_os = "redox", target_os = "openbsd")))]
 bitflags! {
     /// Options for modifying the behavior of waitid
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct WaitidOptions: u32 {
         /// Return immediately if no child has exited.
-        const NOHANG = backend::process::wait::WNOHANG as _;
+        const NOHANG = bitcast!(backend::process::wait::WNOHANG);
         /// Return if a stopped child has been resumed by delivery of
         /// [`Signal::Cont`]
-        const CONTINUED = backend::process::wait::WCONTINUED as _;
+        const CONTINUED = bitcast!(backend::process::wait::WCONTINUED);
         /// Wait for processed that have exited.
-        const EXITED = backend::process::wait::WEXITED as _;
+        const EXITED = bitcast!(backend::process::wait::WEXITED);
         /// Keep processed in a waitable state.
-        const NOWAIT = backend::process::wait::WNOWAIT as _;
+        const NOWAIT = bitcast!(backend::process::wait::WNOWAIT);
         /// Wait for processes that have been stopped.
-        const STOPPED = backend::process::wait::WSTOPPED as _;
+        const STOPPED = bitcast!(backend::process::wait::WSTOPPED);
     }
 }
 

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -16,6 +16,7 @@ bitflags::bitflags! {
     /// `O_*` flags for use with [`openpt`] and [`ioctl_tiocgptpeer`].
     ///
     /// [`ioctl_tiocgtpeer`]: https://docs.rs/rustix/*/x86_64-unknown-linux-gnu/rustix/pty/fn.ioctl_tiocgtpeer.html
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct OpenptFlags: u32 {
         /// `O_RDWR`

--- a/src/thread/libcap.rs
+++ b/src/thread/libcap.rs
@@ -17,6 +17,7 @@ pub struct CapabilitySets {
 
 bitflags! {
     /// `CAP_*` constants.
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct CapabilityFlags: u64 {
         /// `CAP_CHOWN`

--- a/src/thread/prctl.rs
+++ b/src/thread/prctl.rs
@@ -411,6 +411,7 @@ const PR_GET_SECUREBITS: c_int = 27;
 
 bitflags! {
     /// `SECBIT_*`.
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct CapabilitiesSecureBits: u32 {
         /// If this bit is set, then the kernel does not grant capabilities when
@@ -733,6 +734,7 @@ const PR_MTE_TAG_MASK: u32 = 0xffff_u32 << PR_MTE_TAG_SHIFT;
 
 bitflags! {
     /// Zero means addresses that are passed for the purpose of being dereferenced by the kernel must be untagged.
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct TaggedAddressMode: u32 {
         /// Addresses that are passed for the purpose of being dereferenced by the kernel may be tagged.

--- a/src/thread/setns.rs
+++ b/src/thread/setns.rs
@@ -11,6 +11,7 @@ use crate::io;
 
 bitflags! {
     /// Thread name space type.
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct ThreadNameSpaceType: u32 {
         /// Time name space.
@@ -56,6 +57,7 @@ pub enum LinkNameSpaceType {
 
 bitflags! {
     /// `CLONE_*` for use with [`unshare`].
+    #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct UnshareFlags: u32 {
         /// `CLONE_FILES`.


### PR DESCRIPTION
This makes the types consistent between the linux_raw and libc backends. And, using unsigned types for flags is more idiomatic for Rust.

To avoid the risk of `as` silently casting away bits, introduce new `bitcast` and `bitflags_bits` macros which convert their argument to the needed integer type while only changing its signedness interpretation.

These macros use `transmute` internally, to ensure that the source and destination are the same size, so they also include code to prevent them from being used on non-integer types.