### PR TITLE
Remove `preserves_flags` on 32-bit x86.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
             rust: stable
           - build: nightly
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2023-07-03
           - build: 1.48
             os: ubuntu-latest
             rust: 1.48
@@ -142,7 +142,7 @@ jobs:
         include:
           - build: nightly
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2023-07-03
 
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.
@@ -172,7 +172,7 @@ jobs:
         include:
           - build: nightly
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2023-07-03
 
     steps:
     - uses: actions/checkout@v3
@@ -199,7 +199,7 @@ jobs:
         include:
           - build: nightly
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2023-07-03
 
     steps:
     - uses: actions/checkout@v3
@@ -235,20 +235,20 @@ jobs:
         include:
           - build: ubuntu
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2023-07-03
           - build: ubuntu-20.04
             os: ubuntu-20.04
-            rust: nightly
+            rust: nightly-2023-07-03
           - build: i686-linux
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2023-07-03
             target: i686-unknown-linux-gnu
             gcc_package: gcc-i686-linux-gnu
             gcc: i686-linux-gnu-gcc
             libc_package: libc-dev-i386-cross
           - build: aarch64-linux
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2023-07-03
             target: aarch64-unknown-linux-gnu
             gcc_package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
@@ -257,7 +257,7 @@ jobs:
             qemu_target: aarch64-linux-user
           - build: powerpc64le-linux
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2023-07-03
             target: powerpc64le-unknown-linux-gnu
             gcc_package: gcc-powerpc64le-linux-gnu
             gcc: powerpc64le-linux-gnu-gcc
@@ -266,7 +266,7 @@ jobs:
             qemu_target: ppc64le-linux-user
           - build: mips64el-linux
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2023-07-03
             target: mips64el-unknown-linux-gnuabi64
             gcc_package: gcc-mips64el-linux-gnuabi64
             gcc: mips64el-linux-gnuabi64-gcc
@@ -275,7 +275,7 @@ jobs:
             qemu_target: mips64el-linux-user
           - build: mipsel-linux
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2023-07-03
             target: mipsel-unknown-linux-gnu
             gcc_package: gcc-mipsel-linux-gnu
             gcc: mipsel-linux-gnu-gcc
@@ -284,7 +284,7 @@ jobs:
             qemu_target: mipsel-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2023-07-03
             target: riscv64gc-unknown-linux-gnu
             gcc_package: gcc-riscv64-linux-gnu
             gcc: riscv64-linux-gnu-gcc
@@ -293,7 +293,7 @@ jobs:
             qemu_target: riscv64-linux-user
           - build: s390x-linux
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2023-07-03
             target: s390x-unknown-linux-gnu
             gcc_package: gcc-s390x-linux-gnu
             gcc: s390x-linux-gnu-gcc
@@ -302,7 +302,7 @@ jobs:
             qemu_target: s390x-linux-user
           - build: arm-linux
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2023-07-03
             target: armv5te-unknown-linux-gnueabi
             gcc_package: gcc-arm-linux-gnueabi
             gcc: arm-linux-gnueabi-gcc
@@ -463,10 +463,10 @@ jobs:
             rust: stable
           - build: windows
             os: windows-latest
-            rust: nightly
+            rust: nightly-2023-07-03
           - build: windows-2019
             os: windows-2019
-            rust: nightly
+            rust: nightly-2023-07-03
     steps:
     - uses: actions/checkout@v3
       with:
@@ -726,7 +726,7 @@ jobs:
         include:
           - build: powerpc64le-linux
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2023-07-03
             target: powerpc64le-unknown-linux-gnu
             gcc_package: gcc-powerpc64le-linux-gnu
             gcc: powerpc64le-linux-gnu-gcc
@@ -735,7 +735,7 @@ jobs:
             qemu_target: ppc64le-linux-user
           - build: mips64el-linux
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2023-07-03
             target: mips64el-unknown-linux-gnuabi64
             gcc_package: gcc-mips64el-linux-gnuabi64
             gcc: mips64el-linux-gnuabi64-gcc
@@ -744,7 +744,7 @@ jobs:
             qemu_target: mips64el-linux-user
           - build: mipsel-linux
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2023-07-03
             target: mipsel-unknown-linux-gnu
             gcc_package: gcc-mipsel-linux-gnu
             gcc: mipsel-linux-gnu-gcc

--- a/src/backend/linux_raw/arch/inline/x86.rs
+++ b/src/backend/linux_raw/arch/inline/x86.rs
@@ -5,7 +5,10 @@
 //! instruction.
 //!
 //! Most `rustix` syscalls use the vsyscall mechanism rather than going using
-//! `int 0x80` sequences.
+//! `int 0x80` sequences, as vsyscall is much faster.
+//!
+//! Syscalls made with `int 0x80` preserve the flags register, while syscalls
+//! made using vsyscall do not.
 
 #![allow(dead_code)]
 
@@ -25,7 +28,6 @@ pub(in crate::backend) unsafe fn indirect_syscall0(
         "call {callee}",
         callee = in(reg) callee,
         inlateout("eax") nr.to_asm() => r0,
-        options(preserves_flags)
     );
     FromAsm::from_asm(r0)
 }
@@ -42,7 +44,6 @@ pub(in crate::backend) unsafe fn indirect_syscall1(
         callee = in(reg) callee,
         inlateout("eax") nr.to_asm() => r0,
         in("ebx") a0.to_asm(),
-        options(preserves_flags)
     );
     FromAsm::from_asm(r0)
 }
@@ -76,7 +77,6 @@ pub(in crate::backend) unsafe fn indirect_syscall2(
         inlateout("eax") nr.to_asm() => r0,
         in("ebx") a0.to_asm(),
         in("ecx") a1.to_asm(),
-        options(preserves_flags)
     );
     FromAsm::from_asm(r0)
 }
@@ -97,7 +97,6 @@ pub(in crate::backend) unsafe fn indirect_syscall3(
         in("ebx") a0.to_asm(),
         in("ecx") a1.to_asm(),
         in("edx") a2.to_asm(),
-        options(preserves_flags)
     );
     FromAsm::from_asm(r0)
 }
@@ -128,7 +127,6 @@ pub(in crate::backend) unsafe fn indirect_syscall4(
         in("ebx") a0.to_asm(),
         in("ecx") a1.to_asm(),
         in("edx") a2.to_asm(),
-        options(preserves_flags)
     );
     FromAsm::from_asm(r0)
 }
@@ -161,7 +159,6 @@ pub(in crate::backend) unsafe fn indirect_syscall5(
         in("ecx") a1.to_asm(),
         in("edx") a2.to_asm(),
         in("edi") a4.to_asm(),
-        options(preserves_flags)
     );
     FromAsm::from_asm(r0)
 }
@@ -203,7 +200,6 @@ pub(in crate::backend) unsafe fn indirect_syscall6(
         in("ecx") a1.to_asm(),
         in("edx") a2.to_asm(),
         in("edi") a4.to_asm(),
-        options(preserves_flags)
     );
     FromAsm::from_asm(r0)
 }


### PR DESCRIPTION
The `__kernel_vsyscall` function used on 32-bit x86 does not preserve the flags register, so remove the `preserves_flags` option on inline asm blocks that call it.