### PR TITLE
Fix `runtime::startup_tls_info` to return a pointer suitable for a slice.

### DIFF
--- a/src/backend/linux_raw/runtime/tls.rs
+++ b/src/backend/linux_raw/runtime/tls.rs
@@ -9,7 +9,7 @@
 use crate::backend::c;
 use crate::backend::elf::*;
 use crate::backend::param::auxv::exe_phdrs_slice;
-use core::ptr::null;
+use core::ptr::{null, NonNull};
 
 /// For use with [`set_thread_area`].
 ///
@@ -38,7 +38,7 @@ pub(crate) fn startup_tls_info() -> StartupTlsInfo {
 
         if tls_phdr.is_null() {
             StartupTlsInfo {
-                addr: null(),
+                addr: NonNull::dangling().as_ptr(),
                 mem_size: 0,
                 file_size: 0,
                 align: 1,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -163,6 +163,10 @@ pub fn exit_group(status: i32) -> ! {
 
 /// Return fields from the main executable segment headers ("phdrs") relevant
 /// to initializing TLS provided to the program at startup.
+///
+/// `addr` will always be non-null, even when the TLS data is absent, ao that
+/// the `addr` and `file_size` parameters are suitable for creating a slice
+/// with `slice::from_raw_parts`.
 #[inline]
 pub fn startup_tls_info() -> StartupTlsInfo {
     backend::runtime::tls::startup_tls_info()


### PR DESCRIPTION
Slices require non-null pointers, so fix the `addr` parameter of the returned TLS data to always be non-null.

This will obviate https://github.com/sunfishcode/origin/pull/8.