### PR TITLE
Update to bitflags 2.3.3 and remove workarounds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.63"
 cc = { version = "1.0.68", optional = true }
 
 [dependencies]
-bitflags = "2.3.0"
+bitflags = "2.3.3"
 itoa = { version = "1.0.1", default-features = false, optional = true }
 
 # Special dependencies used in rustc-dep-of-std mode.

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -233,9 +233,7 @@ pub(crate) fn set_speed(termios: &mut Termios, arbitrary_speed: u32) -> io::Resu
 
         debug_assert_eq!(encoded_speed & !c::CBAUD, 0);
 
-        // Use `=` and `-` because `-=` behaves differently.
-        termios.control_modes =
-            termios.control_modes - ControlModes::from_bits_retain(c::CBAUD | c::CIBAUD);
+        termios.control_modes -= ControlModes::from_bits_retain(c::CBAUD | c::CIBAUD);
         termios.control_modes |=
             ControlModes::from_bits_retain(encoded_speed | (encoded_speed << c::IBSHIFT));
 
@@ -277,8 +275,7 @@ pub(crate) fn set_output_speed(termios: &mut Termios, arbitrary_speed: u32) -> i
 
         debug_assert_eq!(encoded_speed & !c::CBAUD, 0);
 
-        // Use `=` and `-` because `-=` behaves differently.
-        termios.control_modes = termios.control_modes - ControlModes::from_bits_retain(c::CBAUD);
+        termios.control_modes -= ControlModes::from_bits_retain(c::CBAUD);
         termios.control_modes |= ControlModes::from_bits_retain(encoded_speed);
 
         termios.output_speed = arbitrary_speed;
@@ -318,8 +315,7 @@ pub(crate) fn set_input_speed(termios: &mut Termios, arbitrary_speed: u32) -> io
 
         debug_assert_eq!(encoded_speed & !c::CBAUD, 0);
 
-        // Use `=` and `-` because `-=` behaves differently.
-        termios.control_modes = termios.control_modes - ControlModes::from_bits_retain(c::CIBAUD);
+        termios.control_modes -= ControlModes::from_bits_retain(c::CIBAUD);
         termios.control_modes |= ControlModes::from_bits_retain(encoded_speed << c::IBSHIFT);
 
         termios.input_speed = arbitrary_speed;

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -85,7 +85,7 @@ pub(crate) fn openat2(
     // Enable support for large files, but not with `O_PATH` because
     // `openat2` doesn't like those flags together.
     if !flags.contains(OFlags::PATH) {
-        flags = flags | OFlags::from_bits_retain(c::O_LARGEFILE);
+        flags |= OFlags::from_bits_retain(c::O_LARGEFILE);
     }
 
     unsafe {

--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -157,9 +157,7 @@ pub(crate) fn set_speed(termios: &mut Termios, arbitrary_speed: u32) -> io::Resu
 
     debug_assert_eq!(encoded_speed & !c::CBAUD, 0);
 
-    // Use `=` and `-` because `-=` behaves differently.
-    termios.control_modes =
-        termios.control_modes - ControlModes::from_bits_retain(c::CBAUD | c::CIBAUD);
+    termios.control_modes -= ControlModes::from_bits_retain(c::CBAUD | c::CIBAUD);
     termios.control_modes |=
         ControlModes::from_bits_retain(encoded_speed | (encoded_speed << IBSHIFT));
 
@@ -177,8 +175,7 @@ pub(crate) fn set_output_speed(termios: &mut Termios, arbitrary_speed: u32) -> i
 
     debug_assert_eq!(encoded_speed & !c::CBAUD, 0);
 
-    // Use `=` and `-` because `-=` behaves differently.
-    termios.control_modes = termios.control_modes - ControlModes::from_bits_retain(c::CBAUD);
+    termios.control_modes -= ControlModes::from_bits_retain(c::CBAUD);
     termios.control_modes |= ControlModes::from_bits_retain(encoded_speed);
 
     termios.output_speed = arbitrary_speed;
@@ -194,8 +191,7 @@ pub(crate) fn set_input_speed(termios: &mut Termios, arbitrary_speed: u32) -> io
 
     debug_assert_eq!(encoded_speed & !c::CBAUD, 0);
 
-    // Use `=` and `-` because `-=` behaves differently.
-    termios.control_modes = termios.control_modes - ControlModes::from_bits_retain(c::CIBAUD);
+    termios.control_modes -= ControlModes::from_bits_retain(c::CIBAUD);
     termios.control_modes |= ControlModes::from_bits_retain(encoded_speed << IBSHIFT);
 
     termios.input_speed = arbitrary_speed;
@@ -208,25 +204,21 @@ pub(crate) fn cfmakeraw(termios: &mut Termios) {
     // From the Linux [`cfmakeraw` manual page]:
     //
     // [`cfmakeraw` manual page]: https://man7.org/linux/man-pages/man3/cfmakeraw.3.html
-    //
-    // Use `=` and `-` because `-=` behaves differently.
-    termios.input_modes = termios.input_modes
-        - (InputModes::IGNBRK
-            | InputModes::BRKINT
-            | InputModes::PARMRK
-            | InputModes::ISTRIP
-            | InputModes::INLCR
-            | InputModes::IGNCR
-            | InputModes::ICRNL
-            | InputModes::IXON);
-    termios.output_modes = termios.output_modes - OutputModes::OPOST;
-    termios.local_modes = termios.local_modes
-        - (LocalModes::ECHO
-            | LocalModes::ECHONL
-            | LocalModes::ICANON
-            | LocalModes::ISIG
-            | LocalModes::IEXTEN);
-    termios.control_modes = termios.control_modes - (ControlModes::CSIZE | ControlModes::PARENB);
+    termios.input_modes -= InputModes::IGNBRK
+        | InputModes::BRKINT
+        | InputModes::PARMRK
+        | InputModes::ISTRIP
+        | InputModes::INLCR
+        | InputModes::IGNCR
+        | InputModes::ICRNL
+        | InputModes::IXON;
+    termios.output_modes -= OutputModes::OPOST;
+    termios.local_modes -= LocalModes::ECHO
+        | LocalModes::ECHONL
+        | LocalModes::ICANON
+        | LocalModes::ISIG
+        | LocalModes::IEXTEN;
+    termios.control_modes -= ControlModes::CSIZE | ControlModes::PARENB;
     termios.control_modes |= ControlModes::CS8;
 
     // Musl and glibc also do these:


### PR DESCRIPTION
Bitflags 2.3.3 fixes `-=` to behave the same as `-` and `=` separately, so we can now remove the workarounds.

Fixes #695.