### PR TITLE
Miscellaneous cleanups

### DIFF
--- a/src/backend/libc/conv.rs
+++ b/src/backend/libc/conv.rs
@@ -2,8 +2,6 @@
 //! `c_uint`, or libc-specific pointer types. This module provides functions
 //! for converting between rustix's types and libc types.
 
-#![allow(dead_code)]
-
 use super::c;
 use super::fd::{AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, LibcFd, OwnedFd, RawFd};
 #[cfg(not(windows))]
@@ -16,7 +14,7 @@ pub(super) fn c_str(c: &CStr) -> *const c::c_char {
     c.as_ptr()
 }
 
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "wasi")))]
 #[inline]
 pub(super) fn no_fd() -> LibcFd {
     -1
@@ -41,6 +39,7 @@ pub(super) fn ret(raw: c::c_int) -> io::Result<()> {
     }
 }
 
+#[cfg(apple)]
 #[inline]
 pub(super) fn nonnegative_ret(raw: c::c_int) -> io::Result<()> {
     if raw >= 0 {
@@ -50,6 +49,7 @@ pub(super) fn nonnegative_ret(raw: c::c_int) -> io::Result<()> {
     }
 }
 
+#[cfg(not(target_os = "wasi"))]
 #[inline]
 pub(super) unsafe fn ret_infallible(raw: c::c_int) {
     debug_assert_eq!(raw, 0, "unexpected error: {:?}", io::Errno::last_os_error());
@@ -64,6 +64,7 @@ pub(super) fn ret_c_int(raw: c::c_int) -> io::Result<c::c_int> {
     }
 }
 
+#[cfg(linux_kernel)]
 #[inline]
 pub(super) fn ret_u32(raw: c::c_int) -> io::Result<u32> {
     if raw == -1 {
@@ -94,7 +95,7 @@ pub(super) fn ret_off_t(raw: c::off_t) -> io::Result<c::off_t> {
     }
 }
 
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "wasi")))]
 #[inline]
 pub(super) fn ret_pid_t(raw: c::pid_t) -> io::Result<c::pid_t> {
     if raw == -1 {
@@ -119,6 +120,7 @@ pub(super) unsafe fn ret_owned_fd(raw: LibcFd) -> io::Result<OwnedFd> {
     }
 }
 
+#[cfg(not(target_os = "wasi"))]
 #[inline]
 pub(super) fn ret_discarded_fd(raw: LibcFd) -> io::Result<()> {
     if raw == !0 {
@@ -128,6 +130,7 @@ pub(super) fn ret_discarded_fd(raw: LibcFd) -> io::Result<()> {
     }
 }
 
+#[cfg(not(target_os = "wasi"))]
 #[inline]
 pub(super) fn ret_discarded_char_ptr(raw: *mut c::c_char) -> io::Result<()> {
     if raw.is_null() {
@@ -138,7 +141,7 @@ pub(super) fn ret_discarded_char_ptr(raw: *mut c::c_char) -> io::Result<()> {
 }
 
 /// Convert the buffer-length argument value of a `send` or `recv` call.
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "wasi")))]
 #[inline]
 pub(super) fn send_recv_len(len: usize) -> usize {
     len
@@ -155,7 +158,7 @@ pub(super) fn send_recv_len(len: usize) -> i32 {
 }
 
 /// Convert the return value of a `send` or `recv` call.
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "wasi")))]
 #[inline]
 pub(super) fn ret_send_recv(len: isize) -> io::Result<usize> {
     ret_usize(len)

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -1135,6 +1135,7 @@ pub(crate) fn fcntl_add_seals(fd: BorrowedFd<'_>, seals: SealFlags) -> io::Resul
 
 #[cfg(not(any(
     target_os = "emscripten",
+    target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
     target_os = "wasi"

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -256,6 +256,11 @@ pub(crate) fn fcntl_dupfd_cloexec(fd: BorrowedFd<'_>, min: RawFd) -> io::Result<
     unsafe { ret_owned_fd(c::fcntl(borrowed_fd(fd), c::F_DUPFD_CLOEXEC, min)) }
 }
 
+#[cfg(target_os = "espidf")]
+pub(crate) fn fcntl_dupfd(fd: BorrowedFd<'_>, min: RawFd) -> io::Result<OwnedFd> {
+    unsafe { ret_owned_fd(c::fcntl(borrowed_fd(fd), c::F_DUPFD, min)) }
+}
+
 #[cfg(not(target_os = "wasi"))]
 pub(crate) fn dup(fd: BorrowedFd<'_>) -> io::Result<OwnedFd> {
     unsafe { ret_owned_fd(c::dup(borrowed_fd(fd))) }

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -1,8 +1,8 @@
 //! libc syscalls supporting `rustix::io`.
 
-use crate::backend::conv::{
-    borrowed_fd, ret, ret_c_int, ret_discarded_fd, ret_owned_fd, ret_usize,
-};
+#[cfg(not(target_os = "wasi"))]
+use crate::backend::conv::ret_discarded_fd;
+use crate::backend::conv::{borrowed_fd, ret, ret_c_int, ret_owned_fd, ret_usize};
 use crate::backend::{c, MAX_IOV};
 use crate::fd::{AsFd, BorrowedFd, OwnedFd, RawFd};
 #[cfg(not(any(target_os = "aix", target_os = "wasi")))]

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -3,14 +3,16 @@
 #[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
 use super::types::RawCpuSet;
 use crate::backend::c;
+#[cfg(feature = "fs")]
+use crate::backend::conv::c_str;
+#[cfg(all(feature = "fs", not(target_os = "wasi")))]
+use crate::backend::conv::ret_discarded_char_ptr;
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 use crate::backend::conv::ret_infallible;
 #[cfg(linux_kernel)]
 use crate::backend::conv::ret_u32;
 #[cfg(not(target_os = "wasi"))]
 use crate::backend::conv::{borrowed_fd, ret_pid_t, ret_usize};
-#[cfg(feature = "fs")]
-use crate::backend::conv::{c_str, ret_discarded_char_ptr};
 use crate::backend::conv::{ret, ret_c_int};
 #[cfg(not(target_os = "wasi"))]
 use crate::fd::BorrowedFd;

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -5,7 +5,9 @@
 //! See the `rustix::backend::syscalls` module documentation for details.
 
 use crate::backend::c;
-use crate::backend::conv::{borrowed_fd, ret, ret_pid_t};
+#[cfg(not(target_os = "wasi"))]
+use crate::backend::conv::ret_pid_t;
+use crate::backend::conv::{borrowed_fd, ret};
 use crate::fd::BorrowedFd;
 #[cfg(feature = "procfs")]
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -206,9 +206,9 @@ pub(crate) fn seek(fd: BorrowedFd<'_>, pos: SeekFrom) -> io::Result<u64> {
         }
         SeekFrom::End(offset) => (SEEK_END, offset),
         SeekFrom::Current(offset) => (SEEK_CUR, offset),
-        #[cfg(any(freebsdlike, target_os = "linux", target_os = "solaris"))]
+        #[cfg(target_os = "linux")]
         SeekFrom::Data(offset) => (SEEK_DATA, offset),
-        #[cfg(any(freebsdlike, target_os = "linux", target_os = "solaris"))]
+        #[cfg(target_os = "linux")]
         SeekFrom::Hole(offset) => (SEEK_HOLE, offset),
     };
     _seek(fd, offset, whence)

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -26,8 +26,6 @@ use crate::io::{self, DupFlags, FdFlags, IoSlice, IoSliceMut, ReadWriteFlags};
 use crate::net::{RecvFlags, SendFlags};
 use core::cmp;
 use core::mem::MaybeUninit;
-#[cfg(target_os = "espidf")]
-use linux_raw_sys::general::F_DUPFD;
 use linux_raw_sys::general::{F_DUPFD_CLOEXEC, F_GETFD, F_SETFD};
 use linux_raw_sys::ioctl::{FIONBIO, FIONREAD};
 
@@ -400,29 +398,6 @@ pub(crate) fn fcntl_setfd(fd: BorrowedFd<'_>, flags: FdFlags) -> io::Result<()> 
     #[cfg(target_pointer_width = "64")]
     unsafe {
         ret(syscall_readonly!(__NR_fcntl, fd, c_uint(F_SETFD), flags))
-    }
-}
-
-#[cfg(target_os = "espidf")]
-#[inline]
-pub(crate) fn fcntl_dupfd(fd: BorrowedFd<'_>, min: RawFd) -> io::Result<OwnedFd> {
-    #[cfg(target_pointer_width = "32")]
-    unsafe {
-        ret_owned_fd(syscall_readonly!(
-            __NR_fcntl64,
-            fd,
-            c_uint(F_DUPFD),
-            raw_fd(min)
-        ))
-    }
-    #[cfg(target_pointer_width = "64")]
-    unsafe {
-        ret_owned_fd(syscall_readonly!(
-            __NR_fcntl,
-            fd,
-            c_uint(F_DUPFD),
-            raw_fd(min)
-        ))
     }
 }
 

--- a/src/backend/linux_raw/param/libc_auxv.rs
+++ b/src/backend/linux_raw/param/libc_auxv.rs
@@ -41,14 +41,10 @@ extern "C" {
 
 #[cfg(target_os = "android")]
 const _SC_PAGESIZE: c::c_int = 39;
-#[cfg(target_os = "emscripten")]
-const _SC_PAGESIZE: c::c_int = 30;
 #[cfg(target_os = "linux")]
 const _SC_PAGESIZE: c::c_int = 30;
 #[cfg(target_os = "android")]
 const _SC_CLK_TCK: c::c_int = 6;
-#[cfg(target_os = "emscripten")]
-const _SC_CLK_TCK: c::c_int = 2;
 #[cfg(target_os = "linux")]
 const _SC_CLK_TCK: c::c_int = 2;
 

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -33,7 +33,6 @@ use linux_raw_sys::general::{
     RLIM64_INFINITY, RLIM_INFINITY,
 };
 use linux_raw_sys::ioctl::TIOCSCTTY;
-#[cfg(not(target_os = "wasi"))]
 #[cfg(feature = "fs")]
 use {crate::backend::conv::ret_c_uint_infallible, crate::fs::Mode};
 

--- a/src/backend/linux_raw/pty/syscalls.rs
+++ b/src/backend/linux_raw/pty/syscalls.rs
@@ -13,12 +13,10 @@ use crate::ffi::CString;
 use crate::io;
 use crate::path::DecInt;
 use crate::pty::OpenptFlags;
-#[cfg(any(apple, freebsdlike, linux_like, target_os = "fuchsia"))]
 use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 use linux_raw_sys::ioctl::{TIOCGPTN, TIOCGPTPEER, TIOCSPTLCK};
 
-#[cfg(any(apple, freebsdlike, linux_like, target_os = "fuchsia"))]
 #[inline]
 pub(crate) fn ptsname(fd: BorrowedFd, mut buffer: Vec<u8>) -> io::Result<CString> {
     unsafe {

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -573,7 +573,7 @@ pub mod ipproto {
     #[cfg(not(any(solarish, target_os = "haiku")))]
     pub const PIM: Protocol = Protocol(unsafe { RawProtocol::new_unchecked(c::IPPROTO_PIM as _) });
     /// `IPPROTO_COMP`
-    #[cfg(not(any(bsd, solarish, windows, target_os = "haiku")))]
+    #[cfg(not(any(bsd, solarish, windows, target_os = "espidf", target_os = "haiku")))]
     pub const COMP: Protocol =
         Protocol(unsafe { RawProtocol::new_unchecked(c::IPPROTO_COMP as _) });
     /// `IPPROTO_SCTP`


### PR DESCRIPTION
 - Remove an `#[allow(dead_code)]`.
 - Some espidf fixes (though espidf support would need more work).
 - Remove redundant `target_os` checks in the linux_raw directory.