### PR TITLE
Miscellaneous cleanups

### DIFF
--- a/examples/process.rs
+++ b/examples/process.rs
@@ -1,10 +1,8 @@
 //! A command which prints out information about the process it runs in.
 
-use rustix::io;
-
 #[cfg(all(feature = "process", feature = "param"))]
 #[cfg(not(windows))]
-fn main() -> io::Result<()> {
+fn main() -> rustix::io::Result<()> {
     #[cfg(not(target_os = "espidf"))]
     use rustix::param::*;
     use rustix::process::*;

--- a/src/backend/libc/pipe/syscalls.rs
+++ b/src/backend/libc/pipe/syscalls.rs
@@ -18,7 +18,7 @@ use {
     crate::backend::MAX_IOV,
     crate::fd::BorrowedFd,
     crate::pipe::{IoSliceRaw, SpliceFlags},
-    crate::utils::optional_as_mut_ptr,
+    crate::utils::option_as_mut_ptr,
     core::cmp::min,
 };
 
@@ -62,8 +62,8 @@ pub fn splice(
     len: usize,
     flags: SpliceFlags,
 ) -> io::Result<usize> {
-    let off_in = optional_as_mut_ptr(off_in).cast();
-    let off_out = optional_as_mut_ptr(off_out).cast();
+    let off_in = option_as_mut_ptr(off_in).cast();
+    let off_out = option_as_mut_ptr(off_out).cast();
 
     unsafe {
         ret_usize(c::splice(

--- a/src/backend/linux_raw/param/auxv.rs
+++ b/src/backend/linux_raw/param/auxv.rs
@@ -161,6 +161,7 @@ fn pr_get_auxv() -> crate::io::Result<Vec<u8>> {
 /// On non-Mustang platforms, we read the aux vector via the `prctl`
 /// `PR_GET_AUXV`, with a fallback to /proc/self/auxv for kernels that don't
 /// support `PR_GET_AUXV`.
+#[cold]
 fn init_auxv() {
     match pr_get_auxv() {
         Ok(buffer) => {
@@ -185,6 +186,7 @@ fn init_auxv() {
 }
 
 /// Process auxv entries from the open file `auxv`.
+#[cold]
 fn init_from_auxv_file(auxv: OwnedFd) -> Option<()> {
     let mut buffer = Vec::<u8>::with_capacity(512);
     loop {
@@ -220,6 +222,7 @@ fn init_from_auxv_file(auxv: OwnedFd) -> Option<()> {
 ///
 /// The buffer contains `Elf_aux_t` elements, though it need not be aligned;
 /// function uses `read_unaligned` to read from it.
+#[cold]
 unsafe fn init_from_auxp(mut auxp: *const Elf_auxv_t) -> Option<()> {
     let mut pagesz = 0;
     let mut clktck = 0;
@@ -272,6 +275,7 @@ unsafe fn init_from_auxp(mut auxp: *const Elf_auxv_t) -> Option<()> {
 /// `base` is some value we got from a `AT_BASE` aux record somewhere,
 /// which hopefully holds the value of the program interpreter in memory. Do a
 /// series of checks to be as sure as we can that it's safe to use.
+#[cold]
 unsafe fn check_interpreter_base(base: *const Elf_Ehdr) -> Option<()> {
     check_elf_base(base)?;
     Some(())
@@ -282,6 +286,7 @@ unsafe fn check_interpreter_base(base: *const Elf_Ehdr) -> Option<()> {
 /// `base` is some value we got from a `AT_SYSINFO_EHDR` aux record somewhere,
 /// which hopefully holds the value of the kernel-provided vDSO in memory. Do a
 /// series of checks to be as sure as we can that it's safe to use.
+#[cold]
 unsafe fn check_vdso_base(base: *const Elf_Ehdr) -> Option<NonNull<Elf_Ehdr>> {
     // In theory, we could check that we're not attempting to parse our own ELF
     // image, as an additional check. However, older Linux toolchains don't
@@ -331,6 +336,7 @@ unsafe fn check_vdso_base(base: *const Elf_Ehdr) -> Option<NonNull<Elf_Ehdr>> {
 }
 
 /// Check that `base` is a valid pointer to an ELF image.
+#[cold]
 unsafe fn check_elf_base(base: *const Elf_Ehdr) -> Option<NonNull<Elf_Ehdr>> {
     // If we're reading a 64-bit auxv on a 32-bit platform, we'll see
     // a zero `a_val` because `AT_*` values are never greater than

--- a/src/backend/linux_raw/param/libc_auxv.rs
+++ b/src/backend/linux_raw/param/libc_auxv.rs
@@ -50,14 +50,14 @@ const _SC_CLK_TCK: c::c_int = 2;
 
 #[test]
 fn test_abi() {
-    assert_eq!(self::_SC_PAGESIZE, ::libc::_SC_PAGESIZE);
-    assert_eq!(self::_SC_CLK_TCK, ::libc::_SC_CLK_TCK);
-    assert_eq!(self::AT_PHDR, ::libc::AT_PHDR);
-    assert_eq!(self::AT_PHNUM, ::libc::AT_PHNUM);
-    assert_eq!(self::AT_HWCAP, ::libc::AT_HWCAP);
-    assert_eq!(self::AT_HWCAP2, ::libc::AT_HWCAP2);
-    assert_eq!(self::AT_EXECFN, ::libc::AT_EXECFN);
-    assert_eq!(self::AT_SYSINFO_EHDR, ::libc::AT_SYSINFO_EHDR);
+    const_assert_eq!(self::_SC_PAGESIZE, ::libc::_SC_PAGESIZE);
+    const_assert_eq!(self::_SC_CLK_TCK, ::libc::_SC_CLK_TCK);
+    const_assert_eq!(self::AT_PHDR, ::libc::AT_PHDR);
+    const_assert_eq!(self::AT_PHNUM, ::libc::AT_PHNUM);
+    const_assert_eq!(self::AT_HWCAP, ::libc::AT_HWCAP);
+    const_assert_eq!(self::AT_HWCAP2, ::libc::AT_HWCAP2);
+    const_assert_eq!(self::AT_EXECFN, ::libc::AT_EXECFN);
+    const_assert_eq!(self::AT_SYSINFO_EHDR, ::libc::AT_SYSINFO_EHDR);
 }
 
 #[cfg(feature = "param")]

--- a/src/backend/linux_raw/runtime/syscalls.rs
+++ b/src/backend/linux_raw/runtime/syscalls.rs
@@ -22,7 +22,7 @@ use crate::pid::Pid;
 use crate::runtime::{How, Sigaction, Siginfo, Sigset, Stack};
 use crate::signal::Signal;
 use crate::timespec::Timespec;
-use crate::utils::optional_as_ptr;
+use crate::utils::option_as_ptr;
 use core::mem::MaybeUninit;
 #[cfg(target_pointer_width = "32")]
 use linux_raw_sys::general::__kernel_old_timespec;
@@ -117,7 +117,7 @@ pub(crate) mod tls {
 #[inline]
 pub(crate) unsafe fn sigaction(signal: Signal, new: Option<Sigaction>) -> io::Result<Sigaction> {
     let mut old = MaybeUninit::<Sigaction>::uninit();
-    let new = optional_as_ptr(new.as_ref());
+    let new = option_as_ptr(new.as_ref());
     ret(syscall!(
         __NR_rt_sigaction,
         signal,
@@ -131,7 +131,7 @@ pub(crate) unsafe fn sigaction(signal: Signal, new: Option<Sigaction>) -> io::Re
 #[inline]
 pub(crate) unsafe fn sigaltstack(new: Option<Stack>) -> io::Result<Stack> {
     let mut old = MaybeUninit::<Stack>::uninit();
-    let new = optional_as_ptr(new.as_ref());
+    let new = option_as_ptr(new.as_ref());
     ret(syscall!(__NR_sigaltstack, new, &mut old))?;
     Ok(old.assume_init())
 }
@@ -144,7 +144,7 @@ pub(crate) unsafe fn tkill(tid: Pid, sig: Signal) -> io::Result<()> {
 #[inline]
 pub(crate) unsafe fn sigprocmask(how: How, new: Option<&Sigset>) -> io::Result<Sigset> {
     let mut old = MaybeUninit::<Sigset>::uninit();
-    let new = optional_as_ptr(new);
+    let new = option_as_ptr(new);
     ret(syscall!(
         __NR_rt_sigprocmask,
         how,
@@ -189,7 +189,7 @@ pub(crate) fn sigwaitinfo(set: &Sigset) -> io::Result<Siginfo> {
 #[inline]
 pub(crate) fn sigtimedwait(set: &Sigset, timeout: Option<Timespec>) -> io::Result<Siginfo> {
     let mut info = MaybeUninit::<Siginfo>::uninit();
-    let timeout_ptr = optional_as_ptr(timeout.as_ref());
+    let timeout_ptr = option_as_ptr(timeout.as_ref());
 
     // `rt_sigtimedwait_time64` was introduced in Linux 5.1. The old
     // `rt_sigtimedwait` syscall is not y2038-compatible on 32-bit
@@ -237,7 +237,7 @@ unsafe fn sigtimedwait_old(
         None => None,
     };
 
-    let old_timeout_ptr = optional_as_ptr(old_timeout.as_ref());
+    let old_timeout_ptr = option_as_ptr(old_timeout.as_ref());
 
     let _signum = ret_c_int(syscall!(
         __NR_rt_sigtimedwait,

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -9,13 +9,13 @@
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```
 /// # #[cfg(feature = "fs")]
 /// # fn main() -> rustix::io::Result<()> {
 /// use rustix::cstr;
 /// use rustix::fs::{statat, AtFlags, CWD};
 ///
-/// let metadata = statat(CWD, cstr!("test.txt"), AtFlags::empty())?;
+/// let metadata = statat(CWD, cstr!("Cargo.toml"), AtFlags::empty())?;
 /// # Ok(())
 /// # }
 /// # #[cfg(not(feature = "fs"))]

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -94,11 +94,10 @@ fn test_sizes() {
 
     // Rustix doesn't depend on `Option<Pid>` matching the ABI of a raw integer
     // for correctness, but it should work nonetheless.
-    unsafe {
-        let t: Option<Pid> = None;
-        assert_eq!(0 as RawPid, transmute(t));
-
-        let t: Option<Pid> = Some(Pid::from_raw_unchecked(4567));
-        assert_eq!(4567 as RawPid, transmute(t));
-    }
+    const_assert_eq!(0 as RawPid, unsafe {
+        transmute::<Option<Pid>, RawPid>(None)
+    });
+    const_assert_eq!(4567 as RawPid, unsafe {
+        transmute::<Option<Pid>, RawPid>(Some(Pid::from_raw_unchecked(4567)))
+    });
 }

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -283,14 +283,12 @@ bitflags! {
 
         /// `IUTF8`
         #[cfg(not(any(
+            freebsdlike,
+            netbsdlike,
             solarish,
             target_os = "aix",
-            target_os = "dragonfly",
             target_os = "emscripten",
-            target_os = "freebsd",
             target_os = "haiku",
-            target_os = "netbsd",
-            target_os = "openbsd",
             target_os = "redox",
         )))]
         const IUTF8 = c::IUTF8;
@@ -308,9 +306,8 @@ bitflags! {
         /// `OLCUC`
         #[cfg(not(any(
             apple,
+            freebsdlike,
             target_os = "aix",
-            target_os = "dragonfly",
-            target_os = "freebsd",
             target_os = "netbsd",
             target_os = "redox",
         )))]
@@ -798,7 +795,7 @@ pub mod speed {
     /// Translate from a `c::speed_t` code to an arbitrary integer speed value
     /// `u32`.
     #[cfg(not(any(linux_kernel, bsd)))]
-    pub(crate) fn decode(encoded_speed: c::speed_t) -> Option<u32> {
+    pub(crate) const fn decode(encoded_speed: c::speed_t) -> Option<u32> {
         match encoded_speed {
             c::B0 => Some(0),
             c::B50 => Some(50),
@@ -935,7 +932,7 @@ pub mod speed {
     /// Translate from an arbitrary `u32` arbitrary integer speed value to a
     /// `c::speed_t` code.
     #[cfg(not(bsd))]
-    pub(crate) fn encode(speed: u32) -> Option<c::speed_t> {
+    pub(crate) const fn encode(speed: u32) -> Option<c::speed_t> {
         match speed {
             0 => Some(c::B0),
             50 => Some(c::B50),
@@ -1118,15 +1115,11 @@ impl SpecialCodeIndex {
 
     /// `VSWTC`
     #[cfg(not(any(
-        apple,
+        bsd,
         solarish,
         target_os = "aix",
-        target_os = "dragonfly",
-        target_os = "freebsd",
         target_os = "haiku",
-        target_os = "netbsd",
         target_os = "nto",
-        target_os = "openbsd",
     )))]
     pub const VSWTC: Self = Self(c::VSWTC as usize);
 
@@ -1261,7 +1254,7 @@ fn termios_layouts() {
         // On everything except PowerPC, `termios` matches `termios2` except for
         // the addition of `c_ispeed` and `c_ospeed`.
         #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
-        assert_eq!(
+        const_assert_eq!(
             memoffset::offset_of!(Termios, input_speed),
             core::mem::size_of::<c::termios>()
         );
@@ -1346,8 +1339,8 @@ fn termios_layouts() {
 )))]
 fn termios_legacy() {
     // Check that our doc aliases above are correct.
-    assert_eq!(c::EXTA, c::B19200);
-    assert_eq!(c::EXTB, c::B38400);
+    const_assert_eq!(c::EXTA, c::B19200);
+    const_assert_eq!(c::EXTB, c::B38400);
 }
 
 #[cfg(bsd)]
@@ -1355,10 +1348,10 @@ fn termios_legacy() {
 fn termios_bsd() {
     // On BSD platforms we can assume that the `B*` constants have their
     // arbitrary integer speed value. Confirm this.
-    assert_eq!(c::B0, 0);
-    assert_eq!(c::B50, 50);
-    assert_eq!(c::B19200, 19200);
-    assert_eq!(c::B38400, 38400);
+    const_assert_eq!(c::B0, 0);
+    const_assert_eq!(c::B50, 50);
+    const_assert_eq!(c::B19200, 19200);
+    const_assert_eq!(c::B38400, 38400);
 }
 
 #[test]
@@ -1386,13 +1379,13 @@ fn termios_ioctl_contiguity() {
     // When using `termios2`, we assume that we can add the optional actions
     // value to the ioctl request code. Test this assumption.
 
-    assert_eq!(c::TCSETS2, c::TCSETS2 + 0);
-    assert_eq!(c::TCSETSW2, c::TCSETS2 + 1);
-    assert_eq!(c::TCSETSF2, c::TCSETS2 + 2);
+    const_assert_eq!(c::TCSETS2, c::TCSETS2 + 0);
+    const_assert_eq!(c::TCSETSW2, c::TCSETS2 + 1);
+    const_assert_eq!(c::TCSETSF2, c::TCSETS2 + 2);
 
-    assert_eq!(c::TCSANOW - c::TCSANOW, 0);
-    assert_eq!(c::TCSADRAIN - c::TCSANOW, 1);
-    assert_eq!(c::TCSAFLUSH - c::TCSANOW, 2);
+    const_assert_eq!(c::TCSANOW - c::TCSANOW, 0);
+    const_assert_eq!(c::TCSADRAIN - c::TCSANOW, 1);
+    const_assert_eq!(c::TCSAFLUSH - c::TCSANOW, 2);
 
     // MIPS is different here.
     #[cfg(any(target_arch = "mips", target_arch = "mips64"))]
@@ -1403,9 +1396,9 @@ fn termios_ioctl_contiguity() {
     }
     #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
     {
-        assert_eq!(c::TCSANOW, 0);
-        assert_eq!(c::TCSADRAIN, 1);
-        assert_eq!(c::TCSAFLUSH, 2);
+        const_assert_eq!(c::TCSANOW, 0);
+        const_assert_eq!(c::TCSADRAIN, 1);
+        const_assert_eq!(c::TCSAFLUSH, 2);
     }
 }
 
@@ -1413,5 +1406,5 @@ fn termios_ioctl_contiguity() {
 #[test]
 fn termios_cibaud() {
     // Test an assumption.
-    assert_eq!(c::CIBAUD, c::CBAUD << c::IBSHIFT);
+    const_assert_eq!(c::CIBAUD, c::CBAUD << c::IBSHIFT);
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,7 +18,7 @@ pub(crate) fn as_mut_ptr<T>(t: &mut T) -> *mut T {
 
 /// Convert an `Option<&T>` into a possibly-null `*const T`.
 #[inline]
-pub(crate) const fn optional_as_ptr<T>(t: Option<&T>) -> *const T {
+pub(crate) const fn option_as_ptr<T>(t: Option<&T>) -> *const T {
     match t {
         Some(t) => t,
         None => null(),
@@ -27,7 +27,7 @@ pub(crate) const fn optional_as_ptr<T>(t: Option<&T>) -> *const T {
 
 /// Convert an `Option<&mut T>` into a possibly-null `*mut T`.
 #[inline]
-pub(crate) fn optional_as_mut_ptr<T>(t: Option<&mut T>) -> *mut T {
+pub(crate) fn option_as_mut_ptr<T>(t: Option<&mut T>) -> *mut T {
     match t {
         Some(t) => t,
         None => null_mut(),


### PR DESCRIPTION
 - Fix and re-enable a documentation test.
 - Rename `optional_as_ptr` to `option_as_ptr`.
 - Use the `freebsdlike` and `netbsdlike` configs.
 - Mark auxv one-time initialization functions as `#[cold]`.
 - Convert some asserts to `const_assert`.