### PR TITLE
Don't set `O_LARGEFILE` on `openat2` when `O_PATH` is set.

### DIFF
--- a/tests/fs/openat2.rs
+++ b/tests/fs/openat2.rs
@@ -75,6 +75,16 @@ fn test_openat2() {
     )
     .unwrap_err();
 
+    // Test with `O_PATH`.
+    let _ = openat2_more(
+        &dir,
+        "test.txt",
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::PATH,
+        Mode::empty(),
+        ResolveFlags::empty(),
+    )
+    .unwrap();
+
     // Test `NO_MAGICLINKS`.
     let test = openat2_more(
         &dir,


### PR DESCRIPTION
Linux appears to reject `O_LARGEFILE` with `O_PATH` in `openat2`, so avoid that combination.