### PR TITLE
Use the upstreamed `IPPROTO_ETHERNET` definition.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ once_cell = { version = "1.5.2", optional = true }
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64", target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
 linux-raw-sys = { version = "0.4.3", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 libc_errno = { package = "errno", version = "0.3.1", default-features = false, optional = true }
-libc = { version = "0.2.146", features = ["extra_traits"], optional = true }
+libc = { version = "0.2.147", features = ["extra_traits"], optional = true }
 
 # Dependencies for platforms where only libc is supported:
 #
@@ -48,7 +48,7 @@ libc = { version = "0.2.146", features = ["extra_traits"], optional = true }
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64", target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.1", default-features = false }
-libc = { version = "0.2.146", features = ["extra_traits"] }
+libc = { version = "0.2.147", features = ["extra_traits"] }
 
 # Additional dependencies for Linux with the libc backend:
 #
@@ -76,7 +76,7 @@ default-features = false
 
 [dev-dependencies]
 tempfile = "3.5.0"
-libc = "0.2.146"
+libc = "0.2.147"
 libc_errno = { package = "errno", version = "0.3.1", default-features = false }
 serial_test = "2.0.0"
 memoffset = "0.9.0"

--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -12,10 +12,6 @@ pub(crate) const PROC_SUPER_MAGIC: u32 = 0x0000_9fa0;
 #[cfg(all(linux_kernel, target_env = "musl"))]
 pub(crate) const NFS_SUPER_MAGIC: u32 = 0x0000_6969;
 
-// Submitted upstream in <https://github.com/rust-lang/libc/pull/3272>.
-#[cfg(all(linux_kernel, feature = "net"))]
-pub(crate) const IPPROTO_ETHERNET: c_int = linux_raw_sys::net::IPPROTO_ETHERNET as _;
-
 // TODO: Upstream these.
 #[cfg(all(linux_kernel, feature = "net"))]
 pub(crate) const ETH_P_TSN: c_int = linux_raw_sys::if_ether::ETH_P_TSN as _;


### PR DESCRIPTION
https://github.com/rust-lang/libc/pull/3272 is now released, so remove the custom definition.