### PR TITLE
Use `weakcall` for `eventfd` on FreeBSD.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,3 +13,16 @@ task:
   test_script:
     - . $HOME/.cargo/env
     - cargo test --workspace --features=all-apis
+
+task:
+  name: stable x86_64-unknown-freebsd-12
+  freebsd_instance:
+    image_family: freebsd-12-1
+  setup_script:
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh --default-toolchain stable -y --profile=minimal
+    - . $HOME/.cargo/env
+    - rustup default stable
+  test_script:
+    - . $HOME/.cargo/env
+    - cargo test --workspace --features=all-apis

--- a/src/backend/libc/pty/syscalls.rs
+++ b/src/backend/libc/pty/syscalls.rs
@@ -38,14 +38,18 @@ pub(crate) fn ptsname(fd: BorrowedFd, mut buffer: Vec<u8>) -> io::Result<CString
         // FreeBSD 12 doesn't have `ptsname_r`.
         #[cfg(target_os = "freebsd")]
         let r = unsafe {
-            weakcall! {
+            weak! {
                 fn ptsname_r(
-                     fildes: c::c_int,
-                     buffer: *mut c::c_char,
-                     buflen: c::size_t
+                     c::c_int,
+                     *mut c::c_char,
+                     c::size_t
                 ) -> c::c_int
             }
-            ptsname_r(borrowed_fd(fd), buffer.as_mut_ptr().cast(), buffer.len())
+            if let Some(func) = ptsname_r.get() {
+                func(borrowed_fd(fd), buffer.as_mut_ptr().cast(), buffer.len())
+            } else {
+                libc::ENOSYS
+            }
         };
 
         // MacOS 10.13.4 has `ptsname_r`; use it if we have it, otherwise fall

--- a/src/backend/libc/pty/syscalls.rs
+++ b/src/backend/libc/pty/syscalls.rs
@@ -31,9 +31,22 @@ pub(crate) fn ptsname(fd: BorrowedFd, mut buffer: Vec<u8>) -> io::Result<CString
 
     loop {
         // On platforms with `ptsname_r`, use it.
-        #[cfg(any(target_os = "freebsd", linux_like, target_os = "fuchsia"))]
+        #[cfg(any(linux_like, target_os = "fuchsia"))]
         let r =
             unsafe { libc::ptsname_r(borrowed_fd(fd), buffer.as_mut_ptr().cast(), buffer.len()) };
+
+        // FreeBSD 12 doesn't have `ptsname_r`.
+        #[cfg(target_os = "freebsd")]
+        let r = unsafe {
+            weakcall! {
+                fn ptsname_r(
+                     fildes: c::c_int,
+                     buffer: *mut c::c_char,
+                     buflen: c::size_t
+                ) -> c::c_int
+            }
+            ptsname_r(borrowed_fd(fd), buffer.as_mut_ptr().cast(), buffer.len())
+        };
 
         // MacOS 10.13.4 has `ptsname_r`; use it if we have it, otherwise fall
         // back to calling the underlying ioctl directly.

--- a/tests/io/eventfd.rs
+++ b/tests/io/eventfd.rs
@@ -5,7 +5,12 @@ fn test_eventfd() {
     use std::mem::size_of;
     use std::thread;
 
-    let efd = eventfd(0, EventfdFlags::CLOEXEC).unwrap();
+    let efd = match eventfd(0, EventfdFlags::CLOEXEC) {
+        Ok(efd) => efd,
+        #[cfg(target_os = "freebsd")]
+        Err(rustix::io::Errno::NOSYS) => return, // FreeBSD 12 lacks `eventfd`
+        Err(e) => Err(e).unwrap(),
+    };
 
     let child = thread::spawn(move || {
         for u in [1_u64, 3, 6, 11, 5000].iter() {

--- a/tests/pty/openpty.rs
+++ b/tests/pty/openpty.rs
@@ -1,72 +1,76 @@
 use rustix::fs::{cwd, openat, Mode, OFlags};
 use rustix::pty::*;
 use std::fs::File;
-use std::io;
 use std::io::{Read, Write};
 
 #[test]
-fn openpty_basic() -> io::Result<()> {
+fn openpty_basic() {
     // Use `CLOEXEC` if we can.
     #[cfg(any(linux_kernel, target_os = "freebsd", target_os = "netbsd"))]
     let flags = OpenptFlags::RDWR | OpenptFlags::NOCTTY | OpenptFlags::CLOEXEC;
     #[cfg(not(any(linux_kernel, target_os = "freebsd", target_os = "netbsd")))]
     let flags = OpenptFlags::RDWR | OpenptFlags::NOCTTY;
 
-    let controller = openpt(flags)?;
+    let controller = openpt(flags).unwrap();
 
-    grantpt(&controller)?;
-    unlockpt(&controller)?;
+    grantpt(&controller).unwrap();
+    unlockpt(&controller).unwrap();
 
-    let name = ptsname(&controller, Vec::new())?;
+    let name = match ptsname(&controller, Vec::new()) {
+        Ok(name) => name,
+        #[cfg(target_os = "freebsd")]
+        Err(rustix::io::Errno::NOSYS) => return, // FreeBSD 12 doesn't support this
+        Err(err) => Err(err).unwrap(),
+    };
     let user = openat(
         cwd(),
         name,
         OFlags::RDWR | OFlags::NOCTTY | OFlags::CLOEXEC,
         Mode::empty(),
-    )?;
+    )
+    .unwrap();
 
     let mut controller = File::from(controller);
     let mut user = File::from(user);
 
     // The '\x04' is Ctrl-D, the default EOF control code.
-    controller.write_all(b"Hello, world!\n\x04")?;
+    controller.write_all(b"Hello, world!\n\x04").unwrap();
 
     let mut s = String::new();
-    user.read_to_string(&mut s)?;
+    user.read_to_string(&mut s).unwrap();
 
     assert_eq!(s, "Hello, world!\n");
-    Ok(())
 }
 
 // Like `openpty_basic` but use `ioctl_tiocgptpeer` instead of `ptsname`.
 #[cfg(target_os = "linux")]
 #[test]
-fn openpty_get_peer() -> io::Result<()> {
+fn openpty_get_peer() {
     // Use `CLOEXEC` if we can.
     #[cfg(any(linux_kernel, target_os = "freebsd", target_os = "netbsd"))]
     let flags = OpenptFlags::RDWR | OpenptFlags::NOCTTY | OpenptFlags::CLOEXEC;
     #[cfg(not(any(linux_kernel, target_os = "freebsd", target_os = "netbsd")))]
     let flags = OpenptFlags::RDWR | OpenptFlags::NOCTTY;
 
-    let controller = openpt(flags)?;
+    let controller = openpt(flags).unwrap();
 
-    grantpt(&controller)?;
-    unlockpt(&controller)?;
+    grantpt(&controller).unwrap();
+    unlockpt(&controller).unwrap();
 
     let user = ioctl_tiocgptpeer(
         &controller,
         OpenptFlags::RDWR | OpenptFlags::NOCTTY | OpenptFlags::CLOEXEC,
-    )?;
+    )
+    .unwrap();
 
     let mut controller = File::from(controller);
     let mut user = File::from(user);
 
     // The '\x04' is Ctrl-D, the default EOF control code.
-    controller.write_all(b"Hello, world!\n\x04")?;
+    controller.write_all(b"Hello, world!\n\x04").unwrap();
 
     let mut s = String::new();
-    user.read_to_string(&mut s)?;
+    user.read_to_string(&mut s).unwrap();
 
     assert_eq!(s, "Hello, world!\n");
-    Ok(())
 }


### PR DESCRIPTION
`eventfd` was introduced in FreeBSD 13, so it isn't in FreeBSD 12. Use `weakcall` to call it on FreeBSD so that we don't have a link-time dependency on it.

Fixes #716.