### PR TITLE
Fix `test_symlink` on pre-statx Linux kernels.

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -572,7 +572,7 @@ pub(crate) fn lstat(path: &CStr) -> io::Result<Stat> {
             StatxFlags::BASIC_STATS,
         ) {
             Ok(x) => statx_to_stat(x),
-            Err(io::Errno::NOSYS) => statat_old(crate::fs::CWD, path, AtFlags::empty()),
+            Err(io::Errno::NOSYS) => statat_old(crate::fs::CWD, path, AtFlags::SYMLINK_NOFOLLOW),
             Err(err) => Err(err),
         }
     }


### PR DESCRIPTION
Use the correct flags in the `lstat` function to suppress following of symlinks, in the path where `statx` is unavailable.