### PR TITLE
Convert mustang support to a cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,10 +214,15 @@ all-apis = [
     "time",
 ]
 
-# When using the linux_raw backend, and not using Mustang, should we use libc
-# for reading the aux vectors, instead of reading them ourselves from
-# /proc/self/auxv?
+# When using the linux_raw backend, should we use libc for reading the aux
+# vectors, instead of reading them ourselves from /proc/self/auxv?
 use-libc-auxv = []
+
+# Enable "use-explicitly-provided-auxv" mode, with a public
+# `rustix::param::init` function that must be called before anything else in
+# rustix. This is unstable and experimental and not intended for
+# general-purpose use.
+use-explicitly-provided-auxv = []
 
 # OS compatibility features
 

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -25,7 +25,7 @@ pub(crate) use linux_raw_sys::general::epoll_event;
     feature = "fs",
     all(
         not(feature = "use-libc-auxv"),
-        not(target_vendor = "mustang"),
+        not(feature = "use-explicitly-provided-auxv"),
         any(
             feature = "param",
             feature = "runtime",

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -300,7 +300,7 @@ pub(super) fn socklen_t<'a, Num: ArgNumber>(i: socklen_t) -> ArgReg<'a, Num> {
     feature = "fs",
     all(
         not(feature = "use-libc-auxv"),
-        not(target_vendor = "mustang"),
+        not(feature = "use-explicitly-provided-auxv"),
         any(
             feature = "param",
             feature = "runtime",

--- a/src/backend/linux_raw/elf.rs
+++ b/src/backend/linux_raw/elf.rs
@@ -2,7 +2,10 @@
 
 #![allow(non_snake_case)]
 #![cfg_attr(
-    all(not(target_vendor = "mustang"), feature = "use-libc-auxv"),
+    all(
+        not(feature = "use-explicitly-provided-auxv"),
+        feature = "use-libc-auxv"
+    ),
     allow(dead_code)
 )]
 

--- a/src/backend/linux_raw/mod.rs
+++ b/src/backend/linux_raw/mod.rs
@@ -36,7 +36,7 @@ pub(crate) mod event;
     feature = "fs",
     all(
         not(feature = "use-libc-auxv"),
-        not(target_vendor = "mustang"),
+        not(feature = "use-explicitly-provided-auxv"),
         any(
             feature = "param",
             feature = "runtime",
@@ -104,7 +104,7 @@ pub(crate) mod prctl;
     feature = "thread",
     all(
         not(feature = "use-libc-auxv"),
-        not(target_vendor = "mustang"),
+        not(feature = "use-explicitly-provided-auxv"),
         any(
             feature = "param",
             feature = "runtime",

--- a/src/backend/linux_raw/param/auxv.rs
+++ b/src/backend/linux_raw/param/auxv.rs
@@ -158,9 +158,9 @@ fn pr_get_auxv() -> crate::io::Result<Vec<u8>> {
     return Ok(buffer);
 }
 
-/// On non-Mustang platforms, we read the aux vector via the `prctl`
-/// `PR_GET_AUXV`, with a fallback to /proc/self/auxv for kernels that don't
-/// support `PR_GET_AUXV`.
+/// If we don't have "use-explicitly-provided-auxv" or "use-libc-auxv", we
+/// read the aux vector via the `prctl` `PR_GET_AUXV`, with a fallback to
+/// /proc/self/auxv for kernels that don't support `PR_GET_AUXV`.
 #[cold]
 fn init_auxv() {
     match pr_get_auxv() {

--- a/src/backend/linux_raw/param/init.rs
+++ b/src/backend/linux_raw/param/init.rs
@@ -1,4 +1,4 @@
-//! Linux auxv support, for Mustang.
+//! Linux auxv `init` function, for "use-explicitly-provided-auxv" mode.
 //!
 //! # Safety
 //!
@@ -11,9 +11,10 @@ use crate::backend::elf::*;
 use crate::ffi::CStr;
 use core::ffi::c_void;
 use core::mem::size_of;
-use core::ptr::{null, read};
+use core::ptr::{null_mut, read, NonNull};
 #[cfg(feature = "runtime")]
 use core::slice;
+use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 use linux_raw_sys::general::{
     AT_CLKTCK, AT_EXECFN, AT_HWCAP, AT_HWCAP2, AT_NULL, AT_PAGESZ, AT_PHDR, AT_PHENT, AT_PHNUM,
     AT_SYSINFO_EHDR,
@@ -22,37 +23,49 @@ use linux_raw_sys::general::{
 #[cfg(feature = "param")]
 #[inline]
 pub(crate) fn page_size() -> usize {
-    // SAFETY: This is initialized during program startup.
-    unsafe { PAGE_SIZE }
+    unsafe { PAGE_SIZE.load(Ordering::Relaxed) }
 }
 
 #[cfg(feature = "param")]
 #[inline]
 pub(crate) fn clock_ticks_per_second() -> u64 {
-    // SAFETY: This is initialized during program startup.
-    unsafe { CLOCK_TICKS_PER_SECOND as u64 }
+    unsafe { CLOCK_TICKS_PER_SECOND.load(Ordering::Relaxed) as u64 }
 }
 
 #[cfg(feature = "param")]
 #[inline]
 pub(crate) fn linux_hwcap() -> (usize, usize) {
-    // SAFETY: This is initialized during program startup.
-    unsafe { (HWCAP, HWCAP2) }
+    unsafe {
+        (
+            HWCAP.load(Ordering::Relaxed),
+            HWCAP2.load(Ordering::Relaxed),
+        )
+    }
 }
 
 #[cfg(feature = "param")]
 #[inline]
 pub(crate) fn linux_execfn() -> &'static CStr {
-    // SAFETY: This is initialized during program startup. And we
-    // assume it's a valid pointer to a NUL-terminated string.
-    unsafe { CStr::from_ptr(EXECFN.0.cast()) }
+    let execfn = unsafe { EXECFN.load(Ordering::Relaxed) };
+
+    // The user should have called `rustix::param::init` before calling this
+    // function.
+    assert!(!execfn.is_null());
+
+    // SAFETY: We assume the `AT_EXECFN` value provided by the kernel points
+    // to a valid C string.
+    unsafe { CStr::from_ptr(execfn.cast()) }
 }
 
 #[cfg(feature = "runtime")]
 #[inline]
 pub(crate) fn exe_phdrs() -> (*const c_void, usize) {
-    // SAFETY: This is initialized during program startup.
-    unsafe { (PHDR.0.cast(), PHNUM) }
+    unsafe {
+        (
+            PHDR.load(Ordering::Relaxed).cast(),
+            PHNUM.load(Ordering::Relaxed),
+        )
+    }
 }
 
 #[cfg(feature = "runtime")]
@@ -69,38 +82,22 @@ pub(in super::super) fn exe_phdrs_slice() -> &'static [Elf_Phdr] {
 /// if we don't see it, this function returns a null pointer.
 #[inline]
 pub(in super::super) fn sysinfo_ehdr() -> *const Elf_Ehdr {
-    // SAFETY: This is initialized during program startup.
-    unsafe { SYSINFO_EHDR.0 }
+    unsafe { SYSINFO_EHDR.load(Ordering::Relaxed) }
 }
 
-/// A const pointer to `T` that implements [`Sync`].
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct SyncConstPtr<T>(*const T);
-unsafe impl<T> Sync for SyncConstPtr<T> {}
+static mut PAGE_SIZE: AtomicUsize = AtomicUsize::new(0);
+static mut CLOCK_TICKS_PER_SECOND: AtomicUsize = AtomicUsize::new(0);
+static mut HWCAP: AtomicUsize = AtomicUsize::new(0);
+static mut HWCAP2: AtomicUsize = AtomicUsize::new(0);
+static mut SYSINFO_EHDR: AtomicPtr<Elf_Ehdr> = AtomicPtr::new(null_mut());
+// Use `dangling` so that we can always pass it to `slice::from_raw_parts`.
+static mut PHDR: AtomicPtr<Elf_Phdr> = AtomicPtr::new(NonNull::dangling().as_ptr());
+static mut PHNUM: AtomicUsize = AtomicUsize::new(0);
+static mut EXECFN: AtomicPtr<c::c_char> = AtomicPtr::new(null_mut());
 
-impl<T> SyncConstPtr<T> {
-    /// Creates a `SyncConstPointer` from a raw pointer.
-    ///
-    /// Behavior is undefined if `ptr` is actually not
-    /// safe to share across threads.
-    pub const unsafe fn new(ptr: *const T) -> Self {
-        Self(ptr)
-    }
-}
-
-static mut PAGE_SIZE: usize = 0;
-static mut CLOCK_TICKS_PER_SECOND: usize = 0;
-static mut HWCAP: usize = 0;
-static mut HWCAP2: usize = 0;
-static mut SYSINFO_EHDR: SyncConstPtr<Elf_Ehdr> = unsafe { SyncConstPtr::new(null()) };
-static mut PHDR: SyncConstPtr<Elf_Phdr> = unsafe { SyncConstPtr::new(null()) };
-static mut PHNUM: usize = 0;
-static mut EXECFN: SyncConstPtr<c::c_char> = unsafe { SyncConstPtr::new(null()) };
-
-/// On mustang, we export a function to be called during initialization, and
-/// passed a pointer to the original environment variable block set up by the
-/// OS.
+/// When "use-explicitly-provided-auxv" is enabled, we export a function to be
+/// called during initialization, and passed a pointer to the original
+/// environment variable block set up by the OS.
 pub(crate) unsafe fn init(envp: *mut *mut u8) {
     init_from_envp(envp);
 }
@@ -129,15 +126,15 @@ unsafe fn init_from_auxp(mut auxp: *const Elf_auxv_t) {
         let Elf_auxv_t { a_type, a_val } = read(auxp);
 
         match a_type as _ {
-            AT_PAGESZ => PAGE_SIZE = a_val as usize,
-            AT_CLKTCK => CLOCK_TICKS_PER_SECOND = a_val as usize,
-            AT_HWCAP => HWCAP = a_val as usize,
-            AT_HWCAP2 => HWCAP2 = a_val as usize,
-            AT_PHDR => PHDR = SyncConstPtr::new(a_val.cast::<Elf_Phdr>()),
-            AT_PHNUM => PHNUM = a_val as usize,
+            AT_PAGESZ => PAGE_SIZE.store(a_val as usize, Ordering::Relaxed),
+            AT_CLKTCK => CLOCK_TICKS_PER_SECOND.store(a_val as usize, Ordering::Relaxed),
+            AT_HWCAP => HWCAP.store(a_val as usize, Ordering::Relaxed),
+            AT_HWCAP2 => HWCAP2.store(a_val as usize, Ordering::Relaxed),
+            AT_PHDR => PHDR.store(a_val.cast::<Elf_Phdr>(), Ordering::Relaxed),
+            AT_PHNUM => PHNUM.store(a_val as usize, Ordering::Relaxed),
             AT_PHENT => assert_eq!(a_val as usize, size_of::<Elf_Phdr>()),
-            AT_EXECFN => EXECFN = SyncConstPtr::new(a_val.cast::<c::c_char>()),
-            AT_SYSINFO_EHDR => SYSINFO_EHDR = SyncConstPtr::new(a_val.cast::<Elf_Ehdr>()),
+            AT_EXECFN => EXECFN.store(a_val.cast::<c::c_char>(), Ordering::Relaxed),
+            AT_SYSINFO_EHDR => SYSINFO_EHDR.store(a_val.cast::<Elf_Ehdr>(), Ordering::Relaxed),
             AT_NULL => break,
             _ => (),
         }
@@ -155,5 +152,5 @@ struct Elf_auxv_t {
     // Some of the values in the auxv array are pointers, so we make `a_val` a
     // pointer, in order to preserve their provenance. For the values which are
     // integers, we cast this to `usize`.
-    a_val: *const c_void,
+    a_val: *mut c_void,
 }

--- a/src/backend/linux_raw/param/mod.rs
+++ b/src/backend/linux_raw/param/mod.rs
@@ -1,12 +1,15 @@
-// On Mustang, origin is in control of program startup and can access the
-// incoming aux values on the stack.
+// With "use-explicitly-provided-auxv" enabled, we expect to be initialized
+// with an explicit `rustix::param::init` call.
 //
 // With "use-libc-auxv" enabled, use libc's `getauxval`.
 //
 // Otherwise, we read aux values from /proc/self/auxv.
-#[cfg_attr(target_vendor = "mustang", path = "mustang_auxv.rs")]
+#[cfg_attr(feature = "use-explicitly-provided-auxv", path = "init.rs")]
 #[cfg_attr(
-    all(not(target_vendor = "mustang"), feature = "use-libc-auxv"),
+    all(
+        not(feature = "use-explicitly-provided-auxv"),
+        feature = "use-libc-auxv"
+    ),
     path = "libc_auxv.rs"
 )]
 pub(crate) mod auxv;

--- a/src/backend/linux_raw/runtime/tls.rs
+++ b/src/backend/linux_raw/runtime/tls.rs
@@ -17,7 +17,7 @@ use core::ptr::null;
 #[cfg(target_arch = "x86")]
 pub type UserDesc = linux_raw_sys::general::user_desc;
 
-pub(crate) fn startup_tls_info() -> StartupTlsInfo {
+pub(crate) fn startup_tls_info() -> Option<StartupTlsInfo> {
     let mut base = null();
     let mut tls_phdr = null();
     let mut stack_size = 0;
@@ -36,13 +36,17 @@ pub(crate) fn startup_tls_info() -> StartupTlsInfo {
             }
         }
 
-        StartupTlsInfo {
+        if tls_phdr.is_null() {
+            return None;
+        }
+
+        Some(StartupTlsInfo {
             addr: base.cast::<u8>().add((*tls_phdr).p_vaddr).cast(),
             mem_size: (*tls_phdr).p_memsz,
             file_size: (*tls_phdr).p_filesz,
             align: (*tls_phdr).p_align,
             stack_size,
-        }
+        })
     }
 }
 

--- a/src/backend/linux_raw/thread/futex.rs
+++ b/src/backend/linux_raw/thread/futex.rs
@@ -10,8 +10,9 @@ bitflags::bitflags! {
         /// `FUTEX_CLOCK_REALTIME`
         const CLOCK_REALTIME = linux_raw_sys::general::FUTEX_CLOCK_REALTIME;
 
-        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
-        const _ = !0;
+        // This deliberately lacks a `const _ = !0`, so that users can use
+        // `from_bits_truncate` to extract the `SocketFlags` from a flags
+        // value that also includes a `SocketType`.
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,20 +192,7 @@ pub mod event;
 #[cfg(not(windows))]
 pub mod ffi;
 #[cfg(not(windows))]
-#[cfg(any(
-    feature = "fs",
-    all(
-        linux_raw,
-        not(feature = "use-libc-auxv"),
-        not(target_vendor = "mustang"),
-        any(
-            feature = "param",
-            feature = "runtime",
-            feature = "time",
-            target_arch = "x86",
-        )
-    )
-))]
+#[cfg(feature = "fs")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
 pub mod fs;
 pub mod io;
@@ -230,22 +217,7 @@ pub mod net;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "param")))]
 pub mod param;
 #[cfg(not(windows))]
-#[cfg(any(
-    feature = "fs",
-    feature = "mount",
-    feature = "net",
-    all(
-        linux_raw,
-        not(feature = "use-libc-auxv"),
-        not(target_vendor = "mustang"),
-        any(
-            feature = "param",
-            feature = "runtime",
-            feature = "time",
-            target_arch = "x86",
-        )
-    )
-))]
+#[cfg(any(feature = "fs", feature = "mount", feature = "net"))]
 #[cfg_attr(
     doc_cfg,
     doc(cfg(any(feature = "fs", feature = "mount", feature = "net")))
@@ -306,6 +278,40 @@ pub mod runtime;
 #[cfg(linux_kernel)]
 #[cfg(all(feature = "fs", not(feature = "mount")))]
 pub(crate) mod mount;
+
+// Declare "fs" as a non-public module if "fs" isn't enabled but we need it for
+// reading procfs.
+#[cfg(not(windows))]
+#[cfg(not(feature = "fs"))]
+#[cfg(all(
+    linux_raw,
+    not(feature = "use-libc-auxv"),
+    not(target_vendor = "mustang"),
+    any(
+        feature = "param",
+        feature = "runtime",
+        feature = "time",
+        target_arch = "x86",
+    )
+))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
+pub(crate) mod fs;
+
+// Similarly, declare `path` as a non-public module if needed.
+#[cfg(not(windows))]
+#[cfg(not(any(feature = "fs", feature = "mount", feature = "net")))]
+#[cfg(all(
+    linux_raw,
+    not(feature = "use-libc-auxv"),
+    not(target_vendor = "mustang"),
+    any(
+        feature = "param",
+        feature = "runtime",
+        feature = "time",
+        target_arch = "x86",
+    )
+))]
+pub(crate) mod path;
 
 // Private modules used by multiple public modules.
 #[cfg(not(any(windows, target_os = "espidf")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,7 +286,7 @@ pub(crate) mod mount;
 #[cfg(all(
     linux_raw,
     not(feature = "use-libc-auxv"),
-    not(target_vendor = "mustang"),
+    not(feature = "use-explicitly-provided-auxv"),
     any(
         feature = "param",
         feature = "runtime",
@@ -303,7 +303,7 @@ pub(crate) mod fs;
 #[cfg(all(
     linux_raw,
     not(feature = "use-libc-auxv"),
-    not(target_vendor = "mustang"),
+    not(feature = "use-explicitly-provided-auxv"),
     any(
         feature = "param",
         feature = "runtime",
@@ -342,7 +342,7 @@ mod signal;
     all(
         linux_raw,
         not(feature = "use-libc-auxv"),
-        not(target_vendor = "mustang"),
+        not(feature = "use-explicitly-provided-auxv"),
         any(
             feature = "param",
             feature = "runtime",
@@ -360,7 +360,7 @@ mod timespec;
     all(
         linux_raw,
         not(feature = "use-libc-auxv"),
-        not(target_vendor = "mustang"),
+        not(feature = "use-explicitly-provided-auxv"),
         any(
             feature = "param",
             feature = "runtime",

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1273,8 +1273,9 @@ bitflags! {
         #[cfg(not(any(apple, windows, target_os = "haiku")))]
         const CLOEXEC = bitcast!(c::SOCK_CLOEXEC);
 
-        /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
-        const _ = !0;
+        // This deliberately lacks a `const _ = !0`, so that users can use
+        // `from_bits_truncate` to extract the `SocketFlags` from a flags
+        // value that also includes a `SocketType`.
     }
 }
 

--- a/src/param/init.rs
+++ b/src/param/init.rs
@@ -2,8 +2,8 @@
 //!
 //! # Safety
 //!
-//! On mustang, or on any non-glibc non-musl platform, the `init` function must
-//! be called before any other function in this module. It is unsafe because it
+//! When "use-explicitly-provided-auxv" is enabled, the `init` function must be
+//! called before any other function in this module. It is unsafe because it
 //! operates on raw pointers.
 #![allow(unsafe_code)]
 

--- a/src/param/mod.rs
+++ b/src/param/mod.rs
@@ -6,9 +6,9 @@
 //! between different processes on the same system.
 
 mod auxv;
-#[cfg(target_vendor = "mustang")]
+#[cfg(feature = "use-explicitly-provided-auxv")]
 mod init;
 
 pub use auxv::*;
-#[cfg(target_vendor = "mustang")]
+#[cfg(feature = "use-explicitly-provided-auxv")]
 pub use init::init;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -164,7 +164,7 @@ pub fn exit_group(status: i32) -> ! {
 /// Return fields from the main executable segment headers ("phdrs") relevant
 /// to initializing TLS provided to the program at startup.
 #[inline]
-pub fn startup_tls_info() -> StartupTlsInfo {
+pub fn startup_tls_info() -> Option<StartupTlsInfo> {
     backend::runtime::tls::startup_tls_info()
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -14,7 +14,7 @@
 //! The API for these functions is not stable, and this module is
 //! `doc(hidden)`.
 //!
-//! [origin]: https://github.com/sunfishcode/mustang/tree/main/origin
+//! [origin]: https://github.com/sunfishcode/origin
 //!
 //! # Safety
 //!


### PR DESCRIPTION
Replace `cfg(target_vendor = "mustang")` conditionals with `cfg(feature = "use-explicitly-provided-auxv")`, so that rustix itself has no knowledge of the "mustang" target per se, and the features mustang needs are just features that can be enabled.
