### PR TITLE
Move experimental Rust features behind a `--cfg=`.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -221,6 +221,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       QEMU_BUILD_VERSION: 8.0.2
+      # Enabling testing of experimental features.
+      RUSTFLAGS: --cfg rustix_use_experimental_features
     strategy:
       matrix:
         build: [ubuntu, ubuntu-20.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, ubuntu-1.63, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, mipsel-linux-stable, mips64el-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.63, i686-linux-1.63, aarch64-linux-1.63, riscv64-linux-1.63, s390x-linux-1.63, mipsel-linux-1.63, mips64el-linux-1.63, powerpc64le-linux-1.63, arm-linux-1.63, macos-latest, macos-11, windows, windows-2019]


### PR DESCRIPTION
Instead of just autodetecting nightly-only Rust features, put them behind a `--cfg` so that they're not feature-detected for users.