### PR TITLE
`uname` can return any non-negative value on POSIX.

### DIFF
--- a/src/backend/libc/system/syscalls.rs
+++ b/src/backend/libc/system/syscalls.rs
@@ -20,7 +20,15 @@ use {crate::backend::conv::ret, crate::io};
 pub(crate) fn uname() -> RawUname {
     let mut uname = MaybeUninit::<RawUname>::uninit();
     unsafe {
-        ret_infallible(c::uname(uname.as_mut_ptr()));
+        let r = c::uname(uname.as_mut_ptr());
+
+        // On POSIX, `uname` is documented to return non-negative on success
+        // instead of the usual 0, though some specific systems do document
+        // that they always use zero allowing us to skip this check.
+        #[cfg(not(any(apple, freebsdlike, linux_like, target_os = "netbsd")))]
+        let r = core::cmp::min(r, 0);
+
+        ret_infallible(r);
         uname.assume_init()
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -21,9 +21,23 @@ pub use backend::system::types::Sysinfo;
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
+///  - [Apple]
+///  - [NetBSD]
+///  - [FreeBSD]
+///  - [OpenBSD]
+///  - [DragonFly BSD]
+///  - [illumos]
+///  - [glibc]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/uname.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/uname.2.html
+/// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/uname.3.html
+/// [NetBSD]: https://man.netbsd.org/uname.3
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=uname&sektion=3
+/// [OpenBSD]: https://man.openbsd.org/uname.3
+/// [DragonFly BSD]: https://man.dragonflybsd.org/?command=uname&section=3
+/// [illumos]: https://illumos.org/man/2/uname
+/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Platform-Type.html
 #[inline]
 pub fn uname() -> Uname {
     Uname(backend::system::syscalls::uname())


### PR DESCRIPTION
POSIX specifies that `uname` can return any non-negative value on success, though some specific platforms guarantee that it's always zero.

Also, add more documentation links for `uname`.