### PR TITLE
Enable bitflags' support for externally-defined flags.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md", "b
 rust-version = "1.63"
 
 [dependencies]
-bitflags = { version = "2.3.3", default-features = false }
+bitflags = { version = "2.4.0", default-features = false }
 itoa = { version = "1.0.1", default-features = false, optional = true }
 
 # Special dependencies used in rustc-dep-of-std mode.

--- a/src/backend/libc/event/epoll.rs
+++ b/src/backend/libc/event/epoll.rs
@@ -92,6 +92,9 @@ bitflags! {
     pub struct CreateFlags: u32 {
         /// `EPOLL_CLOEXEC`
         const CLOEXEC = bitcast!(c::EPOLL_CLOEXEC);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -145,6 +148,9 @@ bitflags! {
         /// `EPOLLEXCLUSIVE`
         #[cfg(not(target_os = "android"))]
         const EXCLUSIVE = bitcast!(c::EPOLLEXCLUSIVE);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/backend/libc/event/poll_fd.rs
+++ b/src/backend/libc/event/poll_fd.rs
@@ -47,6 +47,9 @@ bitflags! {
             not(any(target_arch = "sparc", target_arch = "sparc64"))),
         )]
         const RDHUP = c::POLLRDHUP;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/backend/libc/event/types.rs
+++ b/src/backend/libc/event/types.rs
@@ -30,5 +30,8 @@ bitflags! {
         /// `EFD_SEMAPHORE`
         #[cfg(not(target_os = "espidf"))]
         const SEMAPHORE = bitcast!(c::EFD_SEMAPHORE);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }

--- a/src/backend/libc/fs/inotify.rs
+++ b/src/backend/libc/fs/inotify.rs
@@ -17,6 +17,9 @@ bitflags! {
         const CLOEXEC = bitcast!(c::IN_CLOEXEC);
         /// `IN_NONBLOCK`
         const NONBLOCK = bitcast!(c::IN_NONBLOCK);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -71,6 +74,9 @@ bitflags! {
         const ONESHOT = c::IN_ONESHOT;
         /// `IN_ONLYDIR`
         const ONLYDIR = c::IN_ONLYDIR;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -20,6 +20,9 @@ bitflags! {
 
         /// `F_OK`
         const EXISTS = c::F_OK;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -73,6 +76,9 @@ bitflags! {
         /// `AT_STATX_DONT_SYNC`
         #[cfg(all(target_os = "linux", target_env = "gnu"))]
         const STATX_DONT_SYNC = bitcast!(c::AT_STATX_DONT_SYNC);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -144,6 +150,9 @@ bitflags! {
         /// `S_ISVTX`
         #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have Unix-style mode flags.
         const SVTX = c::S_ISVTX as RawMode;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -318,6 +327,9 @@ bitflags! {
         /// `O_EMPTY_PATH`
         #[cfg(target_os = "freebsd")]
         const EMPTY_PATH = bitcast!(c::O_EMPTY_PATH);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -334,6 +346,9 @@ bitflags! {
 
         /// `CLONE_NOOWNERCOPY`
         const NOOWNERCOPY = 2;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -376,6 +391,9 @@ bitflags! {
 
         /// `COPYFILE_ALL`
         const ALL = copyfile::ALL;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -404,6 +422,9 @@ bitflags! {
 
         /// `RESOLVE_CACHED` (since Linux 5.12)
         const CACHED = 0x20;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -423,6 +444,9 @@ bitflags! {
 
         /// `RENAME_WHITEOUT`
         const WHITEOUT = bitcast!(c::RENAME_WHITEOUT);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -597,6 +621,9 @@ bitflags! {
         const HUGE_2GB = c::MFD_HUGE_2GB;
         /// `MFD_HUGE_16GB`
         const HUGE_16GB = c::MFD_HUGE_16GB;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -610,17 +637,20 @@ bitflags! {
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct SealFlags: u32 {
-       /// `F_SEAL_SEAL`.
-       const SEAL = bitcast!(c::F_SEAL_SEAL);
-       /// `F_SEAL_SHRINK`.
-       const SHRINK = bitcast!(c::F_SEAL_SHRINK);
-       /// `F_SEAL_GROW`.
-       const GROW = bitcast!(c::F_SEAL_GROW);
-       /// `F_SEAL_WRITE`.
-       const WRITE = bitcast!(c::F_SEAL_WRITE);
-       /// `F_SEAL_FUTURE_WRITE` (since Linux 5.1)
-       #[cfg(linux_kernel)]
-       const FUTURE_WRITE = bitcast!(c::F_SEAL_FUTURE_WRITE);
+        /// `F_SEAL_SEAL`.
+        const SEAL = bitcast!(c::F_SEAL_SEAL);
+        /// `F_SEAL_SHRINK`.
+        const SHRINK = bitcast!(c::F_SEAL_SHRINK);
+        /// `F_SEAL_GROW`.
+        const GROW = bitcast!(c::F_SEAL_GROW);
+        /// `F_SEAL_WRITE`.
+        const WRITE = bitcast!(c::F_SEAL_WRITE);
+        /// `F_SEAL_FUTURE_WRITE` (since Linux 5.1)
+        #[cfg(linux_kernel)]
+        const FUTURE_WRITE = bitcast!(c::F_SEAL_FUTURE_WRITE);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -679,6 +709,9 @@ bitflags! {
 
         /// `STATX_ALL`
         const ALL = c::STATX_ALL;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -737,6 +770,9 @@ bitflags! {
 
         /// `STATX_ALL`
         const ALL = 0xfff;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -819,6 +855,9 @@ bitflags! {
             target_os = "wasi",
         )))]
         const UNSHARE_RANGE = bitcast!(c::FALLOC_FL_UNSHARE_RANGE);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -868,6 +907,9 @@ bitflags! {
         /// `ST_SYNCHRONOUS`
         #[cfg(any(linux_kernel, target_os = "emscripten", target_os = "fuchsia"))]
         const SYNCHRONOUS = c::ST_SYNCHRONOUS as u64;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/backend/libc/io/types.rs
+++ b/src/backend/libc/io/types.rs
@@ -11,6 +11,9 @@ bitflags! {
     pub struct FdFlags: u32 {
         /// `FD_CLOEXEC`
         const CLOEXEC = bitcast!(c::FD_CLOEXEC);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -33,6 +36,9 @@ bitflags! {
         const NOWAIT = linux_raw_sys::general::RWF_NOWAIT;
         /// `RWF_APPEND` (since Linux 4.16)
         const APPEND = linux_raw_sys::general::RWF_APPEND;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -52,5 +58,8 @@ bitflags! {
             target_os = "redox",
         )))] // Android 5.0 has dup3, but libc doesn't have bindings
         const CLOEXEC = bitcast!(c::O_CLOEXEC);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }

--- a/src/backend/libc/mm/types.rs
+++ b/src/backend/libc/mm/types.rs
@@ -16,6 +16,9 @@ bitflags! {
         const WRITE = bitcast!(c::PROT_WRITE);
         /// `PROT_EXEC`
         const EXEC = bitcast!(c::PROT_EXEC);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -55,6 +58,9 @@ bitflags! {
         /// `PROT_ADI`
         #[cfg(all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64")))]
         const ADI = linux_raw_sys::general::PROT_ADI;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -208,6 +214,9 @@ bitflags! {
         /// `MAP_UNINITIALIZED`
         #[cfg(any())]
         const UNINITIALIZED = bitcast!(c::MAP_UNINITIALIZED);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -224,6 +233,9 @@ bitflags! {
     pub struct MremapFlags: u32 {
         /// `MREMAP_MAYMOVE`
         const MAYMOVE = bitcast!(c::MREMAP_MAYMOVE);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -243,6 +255,9 @@ bitflags! {
         /// file (so that they can be updated with the fresh values just
         /// written).
         const INVALIDATE = bitcast!(c::MS_INVALIDATE);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -256,6 +271,9 @@ bitflags! {
     pub struct MlockFlags: u32 {
         /// `MLOCK_ONFAULT`
         const ONFAULT = bitcast!(c::MLOCK_ONFAULT);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -403,5 +421,8 @@ bitflags! {
         const CLOEXEC = bitcast!(c::O_CLOEXEC);
         /// `O_NONBLOCK`
         const NONBLOCK = bitcast!(c::O_NONBLOCK);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }

--- a/src/backend/libc/mount/types.rs
+++ b/src/backend/libc/mount/types.rs
@@ -54,6 +54,9 @@ bitflags! {
 
         /// `MS_SYNCHRONOUS`
         const SYNCHRONOUS = c::MS_SYNCHRONOUS;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -73,6 +76,9 @@ bitflags! {
         const EXPIRE = bitcast!(c::MNT_EXPIRE);
         /// `UMOUNT_NOFOLLOW`
         const NOFOLLOW = bitcast!(c::UMOUNT_NOFOLLOW);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -85,9 +91,11 @@ bitflags! {
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct FsOpenFlags: c::c_uint {
-
         /// `FSOPEN_CLOEXEC`
         const FSOPEN_CLOEXEC = 0x00000001;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -102,6 +110,9 @@ bitflags! {
     pub struct FsMountFlags: c::c_uint {
         /// `FSMOUNT_CLOEXEC`
         const FSMOUNT_CLOEXEC = 0x00000001;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -180,6 +191,9 @@ bitflags! {
 
         /// `MOUNT_ATTR__ATIME_FLAGS`
         const MOUNT_ATTR_SIZE_VER0 = 32;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -219,6 +233,9 @@ bitflags! {
 
         /// `MOVE_MOUNT__MASK`
         const MOVE_MOUNT__MASK = 0x00000377;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -248,6 +265,9 @@ bitflags! {
 
         /// `AT_SYMLINK_NOFOLLOW`
         const AT_SYMLINK_NOFOLLOW = c::AT_SYMLINK_NOFOLLOW as c::c_uint;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -271,6 +291,9 @@ bitflags! {
 
         /// `FSPICK_EMPTY_PATH`
         const FSPICK_EMPTY_PATH = 0x00000008;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -294,6 +317,9 @@ bitflags! {
         const UNBINDABLE = c::MS_UNBINDABLE;
         /// `MS_REC`
         const REC = c::MS_REC;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -304,6 +330,9 @@ bitflags! {
     pub(crate) struct InternalMountFlags: c::c_ulong {
         const REMOUNT = c::MS_REMOUNT;
         const MOVE = c::MS_MOVE;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/backend/libc/net/send_recv.rs
+++ b/src/backend/libc/net/send_recv.rs
@@ -41,6 +41,9 @@ bitflags! {
         const NOSIGNAL = bitcast!(c::MSG_NOSIGNAL);
         /// `MSG_OOB`
         const OOB = bitcast!(c::MSG_OOB);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -76,5 +79,8 @@ bitflags! {
         const TRUNC = bitcast!(c::MSG_TRUNC);
         /// `MSG_WAITALL`
         const WAITALL = bitcast!(c::MSG_WAITALL);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }

--- a/src/backend/libc/pipe/types.rs
+++ b/src/backend/libc/pipe/types.rs
@@ -25,6 +25,9 @@ bitflags! {
         const DIRECT = bitcast!(c::O_DIRECT);
         /// `O_NONBLOCK`
         const NONBLOCK = bitcast!(c::O_NONBLOCK);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -43,6 +46,9 @@ bitflags! {
         const MORE = c::SPLICE_F_MORE;
         /// `SPLICE_F_GIFT`
         const GIFT = c::SPLICE_F_GIFT;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/backend/libc/rand/types.rs
+++ b/src/backend/libc/rand/types.rs
@@ -17,5 +17,8 @@ bitflags! {
         const NONBLOCK = c::GRND_NONBLOCK;
         /// `GRND_INSECURE`
         const INSECURE = c::GRND_INSECURE;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }

--- a/src/backend/libc/time/types.rs
+++ b/src/backend/libc/time/types.rs
@@ -87,6 +87,9 @@ bitflags! {
 
         /// `TFD_CLOEXEC`
         const CLOEXEC = bitcast!(c::TFD_CLOEXEC);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -104,6 +107,9 @@ bitflags! {
         /// `TFD_TIMER_CANCEL_ON_SET`
         #[cfg(linux_kernel)]
         const CANCEL_ON_SET = bitcast!(c::TFD_TIMER_CANCEL_ON_SET);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/backend/linux_raw/event/epoll.rs
+++ b/src/backend/linux_raw/event/epoll.rs
@@ -92,6 +92,9 @@ bitflags! {
     pub struct CreateFlags: c::c_uint {
         /// `EPOLL_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::EPOLL_CLOEXEC;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -144,6 +147,9 @@ bitflags! {
 
         /// `EPOLLEXCLUSIVE`
         const EXCLUSIVE = linux_raw_sys::general::EPOLLEXCLUSIVE as u32;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/backend/linux_raw/event/poll_fd.rs
+++ b/src/backend/linux_raw/event/poll_fd.rs
@@ -30,6 +30,9 @@ bitflags! {
         const NVAL = linux_raw_sys::general::POLLNVAL as u16;
         /// `POLLRDHUP`
         const RDHUP = linux_raw_sys::general::POLLRDHUP as u16;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/backend/linux_raw/event/types.rs
+++ b/src/backend/linux_raw/event/types.rs
@@ -14,5 +14,8 @@ bitflags! {
         const NONBLOCK = linux_raw_sys::general::EFD_NONBLOCK;
         /// `EFD_SEMAPHORE`
         const SEMAPHORE = linux_raw_sys::general::EFD_SEMAPHORE;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }

--- a/src/backend/linux_raw/fs/inotify.rs
+++ b/src/backend/linux_raw/fs/inotify.rs
@@ -17,6 +17,9 @@ bitflags! {
         const CLOEXEC = linux_raw_sys::general::IN_CLOEXEC;
         /// `IN_NONBLOCK`
         const NONBLOCK = linux_raw_sys::general::IN_NONBLOCK;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -71,6 +74,9 @@ bitflags! {
         const ONESHOT = linux_raw_sys::general::IN_ONESHOT;
         /// `IN_ONLYDIR`
         const ONLYDIR = linux_raw_sys::general::IN_ONLYDIR;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -19,6 +19,9 @@ bitflags! {
 
         /// `F_OK`
         const EXISTS = linux_raw_sys::general::F_OK;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -57,6 +60,9 @@ bitflags! {
 
         /// `AT_STATX_DONT_SYNC`
         const STATX_DONT_SYNC = linux_raw_sys::general::AT_STATX_DONT_SYNC;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -113,6 +119,9 @@ bitflags! {
 
         /// `S_ISVTX`
         const SVTX = linux_raw_sys::general::S_ISVTX;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -240,6 +249,9 @@ bitflags! {
 
         /// `O_DIRECT`
         const DIRECT = linux_raw_sys::general::O_DIRECT;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -267,6 +279,9 @@ bitflags! {
 
         /// `RESOLVE_CACHED` (since Linux 5.12)
         const CACHED = linux_raw_sys::general::RESOLVE_CACHED as u64;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -285,6 +300,9 @@ bitflags! {
 
         /// `RENAME_WHITEOUT`
         const WHITEOUT = linux_raw_sys::general::RENAME_WHITEOUT;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -434,6 +452,9 @@ bitflags! {
         const HUGE_2GB = linux_raw_sys::general::MFD_HUGE_2GB;
         /// `MFD_HUGE_16GB`
         const HUGE_16GB = linux_raw_sys::general::MFD_HUGE_16GB;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -446,16 +467,19 @@ bitflags! {
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct SealFlags: u32 {
-       /// `F_SEAL_SEAL`.
-       const SEAL = linux_raw_sys::general::F_SEAL_SEAL;
-       /// `F_SEAL_SHRINK`.
-       const SHRINK = linux_raw_sys::general::F_SEAL_SHRINK;
-       /// `F_SEAL_GROW`.
-       const GROW = linux_raw_sys::general::F_SEAL_GROW;
-       /// `F_SEAL_WRITE`.
-       const WRITE = linux_raw_sys::general::F_SEAL_WRITE;
-       /// `F_SEAL_FUTURE_WRITE` (since Linux 5.1)
-       const FUTURE_WRITE = linux_raw_sys::general::F_SEAL_FUTURE_WRITE;
+        /// `F_SEAL_SEAL`.
+        const SEAL = linux_raw_sys::general::F_SEAL_SEAL;
+        /// `F_SEAL_SHRINK`.
+        const SHRINK = linux_raw_sys::general::F_SEAL_SHRINK;
+        /// `F_SEAL_GROW`.
+        const GROW = linux_raw_sys::general::F_SEAL_GROW;
+        /// `F_SEAL_WRITE`.
+        const WRITE = linux_raw_sys::general::F_SEAL_WRITE;
+        /// `F_SEAL_FUTURE_WRITE` (since Linux 5.1)
+        const FUTURE_WRITE = linux_raw_sys::general::F_SEAL_FUTURE_WRITE;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -513,6 +537,9 @@ bitflags! {
 
         /// `STATX_ALL`
         const ALL = linux_raw_sys::general::STATX_ALL;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -537,6 +564,9 @@ bitflags! {
         const INSERT_RANGE = linux_raw_sys::general::FALLOC_FL_INSERT_RANGE;
         /// `FALLOC_FL_UNSHARE_RANGE`
         const UNSHARE_RANGE = linux_raw_sys::general::FALLOC_FL_UNSHARE_RANGE;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -571,6 +601,9 @@ bitflags! {
 
         /// `ST_SYNCHRONOUS`
         const SYNCHRONOUS = linux_raw_sys::general::MS_SYNCHRONOUS as u64;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/backend/linux_raw/io/types.rs
+++ b/src/backend/linux_raw/io/types.rs
@@ -11,6 +11,9 @@ bitflags! {
     pub struct FdFlags: c::c_uint {
         /// `FD_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::FD_CLOEXEC;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -32,6 +35,9 @@ bitflags! {
         const NOWAIT = linux_raw_sys::general::RWF_NOWAIT;
         /// `RWF_APPEND` (since Linux 4.16)
         const APPEND = linux_raw_sys::general::RWF_APPEND;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -44,5 +50,8 @@ bitflags! {
     pub struct DupFlags: c::c_uint {
         /// `O_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::O_CLOEXEC;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }

--- a/src/backend/linux_raw/mm/types.rs
+++ b/src/backend/linux_raw/mm/types.rs
@@ -16,6 +16,9 @@ bitflags! {
         const WRITE = linux_raw_sys::general::PROT_WRITE;
         /// `PROT_EXEC`
         const EXEC = linux_raw_sys::general::PROT_EXEC;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -52,6 +55,9 @@ bitflags! {
         /// `PROT_ADI`
         #[cfg(any(target_arch = "sparc", target_arch = "sparc64"))]
         const ADI = linux_raw_sys::general::PROT_ADI;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -99,6 +105,9 @@ bitflags! {
         /// `MAP_UNINITIALIZED`
         #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6", target_arch = "mips64", target_arch = "mips64r6")))]
         const UNINITIALIZED = linux_raw_sys::general::MAP_UNINITIALIZED;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -116,6 +125,9 @@ bitflags! {
         const MAYMOVE = linux_raw_sys::general::MREMAP_MAYMOVE;
         /// `MREMAP_DONTUNMAP` (since Linux 5.7)
         const DONTUNMAP = linux_raw_sys::general::MREMAP_DONTUNMAP;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -135,6 +147,9 @@ bitflags! {
         /// file (so that they can be updated with the fresh values just
         /// written).
         const INVALIDATE = linux_raw_sys::general::MS_INVALIDATE;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -147,6 +162,9 @@ bitflags! {
     pub struct MlockFlags: u32 {
         /// `MLOCK_ONFAULT`
         const ONFAULT = linux_raw_sys::general::MLOCK_ONFAULT;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -239,5 +257,8 @@ bitflags! {
         const CLOEXEC = linux_raw_sys::general::O_CLOEXEC;
         /// `O_NONBLOCK`
         const NONBLOCK = linux_raw_sys::general::O_NONBLOCK;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }

--- a/src/backend/linux_raw/mount/types.rs
+++ b/src/backend/linux_raw/mount/types.rs
@@ -56,6 +56,9 @@ bitflags! {
 
         /// `MS_NOSYMFOLLOW`
         const NOSYMFOLLOW = linux_raw_sys::general::MS_NOSYMFOLLOW;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -74,6 +77,9 @@ bitflags! {
         const EXPIRE = linux_raw_sys::general::MNT_EXPIRE;
         /// `UMOUNT_NOFOLLOW`
         const NOFOLLOW = linux_raw_sys::general::UMOUNT_NOFOLLOW;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -85,9 +91,11 @@ bitflags! {
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct FsOpenFlags: c::c_uint {
-
         /// `FSOPEN_CLOEXEC`
         const FSOPEN_CLOEXEC = linux_raw_sys::general::FSOPEN_CLOEXEC;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -101,6 +109,9 @@ bitflags! {
     pub struct FsMountFlags: c::c_uint {
         /// `FSMOUNT_CLOEXEC`
         const FSMOUNT_CLOEXEC = linux_raw_sys::general::FSMOUNT_CLOEXEC;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -177,6 +188,9 @@ bitflags! {
 
         /// `MOUNT_ATTR__ATIME_FLAGS`
         const MOUNT_ATTR_SIZE_VER0 = linux_raw_sys::general::MOUNT_ATTR_SIZE_VER0;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -215,6 +229,9 @@ bitflags! {
 
         /// `MOVE_MOUNT__MASK`
         const MOVE_MOUNT__MASK = linux_raw_sys::general::MOVE_MOUNT__MASK;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -243,6 +260,9 @@ bitflags! {
 
         /// `AT_SYMLINK_NOFOLLOW`
         const AT_SYMLINK_NOFOLLOW = linux_raw_sys::general::AT_SYMLINK_NOFOLLOW;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -265,6 +285,9 @@ bitflags! {
 
         /// `FSPICK_EMPTY_PATH`
         const FSPICK_EMPTY_PATH = linux_raw_sys::general::FSPICK_EMPTY_PATH;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -287,6 +310,9 @@ bitflags! {
         const UNBINDABLE = linux_raw_sys::general::MS_UNBINDABLE;
         /// `MS_REC`
         const REC = linux_raw_sys::general::MS_REC;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -296,6 +322,9 @@ bitflags! {
     pub(crate) struct InternalMountFlags: c::c_uint {
         const REMOUNT = linux_raw_sys::general::MS_REMOUNT;
         const MOVE = linux_raw_sys::general::MS_MOVE;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/backend/linux_raw/net/send_recv.rs
+++ b/src/backend/linux_raw/net/send_recv.rs
@@ -23,6 +23,9 @@ bitflags! {
         const NOSIGNAL = c::MSG_NOSIGNAL;
         /// `MSG_OOB`
         const OOB = c::MSG_OOB;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -48,5 +51,8 @@ bitflags! {
         const TRUNC = c::MSG_TRUNC;
         /// `MSG_WAITALL`
         const WAITALL = c::MSG_WAITALL;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }

--- a/src/backend/linux_raw/pipe/types.rs
+++ b/src/backend/linux_raw/pipe/types.rs
@@ -15,6 +15,9 @@ bitflags! {
         const DIRECT = linux_raw_sys::general::O_DIRECT;
         /// `O_NONBLOCK`
         const NONBLOCK = linux_raw_sys::general::O_NONBLOCK;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -32,6 +35,9 @@ bitflags! {
         const MORE = linux_raw_sys::general::SPLICE_F_MORE;
         /// `SPLICE_F_GIFT`
         const GIFT = linux_raw_sys::general::SPLICE_F_GIFT;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/backend/linux_raw/rand/types.rs
+++ b/src/backend/linux_raw/rand/types.rs
@@ -13,5 +13,8 @@ bitflags! {
         const NONBLOCK = linux_raw_sys::general::GRND_NONBLOCK;
         /// `GRND_INSECURE`
         const INSECURE = linux_raw_sys::general::GRND_INSECURE;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }

--- a/src/backend/linux_raw/thread/futex.rs
+++ b/src/backend/linux_raw/thread/futex.rs
@@ -9,6 +9,9 @@ bitflags::bitflags! {
         const PRIVATE = linux_raw_sys::general::FUTEX_PRIVATE_FLAG;
         /// `FUTEX_CLOCK_REALTIME`
         const CLOCK_REALTIME = linux_raw_sys::general::FUTEX_CLOCK_REALTIME;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/backend/linux_raw/time/types.rs
+++ b/src/backend/linux_raw/time/types.rs
@@ -20,6 +20,9 @@ bitflags! {
 
         /// `TFD_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::TFD_CLOEXEC;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -35,6 +38,9 @@ bitflags! {
 
         /// `TFD_TIMER_CANCEL_ON_SET`
         const CANCEL_ON_SET = linux_raw_sys::general::TFD_TIMER_CANCEL_ON_SET;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/event/kqueue.rs
+++ b/src/event/kqueue.rs
@@ -262,6 +262,9 @@ bitflags::bitflags! {
 
         /// TODO
         const ERROR = c::EV_ERROR as _;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -290,6 +293,9 @@ bitflags::bitflags! {
 
         /// The link count of the file has changed.
         const LINK = c::NOTE_LINK;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -312,6 +318,9 @@ bitflags::bitflags! {
 
         /// An error has occurred with following the process.
         const TRACKERR = c::NOTE_TRACKERR;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -341,6 +350,9 @@ bitflags::bitflags! {
 
         /// Trigger the event.
         const TRIGGER = c::NOTE_TRIGGER;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/fs/xattr.rs
+++ b/src/fs/xattr.rs
@@ -14,6 +14,9 @@ bitflags! {
 
         /// `XATTR_REPLACE`
         const REPLACE = c::XATTR_REPLACE as c::c_uint;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -120,6 +120,9 @@ bitflags::bitflags! {
 
         /// `IORING_ENTER_EXT_ARG`
         const EXT_ARG = sys::IORING_ENTER_EXT_ARG;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -455,6 +458,9 @@ bitflags::bitflags! {
 
         /// `IORING_SETUP_DEFER_TASKRUN`
         const DEFER_TASKRUN = sys::IORING_SETUP_DEFER_TASKRUN;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -483,6 +489,9 @@ bitflags::bitflags! {
 
         /// `1 << IOSQE_CQE_SKIP_SUCCESS_BIT`
         const CQE_SKIP_SUCCESS = 1 << sys::IOSQE_CQE_SKIP_SUCCESS_BIT as u8;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -502,6 +511,9 @@ bitflags::bitflags! {
 
         /// `IORING_CQE_F_NOTIF`
         const NOTIF = bitcast!(sys::IORING_CQE_F_NOTIF);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -512,6 +524,9 @@ bitflags::bitflags! {
     pub struct IoringFsyncFlags: u32 {
         /// `IORING_FSYNC_DATASYNC`
         const DATASYNC = sys::IORING_FSYNC_DATASYNC;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -544,6 +559,9 @@ bitflags::bitflags! {
 
         /// `IORING_LINK_TIMEOUT_UPDATE`
         const LINK_TIMEOUT_UPDATE = sys::IORING_LINK_TIMEOUT_UPDATE;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -554,6 +572,9 @@ bitflags::bitflags! {
     pub struct SpliceFlags: u32 {
         /// `SPLICE_F_FD_IN_FIXED`
         const FD_IN_FIXED = sys::SPLICE_F_FD_IN_FIXED;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -564,6 +585,9 @@ bitflags::bitflags! {
     pub struct IoringMsgringFlags: u32 {
         /// `IORING_MSG_RING_CQE_SKIP`
         const CQE_SKIP = sys::IORING_MSG_RING_CQE_SKIP;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -583,6 +607,9 @@ bitflags::bitflags! {
 
         /// `IORING_ASYNC_CANCEL_FD`
         const FD_FIXED = sys::IORING_ASYNC_CANCEL_FD_FIXED;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -629,6 +656,9 @@ bitflags::bitflags! {
 
         /// `IORING_FEAT_LINKED_FILE`
         const LINKED_FILE = sys::IORING_FEAT_LINKED_FILE;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -639,6 +669,9 @@ bitflags::bitflags! {
     pub struct IoringOpFlags: u16 {
         /// `IO_URING_OP_SUPPORTED`
         const SUPPORTED = sys::IO_URING_OP_SUPPORTED as _;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -649,6 +682,9 @@ bitflags::bitflags! {
     pub struct IoringRsrcFlags: u32 {
         /// `IORING_RSRC_REGISTER_SPARSE`
         const REGISTER_SPARSE = sys::IORING_RSRC_REGISTER_SPARSE as _;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -665,6 +701,9 @@ bitflags::bitflags! {
 
         /// `IORING_SQ_TASKRUN`
         const TASKRUN = sys::IORING_SQ_TASKRUN;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -675,6 +714,9 @@ bitflags::bitflags! {
     pub struct IoringCqFlags: u32 {
         /// `IORING_CQ_EVENTFD_DISABLED`
         const EVENTFD_DISABLED = sys::IORING_CQ_EVENTFD_DISABLED;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -694,6 +736,9 @@ bitflags::bitflags! {
 
         /// `IORING_POLL_ADD_LEVEL`
         const ADD_LEVEL = sys::IORING_POLL_ADD_LEVEL;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -714,6 +759,9 @@ bitflags::bitflags! {
 
         /// `IORING_SEND_ZC_REPORT_USAGE` (since Linux 6.2)
         const ZC_REPORT_USAGE = sys::IORING_SEND_ZC_REPORT_USAGE as _;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -734,6 +782,9 @@ bitflags::bitflags! {
         ///
         /// See also [`IoringSendFlags::FIXED_BUF`].
         const FIXED_BUF = sys::IORING_RECVSEND_FIXED_BUF as _;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -744,6 +795,9 @@ bitflags::bitflags! {
     pub struct IoringAcceptFlags: u16 {
         /// `IORING_ACCEPT_MULTISHOT`
         const MULTISHOT = sys::IORING_ACCEPT_MULTISHOT as _;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -766,6 +820,9 @@ bitflags::bitflags! {
 
         /// `MSG_ERRQUEUE`
         const ERRQUEUE = net::MSG_ERRQUEUE;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,8 @@
 //!  - Path arguments use [`Arg`], so they accept any string type.
 //!  - File descriptors are passed and returned via [`AsFd`] and [`OwnedFd`]
 //!    instead of bare integers, ensuring I/O safety.
-//!  - Constants use `enum`s and [`bitflags`] types.
+//!  - Constants use `enum`s and [`bitflags`] types, and enable
+//!    [support for externally defined flags].
 //!  - Multiplexed functions (eg. `fcntl`, `ioctl`, etc.) are de-multiplexed.
 //!  - Variadic functions (eg. `openat`, etc.) are presented as non-variadic.
 //!  - Functions that return strings automatically allocate sufficient memory
@@ -93,6 +94,7 @@
 //! [I/O-safe]: https://github.com/rust-lang/rfcs/blob/master/text/3128-io-safety.md
 //! [`Result`]: https://doc.rust-lang.org/stable/std/result/enum.Result.html
 //! [`Arg`]: https://docs.rs/rustix/*/rustix/path/trait.Arg.html
+//! [support for externally defined flags]: https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags
 
 #![deny(missing_docs)]
 #![allow(stable_features)]

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -53,6 +53,10 @@ pub type RawAddressFamily = c::sa_family_t;
 
 /// `AF_*` constants for use with [`socket`], [`socket_with`], and
 /// [`socketpair`].
+///
+/// [`socket`]: crate::net::socket()
+/// [`socket_with`]: crate::net::socket_with
+/// [`socketpair`]: crate::net::socketpair()
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(transparent)]
 pub struct AddressFamily(pub(crate) RawAddressFamily);
@@ -1268,6 +1272,9 @@ bitflags! {
         /// `SOCK_CLOEXEC`
         #[cfg(not(any(apple, windows, target_os = "haiku")))]
         const CLOEXEC = bitcast!(c::SOCK_CLOEXEC);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/prctl.rs
+++ b/src/prctl.rs
@@ -25,6 +25,9 @@ bitflags! {
         const DATA_AUTHENTICATION_KEY_B = linux_raw_sys::prctl::PR_PAC_APDBKEY;
         /// `PR_PAC_APGAKEY`—Generic authentication `A` key.
         const GENERIC_AUTHENTICATION_KEY_A = linux_raw_sys::prctl::PR_PAC_APGAKEY;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/process/membarrier.rs
+++ b/src/process/membarrier.rs
@@ -14,26 +14,29 @@ bitflags::bitflags! {
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MembarrierQuery: u32 {
-       /// `MEMBARRIER_CMD_GLOBAL` (also known as `MEMBARRIER_CMD_SHARED`)
-       #[doc(alias = "SHARED")]
-       #[doc(alias = "MEMBARRIER_CMD_SHARED")]
-       const GLOBAL = MembarrierCommand::Global as _;
-       /// `MEMBARRIER_CMD_GLOBAL_EXPEDITED`
-       const GLOBAL_EXPEDITED = MembarrierCommand::GlobalExpedited as _;
-       /// `MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED`
-       const REGISTER_GLOBAL_EXPEDITED = MembarrierCommand::RegisterGlobalExpedited as _;
-       /// `MEMBARRIER_CMD_PRIVATE_EXPEDITED`
-       const PRIVATE_EXPEDITED = MembarrierCommand::PrivateExpedited as _;
-       /// `MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED`
-       const REGISTER_PRIVATE_EXPEDITED = MembarrierCommand::RegisterPrivateExpedited as _;
-       /// `MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE`
-       const PRIVATE_EXPEDITED_SYNC_CORE = MembarrierCommand::PrivateExpeditedSyncCore as _;
-       /// `MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_SYNC_CORE`
-       const REGISTER_PRIVATE_EXPEDITED_SYNC_CORE = MembarrierCommand::RegisterPrivateExpeditedSyncCore as _;
-       /// `MEMBARRIER_CMD_PRIVATE_EXPEDITED_RSEQ` (since Linux 5.10)
-       const PRIVATE_EXPEDITED_RSEQ = MembarrierCommand::PrivateExpeditedRseq as _;
-       /// `MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_RSEQ` (since Linux 5.10)
-       const REGISTER_PRIVATE_EXPEDITED_RSEQ = MembarrierCommand::RegisterPrivateExpeditedRseq as _;
+        /// `MEMBARRIER_CMD_GLOBAL` (also known as `MEMBARRIER_CMD_SHARED`)
+        #[doc(alias = "SHARED")]
+        #[doc(alias = "MEMBARRIER_CMD_SHARED")]
+        const GLOBAL = MembarrierCommand::Global as _;
+        /// `MEMBARRIER_CMD_GLOBAL_EXPEDITED`
+        const GLOBAL_EXPEDITED = MembarrierCommand::GlobalExpedited as _;
+        /// `MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED`
+        const REGISTER_GLOBAL_EXPEDITED = MembarrierCommand::RegisterGlobalExpedited as _;
+        /// `MEMBARRIER_CMD_PRIVATE_EXPEDITED`
+        const PRIVATE_EXPEDITED = MembarrierCommand::PrivateExpedited as _;
+        /// `MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED`
+        const REGISTER_PRIVATE_EXPEDITED = MembarrierCommand::RegisterPrivateExpedited as _;
+        /// `MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE`
+        const PRIVATE_EXPEDITED_SYNC_CORE = MembarrierCommand::PrivateExpeditedSyncCore as _;
+        /// `MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_SYNC_CORE`
+        const REGISTER_PRIVATE_EXPEDITED_SYNC_CORE = MembarrierCommand::RegisterPrivateExpeditedSyncCore as _;
+        /// `MEMBARRIER_CMD_PRIVATE_EXPEDITED_RSEQ` (since Linux 5.10)
+        const PRIVATE_EXPEDITED_RSEQ = MembarrierCommand::PrivateExpeditedRseq as _;
+        /// `MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_RSEQ` (since Linux 5.10)
+        const REGISTER_PRIVATE_EXPEDITED_RSEQ = MembarrierCommand::RegisterPrivateExpeditedRseq as _;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/process/pidfd.rs
+++ b/src/process/pidfd.rs
@@ -11,6 +11,9 @@ bitflags::bitflags! {
     pub struct PidfdFlags: backend::c::c_uint {
         /// `PIDFD_NONBLOCK`.
         const NONBLOCK = backend::c::PIDFD_NONBLOCK;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/process/pidfd_getfd.rs
+++ b/src/process/pidfd_getfd.rs
@@ -17,7 +17,10 @@ bitflags::bitflags! {
     /// All flags are reserved for future use.
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct PidfdGetfdFlags: backend::c::c_uint {}
+    pub struct PidfdGetfdFlags: backend::c::c_uint {
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
+    }
 }
 
 /// `syscall(SYS_pidfd_getfd, pidfd, flags)`—Obtain a duplicate of another

--- a/src/process/prctl.rs
+++ b/src/process/prctl.rs
@@ -148,6 +148,9 @@ bitflags! {
         /// Generate a [`Signal::Bus`] signal on unaligned user access.
         #[doc(alias = "PR_UNALIGN_SIGBUS")]
         const SIGBUS = 2;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/process/procctl.rs
+++ b/src/process/procctl.rs
@@ -229,6 +229,9 @@ bitflags! {
         const OWNED = 1;
         /// The process is the root of the reaper tree (pid 1).
         const REALINIT = 2;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -22,6 +22,9 @@ bitflags! {
         /// Return if a stopped child has been resumed by delivery of
         /// [`Signal::Cont`].
         const CONTINUED = bitcast!(backend::process::wait::WCONTINUED);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -42,6 +45,9 @@ bitflags! {
         const NOWAIT = bitcast!(backend::process::wait::WNOWAIT);
         /// Wait for processes that have been stopped.
         const STOPPED = bitcast!(backend::process::wait::WSTOPPED);
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -32,6 +32,9 @@ bitflags::bitflags! {
         /// rustix supports it on Linux, and FreeBSD and NetBSD support it.
         #[cfg(any(linux_kernel, target_os = "freebsd", target_os = "netbsd"))]
         const CLOEXEC = c::O_CLOEXEC as c::c_uint;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -292,6 +292,9 @@ bitflags! {
             target_os = "redox",
         )))]
         const IUTF8 = c::IUTF8;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -504,6 +507,9 @@ bitflags! {
             target_os = "redox",
         )))]
         const VT1 = c::VT1;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -564,6 +570,9 @@ bitflags! {
             target_os = "redox",
         )))]
         const CMSPAR = c::CMSPAR;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -627,6 +636,9 @@ bitflags! {
 
         /// `IEXTEN`
         const IEXTEN = c::IEXTEN;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/thread/libcap.rs
+++ b/src/thread/libcap.rs
@@ -102,6 +102,9 @@ bitflags! {
         const BPF = 1 << linux_raw_sys::general::CAP_BPF;
         /// `CAP_CHECKPOINT_RESTORE`
         const CHECKPOINT_RESTORE = 1 << linux_raw_sys::general::CAP_CHECKPOINT_RESTORE;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/thread/prctl.rs
+++ b/src/thread/prctl.rs
@@ -438,6 +438,9 @@ bitflags! {
         const NO_CAP_AMBIENT_RAISE = 1_u32 << 6;
         /// Set [`NO_CAP_AMBIENT_RAISE`] irreversibly.
         const NO_CAP_AMBIENT_RAISE_LOCKED = 1_u32 << 7;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -745,6 +748,9 @@ bitflags! {
         const TCF_SYNC = 1_u32 << 1;
         /// Asynchronous tag check fault mode.
         const TCF_ASYNC = 1_u32 << 2;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/thread/setns.rs
+++ b/src/thread/setns.rs
@@ -30,6 +30,9 @@ bitflags! {
         const PROCESS_ID = CLONE_NEWPID;
         /// Network name space.
         const NETWORK = CLONE_NEWNET;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 
@@ -82,6 +85,9 @@ bitflags! {
         const NEWUTS = CLONE_NEWUTS;
         /// `CLONE_SYSVSEM`.
         const SYSVSEM = CLONE_SYSVSEM;
+
+        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 


### PR DESCRIPTION
Bitflags 2.4.0 supports adding `const _ = !0;` to bitflags declarations as a way to prevent truncation of externally-defined flags. All of rustix's bitflags types corresond to externally-define flags, so use this syntax in all of them.

See [here] for more information.

[here]: https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags