### PR TITLE
Don't use `.unwrap()` or `unimplemented` in examples.

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -34,6 +34,6 @@ fn main() -> std::io::Result<()> {
 }
 
 #[cfg(any(not(feature = "stdio"), not(feature = "std"), windows))]
-fn main() {
-    unimplemented!()
+fn main() -> Result<(), &'static str> {
+    Err("This example requires --features=stdio,std and is not supported on Windows.")
 }

--- a/examples/kq.rs
+++ b/examples/kq.rs
@@ -84,6 +84,6 @@ fn main() -> std::io::Result<()> {
 }
 
 #[cfg(not(all(bsd, feature = "event")))]
-fn main() {
-    unimplemented!()
+fn main() -> Result<(), &'static str> {
+    Err("This example requires --features=event and is only supported on BSD.")
 }

--- a/examples/process.rs
+++ b/examples/process.rs
@@ -16,7 +16,7 @@ fn main() -> io::Result<()> {
     if let Some(ppid) = getppid() {
         println!(
             "Parent Group Pid: {}",
-            getpgid(Some(ppid)).unwrap().as_raw_nonzero()
+            getpgid(Some(ppid))?.as_raw_nonzero()
         );
     }
     println!("Uid: {}", getuid().as_raw());
@@ -91,6 +91,6 @@ fn main() -> io::Result<()> {
 }
 
 #[cfg(any(windows, not(all(feature = "process", feature = "param"))))]
-fn main() -> io::Result<()> {
-    unimplemented!()
+fn main() -> Result<(), &'static str> {
+    Err("This example requires --features=process,param and is not supported on Windows.")
 }

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -343,6 +343,6 @@ fn key(b: u8) -> String {
 }
 
 #[cfg(any(windows, not(feature = "stdio")))]
-fn main() {
-    unimplemented!()
+fn main() -> Result<(), &'static str> {
+    Err("This example requires --features=stdio and is not supported on Windows.")
 }

--- a/examples/termios.rs
+++ b/examples/termios.rs
@@ -44,6 +44,6 @@ fn main() -> std::io::Result<()> {
 }
 
 #[cfg(any(windows, not(feature = "termios")))]
-fn main() {
-    unimplemented!()
+fn main() -> Result<(), &'static str> {
+    Err("This example requires --features=termios and is not supported on Windows.")
 }

--- a/examples/time.rs
+++ b/examples/time.rs
@@ -44,6 +44,6 @@ fn main() {
 }
 
 #[cfg(any(windows, target_os = "espidf", not(feature = "time")))]
-fn main() {
-    unimplemented!()
+fn main() -> Result<(), &'static str> {
+    Err("This example requires --features=time and is not supported on Windows or ESP-IDF.")
 }


### PR DESCRIPTION
Panicking isn't super nice for people who are using the examples to learn their way around.