### PR TITLE
Convert `assert_eq`+`size_of` asserts to `static_assertions`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ libc_errno = { package = "errno", version = "0.3.1", default-features = false }
 serial_test = "2.0.0"
 memoffset = "0.9.0"
 flate2 = "1.0"
+static_assertions = "1.1.0"
 
 [target.'cfg(all(criterion, not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]
 criterion = "0.4"

--- a/build.rs
+++ b/build.rs
@@ -126,6 +126,10 @@ fn main() {
         use_feature_or_nothing("wasi_ext");
     }
 
+    if use_static_assertions() {
+        use_feature("static_assertions");
+    }
+
     println!("cargo:rerun-if-env-changed=CARGO_CFG_RUSTIX_USE_EXPERIMENTAL_ASM");
     println!("cargo:rerun-if-env-changed=CARGO_CFG_RUSTIX_USE_LIBC");
 
@@ -134,6 +138,11 @@ fn main() {
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_USE_LIBC");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_RUSTC_DEP_OF_STD");
     println!("cargo:rerun-if-env-changed=CARGO_CFG_MIRI");
+}
+
+fn use_static_assertions() -> bool {
+    // `offset_from` was made const in Rust 1.65.
+    can_compile("const unsafe fn foo(p: *const u8) -> isize { p.offset_from(p) }")
 }
 
 fn use_thumb_mode() -> bool {

--- a/src/backend/libc/fs/dir.rs
+++ b/src/backend/libc/fs/dir.rs
@@ -249,11 +249,13 @@ struct libc_dirent {
 #[cfg(target_os = "openbsd")]
 fn check_dirent_layout(dirent: &c::dirent) {
     use crate::utils::as_ptr;
-    use core::mem::{align_of, size_of};
 
     // Check that the basic layouts match.
-    assert_eq!(size_of::<libc_dirent>(), size_of::<c::dirent>());
-    assert_eq!(align_of::<libc_dirent>(), align_of::<c::dirent>());
+    #[cfg(test)]
+    {
+        assert_eq_size!(libc_dirent, c::dirent);
+        assert_eq_size!(libc_dirent, c::dirent);
+    }
 
     // Check that the field offsets match.
     assert_eq!(

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -1060,7 +1060,8 @@ pub(crate) fn copy_file_range(
         ) via SYS_copy_file_range -> c::ssize_t
     }
 
-    assert_eq!(size_of::<c::loff_t>(), size_of::<u64>());
+    #[cfg(test)]
+    assert_eq_size!(c::loff_t, u64);
 
     let mut off_in_val: c::loff_t = 0;
     let mut off_out_val: c::loff_t = 0;

--- a/src/backend/libc/pipe/types.rs
+++ b/src/backend/libc/pipe/types.rs
@@ -87,9 +87,8 @@ impl<'a> IoSliceRaw<'a> {
 #[cfg(not(any(apple, target_os = "wasi")))]
 #[test]
 fn test_types() {
-    use core::mem::size_of;
-    assert_eq!(size_of::<PipeFlags>(), size_of::<c::c_int>());
+    assert_eq_size!(PipeFlags, c::c_int);
 
     #[cfg(linux_kernel)]
-    assert_eq!(size_of::<SpliceFlags>(), size_of::<c::c_int>());
+    assert_eq_size!(SpliceFlags, c::c_int);
 }

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -67,6 +67,8 @@ pub(crate) fn tcgetattr(fd: BorrowedFd<'_>) -> io::Result<Termios> {
     unsafe {
         let mut result = MaybeUninit::<Termios>::uninit();
 
+        // `result` is a `Termios` which starts with the same layout as
+        // `libc::termios`, so we can cast the pointer.
         ret(c::tcgetattr(borrowed_fd(fd), result.as_mut_ptr().cast()))?;
 
         Ok(result.assume_init())

--- a/src/backend/libc/time/types.rs
+++ b/src/backend/libc/time/types.rs
@@ -179,7 +179,6 @@ pub enum TimerfdClockId {
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[test]
 fn test_types() {
-    use core::mem::size_of;
-    assert_eq!(size_of::<TimerfdFlags>(), size_of::<c::c_int>());
-    assert_eq!(size_of::<TimerfdTimerFlags>(), size_of::<c::c_int>());
+    assert_eq_size!(TimerfdFlags, c::c_int);
+    assert_eq_size!(TimerfdTimerFlags, c::c_int);
 }

--- a/src/check_types.rs
+++ b/src/check_types.rs
@@ -3,16 +3,8 @@
 /// Check that the size and alignment of a type match the `sys` bindings.
 macro_rules! check_type {
     ($struct:ident) => {
-        assert_eq!(
-            (
-                core::mem::size_of::<$struct>(),
-                core::mem::align_of::<$struct>()
-            ),
-            (
-                core::mem::size_of::<c::$struct>(),
-                core::mem::align_of::<c::$struct>()
-            )
-        );
+        assert_eq_size!($struct, c::$struct);
+        assert_eq_align!($struct, c::$struct);
     };
 }
 
@@ -20,13 +12,8 @@ macro_rules! check_type {
 /// renamed to avoid having types like `bindgen_ty_1` in the API.
 macro_rules! check_renamed_type {
     ($to:ident, $from:ident) => {
-        assert_eq!(
-            (core::mem::size_of::<$to>(), core::mem::align_of::<$to>()),
-            (
-                core::mem::size_of::<c::$from>(),
-                core::mem::align_of::<c::$from>()
-            )
-        );
+        assert_eq_size!($to, c::$from);
+        assert_eq_align!($to, c::$from);
     };
 }
 
@@ -34,15 +21,16 @@ macro_rules! check_renamed_type {
 /// corresponding field in the `sys` bindings.
 macro_rules! check_struct_field {
     ($struct:ident, $field:ident) => {
+        const_assert_eq!(
+            memoffset::offset_of!($struct, $field),
+            memoffset::offset_of!(c::$struct, $field)
+        );
+
+        // This can't use `const_assert_eq` because `span_of` returns a
+        // `Range`, which can't be compared in const contexts.
         assert_eq!(
-            (
-                memoffset::offset_of!($struct, $field),
-                memoffset::span_of!($struct, $field)
-            ),
-            (
-                memoffset::offset_of!(c::$struct, $field),
-                memoffset::span_of!(c::$struct, $field)
-            )
+            memoffset::span_of!($struct, $field),
+            memoffset::span_of!(c::$struct, $field)
         );
     };
 }
@@ -51,15 +39,15 @@ macro_rules! check_struct_field {
 /// we've renamed to avoid having types like `bindgen_ty_1` in the API.
 macro_rules! check_struct_renamed_field {
     ($struct:ident, $to:ident, $from:ident) => {
+        const_assert_eq!(
+            memoffset::offset_of!($struct, $to),
+            memoffset::offset_of!(c::$struct, $from)
+        );
+
+        // As above, this can't use `const_assert_eq`.
         assert_eq!(
-            (
-                memoffset::offset_of!($struct, $to),
-                memoffset::span_of!($struct, $to)
-            ),
-            (
-                memoffset::offset_of!(c::$struct, $from),
-                memoffset::span_of!(c::$struct, $from)
-            )
+            memoffset::span_of!($struct, $to),
+            memoffset::span_of!(c::$struct, $from)
         );
     };
 }
@@ -68,15 +56,15 @@ macro_rules! check_struct_renamed_field {
 /// and a field are renamed.
 macro_rules! check_renamed_struct_renamed_field {
     ($to_struct:ident, $from_struct:ident, $to:ident, $from:ident) => {
+        const_assert_eq!(
+            memoffset::offset_of!($to_struct, $to),
+            memoffset::offset_of!(c::$from_struct, $from)
+        );
+
+        // As above, this can't use `const_assert_eq`.
         assert_eq!(
-            (
-                memoffset::offset_of!($to_struct, $to),
-                memoffset::span_of!($to_struct, $to)
-            ),
-            (
-                memoffset::offset_of!(c::$from_struct, $from),
-                memoffset::span_of!(c::$from_struct, $from)
-            )
+            memoffset::span_of!($to_struct, $to),
+            memoffset::span_of!(c::$from_struct, $from)
         );
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,11 @@
 #[cfg(not(feature = "rustc-dep-of-std"))]
 extern crate alloc;
 
+#[cfg(test)]
+#[macro_use]
+#[allow(unused_imports)]
+extern crate static_assertions;
+
 // Internal utilities.
 #[cfg(not(windows))]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,10 +123,15 @@
 #[cfg(not(feature = "rustc-dep-of-std"))]
 extern crate alloc;
 
-#[cfg(test)]
+// Use `static_assertions` macros if we have them, or a polyfill otherwise.
+#[cfg(all(test, static_assertions))]
 #[macro_use]
 #[allow(unused_imports)]
 extern crate static_assertions;
+#[cfg(all(test, not(static_assertions)))]
+#[macro_use]
+#[allow(unused_imports)]
+mod static_assertions;
 
 // Internal utilities.
 #[cfg(not(windows))]

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -1632,9 +1632,8 @@ pub fn get_tcp_nodelay<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
 #[test]
 fn test_sizes() {
     use c::c_int;
-    use core::mem::size_of;
 
     // Backend code needs to cast these to `c_int` so make sure that cast
     // isn't lossy.
-    assert_eq!(size_of::<Timeout>(), size_of::<c_int>());
+    assert_eq_size!(Timeout, c_int);
 }

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1373,17 +1373,17 @@ bitflags! {
 #[test]
 fn test_sizes() {
     use c::c_int;
-    use core::mem::{size_of, transmute};
+    use core::mem::transmute;
 
     // Backend code needs to cast these to `c_int` so make sure that cast
     // isn't lossy.
-    assert_eq!(size_of::<RawProtocol>(), size_of::<c_int>());
-    assert_eq!(size_of::<Protocol>(), size_of::<c_int>());
-    assert_eq!(size_of::<Option<RawProtocol>>(), size_of::<c_int>());
-    assert_eq!(size_of::<Option<Protocol>>(), size_of::<c_int>());
-    assert_eq!(size_of::<RawSocketType>(), size_of::<c_int>());
-    assert_eq!(size_of::<SocketType>(), size_of::<c_int>());
-    assert_eq!(size_of::<SocketFlags>(), size_of::<c_int>());
+    assert_eq_size!(RawProtocol, c_int);
+    assert_eq_size!(Protocol, c_int);
+    assert_eq_size!(Option<RawProtocol>, c_int);
+    assert_eq_size!(Option<Protocol>, c_int);
+    assert_eq_size!(RawSocketType, c_int);
+    assert_eq_size!(SocketType, c_int);
+    assert_eq_size!(SocketFlags, c_int);
 
     // Rustix doesn't depend on `Option<Protocol>` matching the ABI of
     // a raw integer for correctness, but it should work nonetheless.

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -86,11 +86,11 @@ impl Pid {
 
 #[test]
 fn test_sizes() {
-    use core::mem::{size_of, transmute};
+    use core::mem::transmute;
 
-    assert_eq!(size_of::<RawPid>(), size_of::<NonZeroI32>());
-    assert_eq!(size_of::<RawPid>(), size_of::<Pid>());
-    assert_eq!(size_of::<RawPid>(), size_of::<Option<Pid>>());
+    assert_eq_size!(RawPid, NonZeroI32);
+    assert_eq_size!(RawPid, Pid);
+    assert_eq_size!(RawPid, Option<Pid>);
 
     // Rustix doesn't depend on `Option<Pid>` matching the ABI of a raw integer
     // for correctness, but it should work nonetheless.

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -208,7 +208,5 @@ impl Signal {
 
 #[test]
 fn test_sizes() {
-    use core::mem::size_of;
-
-    assert_eq!(size_of::<Signal>(), size_of::<c::c_int>());
+    assert_eq_size!(Signal, c::c_int);
 }

--- a/src/static_assertions.rs
+++ b/src/static_assertions.rs
@@ -1,0 +1,37 @@
+//! Workarounds for Rust 1.63 where some things in the `static_assertions`
+//! crate do things that don't work in const contexts. We want to call them
+//! in const contexts in Rust versions where that's supported so that
+//! problems are caught at compile time, and fall back to dynamic asserts
+//! in Rust 1.63.
+
+#![allow(unused_macros)]
+
+macro_rules! assert_eq_size {
+    ($x:ty, $y:ty) => {
+        assert_eq!(core::mem::size_of::<$x>(), core::mem::size_of::<$y>());
+    };
+}
+
+macro_rules! assert_eq_align {
+    ($x:ty, $y:ty) => {
+        assert_eq!(core::mem::align_of::<$x>(), core::mem::align_of::<$y>());
+    };
+}
+
+macro_rules! const_assert_eq {
+    ($x:expr, $y:expr) => {
+        assert_eq!($x, $y);
+    };
+}
+
+macro_rules! const_assert_ne {
+    ($x:expr, $y:expr) => {
+        assert_ne!($x, $y);
+    };
+}
+
+macro_rules! const_assert {
+    ($x:expr) => {
+        assert!($x);
+    };
+}

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -1338,7 +1338,12 @@ fn termios_layouts() {
 }
 
 #[test]
-#[cfg(not(any(solarish, target_os = "emscripten", target_os = "redox")))]
+#[cfg(not(any(
+    solarish,
+    target_os = "emscripten",
+    target_os = "haiku",
+    target_os = "redox"
+)))]
 fn termios_legacy() {
     // Check that our doc aliases above are correct.
     assert_eq!(c::EXTA, c::B19200);

--- a/src/ugid.rs
+++ b/src/ugid.rs
@@ -93,8 +93,6 @@ pub(crate) fn translate_fchown_args(owner: Option<Uid>, group: Option<Gid>) -> (
 
 #[test]
 fn test_sizes() {
-    use core::mem::size_of;
-
-    assert_eq!(size_of::<RawUid>(), size_of::<u32>());
-    assert_eq!(size_of::<RawGid>(), size_of::<u32>());
+    assert_eq_size!(RawUid, u32);
+    assert_eq_size!(RawGid, u32);
 }


### PR DESCRIPTION
Convert `assert_eq` asserts using `size_of` and `align_of` to use `static_assertions`' `assert_eq_size` and `assert_eq_align`, so that they're checked at compile time instead of runtime, and adjust the layout of the `Termios` struct to fix some differences with the libc `termios` on some platforms.