### PR TITLE
Add data() method to kqueue events

### DIFF
--- a/src/event/kqueue.rs
+++ b/src/event/kqueue.rs
@@ -100,8 +100,8 @@ impl Event {
     }
 
     /// Get the raw data for this event.
-    pub fn data(&self) -> isize {
-        // On openbsd, data is an i64 and not an isize
+    pub fn data(&self) -> i64 {
+        // On some bsds, data is an isize and not an i64
         self.inner.data as _
     }
 

--- a/src/event/kqueue.rs
+++ b/src/event/kqueue.rs
@@ -99,6 +99,12 @@ impl Event {
         self.inner.udata as _
     }
 
+    /// Get the raw data for this event.
+    pub fn data(&self) -> isize {
+        // On openbsd, data is an i64 and not an isize
+        self.inner.data as _
+    }
+
     /// Get the filter of this event.
     pub fn filter(&self) -> EventFilter {
         match self.inner.filter as _ {


### PR DESCRIPTION
This allows us to get the raw data field out, which is useful for reading receipt events.

This lets us fully remove libc from polling, see this line: https://github.com/smol-rs/polling/blob/6d13def8abd73da96d1e73090f490ae0ad36d6bd/src/kqueue.rs#L132