### PR TITLE
Fix some test failures on illumos.

### DIFF
--- a/src/mm/mmap.rs
+++ b/src/mm/mmap.rs
@@ -222,7 +222,8 @@ pub unsafe fn mprotect(ptr: *mut c_void, len: usize, flags: MprotectFlags) -> io
 ///
 /// Some implementations implicitly round the memory region out to the nearest
 /// page boundaries, so this function may lock more memory than explicitly
-/// requested if the memory isn't page-aligned.
+/// requested if the memory isn't page-aligned. Other implementations fail if
+/// the memory isn't page-aligned.
 ///
 /// # References
 ///  - [POSIX]

--- a/tests/fs/mknodat.rs
+++ b/tests/fs/mknodat.rs
@@ -8,8 +8,13 @@ fn test_mknodat() {
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(CWD, tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
 
-    // Create a regular file. Not supported on FreeBSD or OpenBSD.
-    #[cfg(not(any(target_os = "freebsd", target_os = "openbsd", target_os = "solaris")))]
+    // Create a regular file. Not supported on FreeBSD, OpenBSD, or illumos.
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "illumos",
+        target_os = "openbsd",
+        target_os = "solaris"
+    )))]
     {
         mknodat(&dir, "foo", FileType::RegularFile, Mode::empty(), 0).unwrap();
         let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();

--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -25,9 +25,9 @@ fn test_sockopts_ipv4() {
     assert!(!rustix::net::sockopt::get_socket_passcred(&s).unwrap());
     assert_ne!(rustix::net::sockopt::get_ip_ttl(&s).unwrap(), 0);
     assert_ne!(rustix::net::sockopt::get_ip_ttl(&s).unwrap(), 77);
-    #[cfg(not(any(bsd, windows)))]
+    #[cfg(not(any(bsd, windows, target_os = "illumos")))]
     assert!(rustix::net::sockopt::get_ip_multicast_loop(&s).unwrap());
-    #[cfg(not(any(bsd, windows)))]
+    #[cfg(not(any(bsd, windows, target_os = "illumos")))]
     assert_eq!(rustix::net::sockopt::get_ip_multicast_ttl(&s).unwrap(), 1);
     assert!(!rustix::net::sockopt::get_tcp_nodelay(&s).unwrap());
     // On a new socket we shouldn't have an error yet.
@@ -111,7 +111,7 @@ fn test_sockopts_ipv4() {
     // Check the ip ttl.
     assert_eq!(rustix::net::sockopt::get_ip_ttl(&s).unwrap(), 77);
 
-    #[cfg(not(any(bsd, windows)))]
+    #[cfg(not(any(bsd, windows, target_os = "illumos")))]
     {
         // Set the multicast loop flag;
         rustix::net::sockopt::set_ip_multicast_loop(&s, false).unwrap();
@@ -152,6 +152,7 @@ fn test_sockopts_ipv6() {
         Ok(multicast_loop) => assert!(multicast_loop),
         Err(rustix::io::Errno::OPNOTSUPP) => (),
         Err(rustix::io::Errno::INVAL) => (),
+        Err(rustix::io::Errno::NOPROTOOPT) => (),
         Err(err) => Err(err).unwrap(),
     }
     assert_ne!(rustix::net::sockopt::get_ipv6_unicast_hops(&s).unwrap(), 0);
@@ -175,13 +176,12 @@ fn test_sockopts_ipv6() {
             // Check that the IPV6 multicast loop value is set.
             match rustix::net::sockopt::get_ipv6_multicast_loop(&s) {
                 Ok(multicast_loop) => assert!(!multicast_loop),
-                Err(rustix::io::Errno::OPNOTSUPP) => (),
-                Err(rustix::io::Errno::INVAL) => (),
                 Err(err) => Err(err).unwrap(),
             }
         }
         Err(rustix::io::Errno::OPNOTSUPP) => (),
         Err(rustix::io::Errno::INVAL) => (),
+        Err(rustix::io::Errno::NOPROTOOPT) => (),
         Err(err) => Err(err).unwrap(),
     }
 

--- a/tests/net/unix.rs
+++ b/tests/net/unix.rs
@@ -216,7 +216,8 @@ fn do_test_unix_msg(addr: SocketAddrUnix) {
             );
             // Don't ask me why, but this was seen to fail on FreeBSD.
             // `SocketAddrUnix::path()` returned `None` for some reason.
-            #[cfg(not(target_os = "freebsd"))]
+            // illumos too.
+            #[cfg(not(any(target_os = "freebsd", target_os = "illumos")))]
             assert_eq!(
                 Some(rustix::net::SocketAddrAny::Unix(addr.clone())),
                 result.address

--- a/tests/termios/termios.rs
+++ b/tests/termios/termios.rs
@@ -1,3 +1,6 @@
+// Disable on illumos where `tcgetattr` doesn't appear to support
+// pseudoterminals.
+#[cfg(not(target_os = "illumos"))]
 #[test]
 fn test_termios_speeds() {
     use rustix::pty::*;

--- a/tests/time/settime.rs
+++ b/tests/time/settime.rs
@@ -4,14 +4,14 @@ use rustix::time::{clock_settime, ClockId, Timespec};
 #[test]
 fn test_settime() {
     // Monotonic clocks are never settable.
-    assert_eq!(
-        clock_settime(
-            ClockId::Monotonic,
-            Timespec {
-                tv_sec: 0,
-                tv_nsec: 0
-            }
-        ),
-        Err(io::Errno::INVAL)
-    );
+    match clock_settime(
+        ClockId::Monotonic,
+        Timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        },
+    ) {
+        Err(io::Errno::INVAL | io::Errno::PERM) => (),
+        _otherwise => panic!(),
+    }
 }


### PR DESCRIPTION
`mlock` fails if the memory is not aligned. `tcgetattr` doesn't work on pseudoterminals. A few errno values are different. And disable some tests that are disabled on other platforms too.