### PR TITLE
Detect MIPS R6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ once_cell = { version = "1.5.2", optional = true }
 # addition to the libc backend. The linux_raw backend is used by default. The
 # libc backend can be selected via adding `--cfg=rustix_use_libc` to
 # `RUSTFLAGS` or enabling the `use-libc` cargo feature.
-[target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
+[target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
 linux-raw-sys = { version = "0.4.3", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 libc_errno = { package = "errno", version = "0.3.1", default-features = false, optional = true }
 libc = { version = "0.2.147", features = ["extra_traits"], optional = true }
@@ -44,7 +44,7 @@ libc = { version = "0.2.147", features = ["extra_traits"], optional = true }
 #
 # On all other Unix-family platforms, and under Miri, we always use the libc
 # backend, so enable its dependencies unconditionally.
-[target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
+[target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.1", default-features = false }
 libc = { version = "0.2.147", features = ["extra_traits"] }
 
@@ -52,7 +52,7 @@ libc = { version = "0.2.147", features = ["extra_traits"] }
 #
 # Some syscalls do not have libc wrappers, such as in `io_uring`. For these,
 # the libc backend uses the linux-raw-sys ABI and `libc::syscall`.
-[target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
+[target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 linux-raw-sys = { version = "0.4.3", default-features = false, features = ["general", "ioctl", "no_std"] }
 
 # For the libc backend on Windows, use the Winsock2 API in windows-sys.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ once_cell = { version = "1.5.2", optional = true }
 # addition to the libc backend. The linux_raw backend is used by default. The
 # libc backend can be selected via adding `--cfg=rustix_use_libc` to
 # `RUSTFLAGS` or enabling the `use-libc` cargo feature.
-[target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips64"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
+[target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
 linux-raw-sys = { version = "0.4.3", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 libc_errno = { package = "errno", version = "0.3.1", default-features = false, optional = true }
 libc = { version = "0.2.147", features = ["extra_traits"], optional = true }
@@ -44,7 +44,7 @@ libc = { version = "0.2.147", features = ["extra_traits"], optional = true }
 #
 # On all other Unix-family platforms, and under Miri, we always use the libc
 # backend, so enable its dependencies unconditionally.
-[target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips64"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
+[target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.1", default-features = false }
 libc = { version = "0.2.147", features = ["extra_traits"] }
 
@@ -52,7 +52,7 @@ libc = { version = "0.2.147", features = ["extra_traits"] }
 #
 # Some syscalls do not have libc wrappers, such as in `io_uring`. For these,
 # the libc backend uses the linux-raw-sys ABI and `libc::syscall`.
-[target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips64"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
+[target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 linux-raw-sys = { version = "0.4.3", default-features = false, features = ["general", "ioctl", "no_std"] }
 
 # For the libc backend on Windows, use the Winsock2 API in windows-sys.

--- a/build.rs
+++ b/build.rs
@@ -22,8 +22,8 @@ fn main() {
     let is_x32 = arch == "x86_64" && pointer_width == "32";
     let is_arm64_ilp32 = arch == "aarch64" && pointer_width == "32";
     let is_powerpc64be = arch == "powerpc64" && endian == "big";
-    let is_mipseb = arch == "mips" && endian == "big";
-    let is_mips64eb = arch == "mips64" && endian == "big";
+    let is_mipseb = (arch == "mips" || arch == "mips32r6") && endian == "big";
+    let is_mips64eb = arch.contains("mips64") && endian == "big";
     let is_unsupported_abi = is_x32 || is_arm64_ilp32 || is_powerpc64be || is_mipseb || is_mips64eb;
 
     // Check for `--features=use-libc`. This allows crate users to enable the
@@ -83,7 +83,7 @@ fn main() {
         || !inline_asm_name_present
         || is_unsupported_abi
         || miri
-        || ((arch == "powerpc64" || arch == "mips" || arch == "mips64")
+        || ((arch == "powerpc64" || arch == "mips" || arch == "mips64" || arch == "mips64r6")
             && !rustix_use_experimental_asm);
     if libc {
         // Use the libc backend.

--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -62,6 +62,7 @@ pub(crate) const ETH_P_MCTP: c_int = linux_raw_sys::if_ether::ETH_P_MCTP as _;
     linux_kernel,
     any(
         target_arch = "mips",
+        target_arch = "mips32r6",
         target_arch = "mips64",
         target_arch = "mips64r6",
         target_arch = "sparc",

--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -63,6 +63,7 @@ pub(crate) const ETH_P_MCTP: c_int = linux_raw_sys::if_ether::ETH_P_MCTP as _;
     any(
         target_arch = "mips",
         target_arch = "mips64",
+        target_arch = "mips64r6",
         target_arch = "sparc",
         target_arch = "sparc64"
     )
@@ -123,7 +124,14 @@ pub(super) use libc::{
     host_info64_t as host_info_t, host_statistics64 as host_statistics,
     vm_statistics64_t as vm_statistics_t,
 };
-#[cfg(not(all(linux_kernel, any(target_pointer_width = "32", target_arch = "mips64"))))]
+#[cfg(not(all(
+    linux_kernel,
+    any(
+        target_pointer_width = "32",
+        target_arch = "mips64",
+        target_arch = "mips64r6"
+    )
+)))]
 #[cfg(any(linux_like, target_os = "aix"))]
 pub(super) use libc::{lstat64 as lstat, stat64 as stat};
 #[cfg(any(linux_kernel, target_os = "aix", target_os = "emscripten"))]

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -536,7 +536,14 @@ pub(crate) fn symlinkat(
 
 pub(crate) fn stat(path: &CStr) -> io::Result<Stat> {
     // See the comments in `fstat` about using `crate::fs::statx` here.
-    #[cfg(all(linux_kernel, any(target_pointer_width = "32", target_arch = "mips64")))]
+    #[cfg(all(
+        linux_kernel,
+        any(
+            target_pointer_width = "32",
+            target_arch = "mips64",
+            target_arch = "mips64r6"
+        )
+    ))]
     {
         match crate::fs::statx(
             crate::fs::CWD,
@@ -552,7 +559,14 @@ pub(crate) fn stat(path: &CStr) -> io::Result<Stat> {
 
     // Main version: libc is y2038 safe. Or, the platform is not y2038 safe and
     // there's nothing practical we can do.
-    #[cfg(not(all(linux_kernel, any(target_pointer_width = "32", target_arch = "mips64"))))]
+    #[cfg(not(all(
+        linux_kernel,
+        any(
+            target_pointer_width = "32",
+            target_arch = "mips64",
+            target_arch = "mips64r6"
+        )
+    )))]
     unsafe {
         let mut stat = MaybeUninit::<Stat>::uninit();
         ret(c::stat(c_str(path), stat.as_mut_ptr()))?;
@@ -562,7 +576,14 @@ pub(crate) fn stat(path: &CStr) -> io::Result<Stat> {
 
 pub(crate) fn lstat(path: &CStr) -> io::Result<Stat> {
     // See the comments in `fstat` about using `crate::fs::statx` here.
-    #[cfg(all(linux_kernel, any(target_pointer_width = "32", target_arch = "mips64")))]
+    #[cfg(all(
+        linux_kernel,
+        any(
+            target_pointer_width = "32",
+            target_arch = "mips64",
+            target_arch = "mips64r6"
+        )
+    ))]
     {
         match crate::fs::statx(
             crate::fs::CWD,
@@ -578,7 +599,14 @@ pub(crate) fn lstat(path: &CStr) -> io::Result<Stat> {
 
     // Main version: libc is y2038 safe. Or, the platform is not y2038 safe and
     // there's nothing practical we can do.
-    #[cfg(not(all(linux_kernel, any(target_pointer_width = "32", target_arch = "mips64"))))]
+    #[cfg(not(all(
+        linux_kernel,
+        any(
+            target_pointer_width = "32",
+            target_arch = "mips64",
+            target_arch = "mips64r6"
+        )
+    )))]
     unsafe {
         let mut stat = MaybeUninit::<Stat>::uninit();
         ret(c::lstat(c_str(path), stat.as_mut_ptr()))?;
@@ -589,7 +617,14 @@ pub(crate) fn lstat(path: &CStr) -> io::Result<Stat> {
 #[cfg(not(any(target_os = "espidf", target_os = "redox")))]
 pub(crate) fn statat(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io::Result<Stat> {
     // See the comments in `fstat` about using `crate::fs::statx` here.
-    #[cfg(all(linux_kernel, any(target_pointer_width = "32", target_arch = "mips64")))]
+    #[cfg(all(
+        linux_kernel,
+        any(
+            target_pointer_width = "32",
+            target_arch = "mips64",
+            target_arch = "mips64r6"
+        )
+    ))]
     {
         match crate::fs::statx(dirfd, path, flags, StatxFlags::BASIC_STATS) {
             Ok(x) => statx_to_stat(x),
@@ -600,7 +635,14 @@ pub(crate) fn statat(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io::
 
     // Main version: libc is y2038 safe. Or, the platform is not y2038 safe and
     // there's nothing practical we can do.
-    #[cfg(not(all(linux_kernel, any(target_pointer_width = "32", target_arch = "mips64"))))]
+    #[cfg(not(all(
+        linux_kernel,
+        any(
+            target_pointer_width = "32",
+            target_arch = "mips64",
+            target_arch = "mips64r6"
+        )
+    )))]
     unsafe {
         let mut stat = MaybeUninit::<Stat>::uninit();
         ret(c::fstatat(
@@ -613,7 +655,14 @@ pub(crate) fn statat(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io::
     }
 }
 
-#[cfg(all(linux_kernel, any(target_pointer_width = "32", target_arch = "mips64")))]
+#[cfg(all(
+    linux_kernel,
+    any(
+        target_pointer_width = "32",
+        target_arch = "mips64",
+        target_arch = "mips64r6"
+    )
+))]
 fn statat_old(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io::Result<Stat> {
     unsafe {
         let mut result = MaybeUninit::<c::stat64>::uninit();
@@ -1284,7 +1333,14 @@ pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
     // And, some old platforms don't support `statx`, and some fail with a
     // confusing error code, so we call `crate::fs::statx` to handle that. If
     // `statx` isn't available, fall back to the buggy system call.
-    #[cfg(all(linux_kernel, any(target_pointer_width = "32", target_arch = "mips64")))]
+    #[cfg(all(
+        linux_kernel,
+        any(
+            target_pointer_width = "32",
+            target_arch = "mips64",
+            target_arch = "mips64r6"
+        )
+    ))]
     {
         match crate::fs::statx(fd, cstr!(""), AtFlags::EMPTY_PATH, StatxFlags::BASIC_STATS) {
             Ok(x) => statx_to_stat(x),
@@ -1295,7 +1351,14 @@ pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
 
     // Main version: libc is y2038 safe. Or, the platform is not y2038 safe and
     // there's nothing practical we can do.
-    #[cfg(not(all(linux_kernel, any(target_pointer_width = "32", target_arch = "mips64"))))]
+    #[cfg(not(all(
+        linux_kernel,
+        any(
+            target_pointer_width = "32",
+            target_arch = "mips64",
+            target_arch = "mips64r6"
+        )
+    )))]
     unsafe {
         let mut stat = MaybeUninit::<Stat>::uninit();
         ret(c::fstat(borrowed_fd(fd), stat.as_mut_ptr()))?;
@@ -1303,7 +1366,14 @@ pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
     }
 }
 
-#[cfg(all(linux_kernel, any(target_pointer_width = "32", target_arch = "mips64")))]
+#[cfg(all(
+    linux_kernel,
+    any(
+        target_pointer_width = "32",
+        target_arch = "mips64",
+        target_arch = "mips64r6"
+    )
+))]
 fn fstat_old(fd: BorrowedFd<'_>) -> io::Result<Stat> {
     unsafe {
         let mut result = MaybeUninit::<c::stat64>::uninit();
@@ -1663,7 +1733,7 @@ fn statx_to_stat(x: crate::fs::Statx) -> io::Result<Stat> {
 /// Convert from a Linux `statx` value to rustix's `Stat`.
 ///
 /// mips64' `struct stat64` in libc has private fields, and `stx_blocks`
-#[cfg(all(linux_kernel, target_arch = "mips64"))]
+#[cfg(all(linux_kernel, any(target_arch = "mips64", target_arch = "mips64r6")))]
 fn statx_to_stat(x: crate::fs::Statx) -> io::Result<Stat> {
     let mut result: Stat = unsafe { core::mem::zeroed() };
 
@@ -1735,7 +1805,7 @@ fn stat64_to_stat(s64: c::stat64) -> io::Result<Stat> {
 ///
 /// mips64' `struct stat64` in libc has private fields, and `st_blocks` has
 /// type `i64`.
-#[cfg(all(linux_kernel, target_arch = "mips64"))]
+#[cfg(all(linux_kernel, any(target_arch = "mips64", target_arch = "mips64r6")))]
 fn stat64_to_stat(s64: c::stat64) -> io::Result<Stat> {
     let mut result: Stat = unsafe { core::mem::zeroed() };
 

--- a/src/backend/libc/mm/types.rs
+++ b/src/backend/libc/mm/types.rs
@@ -201,7 +201,7 @@ bitflags! {
             target_os = "redox",
             all(
                 linux_kernel,
-                any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6"),
+                any(target_arch = "mips", target_arch = "mips32r6", target_arch = "mips64", target_arch = "mips64r6"),
             )
         )))]
         const SYNC = bitcast!(c::MAP_SYNC);
@@ -335,7 +335,12 @@ pub enum Advice {
     /// `MADV_SOFT_OFFLINE`
     #[cfg(all(
         linux_kernel,
-        not(any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6"))
+        not(any(
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "mips64",
+            target_arch = "mips64r6"
+        ))
     ))]
     LinuxSoftOffline = bitcast!(c::MADV_SOFT_OFFLINE),
     /// `MADV_MERGEABLE`

--- a/src/backend/libc/mm/types.rs
+++ b/src/backend/libc/mm/types.rs
@@ -201,7 +201,7 @@ bitflags! {
             target_os = "redox",
             all(
                 linux_kernel,
-                any(target_arch = "mips", target_arch = "mips64"),
+                any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6"),
             )
         )))]
         const SYNC = bitcast!(c::MAP_SYNC);
@@ -333,7 +333,10 @@ pub enum Advice {
     #[cfg(linux_kernel)]
     LinuxHwPoison = bitcast!(c::MADV_HWPOISON),
     /// `MADV_SOFT_OFFLINE`
-    #[cfg(all(linux_kernel, not(any(target_arch = "mips", target_arch = "mips64"))))]
+    #[cfg(all(
+        linux_kernel,
+        not(any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6"))
+    ))]
     LinuxSoftOffline = bitcast!(c::MADV_SOFT_OFFLINE),
     /// `MADV_MERGEABLE`
     #[cfg(linux_kernel)]

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -117,6 +117,7 @@ pub(crate) fn tcsetattr(
         let request = TCSETS2
             + if cfg!(any(
                 target_arch = "mips",
+                target_arch = "mips32r6",
                 target_arch = "mips64",
                 target_arch = "mips64r6"
             )) {

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -115,7 +115,11 @@ pub(crate) fn tcsetattr(
         // Translate from `optional_actions` into an ioctl request code. On MIPS,
         // `optional_actions` already has `TCGETS` added to it.
         let request = TCSETS2
-            + if cfg!(any(target_arch = "mips", target_arch = "mips64")) {
+            + if cfg!(any(
+                target_arch = "mips",
+                target_arch = "mips64",
+                target_arch = "mips64r6"
+            )) {
                 optional_actions as u32 - TCSETS
             } else {
                 optional_actions as u32

--- a/src/backend/linux_raw/arch/asm/mips32r6.rs
+++ b/src/backend/linux_raw/arch/asm/mips32r6.rs
@@ -1,0 +1,543 @@
+//! mipsisa32r6el Linux system calls.
+//!
+//! On mipsisa32r6el, Linux indicates success or failure using `$a3` rather
+//! than by returning a negative error code as most other architectures do.
+//!
+//! Mips-family platforms have a special calling convention for `__NR_pipe`,
+//! however we use `__NR_pipe2` instead to avoid having to implement it.
+
+use crate::backend::reg::{
+    ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, A6, R0,
+};
+use core::arch::asm;
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
+    asm!(
+        "syscall",
+        in("$2" /*$v0*/) nr.to_asm(),
+        in("$4" /*$a0*/) a0.to_asm(),
+        options(noreturn)
+    )
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        ".set noat",
+        "subu $sp, 32",
+        "sw {}, 16($sp)",
+        "syscall",
+        "addu $sp, 32",
+        ".set at",
+        in(reg) a4.to_asm(),
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        ".set noat",
+        "subu $sp, 32",
+        "sw {}, 16($sp)",
+        "syscall",
+        "addu $sp, 32",
+        ".set at",
+        in(reg) a4.to_asm(),
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        ".set noat",
+        "subu $sp, 32",
+        "sw {}, 16($sp)",
+        "sw {}, 20($sp)",
+        "syscall",
+        "addu $sp, 32",
+        ".set at",
+        in(reg) a4.to_asm(),
+        in(reg) a5.to_asm(),
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        ".set noat",
+        "subu $sp, 32",
+        "sw {}, 16($sp)",
+        "sw {}, 20($sp)",
+        "syscall",
+        "addu $sp, 32",
+        ".set at",
+        in(reg) a4.to_asm(),
+        in(reg) a5.to_asm(),
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall7_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+    a6: ArgReg<'_, A6>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        ".set noat",
+        "subu $sp, 32",
+        "sw {}, 16($sp)",
+        "sw {}, 20($sp)",
+        "sw {}, 24($sp)",
+        "syscall",
+        "addu $sp, 32",
+        ".set at",
+        in(reg) a4.to_asm(),
+        in(reg) a5.to_asm(),
+        in(reg) a6.to_asm(),
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}

--- a/src/backend/linux_raw/arch/asm/mips64r6.rs
+++ b/src/backend/linux_raw/arch/asm/mips64r6.rs
@@ -1,0 +1,469 @@
+//! mipsisa64r6el Linux system calls.
+//!
+//! On mipsisa64r6el, Linux indicates success or failure using `$a3` (`$7`) rather
+//! than by returning a negative error code as most other architectures do.
+//!
+//! Mips-family platforms have a special calling convention for `__NR_pipe`,
+//! however we use `__NR_pipe2` instead to avoid having to implement it.
+//!
+//! Note that MIPS R6 inline assembly currently doesn't differ from MIPS, because
+//! no explicit call of R6-only or R2-only instructions exist here.
+
+use crate::backend::reg::{
+    ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0,
+};
+use core::arch::asm;
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
+    asm!(
+        "syscall",
+        in("$2" /*$v0*/) nr.to_asm(),
+        in("$4" /*$a0*/) a0.to_asm(),
+        options(noreturn)
+    )
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        inlateout("$8" /*$a4*/) a4.to_asm() => _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        inlateout("$8" /*$a4*/) a4.to_asm() => _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        inlateout("$8" /*$a4*/) a4.to_asm() => _,
+        inlateout("$9" /*$a5*/) a5.to_asm() => _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        inlateout("$8" /*$a4*/) a4.to_asm() => _,
+        inlateout("$9" /*$a5*/) a5.to_asm() => _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}

--- a/src/backend/linux_raw/arch/asm/mod.rs
+++ b/src/backend/linux_raw/arch/asm/mod.rs
@@ -13,6 +13,7 @@
 #[cfg_attr(all(target_arch = "arm", thumb_mode), path = "thumb.rs")]
 #[cfg_attr(target_arch = "mips", path = "mips.rs")]
 #[cfg_attr(target_arch = "mips64", path = "mips64.rs")]
+#[cfg_attr(target_arch = "mips64r6", path = "mips64r6.rs")]
 #[cfg_attr(target_arch = "powerpc64", path = "powerpc64.rs")]
 #[cfg_attr(target_arch = "riscv64", path = "riscv64.rs")]
 #[cfg_attr(target_arch = "x86", path = "x86.rs")]

--- a/src/backend/linux_raw/arch/asm/mod.rs
+++ b/src/backend/linux_raw/arch/asm/mod.rs
@@ -12,6 +12,7 @@
 #[cfg_attr(all(target_arch = "arm", not(thumb_mode)), path = "arm.rs")]
 #[cfg_attr(all(target_arch = "arm", thumb_mode), path = "thumb.rs")]
 #[cfg_attr(target_arch = "mips", path = "mips.rs")]
+#[cfg_attr(target_arch = "mips32r6", path = "mips32r6.rs")]
 #[cfg_attr(target_arch = "mips64", path = "mips64.rs")]
 #[cfg_attr(target_arch = "mips64r6", path = "mips64r6.rs")]
 #[cfg_attr(target_arch = "powerpc64", path = "powerpc64.rs")]

--- a/src/backend/linux_raw/arch/mod.rs
+++ b/src/backend/linux_raw/arch/mod.rs
@@ -24,6 +24,7 @@ pub(in crate::backend) mod asm;
     target_arch = "aarch64",
     target_arch = "mips",
     target_arch = "mips64",
+    target_arch = "mips64r6",
     target_arch = "powerpc64",
     target_arch = "riscv64",
     target_arch = "x86_64",

--- a/src/backend/linux_raw/arch/mod.rs
+++ b/src/backend/linux_raw/arch/mod.rs
@@ -23,6 +23,7 @@ pub(in crate::backend) mod asm;
     target_arch = "arm",
     target_arch = "aarch64",
     target_arch = "mips",
+    target_arch = "mips32r6",
     target_arch = "mips64",
     target_arch = "mips64r6",
     target_arch = "powerpc64",

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -104,7 +104,10 @@ pub(crate) use linux_raw_sys::{
 
 // On MIPS, `TCSANOW` et al have `TCSETS` added to them, so we need it to
 // subtract it out.
-#[cfg(all(feature = "termios", any(target_arch = "mips", target_arch = "mips64")))]
+#[cfg(all(
+    feature = "termios",
+    any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6")
+))]
 pub(crate) use linux_raw_sys::ioctl::TCSETS;
 
 // Define our own `uid_t` and `gid_t` if the kernel's versions are not 32-bit.
@@ -135,6 +138,7 @@ pub(crate) const SIGTERM: c_int = linux_raw_sys::general::SIGTERM as _;
 #[cfg(not(any(
     target_arch = "mips",
     target_arch = "mips64",
+    target_arch = "mips64r6",
     target_arch = "sparc",
     target_arch = "sparc64"
 )))]
@@ -157,6 +161,7 @@ pub(crate) const SIGSYS: c_int = linux_raw_sys::general::SIGSYS as _;
 #[cfg(any(
     target_arch = "mips",
     target_arch = "mips64",
+    target_arch = "mips64r6",
     target_arch = "sparc",
     target_arch = "sparc64"
 ))]

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -106,7 +106,12 @@ pub(crate) use linux_raw_sys::{
 // subtract it out.
 #[cfg(all(
     feature = "termios",
-    any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6")
+    any(
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "mips64",
+        target_arch = "mips64r6"
+    )
 ))]
 pub(crate) use linux_raw_sys::ioctl::TCSETS;
 
@@ -137,6 +142,7 @@ pub(crate) const SIGALRM: c_int = linux_raw_sys::general::SIGALRM as _;
 pub(crate) const SIGTERM: c_int = linux_raw_sys::general::SIGTERM as _;
 #[cfg(not(any(
     target_arch = "mips",
+    target_arch = "mips32r6",
     target_arch = "mips64",
     target_arch = "mips64r6",
     target_arch = "sparc",
@@ -160,6 +166,7 @@ pub(crate) const SIGPWR: c_int = linux_raw_sys::general::SIGPWR as _;
 pub(crate) const SIGSYS: c_int = linux_raw_sys::general::SIGSYS as _;
 #[cfg(any(
     target_arch = "mips",
+    target_arch = "mips32r6",
     target_arch = "mips64",
     target_arch = "mips64r6",
     target_arch = "sparc",

--- a/src/backend/linux_raw/elf.rs
+++ b/src/backend/linux_raw/elf.rs
@@ -62,7 +62,7 @@ pub(super) const EM_CURRENT: u16 = 40; // EM_ARM
 pub(super) const EM_CURRENT: u16 = 3; // EM_386
 #[cfg(target_arch = "powerpc64")]
 pub(super) const EM_CURRENT: u16 = 21; // EM_PPC64
-#[cfg(any(target_arch = "mips", target_arch = "mips64"))]
+#[cfg(any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6"))]
 pub(super) const EM_CURRENT: u16 = 8; // EM_MIPS
 #[cfg(target_arch = "x86_64")]
 pub(super) const EM_CURRENT: u16 = 62; // EM_X86_64

--- a/src/backend/linux_raw/elf.rs
+++ b/src/backend/linux_raw/elf.rs
@@ -62,7 +62,12 @@ pub(super) const EM_CURRENT: u16 = 40; // EM_ARM
 pub(super) const EM_CURRENT: u16 = 3; // EM_386
 #[cfg(target_arch = "powerpc64")]
 pub(super) const EM_CURRENT: u16 = 21; // EM_PPC64
-#[cfg(any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6"))]
+#[cfg(any(
+    target_arch = "mips",
+    target_arch = "mips32r6",
+    target_arch = "mips64",
+    target_arch = "mips64r6"
+))]
 pub(super) const EM_CURRENT: u16 = 8; // EM_MIPS
 #[cfg(target_arch = "x86_64")]
 pub(super) const EM_CURRENT: u16 = 62; // EM_X86_64

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -18,6 +18,7 @@ use crate::backend::conv::{loff_t, loff_t_from_u64, ret_u64};
     target_arch = "aarch64",
     target_arch = "riscv64",
     target_arch = "mips64",
+    target_arch = "mips64r6",
     target_pointer_width = "32",
 ))]
 use crate::fd::AsFd;
@@ -32,7 +33,7 @@ use crate::fs::{
 };
 use crate::io;
 use core::mem::{transmute, zeroed, MaybeUninit};
-#[cfg(target_arch = "mips64")]
+#[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
 use linux_raw_sys::general::stat as linux_stat64;
 use linux_raw_sys::general::{
     __kernel_fsid_t, __kernel_timespec, open_how, statx, AT_EACCESS, AT_FDCWD, AT_REMOVEDIR,
@@ -427,7 +428,11 @@ pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
     // And, some old platforms don't support `statx`, and some fail with a
     // confusing error code, so we call `crate::fs::statx` to handle that. If
     // `statx` isn't available, fall back to the buggy system call.
-    #[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
+    #[cfg(any(
+        target_pointer_width = "32",
+        target_arch = "mips64",
+        target_arch = "mips64r6"
+    ))]
     {
         match crate::fs::statx(fd, cstr!(""), AtFlags::EMPTY_PATH, StatxFlags::BASIC_STATS) {
             Ok(x) => statx_to_stat(x),
@@ -436,7 +441,11 @@ pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
         }
     }
 
-    #[cfg(all(target_pointer_width = "64", not(target_arch = "mips64")))]
+    #[cfg(all(
+        target_pointer_width = "64",
+        not(target_arch = "mips64"),
+        not(target_arch = "mips64r6")
+    ))]
     unsafe {
         let mut result = MaybeUninit::<Stat>::uninit();
         ret(syscall!(__NR_fstat, fd, &mut result))?;
@@ -444,11 +453,15 @@ pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
     }
 }
 
-#[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
+#[cfg(any(
+    target_pointer_width = "32",
+    target_arch = "mips64",
+    target_arch = "mips64r6",
+))]
 fn fstat_old(fd: BorrowedFd<'_>) -> io::Result<Stat> {
     let mut result = MaybeUninit::<linux_stat64>::uninit();
 
-    #[cfg(target_arch = "mips64")]
+    #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
     unsafe {
         ret(syscall!(__NR_fstat, fd, &mut result))?;
         stat_to_stat(result.assume_init())
@@ -464,7 +477,11 @@ fn fstat_old(fd: BorrowedFd<'_>) -> io::Result<Stat> {
 #[inline]
 pub(crate) fn stat(path: &CStr) -> io::Result<Stat> {
     // See the comments in `fstat` about using `crate::fs::statx` here.
-    #[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
+    #[cfg(any(
+        target_pointer_width = "32",
+        target_arch = "mips64",
+        target_arch = "mips64r6"
+    ))]
     {
         match crate::fs::statx(
             crate::fs::CWD.as_fd(),
@@ -478,7 +495,11 @@ pub(crate) fn stat(path: &CStr) -> io::Result<Stat> {
         }
     }
 
-    #[cfg(all(target_pointer_width = "64", not(target_arch = "mips64")))]
+    #[cfg(all(
+        target_pointer_width = "64",
+        not(target_arch = "mips64"),
+        not(target_arch = "mips64r6"),
+    ))]
     unsafe {
         let mut result = MaybeUninit::<Stat>::uninit();
         ret(syscall!(
@@ -492,11 +513,15 @@ pub(crate) fn stat(path: &CStr) -> io::Result<Stat> {
     }
 }
 
-#[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
+#[cfg(any(
+    target_pointer_width = "32",
+    target_arch = "mips64",
+    target_arch = "mips64r6"
+))]
 fn stat_old(path: &CStr) -> io::Result<Stat> {
     let mut result = MaybeUninit::<linux_stat64>::uninit();
 
-    #[cfg(target_arch = "mips64")]
+    #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
     unsafe {
         ret(syscall!(
             __NR_newfstatat,
@@ -524,7 +549,11 @@ fn stat_old(path: &CStr) -> io::Result<Stat> {
 #[inline]
 pub(crate) fn statat(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io::Result<Stat> {
     // See the comments in `fstat` about using `crate::fs::statx` here.
-    #[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
+    #[cfg(any(
+        target_pointer_width = "32",
+        target_arch = "mips64",
+        target_arch = "mips64r6"
+    ))]
     {
         match crate::fs::statx(dirfd, path, flags, StatxFlags::BASIC_STATS) {
             Ok(x) => statx_to_stat(x),
@@ -533,7 +562,11 @@ pub(crate) fn statat(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io::
         }
     }
 
-    #[cfg(all(target_pointer_width = "64", not(target_arch = "mips64")))]
+    #[cfg(all(
+        target_pointer_width = "64",
+        not(target_arch = "mips64"),
+        not(target_arch = "mips64r6"),
+    ))]
     unsafe {
         let mut result = MaybeUninit::<Stat>::uninit();
         ret(syscall!(__NR_newfstatat, dirfd, path, &mut result, flags))?;
@@ -541,11 +574,15 @@ pub(crate) fn statat(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io::
     }
 }
 
-#[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
+#[cfg(any(
+    target_pointer_width = "32",
+    target_arch = "mips64",
+    target_arch = "mips64r6"
+))]
 fn statat_old(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io::Result<Stat> {
     let mut result = MaybeUninit::<linux_stat64>::uninit();
 
-    #[cfg(target_arch = "mips64")]
+    #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
     unsafe {
         ret(syscall!(__NR_newfstatat, dirfd, path, &mut result, flags))?;
         stat_to_stat(result.assume_init())
@@ -593,7 +630,7 @@ pub(crate) fn lstat(path: &CStr) -> io::Result<Stat> {
 fn lstat_old(path: &CStr) -> io::Result<Stat> {
     let mut result = MaybeUninit::<linux_stat64>::uninit();
 
-    #[cfg(target_arch = "mips64")]
+    #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
     unsafe {
         ret(syscall!(
             __NR_newfstatat,
@@ -619,7 +656,11 @@ fn lstat_old(path: &CStr) -> io::Result<Stat> {
 }
 
 /// Convert from a Linux `statx` value to rustix's `Stat`.
-#[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
+#[cfg(any(
+    target_pointer_width = "32",
+    target_arch = "mips64",
+    target_arch = "mips64r6"
+))]
 fn statx_to_stat(x: crate::fs::Statx) -> io::Result<Stat> {
     Ok(Stat {
         st_dev: crate::fs::makedev(x.stx_dev_major, x.stx_dev_minor),
@@ -686,7 +727,7 @@ fn stat_to_stat(s64: linux_raw_sys::general::stat64) -> io::Result<Stat> {
 }
 
 /// Convert from a Linux `stat` value to rustix's `Stat`.
-#[cfg(target_arch = "mips64")]
+#[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
 fn stat_to_stat(s: linux_raw_sys::general::stat) -> io::Result<Stat> {
     Ok(Stat {
         st_dev: s.st_dev.try_into().map_err(|_| io::Errno::OVERFLOW)?,

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -253,7 +253,12 @@ pub(crate) fn ftruncate(fd: BorrowedFd<'_>, length: u64) -> io::Result<()> {
     // <https://github.com/torvalds/linux/blob/fcadab740480e0e0e9fa9bd272acd409884d431a/arch/arm64/kernel/sys32.c#L81-L83>
     #[cfg(all(
         target_pointer_width = "32",
-        any(target_arch = "arm", target_arch = "mips", target_arch = "powerpc"),
+        any(
+            target_arch = "arm",
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "powerpc"
+        ),
     ))]
     unsafe {
         ret(syscall_readonly!(
@@ -266,7 +271,12 @@ pub(crate) fn ftruncate(fd: BorrowedFd<'_>, length: u64) -> io::Result<()> {
     }
     #[cfg(all(
         target_pointer_width = "32",
-        not(any(target_arch = "arm", target_arch = "mips", target_arch = "powerpc")),
+        not(any(
+            target_arch = "arm",
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "powerpc"
+        )),
     ))]
     unsafe {
         ret(syscall_readonly!(
@@ -349,7 +359,7 @@ pub(crate) fn fadvise(fd: BorrowedFd<'_>, pos: u64, len: u64, advice: Advice) ->
     }
     // On mips, the arguments are not reordered, and padding is inserted
     // instead to ensure alignment.
-    #[cfg(target_arch = "mips")]
+    #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
     unsafe {
         ret(syscall_readonly!(
             __NR_fadvise64,
@@ -364,7 +374,12 @@ pub(crate) fn fadvise(fd: BorrowedFd<'_>, pos: u64, len: u64, advice: Advice) ->
     }
     #[cfg(all(
         target_pointer_width = "32",
-        not(any(target_arch = "arm", target_arch = "mips", target_arch = "powerpc")),
+        not(any(
+            target_arch = "arm",
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "powerpc"
+        )),
     ))]
     unsafe {
         ret(syscall_readonly!(

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -631,7 +631,11 @@ pub enum FlockOperation {
 // On 32-bit, and mips64, Linux's `struct stat64` has a 32-bit `st_mtime` and
 // friends, so we use our own struct, populated from `statx` where possible, to
 // avoid the y2038 bug.
-#[cfg(any(target_pointer_width = "32", target_arch = "mips64"))]
+#[cfg(any(
+    target_pointer_width = "32",
+    target_arch = "mips64",
+    target_arch = "mips64r6"
+))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 #[allow(missing_docs)]
@@ -658,7 +662,11 @@ pub struct Stat {
 ///
 /// [`statat`]: crate::fs::statat
 /// [`fstat`]: crate::fs::fstat
-#[cfg(all(target_pointer_width = "64", not(target_arch = "mips64")))]
+#[cfg(all(
+    target_pointer_width = "64",
+    not(target_arch = "mips64"),
+    not(target_arch = "mips64r6")
+))]
 pub type Stat = linux_raw_sys::general::stat;
 
 /// `struct statfs` for use with [`statfs`] and [`fstatfs`].
@@ -719,11 +727,11 @@ pub type RawMode = c::c_uint;
 pub type Dev = u64;
 
 /// `__fsword_t`
-#[cfg(not(target_arch = "mips64"))]
+#[cfg(not(any(target_arch = "mips64", target_arch = "mips64r6")))]
 pub type FsWord = linux_raw_sys::general::__fsword_t;
 
 /// `__fsword_t`
-#[cfg(target_arch = "mips64")]
+#[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
 pub type FsWord = i64;
 
 bitflags! {

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -10,7 +10,12 @@
 use crate::backend::conv::loff_t_from_u64;
 #[cfg(all(
     target_pointer_width = "32",
-    any(target_arch = "arm", target_arch = "mips", target_arch = "power"),
+    any(
+        target_arch = "arm",
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "power"
+    ),
 ))]
 use crate::backend::conv::zero;
 use crate::backend::conv::{
@@ -43,7 +48,12 @@ pub(crate) fn pread(fd: BorrowedFd<'_>, buf: &mut [u8], pos: u64) -> io::Result<
     // <https://github.com/torvalds/linux/blob/fcadab740480e0e0e9fa9bd272acd409884d431a/arch/arm64/kernel/sys32.c#L75>
     #[cfg(all(
         target_pointer_width = "32",
-        any(target_arch = "arm", target_arch = "mips", target_arch = "power"),
+        any(
+            target_arch = "arm",
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "power"
+        ),
     ))]
     unsafe {
         ret_usize(syscall!(
@@ -58,7 +68,12 @@ pub(crate) fn pread(fd: BorrowedFd<'_>, buf: &mut [u8], pos: u64) -> io::Result<
     }
     #[cfg(all(
         target_pointer_width = "32",
-        not(any(target_arch = "arm", target_arch = "mips", target_arch = "power")),
+        not(any(
+            target_arch = "arm",
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "power"
+        )),
     ))]
     unsafe {
         ret_usize(syscall!(
@@ -168,7 +183,12 @@ pub(crate) fn pwrite(fd: BorrowedFd<'_>, buf: &[u8], pos: u64) -> io::Result<usi
     // <https://github.com/torvalds/linux/blob/fcadab740480e0e0e9fa9bd272acd409884d431a/arch/arm64/kernel/sys32.c#L81-L83>
     #[cfg(all(
         target_pointer_width = "32",
-        any(target_arch = "arm", target_arch = "mips", target_arch = "power"),
+        any(
+            target_arch = "arm",
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "power"
+        ),
     ))]
     unsafe {
         ret_usize(syscall_readonly!(
@@ -183,7 +203,12 @@ pub(crate) fn pwrite(fd: BorrowedFd<'_>, buf: &[u8], pos: u64) -> io::Result<usi
     }
     #[cfg(all(
         target_pointer_width = "32",
-        not(any(target_arch = "arm", target_arch = "mips", target_arch = "power")),
+        not(any(
+            target_arch = "arm",
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "power"
+        )),
     ))]
     unsafe {
         ret_usize(syscall_readonly!(

--- a/src/backend/linux_raw/mm/types.rs
+++ b/src/backend/linux_raw/mm/types.rs
@@ -94,10 +94,10 @@ bitflags! {
         /// `MAP_STACK`
         const STACK = linux_raw_sys::general::MAP_STACK;
         /// `MAP_SYNC` (since Linux 4.15)
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
+        #[cfg(not(any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6")))]
         const SYNC = linux_raw_sys::general::MAP_SYNC;
         /// `MAP_UNINITIALIZED`
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
+        #[cfg(not(any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6")))]
         const UNINITIALIZED = linux_raw_sys::general::MAP_UNINITIALIZED;
     }
 }
@@ -183,7 +183,7 @@ pub enum Advice {
     /// `MADV_HWPOISON`
     LinuxHwPoison = linux_raw_sys::general::MADV_HWPOISON,
     /// `MADV_SOFT_OFFLINE`
-    #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
+    #[cfg(not(any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6")))]
     LinuxSoftOffline = linux_raw_sys::general::MADV_SOFT_OFFLINE,
     /// `MADV_MERGEABLE`
     LinuxMergeable = linux_raw_sys::general::MADV_MERGEABLE,

--- a/src/backend/linux_raw/mm/types.rs
+++ b/src/backend/linux_raw/mm/types.rs
@@ -94,10 +94,10 @@ bitflags! {
         /// `MAP_STACK`
         const STACK = linux_raw_sys::general::MAP_STACK;
         /// `MAP_SYNC` (since Linux 4.15)
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6")))]
+        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6", target_arch = "mips64", target_arch = "mips64r6")))]
         const SYNC = linux_raw_sys::general::MAP_SYNC;
         /// `MAP_UNINITIALIZED`
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6")))]
+        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6", target_arch = "mips64", target_arch = "mips64r6")))]
         const UNINITIALIZED = linux_raw_sys::general::MAP_UNINITIALIZED;
     }
 }
@@ -183,7 +183,12 @@ pub enum Advice {
     /// `MADV_HWPOISON`
     LinuxHwPoison = linux_raw_sys::general::MADV_HWPOISON,
     /// `MADV_SOFT_OFFLINE`
-    #[cfg(not(any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6")))]
+    #[cfg(not(any(
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "mips64",
+        target_arch = "mips64r6"
+    )))]
     LinuxSoftOffline = linux_raw_sys::general::MADV_SOFT_OFFLINE,
     /// `MADV_MERGEABLE`
     LinuxMergeable = linux_raw_sys::general::MADV_MERGEABLE,

--- a/src/backend/linux_raw/net/syscalls.rs
+++ b/src/backend/linux_raw/net/syscalls.rs
@@ -430,6 +430,7 @@ pub(crate) fn send(fd: BorrowedFd<'_>, buf: &[u8], flags: SendFlags) -> io::Resu
     #[cfg(not(any(
         target_arch = "aarch64",
         target_arch = "mips64",
+        target_arch = "mips64r6",
         target_arch = "riscv64",
         target_arch = "x86",
         target_arch = "x86_64",
@@ -440,6 +441,7 @@ pub(crate) fn send(fd: BorrowedFd<'_>, buf: &[u8], flags: SendFlags) -> io::Resu
     #[cfg(any(
         target_arch = "aarch64",
         target_arch = "mips64",
+        target_arch = "mips64r6",
         target_arch = "riscv64",
         target_arch = "x86_64",
     ))]
@@ -585,6 +587,7 @@ pub(crate) fn recv(fd: BorrowedFd<'_>, buf: &mut [u8], flags: RecvFlags) -> io::
     #[cfg(not(any(
         target_arch = "aarch64",
         target_arch = "mips64",
+        target_arch = "mips64r6",
         target_arch = "riscv64",
         target_arch = "x86",
         target_arch = "x86_64",
@@ -595,6 +598,7 @@ pub(crate) fn recv(fd: BorrowedFd<'_>, buf: &mut [u8], flags: RecvFlags) -> io::
     #[cfg(any(
         target_arch = "aarch64",
         target_arch = "mips64",
+        target_arch = "mips64r6",
         target_arch = "riscv64",
         target_arch = "x86_64",
     ))]

--- a/src/backend/linux_raw/pipe/syscalls.rs
+++ b/src/backend/linux_raw/pipe/syscalls.rs
@@ -23,6 +23,7 @@ pub(crate) fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     #[cfg(any(
         target_arch = "aarch64",
         target_arch = "mips",
+        target_arch = "mips32r6",
         target_arch = "mips64",
         target_arch = "mips64r6",
         target_arch = "riscv64",
@@ -33,6 +34,7 @@ pub(crate) fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     #[cfg(not(any(
         target_arch = "aarch64",
         target_arch = "mips",
+        target_arch = "mips32r6",
         target_arch = "mips64",
         target_arch = "mips64r6",
         target_arch = "riscv64",

--- a/src/backend/linux_raw/pipe/syscalls.rs
+++ b/src/backend/linux_raw/pipe/syscalls.rs
@@ -24,6 +24,7 @@ pub(crate) fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
         target_arch = "aarch64",
         target_arch = "mips",
         target_arch = "mips64",
+        target_arch = "mips64r6",
         target_arch = "riscv64",
     ))]
     {
@@ -33,6 +34,7 @@ pub(crate) fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
         target_arch = "aarch64",
         target_arch = "mips",
         target_arch = "mips64",
+        target_arch = "mips64r6",
         target_arch = "riscv64",
     )))]
     unsafe {

--- a/src/backend/linux_raw/reg.rs
+++ b/src/backend/linux_raw/reg.rs
@@ -54,7 +54,7 @@ pub(super) struct A2(());
 pub(super) struct A3(());
 pub(super) struct A4(());
 pub(super) struct A5(());
-#[cfg(target_arch = "mips")]
+#[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
 pub(super) struct A6(());
 #[cfg(target_arch = "x86")]
 pub(super) struct SocketArg;
@@ -66,7 +66,7 @@ impl ArgNumber for A2 {}
 impl ArgNumber for A3 {}
 impl ArgNumber for A4 {}
 impl ArgNumber for A5 {}
-#[cfg(target_arch = "mips")]
+#[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
 impl ArgNumber for A6 {}
 #[cfg(target_arch = "x86")]
 impl ArgNumber for SocketArg {}
@@ -250,7 +250,7 @@ mod private {
     impl Sealed for super::A3 {}
     impl Sealed for super::A4 {}
     impl Sealed for super::A5 {}
-    #[cfg(target_arch = "mips")]
+    #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
     impl Sealed for super::A6 {}
     #[cfg(target_arch = "x86")]
     impl Sealed for super::SocketArg {}

--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -63,7 +63,11 @@ pub(crate) fn tcsetattr(
     // Translate from `optional_actions` into an ioctl request code. On MIPS,
     // `optional_actions` already has `TCGETS` added to it.
     let request = linux_raw_sys::ioctl::TCSETS2
-        + if cfg!(any(target_arch = "mips", target_arch = "mips64")) {
+        + if cfg!(any(
+            target_arch = "mips",
+            target_arch = "mips64",
+            target_arch = "mips64r6"
+        )) {
             optional_actions as u32 - linux_raw_sys::ioctl::TCSETS
         } else {
             optional_actions as u32

--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -65,6 +65,7 @@ pub(crate) fn tcsetattr(
     let request = linux_raw_sys::ioctl::TCSETS2
         + if cfg!(any(
             target_arch = "mips",
+            target_arch = "mips32r6",
             target_arch = "mips64",
             target_arch = "mips64r6"
         )) {

--- a/src/backend/linux_raw/vdso_wrappers.rs
+++ b/src/backend/linux_raw/vdso_wrappers.rs
@@ -399,7 +399,7 @@ fn init() {
             let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_clock_gettime"));
             #[cfg(target_arch = "powerpc64")]
             let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_clock_gettime"));
-            #[cfg(target_arch = "mips")]
+            #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
             let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
             #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
             let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime"));
@@ -411,7 +411,12 @@ fn init() {
 
             // On some 32-bit platforms, the 64-bit `clock_gettime` symbols are not
             // available on older kernel versions.
-            #[cfg(any(target_arch = "arm", target_arch = "mips", target_arch = "x86"))]
+            #[cfg(any(
+                target_arch = "arm",
+                target_arch = "mips",
+                target_arch = "mips32r6",
+                target_arch = "x86"
+            ))]
             let ok = !ptr.is_null();
 
             if ok {

--- a/src/backend/linux_raw/vdso_wrappers.rs
+++ b/src/backend/linux_raw/vdso_wrappers.rs
@@ -401,7 +401,7 @@ fn init() {
             let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_clock_gettime"));
             #[cfg(target_arch = "mips")]
             let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
-            #[cfg(target_arch = "mips64")]
+            #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
             let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime"));
 
             // On all 64-bit platforms, the 64-bit `clock_gettime` symbols are

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -54,6 +54,7 @@ pub enum Signal {
             any(
                 target_arch = "mips",
                 target_arch = "mips64",
+                target_arch = "mips64r6",
                 target_arch = "sparc",
                 target_arch = "sparc64"
             ),
@@ -108,6 +109,7 @@ pub enum Signal {
             any(
                 target_arch = "mips",
                 target_arch = "mips64",
+                target_arch = "mips64r6",
                 target_arch = "sparc",
                 target_arch = "sparc64"
             )
@@ -156,6 +158,7 @@ impl Signal {
                     any(
                         target_arch = "mips",
                         target_arch = "mips64",
+                        target_arch = "mips64r6",
                         target_arch = "sparc",
                         target_arch = "sparc64"
                     ),
@@ -189,6 +192,7 @@ impl Signal {
                     any(
                         target_arch = "mips",
                         target_arch = "mips64",
+                        target_arch = "mips64r6",
                         target_arch = "sparc",
                         target_arch = "sparc64"
                     )

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -53,6 +53,7 @@ pub enum Signal {
             linux_kernel,
             any(
                 target_arch = "mips",
+                target_arch = "mips32r6",
                 target_arch = "mips64",
                 target_arch = "mips64r6",
                 target_arch = "sparc",
@@ -108,6 +109,7 @@ pub enum Signal {
             linux_kernel,
             any(
                 target_arch = "mips",
+                target_arch = "mips32r6",
                 target_arch = "mips64",
                 target_arch = "mips64r6",
                 target_arch = "sparc",
@@ -157,6 +159,7 @@ impl Signal {
                     linux_kernel,
                     any(
                         target_arch = "mips",
+                        target_arch = "mips32r6",
                         target_arch = "mips64",
                         target_arch = "mips64r6",
                         target_arch = "sparc",
@@ -191,6 +194,7 @@ impl Signal {
                     linux_kernel,
                     any(
                         target_arch = "mips",
+                        target_arch = "mips32r6",
                         target_arch = "mips64",
                         target_arch = "mips64r6",
                         target_arch = "sparc",

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -1274,6 +1274,7 @@ fn termios_layouts() {
                 any(
                     target_arch = "mips",
                     target_arch = "mips64",
+                    target_arch = "mips64r6",
                     target_arch = "sparc",
                     target_arch = "sparc64"
                 )
@@ -1287,6 +1288,7 @@ fn termios_layouts() {
                 any(
                     target_arch = "mips",
                     target_arch = "mips64",
+                    target_arch = "mips64r6",
                     target_arch = "sparc",
                     target_arch = "sparc64"
                 )
@@ -1388,13 +1390,13 @@ fn termios_ioctl_contiguity() {
     const_assert_eq!(c::TCSAFLUSH - c::TCSANOW, 2);
 
     // MIPS is different here.
-    #[cfg(any(target_arch = "mips", target_arch = "mips64"))]
+    #[cfg(any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6"))]
     {
         assert_eq!(i128::from(c::TCSANOW) - i128::from(c::TCSETS), 0);
         assert_eq!(i128::from(c::TCSADRAIN) - i128::from(c::TCSETS), 1);
         assert_eq!(i128::from(c::TCSAFLUSH) - i128::from(c::TCSETS), 2);
     }
-    #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
+    #[cfg(not(any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6")))]
     {
         const_assert_eq!(c::TCSANOW, 0);
         const_assert_eq!(c::TCSADRAIN, 1);

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -1273,6 +1273,7 @@ fn termios_layouts() {
                 target_env = "gnu",
                 any(
                     target_arch = "mips",
+                    target_arch = "mips32r6",
                     target_arch = "mips64",
                     target_arch = "mips64r6",
                     target_arch = "sparc",
@@ -1287,6 +1288,7 @@ fn termios_layouts() {
                 target_env = "gnu",
                 any(
                     target_arch = "mips",
+                    target_arch = "mips32r6",
                     target_arch = "mips64",
                     target_arch = "mips64r6",
                     target_arch = "sparc",
@@ -1390,13 +1392,23 @@ fn termios_ioctl_contiguity() {
     const_assert_eq!(c::TCSAFLUSH - c::TCSANOW, 2);
 
     // MIPS is different here.
-    #[cfg(any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6"))]
+    #[cfg(any(
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "mips64",
+        target_arch = "mips64r6"
+    ))]
     {
         assert_eq!(i128::from(c::TCSANOW) - i128::from(c::TCSETS), 0);
         assert_eq!(i128::from(c::TCSADRAIN) - i128::from(c::TCSETS), 1);
         assert_eq!(i128::from(c::TCSAFLUSH) - i128::from(c::TCSETS), 2);
     }
-    #[cfg(not(any(target_arch = "mips", target_arch = "mips64", target_arch = "mips64r6")))]
+    #[cfg(not(any(
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "mips64",
+        target_arch = "mips64r6"
+    )))]
     {
         const_assert_eq!(c::TCSANOW, 0);
         const_assert_eq!(c::TCSADRAIN, 1);

--- a/tests/process/prctl.rs
+++ b/tests/process/prctl.rs
@@ -53,7 +53,7 @@ fn test_endian_mode() {
     dbg!(endian_mode().unwrap());
 }
 
-#[cfg(target_arch = "mips")]
+#[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
 #[test]
 fn test_floating_point_mode() {
     dbg!(floating_point_mode().unwrap());


### PR DESCRIPTION
This PR aims to add support for recently [proposed](https://github.com/rust-lang/compiler-team/issues/632) architectures, which should be much easier to do now thanks to the removal of outline assembly.

MIPS R6 shares syscall conventions with MIPS, so the inline assembly files may only differ in their comments.