### PR TITLE
Add `futex` support in the libc backend.

### DIFF
--- a/src/backend/libc/thread/futex.rs
+++ b/src/backend/libc/thread/futex.rs
@@ -1,0 +1,43 @@
+use crate::backend::c;
+
+bitflags::bitflags! {
+    /// `FUTEX_*` flags for use with [`futex`].
+    ///
+    /// [`futex`]: crate::thread::futex
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+    pub struct FutexFlags: u32 {
+        /// `FUTEX_PRIVATE_FLAG`
+        const PRIVATE = bitcast!(c::FUTEX_PRIVATE_FLAG);
+        /// `FUTEX_CLOCK_REALTIME`
+        const CLOCK_REALTIME = bitcast!(c::FUTEX_CLOCK_REALTIME);
+    }
+}
+
+/// `FUTEX_*` operations for use with [`futex`].
+///
+/// [`futex`]: crate::thread::futex
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(u32)]
+pub enum FutexOperation {
+    /// `FUTEX_WAIT`
+    Wait = bitcast!(c::FUTEX_WAIT),
+    /// `FUTEX_WAKE`
+    Wake = bitcast!(c::FUTEX_WAKE),
+    /// `FUTEX_FD`
+    Fd = bitcast!(c::FUTEX_FD),
+    /// `FUTEX_REQUEUE`
+    Requeue = bitcast!(c::FUTEX_REQUEUE),
+    /// `FUTEX_CMP_REQUEUE`
+    CmpRequeue = bitcast!(c::FUTEX_CMP_REQUEUE),
+    /// `FUTEX_WAKE_OP`
+    WakeOp = bitcast!(c::FUTEX_WAKE_OP),
+    /// `FUTEX_LOCK_PI`
+    LockPi = bitcast!(c::FUTEX_LOCK_PI),
+    /// `FUTEX_UNLOCK_PI`
+    UnlockPi = bitcast!(c::FUTEX_UNLOCK_PI),
+    /// `FUTEX_TRYLOCK_PI`
+    TrylockPi = bitcast!(c::FUTEX_TRYLOCK_PI),
+    /// `FUTEX_WAIT_BITSET`
+    WaitBitset = bitcast!(c::FUTEX_WAIT_BITSET),
+}

--- a/src/backend/libc/thread/mod.rs
+++ b/src/backend/libc/thread/mod.rs
@@ -1,2 +1,4 @@
+#[cfg(linux_kernel)]
+pub(crate) mod futex;
 #[cfg(not(windows))]
 pub(crate) mod syscalls;

--- a/src/backend/linux_raw/thread/mod.rs
+++ b/src/backend/linux_raw/thread/mod.rs
@@ -1,4 +1,2 @@
-mod futex;
+pub(crate) mod futex;
 pub(crate) mod syscalls;
-
-pub use futex::{FutexFlags, FutexOperation};

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -22,7 +22,7 @@ use crate::backend::pid::syscalls::getpid;
 use crate::fd::{AsFd, BorrowedFd, OwnedFd};
 use crate::ffi::CStr;
 use crate::fs::{
-    fstat, fstatfs, major, openat, renameat, Dir, FileType, Mode, OFlags, Stat, CWD,
+    fstat, fstatfs, major, openat, renameat, Dir, FileType, FsWord, Mode, OFlags, Stat, CWD,
     PROC_SUPER_MAGIC,
 };
 use crate::io;
@@ -178,7 +178,7 @@ fn check_proc_nonroot(stat: &Stat, proc_stat: Option<&Stat>) -> io::Result<()> {
 fn check_procfs(file: BorrowedFd<'_>) -> io::Result<()> {
     let statfs = fstatfs(file)?;
     let f_type = statfs.f_type;
-    if f_type != PROC_SUPER_MAGIC.into() {
+    if f_type != FsWord::from(PROC_SUPER_MAGIC) {
         return Err(io::Errno::NOTSUP);
     }
 

--- a/src/thread/futex.rs
+++ b/src/thread/futex.rs
@@ -9,7 +9,7 @@
 use crate::thread::Timespec;
 use crate::{backend, io};
 
-pub use backend::thread::{FutexFlags, FutexOperation};
+pub use backend::thread::futex::{FutexFlags, FutexOperation};
 
 /// `futex(uaddr, op, val, utime, uaddr2, val3)`
 ///

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -2,7 +2,7 @@
 
 #[cfg(not(target_os = "redox"))]
 mod clock;
-#[cfg(linux_raw)]
+#[cfg(linux_kernel)]
 mod futex;
 #[cfg(linux_kernel)]
 mod id;
@@ -15,7 +15,7 @@ mod setns;
 
 #[cfg(not(target_os = "redox"))]
 pub use clock::*;
-#[cfg(linux_raw)]
+#[cfg(linux_kernel)]
 pub use futex::{futex, FutexFlags, FutexOperation};
 #[cfg(linux_kernel)]
 pub use id::{

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -184,7 +184,7 @@ macro_rules! syscall {
 
             // Pass `BorrowedFd` values as the integer value.
             impl AsSyscallArg for $crate::fd::BorrowedFd<'_> {
-                type SyscallArgType = ::libc::c_long;
+                type SyscallArgType = ::libc::c_int;
                 fn into_syscall_arg(self) -> Self::SyscallArgType {
                     $crate::fd::AsRawFd::as_raw_fd(&self) as _
                 }
@@ -192,31 +192,31 @@ macro_rules! syscall {
 
             // Coerce integer values into `c_long`.
             impl AsSyscallArg for i8 {
-                type SyscallArgType = ::libc::c_long;
-                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+                type SyscallArgType = ::libc::c_int;
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self.into() }
             }
             impl AsSyscallArg for u8 {
-                type SyscallArgType = ::libc::c_long;
-                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+                type SyscallArgType = ::libc::c_int;
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self.into() }
             }
             impl AsSyscallArg for i16 {
-                type SyscallArgType = ::libc::c_long;
-                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+                type SyscallArgType = ::libc::c_int;
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self.into() }
             }
             impl AsSyscallArg for u16 {
-                type SyscallArgType = ::libc::c_long;
-                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+                type SyscallArgType = ::libc::c_int;
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self.into() }
             }
             impl AsSyscallArg for i32 {
-                type SyscallArgType = ::libc::c_long;
-                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+                type SyscallArgType = ::libc::c_int;
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self }
             }
             impl AsSyscallArg for u32 {
-                type SyscallArgType = ::libc::c_long;
-                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+                type SyscallArgType = ::libc::c_uint;
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self }
             }
             impl AsSyscallArg for usize {
-                type SyscallArgType = ::libc::c_long;
+                type SyscallArgType = ::libc::c_ulong;
                 fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
             }
 
@@ -225,12 +225,12 @@ macro_rules! syscall {
             #[cfg(target_pointer_width = "64")]
             impl AsSyscallArg for i64 {
                 type SyscallArgType = ::libc::c_long;
-                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self }
             }
             #[cfg(target_pointer_width = "64")]
             impl AsSyscallArg for u64 {
-                type SyscallArgType = ::libc::c_long;
-                fn into_syscall_arg(self) -> Self::SyscallArgType { self as _ }
+                type SyscallArgType = ::libc::c_ulong;
+                fn into_syscall_arg(self) -> Self::SyscallArgType { self }
             }
 
             // `concat_idents` is [unstable], so we take an extra `sys_name`


### PR DESCRIPTION
Add `futex` support in the libc backend, so that it doesn't depend on `linux_raw`.

Also, fix the `syscall!` macro to use the correct types to pass to `libc::syscall`, to fix errors reported by miri. With this change, rustix-futex-sync's tests pass under miri.