### PR TITLE
Add more Linux-specific `mprotect` flags.

### DIFF
--- a/src/backend/libc/mm/types.rs
+++ b/src/backend/libc/mm/types.rs
@@ -40,6 +40,21 @@ bitflags! {
         /// `PROT_GROWSDOWN`
         #[cfg(linux_kernel)]
         const GROWSDOWN = bitcast!(c::PROT_GROWSDOWN);
+        /// `PROT_SEM`
+        #[cfg(linux_kernel)]
+        const SEM = linux_raw_sys::general::PROT_SEM;
+        /// `PROT_BTI`
+        #[cfg(all(linux_kernel, target_arch = "aarch64"))]
+        const BTI = linux_raw_sys::general::PROT_BTI;
+        /// `PROT_MTE`
+        #[cfg(all(linux_kernel, target_arch = "aarch64"))]
+        const MTE = linux_raw_sys::general::PROT_MTE;
+        /// `PROT_SAO`
+        #[cfg(all(linux_kernel, any(target_arch = "powerpc", target_arch = "powerpc64")))]
+        const SAO = linux_raw_sys::general::PROT_SAO;
+        /// `PROT_ADI`
+        #[cfg(all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64")))]
+        const ADI = linux_raw_sys::general::PROT_ADI;
     }
 }
 

--- a/src/backend/linux_raw/mm/types.rs
+++ b/src/backend/linux_raw/mm/types.rs
@@ -38,6 +38,20 @@ bitflags! {
         const GROWSUP = linux_raw_sys::general::PROT_GROWSUP;
         /// `PROT_GROWSDOWN`
         const GROWSDOWN = linux_raw_sys::general::PROT_GROWSDOWN;
+        /// `PROT_SEM`
+        const SEM = linux_raw_sys::general::PROT_SEM;
+        /// `PROT_BTI`
+        #[cfg(target_arch = "aarch64")]
+        const BTI = linux_raw_sys::general::PROT_BTI;
+        /// `PROT_MTE`
+        #[cfg(target_arch = "aarch64")]
+        const MTE = linux_raw_sys::general::PROT_MTE;
+        /// `PROT_SAO`
+        #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
+        const SAO = linux_raw_sys::general::PROT_SAO;
+        /// `PROT_ADI`
+        #[cfg(any(target_arch = "sparc", target_arch = "sparc64"))]
+        const ADI = linux_raw_sys::general::PROT_ADI;
     }
 }
 


### PR DESCRIPTION
Add `PROT_SEM`, `PROT_BTI`, and others.