### PR TITLE
Update freebsd ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,9 +2,22 @@
 # at revision 7f4774e76bd5cb9ccb7140d71ef9be9c16009cdf.
 
 task:
+  name: stable x86_64-unknown-freebsd-14
+  freebsd_instance:
+    image: freebsd-14-0-current-amd64-v20230803
+  setup_script:
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh --default-toolchain stable -y --profile=minimal
+    - . $HOME/.cargo/env
+    - rustup default stable
+  test_script:
+    - . $HOME/.cargo/env
+    - cargo test --workspace --features=all-apis
+
+task:
   name: stable x86_64-unknown-freebsd-13
   freebsd_instance:
-    image_family: freebsd-13-1
+    image_family: freebsd-13-2
   setup_script:
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh --default-toolchain stable -y --profile=minimal
@@ -17,7 +30,7 @@ task:
 task:
   name: stable x86_64-unknown-freebsd-12
   freebsd_instance:
-    image_family: freebsd-12-1
+    image_family: freebsd-12-4
   setup_script:
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh --default-toolchain stable -y --profile=minimal


### PR DESCRIPTION
This pr updates the cirrus ci config to the latest version of freebsd 12 and freebsd 13. It also adds freebsd 14 as a testing target. The freebsd image has to be pinned manually since freebsd 14 has not been release yet. A stable release is very near so I think it makes sense to also start testing on that version.