### PR TITLE
Ensure `Secs` is 64-bit on sparc and android.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -22,9 +22,10 @@ fn main() {
 
     // Gather target information.
     let arch = var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let env = var("CARGO_CFG_TARGET_ENV").unwrap();
     let inline_asm_name = format!("{}/{}.rs", ASM_PATH, arch);
     let inline_asm_name_present = std::fs::metadata(inline_asm_name).is_ok();
-    let target_os = var("CARGO_CFG_TARGET_OS").unwrap();
+    let os = var("CARGO_CFG_TARGET_OS").unwrap();
     let pointer_width = var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap();
     let endian = var("CARGO_CFG_TARGET_ENDIAN").unwrap();
 
@@ -59,15 +60,15 @@ fn main() {
     // For now Android uses the libc backend; in theory it could use the
     // linux_raw backend, but to do that we'll need to figure out how to
     // install the toolchain for it.
-    if feature_use_libc
+    let libc = feature_use_libc
         || cfg_use_libc
-        || target_os != "linux"
+        || os != "linux"
         || !inline_asm_name_present
         || is_unsupported_abi
         || miri
         || ((arch == "powerpc64" || arch == "mips" || arch == "mips64")
-            && !rustix_use_experimental_asm)
-    {
+            && !rustix_use_experimental_asm);
+    if libc {
         // Use the libc backend.
         use_feature("libc");
     } else {
@@ -86,43 +87,52 @@ fn main() {
 
     // Rust's libc crate groups some OS's together which have similar APIs;
     // create similarly-named features to make `cfg` tests more concise.
-    if target_os == "freebsd" || target_os == "dragonfly" {
+    let freebsdlike = os == "freebsd" || os == "dragonfly";
+    if freebsdlike {
         use_feature("freebsdlike");
     }
-    if target_os == "openbsd" || target_os == "netbsd" {
+    let netbsdlike = os == "openbsd" || os == "netbsd";
+    if netbsdlike {
         use_feature("netbsdlike");
     }
-    if target_os == "macos" || target_os == "ios" || target_os == "tvos" || target_os == "watchos" {
+    let apple = os == "macos" || os == "ios" || os == "tvos" || os == "watchos";
+    if apple {
         use_feature("apple");
     }
-    if target_os == "linux"
-        || target_os == "l4re"
-        || target_os == "android"
-        || target_os == "emscripten"
-    {
+    if os == "linux" || os == "l4re" || os == "android" || os == "emscripten" {
         use_feature("linux_like");
     }
-    if target_os == "solaris" || target_os == "illumos" {
+    if os == "solaris" || os == "illumos" {
         use_feature("solarish");
     }
-    if target_os == "macos"
-        || target_os == "ios"
-        || target_os == "tvos"
-        || target_os == "watchos"
-        || target_os == "freebsd"
-        || target_os == "dragonfly"
-        || target_os == "openbsd"
-        || target_os == "netbsd"
-    {
+    if apple || freebsdlike || netbsdlike {
         use_feature("bsd");
     }
 
     // Add some additional common target combinations.
-    if target_os == "android" || target_os == "linux" {
+
+    // Android and "regular" Linux both use the Linux kernel.
+    if os == "android" || os == "linux" {
         use_feature("linux_kernel");
     }
 
-    if target_os == "wasi" {
+    // These platforms have a 32-bit `time_t`.
+    if libc
+        && (arch == "arm"
+            || arch == "mips"
+            || arch == "sparc"
+            || arch == "x86"
+            || (arch == "wasm32" && os == "emscripten"))
+        && (apple
+            || os == "android"
+            || os == "emscripten"
+            || env == "gnu"
+            || (env == "musl" && arch == "x86"))
+    {
+        use_feature("fix_y2038");
+    }
+
+    if os == "wasi" {
         use_feature_or_nothing("wasi_ext");
     }
 

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -1087,9 +1087,15 @@ pub type FsWord = u32;
 pub type FsWord = u64;
 
 /// `__fsword_t`
-// s390x uses `u32` for `statfs` entries, even though `__fsword_t` is `u64`.
-#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+// s390x uses `u32` for `statfs` entries on glibc, even though `__fsword_t` is
+// `u64`.
+#[cfg(all(target_os = "linux", target_arch = "s390x", target_env = "gnu"))]
 pub type FsWord = u32;
+
+/// `__fsword_t`
+// s390x uses `u64` for `statfs` entries on musl.
+#[cfg(all(target_os = "linux", target_arch = "s390x", target_env = "musl"))]
+pub type FsWord = u64;
 
 /// `copyfile_state_t`—State for use with [`fcopyfile`].
 ///

--- a/src/backend/libc/time/types.rs
+++ b/src/backend/libc/time/types.rs
@@ -1,15 +1,10 @@
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 use crate::backend::c;
-#[cfg(all(
-    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
-    target_env = "gnu",
-))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
+#[cfg(fix_y2038)]
 use crate::timespec::LibcTimespec;
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[cfg(all(
-    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
-    target_env = "gnu",
-))]
+#[cfg(fix_y2038)]
 use crate::timespec::Timespec;
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 use bitflags::bitflags;
@@ -20,10 +15,7 @@ use bitflags::bitflags;
 /// [`timerfd_gettime`]: crate::time::timerfd_gettime
 /// [`timerfd_settime`]: crate::time::timerfd_settime
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[cfg(not(all(
-    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
-    target_env = "gnu",
-)))]
+#[cfg(not(fix_y2038))]
 pub type Itimerspec = c::itimerspec;
 
 /// `struct itimerspec` for use with [`timerfd_gettime`] and
@@ -32,10 +24,7 @@ pub type Itimerspec = c::itimerspec;
 /// [`timerfd_gettime`]: crate::time::timerfd_gettime
 /// [`timerfd_settime`]: crate::time::timerfd_settime
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[cfg(all(
-    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
-    target_env = "gnu",
-))]
+#[cfg(fix_y2038)]
 #[allow(missing_docs)]
 #[repr(C)]
 #[derive(Debug, Clone)]
@@ -46,19 +35,13 @@ pub struct Itimerspec {
 
 /// On most platforms, `LibcItimerspec` is just `Itimerspec`.
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[cfg(not(all(
-    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
-    target_env = "gnu",
-)))]
+#[cfg(not(fix_y2038))]
 pub(crate) type LibcItimerspec = Itimerspec;
 
 /// On 32-bit glibc platforms, `LibcTimespec` differs from `Timespec`, so we
 /// define our own struct, with bidirectional `From` impls.
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[cfg(all(
-    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
-    target_env = "gnu",
-))]
+#[cfg(fix_y2038)]
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub(crate) struct LibcItimerspec {
@@ -67,10 +50,7 @@ pub(crate) struct LibcItimerspec {
 }
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[cfg(all(
-    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
-    target_env = "gnu",
-))]
+#[cfg(fix_y2038)]
 impl From<LibcItimerspec> for Itimerspec {
     #[inline]
     fn from(t: LibcItimerspec) -> Self {
@@ -82,10 +62,7 @@ impl From<LibcItimerspec> for Itimerspec {
 }
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[cfg(all(
-    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
-    target_env = "gnu",
-))]
+#[cfg(fix_y2038)]
 impl From<Itimerspec> for LibcItimerspec {
     #[inline]
     fn from(t: Itimerspec) -> Self {

--- a/src/thread/clock.rs
+++ b/src/thread/clock.rs
@@ -5,7 +5,6 @@ pub use crate::timespec::Timespec;
 #[cfg(not(any(
     apple,
     target_os = "dragonfly",
-    target_os = "emscripten",
     target_os = "espidf",
     target_os = "freebsd", // FreeBSD 12 has clock_nanosleep, but libc targets FreeBSD 11.
     target_os = "openbsd",

--- a/src/timespec.rs
+++ b/src/timespec.rs
@@ -4,19 +4,11 @@
 use crate::backend::c;
 
 /// `struct timespec`
-#[cfg(not(all(
-    libc,
-    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
-    target_env = "gnu",
-)))]
+#[cfg(not(fix_y2038))]
 pub type Timespec = c::timespec;
 
 /// `struct timespec`
-#[cfg(all(
-    libc,
-    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
-    target_env = "gnu",
-))]
+#[cfg(fix_y2038)]
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct Timespec {
@@ -28,18 +20,12 @@ pub struct Timespec {
 }
 
 /// A type for the `tv_sec` field of [`Timespec`].
-#[cfg(not(all(
-    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
-    target_env = "gnu",
-)))]
+#[cfg(not(fix_y2038))]
 #[allow(deprecated)]
 pub type Secs = c::time_t;
 
 /// A type for the `tv_sec` field of [`Timespec`].
-#[cfg(all(
-    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
-    target_env = "gnu",
-))]
+#[cfg(fix_y2038)]
 pub type Secs = i64;
 
 /// A type for the `tv_nsec` field of [`Timespec`].
@@ -57,11 +43,7 @@ pub type Nsecs = i64;
 /// On 32-bit glibc platforms, `timespec` has anonymous padding fields, which
 /// Rust doesn't support yet (see `unnamed_fields`), so we define our own
 /// struct with explicit padding, with bidirectional `From` impls.
-#[cfg(all(
-    libc,
-    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
-    target_env = "gnu",
-))]
+#[cfg(fix_y2038)]
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub(crate) struct LibcTimespec {
@@ -76,11 +58,7 @@ pub(crate) struct LibcTimespec {
     padding: core::mem::MaybeUninit<u32>,
 }
 
-#[cfg(all(
-    libc,
-    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
-    target_env = "gnu",
-))]
+#[cfg(fix_y2038)]
 impl From<LibcTimespec> for Timespec {
     #[inline]
     fn from(t: LibcTimespec) -> Self {
@@ -91,11 +69,7 @@ impl From<LibcTimespec> for Timespec {
     }
 }
 
-#[cfg(all(
-    libc,
-    any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
-    target_env = "gnu",
-))]
+#[cfg(fix_y2038)]
 impl From<Timespec> for LibcTimespec {
     #[inline]
     fn from(t: Timespec) -> Self {
@@ -105,4 +79,32 @@ impl From<Timespec> for LibcTimespec {
             padding: core::mem::MaybeUninit::uninit(),
         }
     }
+}
+
+#[test]
+fn test_sizes() {
+    assert_eq_size!(Secs, u64);
+    const_assert!(core::mem::size_of::<Timespec>() >= core::mem::size_of::<(u64, u32)>());
+    const_assert!(core::mem::size_of::<Nsecs>() >= 4);
+
+    let mut t = Timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+
+    // `tv_nsec` needs to be able to hold nanoseconds up to a second.
+    t.tv_nsec = 999_999_999_u32 as _;
+    assert_eq!(t.tv_nsec as u64, 999_999_999_u64);
+
+    // `tv_sec` needs to be able to hold more than 32-bits of seconds.
+    t.tv_sec = 0x1_0000_0000_u64 as _;
+    assert_eq!(t.tv_sec as u64, 0x1_0000_0000_u64);
+}
+
+// Test that our workarounds are needed.
+#[cfg(fix_y2038)]
+#[test]
+#[allow(deprecated)]
+fn test_fix_y2038() {
+    assert_eq_size!(libc::time_t, u32);
 }


### PR DESCRIPTION
This is needed for y2038 compatibility. Factor out the predicate for replacing libc::time_t into a `fix_y2038` config, and add 32-bit sparc and android too it.

Also, add a layout testcase for the `Timespec` type.