### PR TITLE
Optimize `clock_gettime`.

### DIFF
--- a/tests/time/clocks.rs
+++ b/tests/time/clocks.rs
@@ -1,0 +1,85 @@
+//! Test all the `ClockId` clocks, which should never fail.
+
+#![cfg(not(any(apple, target_os = "wasi")))]
+
+#[cfg(not(any(solarish, target_os = "netbsd", target_os = "redox")))]
+use rustix::time::{clock_gettime, ClockId};
+
+/// Attempt to test that the uptime clock is monotonic. Time may or may not
+/// advance, but it shouldn't regress.
+#[cfg(any(freebsdlike, target_os = "openbsd"))]
+#[test]
+fn test_uptime_clock() {
+    let a = clock_gettime(ClockId::Uptime);
+    let b = clock_gettime(ClockId::Uptime);
+    if b.tv_sec == a.tv_sec {
+        assert!(b.tv_nsec >= a.tv_nsec);
+    } else {
+        assert!(b.tv_sec > a.tv_sec);
+    }
+}
+
+/// Attempt to test that the process CPU-time clock is monotonic. Time may or
+/// may not advance, but it shouldn't regress.
+#[cfg(not(any(solarish, target_os = "netbsd", target_os = "redox")))]
+#[test]
+fn test_process_cputime_clock() {
+    let a = clock_gettime(ClockId::ProcessCPUTime);
+    let b = clock_gettime(ClockId::ProcessCPUTime);
+    if b.tv_sec == a.tv_sec {
+        assert!(b.tv_nsec >= a.tv_nsec);
+    } else {
+        assert!(b.tv_sec > a.tv_sec);
+    }
+}
+
+/// Attempt to test that the thread CPU-time clock is monotonic. Time may or
+/// may not advance, but it shouldn't regress.
+#[cfg(not(any(solarish, target_os = "netbsd", target_os = "redox")))]
+#[test]
+fn test_thread_cputime_clock() {
+    let a = clock_gettime(ClockId::ThreadCPUTime);
+    let b = clock_gettime(ClockId::ThreadCPUTime);
+    if b.tv_sec == a.tv_sec {
+        assert!(b.tv_nsec >= a.tv_nsec);
+    } else {
+        assert!(b.tv_sec > a.tv_sec);
+    }
+}
+
+#[cfg(any(linux_kernel, target_os = "freebsd"))]
+#[test]
+fn test_realtime_coarse_clock() {
+    let a = clock_gettime(ClockId::RealtimeCoarse);
+
+    // Test that the timespec is valid; there's not much else we can say.
+    assert!(a.tv_nsec < 1_000_000_000);
+}
+
+/// Attempt to test that the coarse monotonic clock is monotonic. Time may or
+/// may not advance, but it shouldn't regress.
+#[cfg(any(linux_kernel, target_os = "freebsd"))]
+#[test]
+fn test_monotonic_coarse_clock() {
+    let a = clock_gettime(ClockId::MonotonicCoarse);
+    let b = clock_gettime(ClockId::MonotonicCoarse);
+    if b.tv_sec == a.tv_sec {
+        assert!(b.tv_nsec >= a.tv_nsec);
+    } else {
+        assert!(b.tv_sec > a.tv_sec);
+    }
+}
+
+/// Attempt to test that the raw monotonic clock is monotonic. Time may or
+/// may not advance, but it shouldn't regress.
+#[cfg(linux_kernel)]
+#[test]
+fn test_monotonic_raw_clock() {
+    let a = clock_gettime(ClockId::MonotonicRaw);
+    let b = clock_gettime(ClockId::MonotonicRaw);
+    if b.tv_sec == a.tv_sec {
+        assert!(b.tv_nsec >= a.tv_nsec);
+    } else {
+        assert!(b.tv_sec > a.tv_sec);
+    }
+}

--- a/tests/time/main.rs
+++ b/tests/time/main.rs
@@ -3,6 +3,7 @@
 #![cfg(feature = "time")]
 #![cfg(not(any(windows, target_os = "espidf")))]
 
+mod clocks;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 mod dynamic_clocks;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]


### PR DESCRIPTION
Mark `init_clock` and `init_syscall` (for 32-bit x86) as `#[cold]` so that the compiler moves calls to them out of line.

Also, add tests for all the infallible clocks.