### PR TITLE
Implement Apple fcntls for disabling caching

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -1977,6 +1977,22 @@ pub(crate) fn fcntl_fullfsync(fd: BorrowedFd<'_>) -> io::Result<()> {
     unsafe { ret(c::fcntl(borrowed_fd(fd), c::F_FULLFSYNC)) }
 }
 
+#[cfg(apple)]
+pub(crate) fn fcntl_nocache(fd: BorrowedFd, value: bool) -> io::Result<()> {
+    unsafe { ret(c::fcntl(borrowed_fd(fd), c::F_NOCACHE, value as c::c_int)) }
+}
+
+#[cfg(apple)]
+pub(crate) fn fcntl_global_nocache(fd: BorrowedFd, value: bool) -> io::Result<()> {
+    unsafe {
+        ret(c::fcntl(
+            borrowed_fd(fd),
+            c::F_GLOBAL_NOCACHE,
+            value as c::c_int,
+        ))
+    }
+}
+
 /// Convert `times` from a `futimens`/`utimensat` argument into `setattrlist`
 /// arguments.
 #[cfg(apple)]

--- a/src/clockid.rs
+++ b/src/clockid.rs
@@ -52,6 +52,8 @@ pub enum ClockId {
 /// has to fail with `INVAL` due to an unsupported clock. See
 /// [`DynamicClockId`] for a greater set of clocks, with the caveat that not
 /// all of them are always supported.
+///
+/// [`clock_gettime`]: crate::time::clock_gettime
 #[cfg(apple)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[repr(u32)]

--- a/src/fs/fcntl_apple.rs
+++ b/src/fs/fcntl_apple.rs
@@ -7,6 +7,7 @@ use backend::fd::AsFd;
 ///  - [Apple]
 ///
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html
+#[doc(alias = "F_RDADVISE")]
 #[inline]
 pub fn fcntl_rdadvise<Fd: AsFd>(fd: Fd, offset: u64, len: u64) -> io::Result<()> {
     backend::fs::syscalls::fcntl_rdadvise(fd.as_fd(), offset, len)
@@ -18,7 +19,48 @@ pub fn fcntl_rdadvise<Fd: AsFd>(fd: Fd, offset: u64, len: u64) -> io::Result<()>
 ///  - [Apple]
 ///
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html
+#[doc(alias = "F_FULLSYNC")]
 #[inline]
 pub fn fcntl_fullfsync<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     backend::fs::syscalls::fcntl_fullfsync(fd.as_fd())
+}
+
+/// `fcntl(fd, F_NOCACHE, value)`—Turn data caching off or on for a file
+/// descriptor.
+///
+/// See [this mailing list post] for additional information about the meanings
+/// of `F_NOCACHE` and `F_GLOBAL_NOCACHE`.
+///
+/// [this mailing list post]: https://lists.apple.com/archives/filesystem-dev/2007/Sep/msg00010.html
+///
+/// See also [`fcntl_global_nocache`].
+///
+/// # References
+///  - [Apple]
+///
+/// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html
+#[doc(alias = "F_NOCACHE")]
+#[inline]
+pub fn fcntl_nocache<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
+    backend::fs::syscalls::fcntl_nocache(fd.as_fd(), value)
+}
+
+/// `fcntl(fd, F_GLOBAL_NOCACHE, value)`—Turn data caching off or on for all
+/// file descriptors.
+///
+/// See [this mailing list post] for additional information about the meanings
+/// of `F_NOCACHE` and `F_GLOBAL_NOCACHE`.
+///
+/// [this mailing list post]: https://lists.apple.com/archives/filesystem-dev/2007/Sep/msg00010.html
+///
+/// See also [`fcntl_nocache`].
+///
+/// # References
+///  - [Apple]
+///
+/// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html
+#[doc(alias = "F_GLOBAL_NOCACHE")]
+#[inline]
+pub fn fcntl_global_nocache<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
+    backend::fs::syscalls::fcntl_global_nocache(fd.as_fd(), value)
 }

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -84,7 +84,7 @@ pub use dir::{Dir, DirEntry};
 pub use fadvise::{fadvise, Advice};
 pub use fcntl::*;
 #[cfg(apple)]
-pub use fcntl_apple::{fcntl_fullfsync, fcntl_rdadvise};
+pub use fcntl_apple::*;
 #[cfg(apple)]
 pub use fcopyfile::*;
 pub use fd::*;

--- a/tests/fs/fcntl.rs
+++ b/tests/fs/fcntl.rs
@@ -15,3 +15,24 @@ fn test_fcntl_dupfd_cloexec() {
     let new = rustix::fs::fcntl_dupfd_cloexec(&file, 700).unwrap();
     assert_eq!(new.as_fd().as_raw_fd(), 700);
 }
+
+#[cfg(apple)]
+#[test]
+fn test_fcntl_apple() {
+    use rustix::fs::{openat, Mode, OFlags, CWD};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = openat(CWD, tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let foo = openat(
+        &dir,
+        "foo",
+        OFlags::RDWR | OFlags::CREATE | OFlags::TRUNC,
+        Mode::RUSR | Mode::WUSR,
+    )
+    .unwrap();
+
+    rustix::fs::fcntl_rdadvise(&foo, 0, 0).unwrap();
+    rustix::fs::fcntl_fullfsync(&foo).unwrap();
+    rustix::fs::fcntl_nocache(&foo, true).unwrap();
+    rustix::fs::fcntl_global_nocache(&foo, true).unwrap();
+}

--- a/tests/fs/fcntl.rs
+++ b/tests/fs/fcntl.rs
@@ -31,6 +31,14 @@ fn test_fcntl_apple() {
     )
     .unwrap();
 
+    // It appears `fsync_rdadvise` at offset 0 length 0 doesn't work if the
+    // file has size zero, so write in some bytes.
+    assert_eq!(
+        rustix::io::write(&foo, b"data").expect("write"),
+        4,
+        "write failed"
+    );
+
     rustix::fs::fcntl_rdadvise(&foo, 0, 0).unwrap();
     rustix::fs::fcntl_fullfsync(&foo).unwrap();
     rustix::fs::fcntl_nocache(&foo, true).unwrap();


### PR DESCRIPTION
Add `fcntl_nocache` and `fcntl_global_nocache` to wrap the Apple `F_NOCACHE` and `F_GLOBAL_NOCACHE` fcntls.

Fixes #761.