### PR TITLE
`recvmsg` requires the pointer to be either valid or NULL on Solarish.

### DIFF
--- a/src/net/send_recv/msg.rs
+++ b/src/net/send_recv/msg.rs
@@ -107,11 +107,15 @@ impl<'buf, 'slice, 'fd> SendAncillaryBuffer<'buf, 'slice, 'fd> {
 
     /// Returns a pointer to the message data.
     pub(crate) fn as_control_ptr(&mut self) -> *mut u8 {
-        if self.length > 0 {
-            self.buffer.as_mut_ptr()
-        } else {
-            ptr::null_mut()
+        // When the length is zero, we may be using a `&[]` address, which
+        // may be an invalid but non-null pointer, and on some platforms, that
+        // causes `sendmsg` to fail with `EFAULT` or `EINVAL`
+        #[cfg(not(linux_kernel))]
+        if self.length == 0 {
+            return core::ptr::null_mut();
         }
+
+        self.buffer.as_mut_ptr()
     }
 
     /// Returns the length of the message data.
@@ -223,6 +227,14 @@ impl<'buf> RecvAncillaryBuffer<'buf> {
 
     /// Returns a pointer to the message data.
     pub(crate) fn as_control_ptr(&mut self) -> *mut u8 {
+        // When the length is zero, we may be using a `&[]` address, which
+        // may be an invalid but non-null pointer, and on some platforms, that
+        // causes `sendmsg` to fail with `EFAULT` or `EINVAL`
+        #[cfg(not(linux_kernel))]
+        if self.buffer.is_empty() {
+            return core::ptr::null_mut();
+        }
+
         self.buffer.as_mut_ptr()
     }
 


### PR DESCRIPTION
When passing the address of a `&[]` slice to `recvmsg`, substitute in NULL so that it doesn't fail with `EFAULT`, on Solarish platforms.