### PR TITLE
Enable `CLOCK_BOOTTIME` on more platforms.

### DIFF
--- a/src/backend/libc/time/syscalls.rs
+++ b/src/backend/libc/time/syscalls.rs
@@ -166,10 +166,15 @@ pub(crate) fn clock_gettime_dynamic(id: DynamicClockId<'_>) -> io::Result<Timesp
         #[cfg(linux_kernel)]
         DynamicClockId::Tai => c::CLOCK_TAI,
 
-        #[cfg(any(linux_kernel, target_os = "openbsd"))]
+        #[cfg(any(
+            freebsdlike,
+            linux_kernel,
+            target_os = "fuchsia",
+            target_os = "openbsd"
+        ))]
         DynamicClockId::Boottime => c::CLOCK_BOOTTIME,
 
-        #[cfg(linux_kernel)]
+        #[cfg(any(linux_kernel, target_os = "fuchsia"))]
         DynamicClockId::BoottimeAlarm => c::CLOCK_BOOTTIME_ALARM,
     };
 

--- a/src/clockid.rs
+++ b/src/clockid.rs
@@ -96,10 +96,15 @@ pub enum DynamicClockId<'a> {
     Tai,
 
     /// `CLOCK_BOOTTIME`, available on Linux >= 2.6.39
-    #[cfg(any(linux_kernel, target_os = "openbsd"))]
+    #[cfg(any(
+        freebsdlike,
+        linux_kernel,
+        target_os = "fuchsia",
+        target_os = "openbsd"
+    ))]
     Boottime,
 
     /// `CLOCK_BOOTTIME_ALARM`, available on Linux >= 2.6.39
-    #[cfg(linux_kernel)]
+    #[cfg(any(linux_kernel, target_os = "fuchsia"))]
     BoottimeAlarm,
 }


### PR DESCRIPTION
Enable `CLOCK_BOOTTIME` and `CLOCK_BOOTTIME_ALARM` on more platforms, and add a testcase for it.