### PR TITLE
Miscellaneous comment cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-all
 compiler_builtins = { version = '0.1.49', optional = true }
 
 # The procfs feature needs once_cell.
+# With Rust 1.70.0, we can switch to `core::cell::OnceCell`.
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 once_cell = { version = "1.5.2", optional = true }
 

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -337,10 +337,7 @@ pub(crate) fn is_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
         // the write side is shut down.
         #[allow(unreachable_patterns)] // `EAGAIN` equals `EWOULDBLOCK`
         match crate::backend::net::syscalls::send(fd, &[], SendFlags::DONTWAIT) {
-            // TODO or-patterns when we don't need 1.51
-            Err(io::Errno::AGAIN) => (),
-            Err(io::Errno::WOULDBLOCK) => (),
-            Err(io::Errno::NOTSOCK) => (),
+            Err(io::Errno::AGAIN | io::Errno::WOULDBLOCK | io::Errno::NOTSOCK) => (),
             Err(io::Errno::PIPE) => write = false,
             Err(err) => return Err(err),
             Ok(_) => (),

--- a/src/backend/linux_raw/vdso_wrappers.rs
+++ b/src/backend/linux_raw/vdso_wrappers.rs
@@ -48,7 +48,7 @@ pub(crate) fn clock_gettime(which_clock: ClockId) -> __kernel_timespec {
         // The `ClockId` enum only contains clocks which never fail. It may be
         // tempting to change this to `debug_assert_eq`, however they can still
         // fail on uncommon kernel configs, so we leave this in place to ensure
-        // that we don't execute UB if they ever do fail.
+        // that we don't execute undefined behavior if they ever do fail.
         assert_eq!(r0, 0);
         result.assume_init()
     }

--- a/src/io/errno.rs
+++ b/src/io/errno.rs
@@ -1,8 +1,8 @@
 //! The `Errno` type, which is a minimal wrapper around an error code.
 //!
-//! We define the error constants as individual `const`s instead of an
-//! enum because we may not know about all of the host's error values
-//! and we don't want unrecognized values to create UB.
+//! We define the error constants as individual `const`s instead of an enum
+//! because we may not know about all of the host's error values and we don't
+//! want unrecognized values to create undefined behavior.
 
 use crate::backend;
 use core::{fmt, result};

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -72,7 +72,7 @@ pub struct Termios {
 }
 
 impl Termios {
-    /// `cfmakeraw(self)`—Set a `Termios` value to the settings for "raw" mode.
+    /// `cfmakeraw(self)`—Set a `Termios` value to the settings for “raw” mode.
     ///
     /// In raw mode, input is available a byte at a time, echoing is disabled,
     /// and special terminal input and output codes are disabled.
@@ -568,7 +568,7 @@ bitflags! {
 }
 
 bitflags! {
-    /// Flags controlling "local" terminal modes.
+    /// Flags controlling “local” terminal modes.
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct LocalModes: c::tcflag_t {

--- a/src/thread/id.rs
+++ b/src/thread/id.rs
@@ -21,7 +21,7 @@ pub fn gettid() -> Pid {
 ///
 /// # Warning
 ///
-/// This is not the setxid you are looking for... POSIX requires xids to be
+/// This is not the setxid you are looking for… POSIX requires xids to be
 /// process granular, but on Linux they are per-thread. Thus, this call only
 /// changes the xid for the current *thread*, not the entire process even
 /// though that is in violation of the POSIX standard.
@@ -46,7 +46,7 @@ pub fn set_thread_uid(uid: Uid) -> io::Result<()> {
 ///
 /// # Warning
 ///
-/// This is not the setresxid you are looking for... POSIX requires xids to be
+/// This is not the setresxid you are looking for… POSIX requires xids to be
 /// process granular, but on Linux they are per-thread. Thus, this call only
 /// changes the xid for the current *thread*, not the entire process even
 /// though that is in violation of the POSIX standard.


### PR DESCRIPTION
Clean up a TODO comment, say "undefined behavior" instead of "UB", and other miscellaneous tidyings.