### PR TITLE
Bindings of eventfd for the ESP-IDF framework

### DIFF
--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -5,7 +5,7 @@ use crate::backend::conv::ret_c_int;
 #[cfg(any(apple, netbsdlike, target_os = "dragonfly", target_os = "solaris"))]
 use crate::backend::conv::ret_owned_fd;
 use crate::event::PollFd;
-#[cfg(any(linux_kernel, bsd, solarish))]
+#[cfg(any(linux_kernel, bsd, solarish, target_os = "espidf"))]
 use crate::fd::OwnedFd;
 use crate::io;
 #[cfg(any(bsd, solarish))]
@@ -15,12 +15,22 @@ use {
     crate::backend::conv::ret, crate::event::port::Event, crate::utils::as_mut_ptr,
     core::ptr::null_mut,
 };
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "illumos"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "illumos",
+    target_os = "espidf"
+))]
 use {crate::backend::conv::ret_owned_fd, crate::event::EventfdFlags};
 #[cfg(bsd)]
 use {crate::event::kqueue::Event, crate::utils::as_ptr, core::ptr::null};
 
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "illumos"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "illumos",
+    target_os = "espidf"
+))]
 pub(crate) fn eventfd(initval: u32, flags: EventfdFlags) -> io::Result<OwnedFd> {
     #[cfg(linux_kernel)]
     unsafe {
@@ -45,7 +55,7 @@ pub(crate) fn eventfd(initval: u32, flags: EventfdFlags) -> io::Result<OwnedFd> 
         ret_owned_fd(eventfd(initval, bitflags_bits!(flags)))
     }
 
-    #[cfg(target_os = "illumos")]
+    #[cfg(any(target_os = "illumos", target_os = "espidf"))]
     unsafe {
         ret_owned_fd(c::eventfd(initval, bitflags_bits!(flags)))
     }

--- a/src/backend/libc/event/types.rs
+++ b/src/backend/libc/event/types.rs
@@ -1,7 +1,19 @@
 #[cfg(any(linux_kernel, target_os = "freebsd", target_os = "illumos"))]
-use {crate::backend::c, bitflags::bitflags};
+use crate::backend::c;
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "illumos",
+    target_os = "espidf"
+))]
+use bitflags::bitflags;
 
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "illumos"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "illumos",
+    target_os = "espidf"
+))]
 bitflags! {
     /// `EFD_*` flags for use with [`eventfd`].
     ///
@@ -10,10 +22,13 @@ bitflags! {
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct EventfdFlags: u32 {
         /// `EFD_CLOEXEC`
+        #[cfg(not(target_os = "espidf"))]
         const CLOEXEC = bitcast!(c::EFD_CLOEXEC);
         /// `EFD_NONBLOCK`
+        #[cfg(not(target_os = "espidf"))]
         const NONBLOCK = bitcast!(c::EFD_NONBLOCK);
         /// `EFD_SEMAPHORE`
+        #[cfg(not(target_os = "espidf"))]
         const SEMAPHORE = bitcast!(c::EFD_SEMAPHORE);
     }
 }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -1,6 +1,11 @@
 //! Event operations.
 
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "illumos"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "illumos",
+    target_os = "espidf"
+))]
 mod eventfd;
 #[cfg(bsd)]
 pub mod kqueue;
@@ -10,6 +15,11 @@ pub mod port;
 
 #[cfg(linux_kernel)]
 pub use crate::backend::event::epoll;
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "illumos"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "illumos",
+    target_os = "espidf"
+))]
 pub use eventfd::{eventfd, EventfdFlags};
 pub use poll::{poll, PollFd, PollFlags};


### PR DESCRIPTION
The `eventfd` sys call [is available on the ESP IDF framework](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/storage/vfs.html#event-fds), although with some restrictions (no support for `EFD_CLOEXEC`, `EFD_NONBLOCK` and `EFD_SEMAPHORE` and non-blocking mode enabled by default).

Given that the ESP IDF framework is already supported in `rustix` we would like to extend the support to include this syscall as well.

Background: support for `eventfd` is key for [upstreaming ESP IDF support in the `smol/polling` crate](https://github.com/esp-rs-compat/polling/blob/espidf/src/poll.rs#L105). 