### PR TITLE
Fix test failures on NetBSD.

### DIFF
--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -34,6 +34,9 @@ fn test_file() {
         Err(err) => Err(err).unwrap(),
     }
 
+    // Check that `SYMLINK_FOLLOW` is rejected. Except on NetBSD which seems
+    // to permit it.
+    #[cfg(not(target_os = "netbsd"))]
     assert_eq!(
         rustix::fs::accessat(
             rustix::fs::CWD,

--- a/tests/fs/makedev.rs
+++ b/tests/fs/makedev.rs
@@ -2,14 +2,16 @@ use rustix::fs::{major, makedev, minor};
 
 #[test]
 fn makedev_roundtrip() {
-    // Apple's, FreeBSD 11's, and DragonFly's `makedev` doesn't handle extra
-    // bits set.
+    // Apple's, FreeBSD 11's, DragonFly's, and NetBSD's `makedev` doesn't
+    // handle extra bits set.
     #[cfg(freebsdlike)]
     let (maj, min) = (0x0000_0026, 0x6564_0061);
-    #[cfg(not(any(apple, freebsdlike)))]
-    let (maj, min) = (0x2324_2526, 0x6564_6361);
     #[cfg(apple)]
     let (maj, min) = (0x0000_0026, 0x0064_6361);
+    #[cfg(target_os = "netbsd")]
+    let (maj, min) = (0x0000_0026, 0x0000_0061);
+    #[cfg(not(any(apple, freebsdlike, target_os = "netbsd")))]
+    let (maj, min) = (0x2324_2526, 0x6564_6361);
 
     let dev = makedev(maj, min);
     assert_eq!(maj, major(dev));

--- a/tests/fs/mknodat.rs
+++ b/tests/fs/mknodat.rs
@@ -8,13 +8,9 @@ fn test_mknodat() {
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(CWD, tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
 
-    // Create a regular file. Not supported on FreeBSD, OpenBSD, or illumos.
-    #[cfg(not(any(
-        target_os = "freebsd",
-        target_os = "illumos",
-        target_os = "openbsd",
-        target_os = "solaris"
-    )))]
+    // Create a regular file. Not supported on FreeBSD, OpenBSD, illumos,
+    // or NetBSD.
+    #[cfg(not(any(solarish, netbsdlike, target_os = "freebsd")))]
     {
         mknodat(&dir, "foo", FileType::RegularFile, Mode::empty(), 0).unwrap();
         let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();

--- a/tests/net/unix.rs
+++ b/tests/net/unix.rs
@@ -216,8 +216,8 @@ fn do_test_unix_msg(addr: SocketAddrUnix) {
             );
             // Don't ask me why, but this was seen to fail on FreeBSD.
             // `SocketAddrUnix::path()` returned `None` for some reason.
-            // illumos too.
-            #[cfg(not(any(target_os = "freebsd", target_os = "illumos")))]
+            // illumos and NetBSD too.
+            #[cfg(not(any(target_os = "freebsd", target_os = "illumos", target_os = "netbsd")))]
             assert_eq!(
                 Some(rustix::net::SocketAddrAny::Unix(addr.clone())),
                 result.address

--- a/tests/thread/clocks.rs
+++ b/tests/thread/clocks.rs
@@ -22,28 +22,28 @@ fn test_invalid_nanosleep() {
         tv_nsec: 1_000_000_000,
     }) {
         NanosleepRelativeResult::Err(io::Errno::INVAL) => (),
-        otherwise => panic!("unexpected resut: {:?}", otherwise),
+        otherwise => panic!("unexpected result: {:?}", otherwise),
     }
     match nanosleep(&Timespec {
         tv_sec: 0,
         tv_nsec: !0,
     }) {
         NanosleepRelativeResult::Err(io::Errno::INVAL) => (),
-        otherwise => panic!("unexpected resut: {:?}", otherwise),
+        otherwise => panic!("unexpected result: {:?}", otherwise),
     }
     match nanosleep(&Timespec {
         tv_sec: !0,
         tv_nsec: 1_000_000_000,
     }) {
         NanosleepRelativeResult::Err(io::Errno::INVAL) => (),
-        otherwise => panic!("unexpected resut: {:?}", otherwise),
+        otherwise => panic!("unexpected result: {:?}", otherwise),
     }
     match nanosleep(&Timespec {
         tv_sec: !0,
         tv_nsec: !0,
     }) {
         NanosleepRelativeResult::Err(io::Errno::INVAL) => (),
-        otherwise => panic!("unexpected resut: {:?}", otherwise),
+        otherwise => panic!("unexpected result: {:?}", otherwise),
     }
 }
 
@@ -56,6 +56,7 @@ fn test_invalid_nanosleep() {
     target_os = "redox",
     target_os = "wasi",
 )))]
+#[cfg(not(target_os = "netbsd"))] // NetBSD doesn't seem to enforce valid timespecs.
 #[test]
 fn test_invalid_nanosleep_absolute() {
     match clock_nanosleep_absolute(
@@ -66,7 +67,7 @@ fn test_invalid_nanosleep_absolute() {
         },
     ) {
         Err(io::Errno::INVAL) => (),
-        otherwise => panic!("unexpected resut: {:?}", otherwise),
+        otherwise => panic!("unexpected result: {:?}", otherwise),
     }
     match clock_nanosleep_absolute(
         ClockId::Monotonic,
@@ -76,7 +77,7 @@ fn test_invalid_nanosleep_absolute() {
         },
     ) {
         Err(io::Errno::INVAL) => (),
-        otherwise => panic!("unexpected resut: {:?}", otherwise),
+        otherwise => panic!("unexpected result: {:?}", otherwise),
     }
     match clock_nanosleep_absolute(
         ClockId::Monotonic,
@@ -86,7 +87,7 @@ fn test_invalid_nanosleep_absolute() {
         },
     ) {
         Err(io::Errno::INVAL) => (),
-        otherwise => panic!("unexpected resut: {:?}", otherwise),
+        otherwise => panic!("unexpected result: {:?}", otherwise),
     }
     match clock_nanosleep_absolute(
         ClockId::Monotonic,
@@ -96,7 +97,7 @@ fn test_invalid_nanosleep_absolute() {
         },
     ) {
         Err(io::Errno::INVAL) => (),
-        otherwise => panic!("unexpected resut: {:?}", otherwise),
+        otherwise => panic!("unexpected result: {:?}", otherwise),
     }
 }
 
@@ -119,7 +120,7 @@ fn test_invalid_nanosleep_relative() {
         },
     ) {
         NanosleepRelativeResult::Err(io::Errno::INVAL) => (),
-        otherwise => panic!("unexpected resut: {:?}", otherwise),
+        otherwise => panic!("unexpected result: {:?}", otherwise),
     }
     match clock_nanosleep_relative(
         ClockId::Monotonic,
@@ -129,7 +130,7 @@ fn test_invalid_nanosleep_relative() {
         },
     ) {
         NanosleepRelativeResult::Err(io::Errno::INVAL) => (),
-        otherwise => panic!("unexpected resut: {:?}", otherwise),
+        otherwise => panic!("unexpected result: {:?}", otherwise),
     }
     match clock_nanosleep_relative(
         ClockId::Monotonic,
@@ -139,7 +140,7 @@ fn test_invalid_nanosleep_relative() {
         },
     ) {
         NanosleepRelativeResult::Err(io::Errno::INVAL) => (),
-        otherwise => panic!("unexpected resut: {:?}", otherwise),
+        otherwise => panic!("unexpected result: {:?}", otherwise),
     }
     match clock_nanosleep_relative(
         ClockId::Monotonic,
@@ -149,7 +150,7 @@ fn test_invalid_nanosleep_relative() {
         },
     ) {
         NanosleepRelativeResult::Err(io::Errno::INVAL) => (),
-        otherwise => panic!("unexpected resut: {:?}", otherwise),
+        otherwise => panic!("unexpected result: {:?}", otherwise),
     }
 }
 
@@ -161,7 +162,7 @@ fn test_zero_nanosleep() {
         tv_nsec: 0,
     }) {
         NanosleepRelativeResult::Ok => (),
-        otherwise => panic!("unexpected resut: {:?}", otherwise),
+        otherwise => panic!("unexpected result: {:?}", otherwise),
     }
 }
 
@@ -184,7 +185,7 @@ fn test_zero_nanosleep_absolute() {
         },
     ) {
         Ok(()) => (),
-        otherwise => panic!("unexpected resut: {:?}", otherwise),
+        otherwise => panic!("unexpected result: {:?}", otherwise),
     }
 }
 
@@ -207,6 +208,6 @@ fn test_zero_nanosleep_relative() {
         },
     ) {
         NanosleepRelativeResult::Ok => (),
-        otherwise => panic!("unexpected resut: {:?}", otherwise),
+        otherwise => panic!("unexpected result: {:?}", otherwise),
     }
 }


### PR DESCRIPTION
Fix test failures on NetBSD, which is mostly adding `target = "netbsd"` for areas where NetBSD is similar to other OS's, though NetBSD does have a few additional special cases; NetBSD doesn't appear to reject `SYMLINK_FOLLOW` on `faccessat`, it doesn't appear to reject invalid timespec values in `clock_nanosleep`, and `get_ipv6_multicasthops` appears to default to 1.