### PR TITLE
Move some `transmute`s out of the main code and into `#[test]`s.

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -785,9 +785,6 @@ pub(crate) fn utimensat(
     unsafe {
         use crate::utils::as_ptr;
 
-        // Assert that `Timestamps` has the expected layout.
-        let _ = core::mem::transmute::<Timestamps, [c::timespec; 2]>(times.clone());
-
         ret(c::utimensat(
             borrowed_fd(dirfd),
             c_str(path),
@@ -823,9 +820,6 @@ pub(crate) fn utimensat(
 
         // If we have `utimensat`, use it.
         if let Some(have_utimensat) = utimensat.get() {
-            // Assert that `Timestamps` has the expected layout.
-            let _ = core::mem::transmute::<Timestamps, [c::timespec; 2]>(times.clone());
-
             return ret(have_utimensat(
                 borrowed_fd(dirfd),
                 c_str(path),
@@ -1093,9 +1087,6 @@ pub(crate) fn copy_file_range(
             flags: c::c_uint
         ) via SYS_copy_file_range -> c::ssize_t
     }
-
-    #[cfg(test)]
-    assert_eq_size!(c::loff_t, u64);
 
     let mut off_in_val: c::loff_t = 0;
     let mut off_out_val: c::loff_t = 0;
@@ -1453,9 +1444,6 @@ pub(crate) fn futimens(fd: BorrowedFd<'_>, times: &Timestamps) -> io::Result<()>
     unsafe {
         use crate::utils::as_ptr;
 
-        // Assert that `Timestamps` has the expected layout.
-        let _ = core::mem::transmute::<Timestamps, [c::timespec; 2]>(times.clone());
-
         ret(c::futimens(borrowed_fd(fd), as_ptr(times).cast()))
     }
 
@@ -1480,9 +1468,6 @@ pub(crate) fn futimens(fd: BorrowedFd<'_>, times: &Timestamps) -> io::Result<()>
 
         // If we have `futimens`, use it.
         if let Some(have_futimens) = futimens.get() {
-            // Assert that `Timestamps` has the expected layout.
-            let _ = core::mem::transmute::<Timestamps, [c::timespec; 2]>(times.clone());
-
             return ret(have_futimens(borrowed_fd(fd), as_ptr(times).cast()));
         }
 
@@ -2467,4 +2452,17 @@ pub(crate) fn ext4_ioc_resize_fs(fd: BorrowedFd<'_>, blocks: u64) -> io::Result<
     use linux_raw_sys::ioctl::EXT4_IOC_RESIZE_FS;
 
     unsafe { ret(c::ioctl(borrowed_fd(fd), EXT4_IOC_RESIZE_FS as _, &blocks)) }
+}
+
+#[test]
+fn test_sizes() {
+    #[cfg(linux_kernel)]
+    assert_eq_size!(c::loff_t, u64);
+
+    // Assert that `Timestamps` has the expected layout. If we're not fixing
+    // y2038, libc's tyupe should match ours. If we are, it's smaller.
+    #[cfg(not(fix_y2038))]
+    assert_eq_size!([c::timespec; 2], Timestamps);
+    #[cfg(fix_y2038)]
+    assert!(core::mem::size_of::<[c::timespec; 2]>() < core::mem::size_of::<Timestamps>());
 }

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -2460,7 +2460,7 @@ fn test_sizes() {
     assert_eq_size!(c::loff_t, u64);
 
     // Assert that `Timestamps` has the expected layout. If we're not fixing
-    // y2038, libc's tyupe should match ours. If we are, it's smaller.
+    // y2038, libc's type should match ours. If we are, it's smaller.
     #[cfg(not(fix_y2038))]
     assert_eq_size!([c::timespec; 2], Timestamps);
     #[cfg(fix_y2038)]

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -32,13 +32,13 @@ use crate::fs::{
     StatVfsMountFlags, StatxFlags, Timestamps, Uid, XattrFlags,
 };
 use crate::io;
-use core::mem::{transmute, zeroed, MaybeUninit};
+use core::mem::{zeroed, MaybeUninit};
 #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
 use linux_raw_sys::general::stat as linux_stat64;
 use linux_raw_sys::general::{
-    __kernel_fsid_t, __kernel_timespec, open_how, statx, AT_EACCESS, AT_FDCWD, AT_REMOVEDIR,
-    AT_SYMLINK_NOFOLLOW, F_ADD_SEALS, F_GETFL, F_GET_SEALS, F_SETFL, SEEK_CUR, SEEK_DATA, SEEK_END,
-    SEEK_HOLE, SEEK_SET, STATX__RESERVED,
+    __kernel_fsid_t, open_how, statx, AT_EACCESS, AT_FDCWD, AT_REMOVEDIR, AT_SYMLINK_NOFOLLOW,
+    F_ADD_SEALS, F_GETFL, F_GET_SEALS, F_SETFL, SEEK_CUR, SEEK_DATA, SEEK_END, SEEK_HOLE, SEEK_SET,
+    STATX__RESERVED,
 };
 use linux_raw_sys::ioctl::{BLKPBSZGET, BLKSSZGET, EXT4_IOC_RESIZE_FS, FICLONE};
 #[cfg(target_pointer_width = "32")]
@@ -1267,9 +1267,6 @@ fn _utimensat(
     times: &Timestamps,
     flags: AtFlags,
 ) -> io::Result<()> {
-    // Assert that `Timestamps` has the expected layout.
-    let _ = unsafe { transmute::<Timestamps, [__kernel_timespec; 2]>(times.clone()) };
-
     // `utimensat_time64` was introduced in Linux 5.1. The old `utimensat`
     // syscall is not y2038-compatible on 32-bit architectures.
     #[cfg(target_pointer_width = "32")]
@@ -1657,4 +1654,12 @@ pub(crate) fn ext4_ioc_resize_fs(fd: BorrowedFd<'_>, blocks: u64) -> io::Result<
             by_ref(&blocks)
         ))
     }
+}
+
+#[test]
+fn test_sizes() {
+    assert_eq_size!(linux_raw_sys::general::__kernel_loff_t, u64);
+
+    // Assert that `Timestamps` has the expected layout.
+    assert_eq_size!([linux_raw_sys::general::__kernel_timespec; 2], Timestamps);
 }

--- a/src/backend/linux_raw/net/msghdr.rs
+++ b/src/backend/linux_raw/net/msghdr.rs
@@ -131,3 +131,16 @@ pub(crate) fn with_unix_msghdr<R>(
         msg_flags: 0,
     })
 }
+
+/// Create a zero-initialized message header struct value.
+pub(crate) fn zero_msghdr() -> c::msghdr {
+    c::msghdr {
+        msg_name: null_mut(),
+        msg_namelen: 0,
+        msg_iov: null_mut(),
+        msg_iovlen: 0,
+        msg_control: null_mut(),
+        msg_controllen: 0,
+        msg_flags: 0,
+    }
+}

--- a/src/backend/linux_raw/net/msghdr.rs
+++ b/src/backend/linux_raw/net/msghdr.rs
@@ -12,7 +12,7 @@ use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::{RecvAncillaryBuffer, SendAncillaryBuffer, SocketAddrV4, SocketAddrV6};
 use crate::utils::as_ptr;
 
-use core::mem::{size_of, zeroed, MaybeUninit};
+use core::mem::{size_of, MaybeUninit};
 use core::ptr::null_mut;
 
 fn msg_iov_len(len: usize) -> c::size_t {
@@ -42,9 +42,7 @@ pub(crate) fn with_recv_msghdr<R>(
         msg_iovlen: msg_iov_len(iov.len()),
         msg_control: control.as_control_ptr().cast(),
         msg_controllen: msg_control_len(control.control_len()),
-
-        // Zero-initialize any padding bytes.
-        ..unsafe { zeroed() }
+        msg_flags: 0,
     };
 
     let res = f(&mut msghdr);
@@ -72,9 +70,7 @@ pub(crate) fn with_noaddr_msghdr<R>(
         msg_iovlen: msg_iov_len(iov.len()),
         msg_control: control.as_control_ptr().cast(),
         msg_controllen: msg_control_len(control.control_len()),
-
-        // Zero-initialize any padding bytes.
-        ..unsafe { zeroed() }
+        msg_flags: 0,
     })
 }
 
@@ -94,9 +90,7 @@ pub(crate) fn with_v4_msghdr<R>(
         msg_iovlen: msg_iov_len(iov.len()),
         msg_control: control.as_control_ptr().cast(),
         msg_controllen: msg_control_len(control.control_len()),
-
-        // Zero-initialize any padding bytes.
-        ..unsafe { zeroed() }
+        msg_flags: 0,
     })
 }
 
@@ -116,9 +110,7 @@ pub(crate) fn with_v6_msghdr<R>(
         msg_iovlen: msg_iov_len(iov.len()),
         msg_control: control.as_control_ptr().cast(),
         msg_controllen: msg_control_len(control.control_len()),
-
-        // Zero-initialize any padding bytes.
-        ..unsafe { zeroed() }
+        msg_flags: 0,
     })
 }
 
@@ -136,8 +128,6 @@ pub(crate) fn with_unix_msghdr<R>(
         msg_iovlen: msg_iov_len(iov.len()),
         msg_control: control.as_control_ptr().cast(),
         msg_controllen: msg_control_len(control.control_len()),
-
-        // Zero-initialize any padding bytes.
-        ..unsafe { zeroed() }
+        msg_flags: 0,
     })
 }

--- a/src/check_types.rs
+++ b/src/check_types.rs
@@ -79,9 +79,9 @@ macro_rules! check_struct {
 
         // Check that we have all the fields.
         if false {
+            #[allow(unreachable_code)]
             let _test = $name {
-                // SAFETY: This code is guarded by `if false`.
-                $($field: unsafe { core::mem::zeroed() }),*
+                $($field: panic!()),*
             };
         }
 

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -27,7 +27,7 @@
 use crate::fd::{AsFd, BorrowedFd, OwnedFd, RawFd};
 use crate::{backend, io};
 use core::ffi::c_void;
-use core::mem::{zeroed, MaybeUninit};
+use core::mem::MaybeUninit;
 use core::ptr::{null_mut, write_bytes};
 use linux_raw_sys::net;
 
@@ -1245,72 +1245,63 @@ pub struct io_uring_buf {
 impl Default for ioprio_union {
     #[inline]
     fn default() -> Self {
-        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
-        unsafe { zeroed::<Self>() }
+        default_union!(ioprio_union, ioprio)
     }
 }
 
 impl Default for len_union {
     #[inline]
     fn default() -> Self {
-        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
-        unsafe { zeroed::<Self>() }
+        default_union!(len_union, len)
     }
 }
 
 impl Default for off_or_addr2_union {
     #[inline]
     fn default() -> Self {
-        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
-        unsafe { zeroed::<Self>() }
+        default_union!(off_or_addr2_union, off)
     }
 }
 
 impl Default for addr_or_splice_off_in_union {
     #[inline]
     fn default() -> Self {
-        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
-        unsafe { zeroed::<Self>() }
+        default_union!(addr_or_splice_off_in_union, splice_off_in)
     }
 }
 
 impl Default for addr3_or_cmd_union {
     #[inline]
     fn default() -> Self {
-        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
-        unsafe { zeroed::<Self>() }
+        default_union!(addr3_or_cmd_union, addr3)
     }
 }
 
 impl Default for op_flags_union {
     #[inline]
     fn default() -> Self {
-        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
-        unsafe { zeroed::<Self>() }
+        default_union!(op_flags_union, sync_range_flags)
     }
 }
 
 impl Default for buf_union {
     #[inline]
     fn default() -> Self {
-        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
-        unsafe { zeroed::<Self>() }
+        default_union!(buf_union, buf_index)
     }
 }
 
 impl Default for splice_fd_in_or_file_index_union {
     #[inline]
     fn default() -> Self {
-        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
-        unsafe { zeroed::<Self>() }
+        default_union!(splice_fd_in_or_file_index_union, splice_fd_in)
     }
 }
 
 impl Default for register_or_sqe_op_or_sqe_flags_union {
     #[inline]
     fn default() -> Self {
-        // SAFETY: All of Linux's io_uring structs may be zero-initialized.
-        unsafe { zeroed::<Self>() }
+        default_union!(register_or_sqe_op_or_sqe_flags_union, sqe_flags)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,7 @@ mod static_assertions;
 #[cfg(not(windows))]
 #[macro_use]
 pub(crate) mod cstr;
+#[macro_use]
 pub(crate) mod utils;
 // Polyfill for `std` in `no_std` builds.
 #[cfg_attr(feature = "std", path = "maybe_polyfill/std/mod.rs")]

--- a/src/net/send_recv/msg.rs
+++ b/src/net/send_recv/msg.rs
@@ -685,10 +685,9 @@ impl<T> DoubleEndedIterator for AncillaryIter<'_, T> {
 }
 
 mod messages {
-    use crate::backend::c;
+    use crate::backend::{c, net::msghdr};
     use core::iter::FusedIterator;
     use core::marker::PhantomData;
-    use core::mem::zeroed;
     use core::ptr::NonNull;
 
     /// An iterator over the messages in an ancillary buffer.
@@ -709,7 +708,7 @@ mod messages {
         /// Create a new iterator over messages from a byte buffer.
         pub(super) fn new(buf: &'buf mut [u8]) -> Self {
             let msghdr = {
-                let mut h: c::msghdr = unsafe { zeroed() };
+                let mut h = msghdr::zero_msghdr();
                 h.msg_control = buf.as_mut_ptr().cast();
                 h.msg_controllen = buf.len().try_into().expect("buffer too large for msghdr");
                 h

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1291,9 +1291,9 @@ fn test_sizes() {
     #[allow(unsafe_code)]
     unsafe {
         let t: Option<Protocol> = None;
-        assert_eq!(0_u32, transmute(t));
+        assert_eq!(0_u32, transmute::<Option<Protocol>, u32>(t));
 
         let t: Option<Protocol> = Some(Protocol::from_raw(RawProtocol::new(4567).unwrap()));
-        assert_eq!(4567_u32, transmute(t));
+        assert_eq!(4567_u32, transmute::<Option<Protocol>, u32>(t));
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -48,3 +48,9 @@ pub(crate) fn check_raw_pointer<T>(value: *mut c_void) -> Option<NonNull<T>> {
 
     NonNull::new(value.cast())
 }
+
+/// Create an array containing all default values, inferring the type.
+#[inline]
+pub(crate) fn default_array<T: Default + Copy, const N: usize>() -> [T; N] {
+    [T::default(); N]
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 //! Miscellaneous minor utilities.
 
 #![allow(dead_code)]
+#![allow(unused_macros)]
 
 use core::ffi::c_void;
 use core::mem::{align_of, size_of};
@@ -49,8 +50,33 @@ pub(crate) fn check_raw_pointer<T>(value: *mut c_void) -> Option<NonNull<T>> {
     NonNull::new(value.cast())
 }
 
-/// Create an array containing all default values, inferring the type.
+/// Create an array value containing all default values, inferring the type.
 #[inline]
 pub(crate) fn default_array<T: Default + Copy, const N: usize>() -> [T; N] {
     [T::default(); N]
+}
+
+/// Create a union value containing a default value in one of its arms.
+///
+/// The field names a union field which must have the same size as the union
+/// itself.
+macro_rules! default_union {
+    ($union:ident, $field:ident) => {{
+        let u = $union {
+            $field: Default::default(),
+        };
+
+        // Assert that the given field initializes the whole union.
+        #[cfg(test)]
+        unsafe {
+            let field_value = u.$field;
+            assert_eq!(
+                core::mem::size_of_val(&u),
+                core::mem::size_of_val(&field_value)
+            );
+            const_assert_eq!(memoffset::offset_of_union!($union, $field), 0);
+        }
+
+        u
+    }};
 }


### PR DESCRIPTION
In a few places, `transmute` was being used to assert that two types have the same size. Remove these `transmute`s and add corresponding `assert_eq_size` tests instead.