### PR TITLE
Set up a unified system for handling ioctl calls

### DIFF
--- a/src/backend/libc/fs/mod.rs
+++ b/src/backend/libc/fs/mod.rs
@@ -12,3 +12,11 @@ pub(crate) mod makedev;
 #[cfg(not(windows))]
 pub(crate) mod syscalls;
 pub(crate) mod types;
+
+// TODO: Fix linux-raw-sys to define ioctl codes for sparc.
+#[cfg(all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64")))]
+pub(crate) const EXT4_IOC_RESIZE_FS: crate::ioctl::RawOpcode = 0x8008_6610;
+
+#[cfg(all(linux_kernel, not(any(target_arch = "sparc", target_arch = "sparc64"))))]
+pub(crate) const EXT4_IOC_RESIZE_FS: crate::ioctl::RawOpcode =
+    linux_raw_sys::ioctl::EXT4_IOC_RESIZE_FS as crate::ioctl::RawOpcode;

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -2405,55 +2405,6 @@ pub(crate) fn fremovexattr(fd: BorrowedFd<'_>, name: &CStr) -> io::Result<()> {
     }
 }
 
-#[cfg(linux_kernel)]
-#[inline]
-pub(crate) fn ioctl_blksszget(fd: BorrowedFd) -> io::Result<u32> {
-    let mut result = MaybeUninit::<c::c_uint>::uninit();
-    unsafe {
-        ret(c::ioctl(borrowed_fd(fd), c::BLKSSZGET, result.as_mut_ptr()))?;
-        Ok(result.assume_init() as u32)
-    }
-}
-
-#[cfg(linux_kernel)]
-#[inline]
-pub(crate) fn ioctl_blkpbszget(fd: BorrowedFd) -> io::Result<u32> {
-    let mut result = MaybeUninit::<c::c_uint>::uninit();
-    unsafe {
-        ret(c::ioctl(
-            borrowed_fd(fd),
-            c::BLKPBSZGET,
-            result.as_mut_ptr(),
-        ))?;
-        Ok(result.assume_init() as u32)
-    }
-}
-
-// Sparc lacks `FICLONE`.
-#[cfg(all(linux_kernel, not(any(target_arch = "sparc", target_arch = "sparc64"))))]
-pub(crate) fn ioctl_ficlone(fd: BorrowedFd<'_>, src_fd: BorrowedFd<'_>) -> io::Result<()> {
-    unsafe {
-        ret(c::ioctl(
-            borrowed_fd(fd),
-            c::FICLONE as _,
-            borrowed_fd(src_fd),
-        ))
-    }
-}
-
-#[cfg(linux_kernel)]
-#[inline]
-pub(crate) fn ext4_ioc_resize_fs(fd: BorrowedFd<'_>, blocks: u64) -> io::Result<()> {
-    // TODO: Fix linux-raw-sys to define ioctl codes for sparc.
-    #[cfg(any(target_arch = "sparc", target_arch = "sparc64"))]
-    const EXT4_IOC_RESIZE_FS: u32 = 0x8008_6610;
-
-    #[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))]
-    use linux_raw_sys::ioctl::EXT4_IOC_RESIZE_FS;
-
-    unsafe { ret(c::ioctl(borrowed_fd(fd), EXT4_IOC_RESIZE_FS as _, &blocks)) }
-}
-
 #[test]
 fn test_sizes() {
     #[cfg(linux_kernel)]

--- a/src/backend/libc/io/windows_syscalls.rs
+++ b/src/backend/libc/io/windows_syscalls.rs
@@ -1,27 +1,30 @@
 //! Windows system calls in the `io` module.
 
 use crate::backend::c;
-use crate::backend::conv::{borrowed_fd, ret};
+use crate::backend::conv::{borrowed_fd, ret_c_int};
 use crate::backend::fd::LibcFd;
 use crate::fd::{BorrowedFd, RawFd};
 use crate::io;
-use core::mem::MaybeUninit;
+use crate::ioctl::{IoctlOutput, RawOpcode};
 
 pub(crate) unsafe fn close(raw_fd: RawFd) {
     let _ = c::close(raw_fd as LibcFd);
 }
 
-pub(crate) fn ioctl_fionread(fd: BorrowedFd<'_>) -> io::Result<u64> {
-    let mut nread = MaybeUninit::<c::c_ulong>::uninit();
-    unsafe {
-        ret(c::ioctl(borrowed_fd(fd), c::FIONREAD, nread.as_mut_ptr()))?;
-        Ok(u64::from(nread.assume_init()))
-    }
+#[inline]
+pub(crate) unsafe fn ioctl(
+    fd: BorrowedFd<'_>,
+    request: RawOpcode,
+    arg: *mut c::c_void,
+) -> io::Result<IoctlOutput> {
+    ret_c_int(c::ioctl(borrowed_fd(fd), request, arg.cast()))
 }
 
-pub(crate) fn ioctl_fionbio(fd: BorrowedFd<'_>, value: bool) -> io::Result<()> {
-    unsafe {
-        let mut data = value as c::c_uint;
-        ret(c::ioctl(borrowed_fd(fd), c::FIONBIO, &mut data))
-    }
+#[inline]
+pub(crate) unsafe fn ioctl_readonly(
+    fd: BorrowedFd<'_>,
+    request: RawOpcode,
+    arg: *mut c::c_void,
+) -> io::Result<IoctlOutput> {
+    ioctl(fd, request, arg)
 }

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -618,14 +618,3 @@ pub(crate) fn getgroups(buf: &mut [Gid]) -> io::Result<usize> {
 
     unsafe { ret_usize(c::getgroups(len, buf.as_mut_ptr().cast()) as isize) }
 }
-
-#[cfg(not(any(
-    target_os = "aix",
-    target_os = "espidf",
-    target_os = "redox",
-    target_os = "wasi"
-)))]
-#[inline]
-pub(crate) fn ioctl_tiocsctty(fd: BorrowedFd<'_>) -> io::Result<()> {
-    unsafe { ret(c::ioctl(borrowed_fd(fd), c::TIOCSCTTY as _, &0_u32)) }
-}

--- a/src/backend/libc/pty/syscalls.rs
+++ b/src/backend/libc/pty/syscalls.rs
@@ -4,8 +4,6 @@ use crate::backend::c;
 use crate::backend::conv::{borrowed_fd, ret};
 use crate::fd::BorrowedFd;
 use crate::io;
-#[cfg(not(target_os = "android"))]
-use {crate::backend::conv::ret_owned_fd, crate::fd::OwnedFd, crate::pty::OpenptFlags};
 #[cfg(any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia"))]
 use {
     crate::ffi::{CStr, CString},
@@ -94,10 +92,4 @@ pub(crate) fn unlockpt(fd: BorrowedFd) -> io::Result<()> {
 #[inline]
 pub(crate) fn grantpt(fd: BorrowedFd) -> io::Result<()> {
     unsafe { ret(c::grantpt(borrowed_fd(fd))) }
-}
-
-#[cfg(target_os = "linux")]
-#[inline]
-pub(crate) fn ioctl_tiocgptpeer(fd: BorrowedFd, flags: OpenptFlags) -> io::Result<OwnedFd> {
-    unsafe { ret_owned_fd(c::ioctl(borrowed_fd(fd), c::TIOCGPTPEER, flags.bits())) }
 }

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -210,26 +210,6 @@ pub(crate) fn tcgetwinsize(fd: BorrowedFd) -> io::Result<Winsize> {
     }
 }
 
-#[cfg(not(any(
-    target_os = "espidf",
-    target_os = "haiku",
-    target_os = "redox",
-    target_os = "wasi"
-)))]
-pub(crate) fn ioctl_tiocexcl(fd: BorrowedFd) -> io::Result<()> {
-    unsafe { ret(c::ioctl(borrowed_fd(fd), c::TIOCEXCL as _)) }
-}
-
-#[cfg(not(any(
-    target_os = "espidf",
-    target_os = "haiku",
-    target_os = "redox",
-    target_os = "wasi"
-)))]
-pub(crate) fn ioctl_tiocnxcl(fd: BorrowedFd) -> io::Result<()> {
-    unsafe { ret(c::ioctl(borrowed_fd(fd), c::TIOCNXCL as _)) }
-}
-
 #[cfg(not(any(target_os = "espidf", target_os = "nto", target_os = "wasi")))]
 #[inline]
 pub(crate) fn set_speed(termios: &mut Termios, arbitrary_speed: u32) -> io::Result<()> {

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -9,6 +9,7 @@
 pub type size_t = usize;
 pub(crate) use linux_raw_sys::ctypes::*;
 pub(crate) use linux_raw_sys::errno::EINVAL;
+pub(crate) use linux_raw_sys::ioctl::{FIONBIO, FIONREAD};
 // Import the kernel's `uid_t` and `gid_t` if they're 32-bit.
 #[cfg(not(any(target_arch = "arm", target_arch = "sparc", target_arch = "x86")))]
 pub(crate) use linux_raw_sys::general::{__kernel_gid_t as gid_t, __kernel_uid_t as uid_t};
@@ -38,6 +39,15 @@ pub(crate) use linux_raw_sys::general::{
     AT_FDCWD, NFS_SUPER_MAGIC, O_LARGEFILE, PROC_SUPER_MAGIC, UTIME_NOW, UTIME_OMIT, XATTR_CREATE,
     XATTR_REPLACE,
 };
+
+#[cfg(feature = "fs")]
+pub(crate) use linux_raw_sys::ioctl::{BLKPBSZGET, BLKSSZGET};
+
+#[cfg(all(
+    feature = "fs",
+    not(any(target_arch = "sparc", target_arch = "sparc64"))
+))]
+pub(crate) use linux_raw_sys::ioctl::FICLONE;
 
 #[cfg(feature = "io_uring")]
 pub(crate) use linux_raw_sys::{general::open_how, io_uring::*};
@@ -77,9 +87,12 @@ pub(crate) use linux_raw_sys::{
 pub(crate) use linux_raw_sys::general::siginfo_t;
 
 #[cfg(feature = "process")]
-pub(crate) use linux_raw_sys::general::{
-    CLD_CONTINUED, CLD_DUMPED, CLD_EXITED, CLD_KILLED, CLD_STOPPED, CLD_TRAPPED,
-    O_NONBLOCK as PIDFD_NONBLOCK, P_ALL, P_PID, P_PIDFD,
+pub(crate) use linux_raw_sys::{
+    general::{
+        CLD_CONTINUED, CLD_DUMPED, CLD_EXITED, CLD_KILLED, CLD_STOPPED, CLD_TRAPPED,
+        O_NONBLOCK as PIDFD_NONBLOCK, P_ALL, P_PID, P_PIDFD,
+    },
+    ioctl::TIOCSCTTY,
 };
 
 #[cfg(feature = "termios")]
@@ -99,7 +112,7 @@ pub(crate) use linux_raw_sys::{
         VKILL, VLNEXT, VMIN, VQUIT, VREPRINT, VSTART, VSTOP, VSUSP, VSWTC, VT0, VT1, VTDLY, VTIME,
         VWERASE, XCASE, XTABS,
     },
-    ioctl::{TCGETS2, TCSETS2, TCSETSF2, TCSETSW2},
+    ioctl::{TCGETS2, TCSETS2, TCSETSF2, TCSETSW2, TIOCEXCL, TIOCNXCL},
 };
 
 // On MIPS, `TCSANOW` et al have `TCSETS` added to them, so we need it to

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -95,6 +95,9 @@ pub(crate) use linux_raw_sys::{
     ioctl::TIOCSCTTY,
 };
 
+#[cfg(feature = "pty")]
+pub(crate) use linux_raw_sys::ioctl::TIOCGPTPEER;
+
 #[cfg(feature = "termios")]
 pub(crate) use linux_raw_sys::{
     general::{

--- a/src/backend/linux_raw/fs/mod.rs
+++ b/src/backend/linux_raw/fs/mod.rs
@@ -3,3 +3,10 @@ pub mod inotify;
 pub(crate) mod makedev;
 pub(crate) mod syscalls;
 pub(crate) mod types;
+
+// TODO: Fix linux-raw-sys to define ioctl codes for sparc.
+#[cfg(all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64")))]
+pub(crate) const EXT4_IOC_RESIZE_FS: u32 = 0x8008_6610;
+
+#[cfg(all(linux_kernel, not(any(target_arch = "sparc", target_arch = "sparc64"))))]
+pub(crate) use linux_raw_sys::ioctl::EXT4_IOC_RESIZE_FS;

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -40,7 +40,6 @@ use linux_raw_sys::general::{
     F_ADD_SEALS, F_GETFL, F_GET_SEALS, F_SETFL, SEEK_CUR, SEEK_DATA, SEEK_END, SEEK_HOLE, SEEK_SET,
     STATX__RESERVED,
 };
-use linux_raw_sys::ioctl::{BLKPBSZGET, BLKSSZGET, EXT4_IOC_RESIZE_FS, FICLONE};
 #[cfg(target_pointer_width = "32")]
 use {
     crate::backend::conv::{hi, lo, slice_just_addr},
@@ -1618,41 +1617,6 @@ pub(crate) fn lremovexattr(path: &CStr, name: &CStr) -> io::Result<()> {
 #[inline]
 pub(crate) fn fremovexattr(fd: BorrowedFd<'_>, name: &CStr) -> io::Result<()> {
     unsafe { ret(syscall_readonly!(__NR_fremovexattr, fd, name)) }
-}
-
-#[inline]
-pub(crate) fn ioctl_blksszget(fd: BorrowedFd) -> io::Result<u32> {
-    let mut result = MaybeUninit::<c::c_uint>::uninit();
-    unsafe {
-        ret(syscall!(__NR_ioctl, fd, c_uint(BLKSSZGET), &mut result))?;
-        Ok(result.assume_init() as u32)
-    }
-}
-
-#[inline]
-pub(crate) fn ioctl_blkpbszget(fd: BorrowedFd) -> io::Result<u32> {
-    let mut result = MaybeUninit::<c::c_uint>::uninit();
-    unsafe {
-        ret(syscall!(__NR_ioctl, fd, c_uint(BLKPBSZGET), &mut result))?;
-        Ok(result.assume_init() as u32)
-    }
-}
-
-#[inline]
-pub(crate) fn ioctl_ficlone(fd: BorrowedFd<'_>, src_fd: BorrowedFd<'_>) -> io::Result<()> {
-    unsafe { ret(syscall_readonly!(__NR_ioctl, fd, c_uint(FICLONE), src_fd)) }
-}
-
-#[inline]
-pub(crate) fn ext4_ioc_resize_fs(fd: BorrowedFd<'_>, blocks: u64) -> io::Result<()> {
-    unsafe {
-        ret(syscall_readonly!(
-            __NR_ioctl,
-            fd,
-            c_uint(EXT4_IOC_RESIZE_FS),
-            by_ref(&blocks)
-        ))
-    }
 }
 
 #[test]

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -32,7 +32,6 @@ use linux_raw_sys::general::{
     membarrier_cmd, membarrier_cmd_flag, rlimit, rlimit64, PRIO_PGRP, PRIO_PROCESS, PRIO_USER,
     RLIM64_INFINITY, RLIM_INFINITY,
 };
-use linux_raw_sys::ioctl::TIOCSCTTY;
 #[cfg(feature = "fs")]
 use {crate::backend::conv::ret_c_uint_infallible, crate::fs::Mode};
 
@@ -619,18 +618,6 @@ pub(crate) fn getgroups(buf: &mut [Gid]) -> io::Result<usize> {
             __NR_getgroups,
             c_int(len),
             slice_just_addr_mut(buf)
-        ))
-    }
-}
-
-#[inline]
-pub(crate) fn ioctl_tiocsctty(fd: BorrowedFd<'_>) -> io::Result<()> {
-    unsafe {
-        ret(syscall_readonly!(
-            __NR_ioctl,
-            fd,
-            c_uint(TIOCSCTTY),
-            by_ref(&0_u32)
         ))
     }
 }

--- a/src/backend/linux_raw/pty/syscalls.rs
+++ b/src/backend/linux_raw/pty/syscalls.rs
@@ -7,15 +7,14 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::c;
-use crate::backend::conv::{by_ref, c_uint, ret, ret_owned_fd};
-use crate::fd::{BorrowedFd, OwnedFd};
+use crate::backend::conv::{by_ref, c_uint, ret};
+use crate::fd::BorrowedFd;
 use crate::ffi::CString;
 use crate::io;
 use crate::path::DecInt;
-use crate::pty::OpenptFlags;
 use alloc::vec::Vec;
 use core::mem::MaybeUninit;
-use linux_raw_sys::ioctl::{TIOCGPTN, TIOCGPTPEER, TIOCSPTLCK};
+use linux_raw_sys::ioctl::{TIOCGPTN, TIOCSPTLCK};
 
 #[inline]
 pub(crate) fn ptsname(fd: BorrowedFd, mut buffer: Vec<u8>) -> io::Result<CString> {
@@ -39,19 +38,6 @@ pub(crate) fn unlockpt(fd: BorrowedFd) -> io::Result<()> {
             fd,
             c_uint(TIOCSPTLCK),
             by_ref(&0)
-        ))
-    }
-}
-
-#[cfg(target_os = "linux")]
-#[inline]
-pub(crate) fn ioctl_tiocgptpeer(fd: BorrowedFd, flags: OpenptFlags) -> io::Result<OwnedFd> {
-    unsafe {
-        ret_owned_fd(syscall_readonly!(
-            __NR_ioctl,
-            fd,
-            c_uint(TIOCGPTPEER),
-            flags
         ))
     }
 }

--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -144,16 +144,6 @@ pub(crate) fn tcsetpgrp(fd: BorrowedFd<'_>, pid: Pid) -> io::Result<()> {
     unsafe { ret(syscall!(__NR_ioctl, fd, c_uint(TIOCSPGRP), pid)) }
 }
 
-#[inline]
-pub(crate) fn ioctl_tiocexcl(fd: BorrowedFd<'_>) -> io::Result<()> {
-    unsafe { ret(syscall_readonly!(__NR_ioctl, fd, c_uint(TIOCEXCL))) }
-}
-
-#[inline]
-pub(crate) fn ioctl_tiocnxcl(fd: BorrowedFd<'_>) -> io::Result<()> {
-    unsafe { ret(syscall_readonly!(__NR_ioctl, fd, c_uint(TIOCNXCL))) }
-}
-
 /// A wrapper around a conceptual `cfsetspeed` which handles an arbitrary
 /// integer speed value.
 #[inline]

--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -22,8 +22,7 @@ use crate::{ffi::CStr, fs::FileType, path::DecInt};
 use core::mem::MaybeUninit;
 use linux_raw_sys::general::IBSHIFT;
 use linux_raw_sys::ioctl::{
-    TCFLSH, TCSBRK, TCXONC, TIOCEXCL, TIOCGPGRP, TIOCGSID, TIOCGWINSZ, TIOCNXCL, TIOCSPGRP,
-    TIOCSWINSZ,
+    TCFLSH, TCSBRK, TCXONC, TIOCGPGRP, TIOCGSID, TIOCGWINSZ, TIOCSPGRP, TIOCSWINSZ,
 };
 
 #[inline]

--- a/src/fs/ioctl.rs
+++ b/src/fs/ioctl.rs
@@ -2,8 +2,10 @@
 
 #[cfg(linux_kernel)]
 use {
-    crate::fd::AsFd,
-    crate::{backend, io},
+    crate::fd::{AsFd, AsRawFd, BorrowedFd},
+    crate::{backend, io, ioctl},
+    backend::c,
+    core::mem::MaybeUninit,
 };
 
 /// `ioctl(fd, BLKSSZGET)`—Returns the logical block size of a block device.
@@ -15,7 +17,7 @@ use {
 #[inline]
 #[doc(alias = "BLKSSZGET")]
 pub fn ioctl_blksszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
-    backend::fs::syscalls::ioctl_blksszget(fd.as_fd())
+    ioctl::ioctl(fd, Blksszget(MaybeUninit::uninit()))
 }
 
 /// `ioctl(fd, BLKPBSZGET)`—Returns the physical block size of a block device.
@@ -23,7 +25,7 @@ pub fn ioctl_blksszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
 #[inline]
 #[doc(alias = "BLKPBSZGET")]
 pub fn ioctl_blkpbszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
-    backend::fs::syscalls::ioctl_blkpbszget(fd.as_fd())
+    ioctl::ioctl(fd, Blkpbszget(MaybeUninit::uninit()))
 }
 
 /// `ioctl(fd, FICLONE, src_fd)`—Share data between open files.
@@ -38,7 +40,7 @@ pub fn ioctl_blkpbszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
 #[inline]
 #[doc(alias = "FICLONE")]
 pub fn ioctl_ficlone<Fd: AsFd, SrcFd: AsFd>(fd: Fd, src_fd: SrcFd) -> io::Result<()> {
-    backend::fs::syscalls::ioctl_ficlone(fd.as_fd(), src_fd.as_fd())
+    ioctl::ioctl(fd, Ficlone(src_fd.as_fd()))
 }
 
 /// `ioctl(fd, EXT4_IOC_RESIZE_FS, blocks)`—Resize ext4 filesystem on fd.
@@ -46,5 +48,101 @@ pub fn ioctl_ficlone<Fd: AsFd, SrcFd: AsFd>(fd: Fd, src_fd: SrcFd) -> io::Result
 #[inline]
 #[doc(alias = "EXT4_IOC_RESIZE_FS")]
 pub fn ext4_ioc_resize_fs<Fd: AsFd>(fd: Fd, blocks: u64) -> io::Result<()> {
-    backend::fs::syscalls::ext4_ioc_resize_fs(fd.as_fd(), blocks)
+    ioctl::ioctl(fd, Ext4IocResizeFs(blocks))
+}
+
+#[cfg(linux_kernel)]
+struct Blksszget(MaybeUninit<c::c_uint>);
+
+#[cfg(linux_kernel)]
+#[allow(unsafe_code)]
+unsafe impl ioctl::Ioctl for Blksszget {
+    type Output = u32;
+
+    const OPCODE: ioctl::Opcode = ioctl::Opcode::Bad(c::BLKSSZGET);
+    const IS_MUTATING: bool = true;
+
+    fn as_ptr(&mut self) -> *mut c::c_void {
+        self.0.as_mut_ptr().cast()
+    }
+
+    unsafe fn output_from_ptr(
+        _: ioctl::IoctlOutput,
+        arg: *mut c::c_void,
+    ) -> io::Result<Self::Output> {
+        let ptr: *mut MaybeUninit<c::c_uint> = arg.cast();
+        let value = ptr.read().assume_init();
+        Ok(value)
+    }
+}
+
+#[cfg(linux_kernel)]
+struct Blkpbszget(MaybeUninit<c::c_uint>);
+
+#[cfg(linux_kernel)]
+#[allow(unsafe_code)]
+unsafe impl ioctl::Ioctl for Blkpbszget {
+    type Output = u32;
+
+    const OPCODE: ioctl::Opcode = ioctl::Opcode::Bad(c::BLKPBSZGET);
+    const IS_MUTATING: bool = true;
+
+    fn as_ptr(&mut self) -> *mut c::c_void {
+        self.0.as_mut_ptr().cast()
+    }
+
+    unsafe fn output_from_ptr(
+        _: ioctl::IoctlOutput,
+        arg: *mut c::c_void,
+    ) -> io::Result<Self::Output> {
+        let ptr: *mut MaybeUninit<c::c_uint> = arg.cast();
+        let value = ptr.read().assume_init();
+        Ok(value)
+    }
+}
+
+#[cfg(all(linux_kernel, not(any(target_arch = "sparc", target_arch = "sparc64"))))]
+struct Ficlone<'a>(BorrowedFd<'a>);
+
+#[cfg(all(linux_kernel, not(any(target_arch = "sparc", target_arch = "sparc64"))))]
+#[allow(unsafe_code)]
+unsafe impl ioctl::Ioctl for Ficlone<'_> {
+    type Output = ();
+
+    const OPCODE: ioctl::Opcode = ioctl::Opcode::Bad(c::FICLONE);
+    const IS_MUTATING: bool = false;
+
+    fn as_ptr(&mut self) -> *mut c::c_void {
+        self.0.as_raw_fd() as *mut c::c_void
+    }
+
+    unsafe fn output_from_ptr(
+        _: ioctl::IoctlOutput,
+        _: *mut c::c_void,
+    ) -> io::Result<Self::Output> {
+        Ok(())
+    }
+}
+
+#[cfg(linux_kernel)]
+struct Ext4IocResizeFs(u64);
+
+#[cfg(linux_kernel)]
+#[allow(unsafe_code)]
+unsafe impl ioctl::Ioctl for Ext4IocResizeFs {
+    type Output = ();
+
+    const OPCODE: ioctl::Opcode = ioctl::Opcode::Bad(backend::fs::EXT4_IOC_RESIZE_FS);
+    const IS_MUTATING: bool = false;
+
+    fn as_ptr(&mut self) -> *mut c::c_void {
+        (&mut self.0 as *mut u64).cast()
+    }
+
+    unsafe fn output_from_ptr(
+        _: ioctl::IoctlOutput,
+        _: *mut c::c_void,
+    ) -> io::Result<Self::Output> {
+        Ok(())
+    }
 }

--- a/src/ioctl.rs
+++ b/src/ioctl.rs
@@ -1,0 +1,133 @@
+//! Unsafe `ioctl` API.
+//!
+//! Unix systems expose a number of `ioctl`'s. Although they were originally meant to modify the
+//! behavior of files, they've now been adopted as a general purpose system call for making calls
+//! into the kernel. In addition to the wide variety of system calls that are included by default
+//! in the kernel, many drivers expose their own `ioctl`'s for controlling their behavior, some
+//! of which are proprietary.  Therefore it is impossible to make a safe interface for every `ioctl`
+//! call, as they all have wildly varying semantics.
+//!
+//! This module provides an unsafe interface to write your own `ioctl` API.
+
+#![allow(unsafe_code)]
+
+use crate::backend::c;
+use crate::fd::{AsFd, BorrowedFd};
+use crate::io::Result;
+
+/// Perform an `ioctl` call.
+#[inline]
+pub fn ioctl<F: AsFd, I: Ioctl>(fd: F, mut ioctl: I) -> Result<I::Output> {
+    let fd = fd.as_fd();
+    let request = I::OPCODE.raw();
+    let arg = ioctl.as_ptr();
+
+    // SAFETY: The variant of `Ioctl` asserts that this is a valid IOCTL call to make.
+    let output = if I::IS_MUTATING {
+        unsafe { _ioctl(fd, request, arg) }?
+    } else {
+        unsafe { _ioctl_readonly(fd, request, arg) }?
+    };
+
+    // SAFETY: The variant of `Ioctl` asserts that this is a valid pointer to the output data.
+    unsafe { I::output_from_ptr(output, arg) }
+}
+
+unsafe fn _ioctl(
+    fd: BorrowedFd<'_>,
+    request: RawOpcode,
+    arg: *mut c::c_void,
+) -> Result<IoctlOutput> {
+    crate::backend::io::syscalls::ioctl(fd, request, arg)
+}
+
+unsafe fn _ioctl_readonly(
+    fd: BorrowedFd<'_>,
+    request: RawOpcode,
+    arg: *mut c::c_void,
+) -> Result<IoctlOutput> {
+    crate::backend::io::syscalls::ioctl_readonly(fd, request, arg)
+}
+
+/// A trait defining the properties of an `ioctl` command.
+///
+/// # Safety
+///
+///
+pub unsafe trait Ioctl {
+    /// The type of the output data.
+    type Output;
+
+    /// The opcode used by this `ioctl` command.
+    const OPCODE: Opcode;
+
+    /// Does the `ioctl` mutate any data in the userspace?
+    const IS_MUTATING: bool;
+
+    /// Get a pointer to the data to be passed to the `ioctl` command.
+    fn as_ptr(&mut self) -> *mut c::c_void;
+
+    /// Cast the output data to the correct type.
+    ///
+    /// # Safety
+    ///
+    /// The `ptr` must be the resulting value after a successful `ioctl` call.
+    unsafe fn output_from_ptr(out: IoctlOutput, ptr: *mut c::c_void) -> Result<Self::Output>;
+}
+
+/// The opcode used by an `Ioctl`.
+#[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
+pub enum Opcode {
+    /// A raw, "bad" opcode.
+    Bad(RawOpcode),
+}
+
+impl Opcode {
+    /// Get the raw opcode.
+    #[inline]
+    pub fn raw(self) -> RawOpcode {
+        match self {
+            Self::Bad(raw) => raw,
+        }
+    }
+}
+
+/// The type used by the `ioctl` to signify the output.
+pub type IoctlOutput = c::c_int;
+
+/// The type used by the `ioctl` to signify the command.
+pub type RawOpcode = _RawOpcode;
+
+// Under raw Linux, this is an unsigned int.
+#[cfg(linux_raw)]
+type _RawOpcode = c::c_uint;
+
+// On libc Linux with GNU libc, this is an unsigned long.
+#[cfg(all(not(linux_raw), target_os = "linux", target_env = "gnu"))]
+type _RawOpcode = c::c_ulong;
+
+// Musl uses a c_uint
+#[cfg(all(not(linux_raw), target_os = "linux", not(target_env = "gnu")))]
+type _RawOpcode = c::c_uint;
+
+// Android uses c_int
+#[cfg(all(not(linux_raw), target_os = "android"))]
+type _RawOpcode = c::c_int;
+
+// Every BSD I looked at, Haiku and Redox uses an unsigned long.
+#[cfg(any(apple, bsd, target_os = "redox", target_os = "haiku"))]
+type _RawOpcode = c::c_ulong;
+
+// Solaris, illumos, WASI and fuchsia use an int.
+#[cfg(any(
+    target_os = "solaris",
+    target_os = "illumos",
+    target_os = "fuchsia",
+    target_os = "wasi"
+))]
+type _RawOpcode = c::c_uint;
+
+// Windows has ioctlsocket, which uses i32
+#[cfg(windows)]
+type _RawOpcode = i32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,7 @@ pub mod io;
 #[cfg(feature = "io_uring")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "io_uring")))]
 pub mod io_uring;
+pub mod ioctl;
 #[cfg(not(any(windows, target_os = "espidf", target_os = "wasi")))]
 #[cfg(feature = "mm")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "mm")))]

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -192,7 +192,7 @@ pub fn tee<FdIn: AsFd, FdOut: AsFd>(
     backend::pipe::syscalls::tee(fd_in.as_fd(), fd_out.as_fd(), len, flags)
 }
 
-/// `ioctl(fd, F_GETPIPE_SZ)`—Return the buffer capacity of a pipe.
+/// `fnctl(fd, F_GETPIPE_SZ)`—Return the buffer capacity of a pipe.
 ///
 /// # References
 ///  - [Linux]
@@ -204,7 +204,7 @@ pub fn fcntl_getpipe_size<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
     backend::pipe::syscalls::fcntl_getpipe_sz(fd.as_fd())
 }
 
-/// `ioctl(fd, F_SETPIPE_SZ)`—Set the buffer capacity of a pipe.
+/// `fnctl(fd, F_SETPIPE_SZ)`—Set the buffer capacity of a pipe.
 ///
 /// # References
 ///  - [Linux]

--- a/src/process/ioctl.rs
+++ b/src/process/ioctl.rs
@@ -31,7 +31,7 @@ unsafe impl ioctl::Ioctl for Tiocsctty {
     const IS_MUTATING: bool = false;
 
     fn as_ptr(&mut self) -> *mut c::c_void {
-        core::ptr::null_mut()
+        (&0u32) as *const u32 as *mut c::c_void
     }
 
     unsafe fn output_from_ptr(

--- a/src/termios/ioctl.rs
+++ b/src/termios/ioctl.rs
@@ -1,7 +1,8 @@
 //! Terminal-related `ioctl` functions.
 
 use crate::fd::AsFd;
-use crate::{backend, io};
+use crate::{backend, io, ioctl};
+use backend::c;
 
 /// `ioctl(fd, TIOCEXCL)`—Enables exclusive mode on a terminal.
 ///
@@ -19,7 +20,7 @@ use crate::{backend, io};
 #[inline]
 #[doc(alias = "TIOCEXCL")]
 pub fn ioctl_tiocexcl<Fd: AsFd>(fd: Fd) -> io::Result<()> {
-    backend::termios::syscalls::ioctl_tiocexcl(fd.as_fd())
+    ioctl::ioctl(fd, Tiocexcl)
 }
 
 /// `ioctl(fd, TIOCNXCL)`—Disables exclusive mode on a terminal.
@@ -38,5 +39,49 @@ pub fn ioctl_tiocexcl<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 #[inline]
 #[doc(alias = "TIOCNXCL")]
 pub fn ioctl_tiocnxcl<Fd: AsFd>(fd: Fd) -> io::Result<()> {
-    backend::termios::syscalls::ioctl_tiocnxcl(fd.as_fd())
+    ioctl::ioctl(fd, Tiocnxcl)
+}
+
+#[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
+struct Tiocexcl;
+
+#[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
+#[allow(unsafe_code)]
+unsafe impl ioctl::Ioctl for Tiocexcl {
+    type Output = ();
+    const OPCODE: ioctl::Opcode = ioctl::Opcode::Bad(c::TIOCEXCL as ioctl::RawOpcode);
+    const IS_MUTATING: bool = false;
+
+    fn as_ptr(&mut self) -> *mut c::c_void {
+        core::ptr::null_mut()
+    }
+
+    unsafe fn output_from_ptr(
+        _: ioctl::IoctlOutput,
+        _: *mut c::c_void,
+    ) -> io::Result<Self::Output> {
+        Ok(())
+    }
+}
+
+#[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
+struct Tiocnxcl;
+
+#[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
+#[allow(unsafe_code)]
+unsafe impl ioctl::Ioctl for Tiocnxcl {
+    type Output = ();
+    const OPCODE: ioctl::Opcode = ioctl::Opcode::Bad(c::TIOCNXCL as ioctl::RawOpcode);
+    const IS_MUTATING: bool = false;
+
+    fn as_ptr(&mut self) -> *mut c::c_void {
+        core::ptr::null_mut()
+    }
+
+    unsafe fn output_from_ptr(
+        _: ioctl::IoctlOutput,
+        _: *mut c::c_void,
+    ) -> io::Result<Self::Output> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
A pain point in rustix is not being able to do custom ioctls; see https://github.com/bytecodealliance/rustix/issues/683
for rationale.

This commit adds an `Ioctl` trait which can be used to define arbitrary
ioctls. It is unsafe to implement, but once implemented can be used
safely. It can then be passed into an `ioctl` method with a file
descriptor in order to call an ioctl.

This commit also reimplements some of the functions used in this crate
in terms of this new system.

Closes https://github.com/bytecodealliance/rustix/issues/683