### PR TITLE
Reintroduce the build-time check for wasi_ext on wasi targets.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -71,6 +71,11 @@ fn main() {
         use_feature("static_assertions");
     }
 
+    // WASI support can utilize wasi_ext if present.
+    if os == "wasi" {
+        use_feature_or_nothing("wasi_ext");
+    }
+
     // If the libc backend is requested, or if we're not on a platform for
     // which we have linux_raw support, use the libc backend.
     //


### PR DESCRIPTION
Reintroduce the build-time check for wasi_ext, when the target os is WASI. This fixes a regression introduced in #754.