### PR TITLE
Misc. documentation cleanups.

### DIFF
--- a/src/fs/fcntl.rs
+++ b/src/fs/fcntl.rs
@@ -15,7 +15,7 @@ use crate::{backend, io};
 use backend::fd::AsFd;
 use backend::fs::types::OFlags;
 
-// These `fcntl` functions like in the `io` module because they're not specific
+// These `fcntl` functions live in the `io` module because they're not specific
 // to files, directories, or memfd objects. We re-export them here in the `fs`
 // module because the other the `fcntl` functions are here.
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]

--- a/src/fs/mount.rs
+++ b/src/fs/mount.rs
@@ -3,43 +3,53 @@
 //! These have been moved to a new `rustix::mount` module.
 
 #[deprecated(note = "rustix::fs::UnmountFlags` moved to `rustix::mount::UnmountFlags`.")]
+#[doc(hidden)]
 pub use crate::mount::UnmountFlags;
 
 #[deprecated(note = "rustix::fs::MountFlags` moved to `rustix::mount::MountFlags`.")]
+#[doc(hidden)]
 pub use crate::mount::MountFlags;
 
 #[deprecated(
     note = "rustix::fs::MountPropagationFlags` moved to `rustix::mount::MountPropagationFlags`."
 )]
+#[doc(hidden)]
 pub use crate::mount::MountPropagationFlags;
 
 #[deprecated(note = "`rustix::fs::mount` moved to `rustix::mount::mount`.")]
+#[doc(hidden)]
 pub use crate::mount::mount;
 
 #[deprecated(note = "`rustix::fs::unmount` moved to `rustix::mount::unmount`.")]
+#[doc(hidden)]
 pub use crate::mount::unmount;
 
 #[deprecated(
     note = "`rustix::fs::remount` is renamed and moved to `rustix::mount::mount_remount`."
 )]
+#[doc(hidden)]
 pub use crate::mount::mount_remount as remount;
 
 #[deprecated(
     note = "`rustix::fs::bind_mount` is renamed and moved to `rustix::mount::mount_bind`."
 )]
+#[doc(hidden)]
 pub use crate::mount::mount_bind as bind_mount;
 
 #[deprecated(
     note = "`rustix::fs::recursive_bind_mount` is renamed and moved to `rustix::mount::mount_recursive_bind`."
 )]
+#[doc(hidden)]
 pub use crate::mount::mount_recursive_bind as recursive_bind_mount;
 
 #[deprecated(
     note = "`rustix::fs::change_mount` is renamed and moved to `rustix::mount::mount_change`."
 )]
+#[doc(hidden)]
 pub use crate::mount::mount_change as change_mount;
 
 #[deprecated(
     note = "`rustix::fs::move_mount` is renamed and moved to `rustix::mount::mount_move`."
 )]
+#[doc(hidden)]
 pub use crate::mount::mount_move as move_mount;

--- a/src/fs/raw_dir.rs
+++ b/src/fs/raw_dir.rs
@@ -136,7 +136,7 @@ impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
     }
 }
 
-/// A raw directory entry, similar to `std::fs::DirEntry`.
+/// A raw directory entry, similar to [`std::fs::DirEntry`].
 ///
 /// Unlike the std version, this may represent the `.` or `..` entries.
 pub struct RawDirEntry<'a> {

--- a/src/io/errno.rs
+++ b/src/io/errno.rs
@@ -14,8 +14,8 @@ pub type Result<T> = result::Result<T, Errno>;
 
 /// `errno`—An error code.
 ///
-/// The error type for `rustix` APIs. This is similar to `std::io::Error`, but
-/// only holds an OS error code, and no extra error value.
+/// The error type for `rustix` APIs. This is similar to [`std::io::Error`],
+/// but only holds an OS error code, and no extra error value.
 ///
 /// # References
 ///  - [POSIX]

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -109,6 +109,13 @@ fn test_file() {
         rustix::fs::OFlags::empty()
     );
 
+    // Test `fcntl_setfd`.
+    rustix::io::fcntl_setfd(&file, rustix::io::FdFlags::CLOEXEC).unwrap();
+    assert_eq!(
+        rustix::io::fcntl_getfd(&file).unwrap(),
+        rustix::io::FdFlags::CLOEXEC
+    );
+
     let stat = rustix::fs::fstat(&file).unwrap();
     assert!(stat.st_size > 0);
     assert!(stat.st_blocks > 0);


### PR DESCRIPTION
Make the deprecated `fs` aliases for the mount functions `doc(hidden)` so that they don't clutter up the `fs` module docs, and a few other minor cleanups.