### PR TITLE
Use `weakcall` for `eventfd` on FreeBSD.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,3 +13,16 @@ task:
   test_script:
     - . $HOME/.cargo/env
     - cargo test --workspace --features=all-apis
+
+task:
+  name: stable x86_64-unknown-freebsd-12
+  freebsd_instance:
+    image_family: freebsd-12-1
+  setup_script:
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh --default-toolchain stable -y --profile=minimal
+    - . $HOME/.cargo/env
+    - rustup default stable
+  test_script:
+    - . $HOME/.cargo/env
+    - cargo test --workspace --features=all-apis

--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -33,7 +33,19 @@ pub(crate) fn eventfd(initval: u32, flags: EventfdFlags) -> io::Result<OwnedFd> 
         ret_owned_fd(eventfd2(initval, bitflags_bits!(flags)))
     }
 
-    #[cfg(any(target_os = "freebsd", target_os = "illumos"))]
+    // `eventfd` was added in FreeBSD 13, so it isn't available on FreeBSD 12.
+    #[cfg(target_os = "freebsd")]
+    unsafe {
+        weakcall! {
+            fn eventfd(
+                initval: c::c_uint,
+                flags: c::c_int
+            ) -> c::c_int
+        }
+        ret_owned_fd(eventfd(initval, bitflags_bits!(flags)))
+    }
+
+    #[cfg(target_os = "illumos")]
     unsafe {
         ret_owned_fd(c::eventfd(initval, bitflags_bits!(flags)))
     }

--- a/tests/pty/openpty.rs
+++ b/tests/pty/openpty.rs
@@ -1,72 +1,76 @@
 use rustix::fs::{openat, Mode, OFlags, CWD};
 use rustix::pty::*;
 use std::fs::File;
-use std::io;
 use std::io::{Read, Write};
 
 #[test]
-fn openpty_basic() -> io::Result<()> {
+fn openpty_basic() {
     // Use `CLOEXEC` if we can.
     #[cfg(any(linux_kernel, target_os = "freebsd", target_os = "netbsd"))]
     let flags = OpenptFlags::RDWR | OpenptFlags::NOCTTY | OpenptFlags::CLOEXEC;
     #[cfg(not(any(linux_kernel, target_os = "freebsd", target_os = "netbsd")))]
     let flags = OpenptFlags::RDWR | OpenptFlags::NOCTTY;
 
-    let controller = openpt(flags)?;
+    let controller = openpt(flags).unwrap();
 
-    grantpt(&controller)?;
-    unlockpt(&controller)?;
+    grantpt(&controller).unwrap();
+    unlockpt(&controller).unwrap();
 
-    let name = ptsname(&controller, Vec::new())?;
+    let name = match ptsname(&controller, Vec::new()) {
+        Ok(name) => name,
+        #[cfg(target_os = "freebsd")]
+        Err(rustix::io::Errno::NOSYS) => return, // FreeBSD 12 doesn't support this
+        Err(err) => Err(err).unwrap(),
+    };
     let user = openat(
         CWD,
         name,
         OFlags::RDWR | OFlags::NOCTTY | OFlags::CLOEXEC,
         Mode::empty(),
-    )?;
+    )
+    .unwrap();
 
     let mut controller = File::from(controller);
     let mut user = File::from(user);
 
     // The '\x04' is Ctrl-D, the default EOF control code.
-    controller.write_all(b"Hello, world!\n\x04")?;
+    controller.write_all(b"Hello, world!\n\x04").unwrap();
 
     let mut s = String::new();
-    user.read_to_string(&mut s)?;
+    user.read_to_string(&mut s).unwrap();
 
     assert_eq!(s, "Hello, world!\n");
-    Ok(())
 }
 
 // Like `openpty_basic` but use `ioctl_tiocgptpeer` instead of `ptsname`.
 #[cfg(target_os = "linux")]
 #[test]
-fn openpty_get_peer() -> io::Result<()> {
+fn openpty_get_peer() {
     // Use `CLOEXEC` if we can.
     #[cfg(any(linux_kernel, target_os = "freebsd", target_os = "netbsd"))]
     let flags = OpenptFlags::RDWR | OpenptFlags::NOCTTY | OpenptFlags::CLOEXEC;
     #[cfg(not(any(linux_kernel, target_os = "freebsd", target_os = "netbsd")))]
     let flags = OpenptFlags::RDWR | OpenptFlags::NOCTTY;
 
-    let controller = openpt(flags)?;
+    let controller = openpt(flags).unwrap();
 
-    grantpt(&controller)?;
-    unlockpt(&controller)?;
+    grantpt(&controller).unwrap();
+    unlockpt(&controller).unwrap();
 
     let user = ioctl_tiocgptpeer(
         &controller,
         OpenptFlags::RDWR | OpenptFlags::NOCTTY | OpenptFlags::CLOEXEC,
-    )?;
+    )
+    .unwrap();
 
     let mut controller = File::from(controller);
     let mut user = File::from(user);
 
     // The '\x04' is Ctrl-D, the default EOF control code.
-    controller.write_all(b"Hello, world!\n\x04")?;
+    controller.write_all(b"Hello, world!\n\x04").unwrap();
 
     let mut s = String::new();
-    user.read_to_string(&mut s)?;
+    user.read_to_string(&mut s).unwrap();
 
     assert_eq!(s, "Hello, world!\n");
-    Ok(())
 }


### PR DESCRIPTION
`eventfd` was introduced in FreeBSD 13, so it isn't in FreeBSD 12. Use `weakcall` to call it on FreeBSD so that we don't have a link-time dependency on it.

Fixes #716.