### PR TITLE
Fix the build with --no-default-features and more circumstances.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,6 +148,10 @@ jobs:
     - run: cargo check --workspace --release --no-default-features --features use-libc -vv
     - run: cargo check --workspace --release --no-default-features --features all-apis -vv
     - run: cargo check --workspace --release --no-default-features --features all-apis,use-libc -vv
+    - run: cargo check --workspace --release --no-default-features --features time -vv
+    - run: cargo check --workspace --release --no-default-features --features time,use-libc -vv
+    - run: rustup component add rust-src
+    - run: cargo check --workspace --release --no-default-features --target=i686-unknown-linux-gnu -Zbuild-std -vv
 
   check_nightly:
     name: Check nightly-only targets

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -21,7 +21,19 @@ pub(crate) use linux_raw_sys::general::{
 #[cfg(test)]
 pub(crate) use linux_raw_sys::general::epoll_event;
 
-#[cfg(feature = "fs")]
+#[cfg(any(
+    feature = "fs",
+    all(
+        not(feature = "use-libc-auxv"),
+        not(target_vendor = "mustang"),
+        any(
+            feature = "param",
+            feature = "runtime",
+            feature = "time",
+            target_arch = "x86",
+        )
+    )
+))]
 pub(crate) use linux_raw_sys::general::{
     AT_FDCWD, NFS_SUPER_MAGIC, O_LARGEFILE, PROC_SUPER_MAGIC, UTIME_NOW, UTIME_OMIT, XATTR_CREATE,
     XATTR_REPLACE,

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -7,9 +7,10 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::c;
+use crate::backend::conv::fs::oflags_for_open_how;
 use crate::backend::conv::{
-    by_ref, c_int, c_uint, dev_t, oflags_for_open_how, opt_mut, pass_usize, raw_fd, ret, ret_c_int,
-    ret_c_uint, ret_infallible, ret_owned_fd, ret_usize, size_of, slice, slice_mut, zero,
+    by_ref, c_int, c_uint, dev_t, opt_mut, pass_usize, raw_fd, ret, ret_c_int, ret_c_uint,
+    ret_infallible, ret_owned_fd, ret_usize, size_of, slice, slice_mut, zero,
 };
 #[cfg(target_pointer_width = "64")]
 use crate::backend::conv::{loff_t, loff_t_from_u64, ret_u64};

--- a/src/backend/linux_raw/mod.rs
+++ b/src/backend/linux_raw/mod.rs
@@ -32,7 +32,19 @@ mod vdso_wrappers;
 
 #[cfg(feature = "event")]
 pub(crate) mod event;
-#[cfg(feature = "fs")]
+#[cfg(any(
+    feature = "fs",
+    all(
+        not(feature = "use-libc-auxv"),
+        not(target_vendor = "mustang"),
+        any(
+            feature = "param",
+            feature = "runtime",
+            feature = "time",
+            target_arch = "x86",
+        )
+    )
+))]
 pub(crate) mod fs;
 pub(crate) mod io;
 #[cfg(feature = "io_uring")]
@@ -82,7 +94,21 @@ pub(crate) mod c;
 pub(crate) mod pid;
 #[cfg(any(feature = "process", feature = "thread"))]
 pub(crate) mod prctl;
-#[cfg(any(feature = "fs", feature = "thread", feature = "process"))]
+#[cfg(any(
+    feature = "fs",
+    feature = "process",
+    feature = "thread",
+    all(
+        not(feature = "use-libc-auxv"),
+        not(target_vendor = "mustang"),
+        any(
+            feature = "param",
+            feature = "runtime",
+            feature = "time",
+            target_arch = "x86",
+        )
+    )
+))]
 pub(crate) mod ugid;
 
 /// The maximum number of buffers that can be passed into a vectored I/O system

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,20 @@ pub mod event;
 #[cfg(not(windows))]
 pub mod ffi;
 #[cfg(not(windows))]
-#[cfg(feature = "fs")]
+#[cfg(any(
+    feature = "fs",
+    all(
+        linux_raw,
+        not(feature = "use-libc-auxv"),
+        not(target_vendor = "mustang"),
+        any(
+            feature = "param",
+            feature = "runtime",
+            feature = "time",
+            target_arch = "x86",
+        )
+    )
+))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
 pub mod fs;
 pub mod io;
@@ -204,7 +217,21 @@ pub mod net;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "param")))]
 pub mod param;
 #[cfg(not(windows))]
-#[cfg(any(feature = "fs", feature = "net"))]
+#[cfg(any(
+    feature = "fs",
+    feature = "net",
+    all(
+        linux_raw,
+        not(feature = "use-libc-auxv"),
+        not(target_vendor = "mustang"),
+        any(
+            feature = "param",
+            feature = "runtime",
+            feature = "time",
+            target_arch = "x86",
+        )
+    )
+))]
 #[cfg_attr(doc_cfg, doc(cfg(any(feature = "fs", feature = "net"))))]
 pub mod path;
 #[cfg(feature = "pipe")]
@@ -282,9 +309,35 @@ mod signal;
     feature = "fs",
     feature = "runtime",
     feature = "thread",
-    feature = "time"
+    feature = "time",
+    all(
+        linux_raw,
+        not(feature = "use-libc-auxv"),
+        not(target_vendor = "mustang"),
+        any(
+            feature = "param",
+            feature = "runtime",
+            feature = "time",
+            target_arch = "x86",
+        )
+    )
 ))]
 mod timespec;
 #[cfg(not(any(windows, target_os = "wasi")))]
-#[cfg(any(feature = "fs", feature = "process", feature = "thread"))]
+#[cfg(any(
+    feature = "fs",
+    feature = "process",
+    feature = "thread",
+    all(
+        linux_raw,
+        not(feature = "use-libc-auxv"),
+        not(target_vendor = "mustang"),
+        any(
+            feature = "param",
+            feature = "runtime",
+            feature = "time",
+            target_arch = "x86",
+        )
+    )
+))]
 mod ugid;


### PR DESCRIPTION
When building with --no-default-features, the default use-libc-auxv feature is disabled, and rustix falls back to reading the auxv variables using /proc/self/auxv. This requires some filesystem functions to do, so ensure that the filesystem code is enabled in configurations that need that.

Fixes #706.