### PR TITLE
Use the `syscall` macro instead of `c::syscall`.

### DIFF
--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -192,19 +192,19 @@ mod readwrite_pv64 {
     // 64-bit offsets on 32-bit platforms are passed in endianness-specific
     // lo/hi pairs. See src/backend/linux_raw/conv.rs for details.
     #[cfg(all(target_endian = "little", target_pointer_width = "32"))]
-    fn lo(x: u64) -> usize {
+    fn lo(x: i64) -> usize {
         (x >> 32) as usize
     }
     #[cfg(all(target_endian = "little", target_pointer_width = "32"))]
-    fn hi(x: u64) -> usize {
-        (x & 0xffff_ffff) as usize
+    fn hi(x: i64) -> usize {
+        x as usize
     }
     #[cfg(all(target_endian = "big", target_pointer_width = "32"))]
-    fn lo(x: u64) -> usize {
-        (x & 0xffff_ffff) as usize
+    fn lo(x: i64) -> usize {
+        x as usize
     }
     #[cfg(all(target_endian = "big", target_pointer_width = "32"))]
-    fn hi(x: u64) -> usize {
+    fn hi(x: i64) -> usize {
         (x >> 32) as usize
     }
 
@@ -226,18 +226,28 @@ mod readwrite_pv64 {
         } else {
             #[cfg(target_pointer_width = "32")]
             {
-                libc::syscall(
-                    libc::SYS_preadv,
-                    fd,
-                    iov,
-                    iovcnt,
-                    hi(offset as u64),
-                    lo(offset as u64),
-                ) as libc::ssize_t
+                syscall! {
+                    fn preadv(
+                        fd: libc::c_int,
+                        iov: *const libc::iovec,
+                        iovcnt: libc::c_int,
+                        offset_hi: usize,
+                        offset_lo: usize
+                    ) via SYS_preadv -> libc::ssize_t
+                }
+                preadv(fd, iov, iovcnt, hi(offset), lo(offset))
             }
             #[cfg(target_pointer_width = "64")]
             {
-                libc::syscall(libc::SYS_preadv, fd, iov, iovcnt, offset) as libc::ssize_t
+                syscall! {
+                    fn preadv(
+                        fd: libc::c_int,
+                        iov: *const libc::iovec,
+                        iovcnt: libc::c_int,
+                        offset: libc::off_t
+                    ) via SYS_preadv -> libc::ssize_t
+                }
+                preadv(fd, iov, iovcnt, offset)
             }
         }
     }
@@ -256,18 +266,28 @@ mod readwrite_pv64 {
         } else {
             #[cfg(target_pointer_width = "32")]
             {
-                libc::syscall(
-                    libc::SYS_pwritev,
-                    fd,
-                    iov,
-                    iovcnt,
-                    hi(offset as u64),
-                    lo(offset as u64),
-                ) as libc::ssize_t
+                syscall! {
+                    fn pwritev(
+                        fd: libc::c_int,
+                        iov: *const libc::iovec,
+                        iovcnt: libc::c_int,
+                        offset_hi: usize,
+                        offset_lo: usize
+                    ) via SYS_pwritev -> libc::ssize_t
+                }
+                pwritev(fd, iov, iovcnt, hi(offset), lo(offset))
             }
             #[cfg(target_pointer_width = "64")]
             {
-                libc::syscall(libc::SYS_pwritev, fd, iov, iovcnt, offset) as libc::ssize_t
+                syscall! {
+                    fn pwritev(
+                        fd: libc::c_int,
+                        iov: *const libc::iovec,
+                        iovcnt: libc::c_int,
+                        offset: libc::off_t
+                    ) via SYS_pwritev -> libc::ssize_t
+                }
+                pwritev(fd, iov, iovcnt, offset)
             }
         }
     }
@@ -303,19 +323,19 @@ mod readwrite_pv64v2 {
     // 64-bit offsets on 32-bit platforms are passed in endianness-specific
     // lo/hi pairs. See src/backend/linux_raw/conv.rs for details.
     #[cfg(all(target_endian = "little", target_pointer_width = "32"))]
-    fn lo(x: u64) -> usize {
+    fn lo(x: i64) -> usize {
         (x >> 32) as usize
     }
     #[cfg(all(target_endian = "little", target_pointer_width = "32"))]
-    fn hi(x: u64) -> usize {
-        (x & 0xffff_ffff) as usize
+    fn hi(x: i64) -> usize {
+        x as usize
     }
     #[cfg(all(target_endian = "big", target_pointer_width = "32"))]
-    fn lo(x: u64) -> usize {
-        (x & 0xffff_ffff) as usize
+    fn lo(x: i64) -> usize {
+        x as usize
     }
     #[cfg(all(target_endian = "big", target_pointer_width = "32"))]
-    fn hi(x: u64) -> usize {
+    fn hi(x: i64) -> usize {
         (x >> 32) as usize
     }
 
@@ -338,19 +358,30 @@ mod readwrite_pv64v2 {
         } else {
             #[cfg(target_pointer_width = "32")]
             {
-                libc::syscall(
-                    libc::SYS_preadv2,
-                    fd,
-                    iov,
-                    iovcnt,
-                    hi(offset as u64),
-                    lo(offset as u64),
-                    flags,
-                ) as libc::ssize_t
+                syscall! {
+                    fn preadv2(
+                        fd: libc::c_int,
+                        iov: *const libc::iovec,
+                        iovcnt: libc::c_int,
+                        offset_hi: usize,
+                        offset_lo: usize,
+                        flags: libc::c_int
+                    ) via SYS_preadv2 -> libc::ssize_t
+                }
+                preadv2(fd, iov, iovcnt, hi(offset), lo(offset), flags)
             }
             #[cfg(target_pointer_width = "64")]
             {
-                libc::syscall(libc::SYS_preadv2, fd, iov, iovcnt, offset, flags) as libc::ssize_t
+                syscall! {
+                    fn preadv2(
+                        fd: libc::c_int,
+                        iov: *const libc::iovec,
+                        iovcnt: libc::c_int,
+                        offset: libc::off_t,
+                        flags: libc::c_int
+                    ) via SYS_preadv2 -> libc::ssize_t
+                }
+                preadv2(fd, iov, iovcnt, offset, flags)
             }
         }
     }
@@ -370,22 +401,136 @@ mod readwrite_pv64v2 {
         } else {
             #[cfg(target_pointer_width = "32")]
             {
-                libc::syscall(
-                    libc::SYS_pwritev,
-                    fd,
-                    iov,
-                    iovcnt,
-                    hi(offset as u64),
-                    lo(offset as u64),
-                    flags,
-                ) as libc::ssize_t
+                syscall! {
+                    fn pwritev2(
+                        fd: libc::c_int,
+                        iov: *const libc::iovec,
+                        iovec: libc::c_int,
+                        offset_hi: usize,
+                        offset_lo: usize,
+                        flags: libc::c_int
+                    ) via SYS_pwritev2 -> libc::ssize_t
+                }
+                pwritev2(fd, iov, iovcnt, hi(offset), lo(offset), flags)
             }
             #[cfg(target_pointer_width = "64")]
             {
-                libc::syscall(libc::SYS_pwritev2, fd, iov, iovcnt, offset, flags) as libc::ssize_t
+                syscall! {
+                    fn pwritev2(
+                        fd: libc::c_int,
+                        iov:*const libc::iovec,
+                        iovcnt: libc::c_int,
+                        offset: libc::off_t,
+                        flags: libc::c_int
+                    ) via SYS_pwritev2 -> libc::ssize_t
+                }
+                pwritev2(fd, iov, iovcnt, offset, flags)
             }
         }
     }
 }
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
+pub(super) use readwrite_pv64v2::{preadv64v2 as preadv2, pwritev64v2 as pwritev2};
+
+// On non-glibc, assume we don't have `pwritev2`/`preadv2` in libc and use
+// `c::syscall` instead.
+#[cfg(any(
+    target_os = "android",
+    all(target_os = "linux", not(target_env = "gnu")),
+))]
+mod readwrite_pv64v2 {
+    // 64-bit offsets on 32-bit platforms are passed in endianness-specific
+    // lo/hi pairs. See src/backend/linux_raw/conv.rs for details.
+    #[cfg(all(target_endian = "little", target_pointer_width = "32"))]
+    fn lo(x: i64) -> usize {
+        (x >> 32) as usize
+    }
+    #[cfg(all(target_endian = "little", target_pointer_width = "32"))]
+    fn hi(x: i64) -> usize {
+        x as usize
+    }
+    #[cfg(all(target_endian = "big", target_pointer_width = "32"))]
+    fn lo(x: i64) -> usize {
+        x as usize
+    }
+    #[cfg(all(target_endian = "big", target_pointer_width = "32"))]
+    fn hi(x: i64) -> usize {
+        (x >> 32) as usize
+    }
+
+    pub(in super::super) unsafe fn preadv64v2(
+        fd: libc::c_int,
+        iov: *const libc::iovec,
+        iovcnt: libc::c_int,
+        offset: libc::off64_t,
+        flags: libc::c_int,
+    ) -> libc::ssize_t {
+        #[cfg(target_pointer_width = "32")]
+        {
+            syscall! {
+                fn preadv2(
+                    fd: libc::c_int,
+                    iov: *const libc::iovec,
+                    iovcnt: libc::c_int,
+                    offset_hi: usize,
+                    offset_lo: usize,
+                    flags: libc::c_int
+                ) via SYS_preadv2 -> libc::ssize_t
+            }
+            preadv2(fd, iov, iovcnt, hi(offset), lo(offset), flags)
+        }
+        #[cfg(target_pointer_width = "64")]
+        {
+            syscall! {
+                fn preadv2(
+                    fd: libc::c_int,
+                    iov: *const libc::iovec,
+                    iovcnt: libc::c_int,
+                    offset: libc::off_t,
+                    flags: libc::c_int
+                ) via SYS_preadv2 -> libc::ssize_t
+            }
+            preadv2(fd, iov, iovcnt, offset, flags)
+        }
+    }
+    pub(in super::super) unsafe fn pwritev64v2(
+        fd: libc::c_int,
+        iov: *const libc::iovec,
+        iovcnt: libc::c_int,
+        offset: libc::off64_t,
+        flags: libc::c_int,
+    ) -> libc::ssize_t {
+        #[cfg(target_pointer_width = "32")]
+        {
+            syscall! {
+                fn pwritev2(
+                    fd: libc::c_int,
+                    iov: *const libc::iovec,
+                    iovcnt: libc::c_int,
+                    offset_hi: usize,
+                    offset_lo: usize,
+                    flags: libc::c_int
+                ) via SYS_pwritev2 -> libc::ssize_t
+            }
+            pwritev2(fd, iov, iovcnt, hi(offset), lo(offset), flags)
+        }
+        #[cfg(target_pointer_width = "64")]
+        {
+            syscall! {
+                fn pwritev2(
+                    fd: libc::c_int,
+                    iov:*const libc::iovec,
+                    iovcnt: libc::c_int,
+                    offset: libc::off_t,
+                    flags: libc::c_int
+                ) via SYS_pwritev2 -> libc::ssize_t
+            }
+            pwritev2(fd, iov, iovcnt, offset, flags)
+        }
+    }
+}
+#[cfg(any(
+    target_os = "android",
+    all(target_os = "linux", not(target_env = "gnu")),
+))]
 pub(super) use readwrite_pv64v2::{preadv64v2 as preadv2, pwritev64v2 as pwritev2};

--- a/src/backend/libc/conv.rs
+++ b/src/backend/libc/conv.rs
@@ -42,15 +42,6 @@ pub(super) fn ret(raw: c::c_int) -> io::Result<()> {
 }
 
 #[inline]
-pub(super) fn syscall_ret(raw: c::c_long) -> io::Result<()> {
-    if raw == 0 {
-        Ok(())
-    } else {
-        Err(io::Errno::last_os_error())
-    }
-}
-
-#[inline]
 pub(super) fn nonnegative_ret(raw: c::c_int) -> io::Result<()> {
     if raw >= 0 {
         Ok(())
@@ -89,31 +80,6 @@ pub(super) fn ret_usize(raw: c::ssize_t) -> io::Result<usize> {
     } else {
         debug_assert!(raw >= 0);
         Ok(raw as usize)
-    }
-}
-
-#[inline]
-pub(super) fn syscall_ret_usize(raw: c::c_long) -> io::Result<usize> {
-    if raw == -1 {
-        Err(io::Errno::last_os_error())
-    } else {
-        debug_assert!(raw >= 0);
-        Ok(raw as c::ssize_t as usize)
-    }
-}
-
-#[cfg(linux_kernel)]
-#[inline]
-pub(super) fn syscall_ret_u32(raw: c::c_long) -> io::Result<u32> {
-    if raw == -1 {
-        Err(io::Errno::last_os_error())
-    } else {
-        let r32 = raw as u32;
-
-        // Converting `raw` to `u32` should be lossless.
-        debug_assert_eq!(r32 as c::c_long, raw);
-
-        Ok(r32)
     }
 }
 
@@ -168,22 +134,6 @@ pub(super) fn ret_discarded_char_ptr(raw: *mut c::c_char) -> io::Result<()> {
         Err(io::Errno::last_os_error())
     } else {
         Ok(())
-    }
-}
-
-/// Convert a `c_long` returned from `syscall` to an `OwnedFd`, if valid.
-///
-/// # Safety
-///
-/// The caller must ensure that this is the return value of a `syscall` call
-/// which returns an owned file descriptor.
-#[cfg(not(windows))]
-#[inline]
-pub(super) unsafe fn syscall_ret_owned_fd(raw: c::c_long) -> io::Result<OwnedFd> {
-    if raw == -1 {
-        Err(io::Errno::last_os_error())
-    } else {
-        Ok(OwnedFd::from_raw_fd(raw as RawFd))
     }
 }
 

--- a/src/backend/libc/mm/syscalls.rs
+++ b/src/backend/libc/mm/syscalls.rs
@@ -9,7 +9,7 @@ use super::types::{MapFlags, MprotectFlags, MsyncFlags, ProtFlags};
 use super::types::{MlockFlags, UserfaultfdFlags};
 use crate::backend::c;
 #[cfg(linux_kernel)]
-use crate::backend::conv::syscall_ret_owned_fd;
+use crate::backend::conv::ret_owned_fd;
 use crate::backend::conv::{borrowed_fd, no_fd, ret};
 use crate::fd::BorrowedFd;
 #[cfg(linux_kernel)]
@@ -213,5 +213,10 @@ pub(crate) unsafe fn munlock(addr: *mut c::c_void, length: usize) -> io::Result<
 
 #[cfg(linux_kernel)]
 pub(crate) unsafe fn userfaultfd(flags: UserfaultfdFlags) -> io::Result<OwnedFd> {
-    syscall_ret_owned_fd(c::syscall(c::SYS_userfaultfd, flags.bits()))
+    syscall! {
+        fn userfaultfd(
+            flags: libc::c_int
+        ) via SYS_userfaultfd -> c::c_int
+    }
+    ret_owned_fd(userfaultfd(bitflags_bits!(flags)))
 }

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -191,6 +191,22 @@ macro_rules! syscall {
             }
 
             // Coerce integer values into `c_long`.
+            impl AsSyscallArg for i8 {
+                type SyscallArgType = ::libc::c_long;
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+            }
+            impl AsSyscallArg for u8 {
+                type SyscallArgType = ::libc::c_long;
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+            }
+            impl AsSyscallArg for i16 {
+                type SyscallArgType = ::libc::c_long;
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+            }
+            impl AsSyscallArg for u16 {
+                type SyscallArgType = ::libc::c_long;
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+            }
             impl AsSyscallArg for i32 {
                 type SyscallArgType = ::libc::c_long;
                 fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
@@ -200,6 +216,19 @@ macro_rules! syscall {
                 fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
             }
             impl AsSyscallArg for usize {
+                type SyscallArgType = ::libc::c_long;
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+            }
+
+            // On 64-bit platforms, also coerce `i64` and `u64` since `c_long`
+            // is 64-bit and can hold those values.
+            #[cfg(target_pointer_width = "64")]
+            impl AsSyscallArg for i64 {
+                type SyscallArgType = ::libc::c_long;
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+            }
+            #[cfg(target_pointer_width = "64")]
+            impl AsSyscallArg for u64 {
                 type SyscallArgType = ::libc::c_long;
                 fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
             }

--- a/tests/mm/mlock.rs
+++ b/tests/mm/mlock.rs
@@ -52,7 +52,7 @@ fn test_mlock_with_onfault() {
     // syscall directly to test for `ENOSYS`, before running the main
     // test below.
     unsafe {
-        if libc::syscall(libc::SYS_mlock2, 0, 0) == -1 && libc_errno::errno().0 == libc::ENOSYS {
+        if libc::syscall(libc::SYS_mlock2, 0, 0, 0) == -1 && libc_errno::errno().0 == libc::ENOSYS {
             return;
         }
     }


### PR DESCRIPTION
This makes the codebase more consistent, as syscalls made by the libc backend are now always done in the same way. And, it's easier to audit the signatures, as they're now always explicitly declared.

This also eliminates the `syscall_*` conversion routines and varous manual conversions to `c::c_long`.