### PR TITLE
Export the `Pid`, `Uid`, and `Gid` types in the `thread` module.

### DIFF
--- a/src/thread/id.rs
+++ b/src/thread/id.rs
@@ -1,6 +1,7 @@
-use crate::pid::Pid;
-use crate::ugid::{Gid, Uid};
 use crate::{backend, io};
+
+pub use crate::pid::Pid;
+pub use crate::ugid::{Gid, Uid};
 
 /// `gettid()`—Returns the thread ID.
 ///

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -18,7 +18,9 @@ pub use clock::*;
 #[cfg(linux_raw)]
 pub use futex::{futex, FutexFlags, FutexOperation};
 #[cfg(linux_kernel)]
-pub use id::{gettid, set_thread_gid, set_thread_res_gid, set_thread_res_uid, set_thread_uid};
+pub use id::{
+    gettid, set_thread_gid, set_thread_res_gid, set_thread_res_uid, set_thread_uid, Gid, Pid, Uid,
+};
 #[cfg(linux_kernel)]
 pub use libcap::{capabilities, set_capabilities, CapabilityFlags, CapabilitySets};
 #[cfg(linux_kernel)]


### PR DESCRIPTION
These are public types of the `thread` module, so export them from the thread module, so that users don't have to separately enable the "process" feature to get them.