### PR TITLE
New release - for `eventfd` on ESP IDF

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustix"
-version = "0.38.6"
+version = "0.38.7"
 authors = [
     "Dan Gohman <dev@sunfishcode.online>",
     "Jakub Konka <kubkon@jakubkonka.com>",


### PR DESCRIPTION
(Not sure what the release policy is for this crate and I do realize `0.38.6` just got pushed.)

I need a new release so as to upstream in the [polling](https://github.com/smol-rs/polling) crate [a CI step that runs `cargo check` against the ESP IDF](https://github.com/smol-rs/polling/pull/128#issuecomment-1666396841).