### PR TITLE
Put features that use global allocation behind cargo feature.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,8 +143,8 @@ jobs:
     - run: cargo check --workspace --release --no-default-features --features use-libc -vv
     - run: cargo check --workspace --release --no-default-features --features all-apis -vv
     - run: cargo check --workspace --release --no-default-features --features all-apis,use-libc -vv
-    - run: cargo check --workspace --release --no-default-features --features all-apis,global-allocator -vv
-    - run: cargo check --workspace --release --no-default-features --features all-apis,use-libc,global-allocator -vv
+    - run: cargo check --workspace --release --no-default-features --features all-apis,alloc -vv
+    - run: cargo check --workspace --release --no-default-features --features all-apis,use-libc,alloc -vv
     - run: cargo check --workspace --release --no-default-features --features time -vv
     - run: cargo check --workspace --release --no-default-features --features time,use-libc -vv
     - run: rustup component add rust-src

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,8 @@ jobs:
     - run: cargo check --workspace --release --no-default-features --features use-libc -vv
     - run: cargo check --workspace --release --no-default-features --features all-apis -vv
     - run: cargo check --workspace --release --no-default-features --features all-apis,use-libc -vv
+    - run: cargo check --workspace --release --no-default-features --features all-apis,global-allocator -vv
+    - run: cargo check --workspace --release --no-default-features --features all-apis,use-libc,global-allocator -vv
     - run: cargo check --workspace --release --no-default-features --features time -vv
     - run: cargo check --workspace --release --no-default-features --features time,use-libc -vv
     - run: rustup component add rust-src

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ default = ["std", "use-libc-auxv"]
 
 # This enables use of std. Disabling this enables `#![no_std], and requires
 # Rust 1.64 or newer.
-std = ["bitflags/std"]
+std = ["bitflags/std", "global-allocator"]
 
 # This is used in the port of std to rustix.
 rustc-dep-of-std = [
@@ -231,6 +231,10 @@ linux_4_11 = []
 
 # Enable all optimizations for the latest Linux versions.
 linux_latest = ["linux_4_11"]
+
+# Enable features which depend on the Rust global allocator, such as functions
+# that return owned strings or `Vec`s.
+global-allocator = []
 
 # Obsolete and deprecated.
 cc = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,13 +123,13 @@ default = ["std", "use-libc-auxv"]
 
 # This enables use of std. Disabling this enables `#![no_std], and requires
 # Rust 1.64 or newer.
-std = ["bitflags/std", "global-allocator"]
+std = ["bitflags/std", "alloc"]
 
 # This is used in the port of std to rustix.
 rustc-dep-of-std = [
-    "core",
-    "alloc",
-    "compiler_builtins",
+    "dep:core",
+    "dep:alloc",
+    "dep:compiler_builtins",
     "linux-raw-sys/rustc-dep-of-std",
     "bitflags/rustc-dep-of-std",
 ]
@@ -234,7 +234,7 @@ linux_latest = ["linux_4_11"]
 
 # Enable features which depend on the Rust global allocator, such as functions
 # that return owned strings or `Vec`s.
-global-allocator = []
+alloc = []
 
 # Obsolete and deprecated.
 cc = []

--- a/src/backend/libc/conv.rs
+++ b/src/backend/libc/conv.rs
@@ -3,7 +3,7 @@
 //! for converting between rustix's types and libc types.
 
 use super::c;
-#[cfg(all(feature = "global-allocator", not(any(windows, target_os = "espidf"))))]
+#[cfg(all(feature = "alloc", not(any(windows, target_os = "espidf"))))]
 use super::fd::IntoRawFd;
 use super::fd::{AsRawFd, BorrowedFd, FromRawFd, LibcFd, OwnedFd, RawFd};
 #[cfg(not(windows))]
@@ -28,7 +28,7 @@ pub(super) fn borrowed_fd(fd: BorrowedFd<'_>) -> LibcFd {
 }
 
 #[cfg(all(
-    feature = "global-allocator",
+    feature = "alloc",
     not(any(windows, target_os = "espidf", target_os = "redox"))
 ))]
 #[inline]
@@ -136,7 +136,7 @@ pub(super) fn ret_discarded_fd(raw: LibcFd) -> io::Result<()> {
     }
 }
 
-#[cfg(all(feature = "global-allocator", not(any(windows, target_os = "wasi"))))]
+#[cfg(all(feature = "alloc", not(any(windows, target_os = "wasi"))))]
 #[inline]
 pub(super) fn ret_discarded_char_ptr(raw: *mut c::c_char) -> io::Result<()> {
     if raw.is_null() {

--- a/src/backend/libc/conv.rs
+++ b/src/backend/libc/conv.rs
@@ -3,7 +3,7 @@
 //! for converting between rustix's types and libc types.
 
 use super::c;
-#[cfg(not(any(windows, target_os = "espidf")))]
+#[cfg(all(feature = "global-allocator", not(any(windows, target_os = "espidf"))))]
 use super::fd::IntoRawFd;
 use super::fd::{AsRawFd, BorrowedFd, FromRawFd, LibcFd, OwnedFd, RawFd};
 #[cfg(not(windows))]
@@ -27,7 +27,10 @@ pub(super) fn borrowed_fd(fd: BorrowedFd<'_>) -> LibcFd {
     fd.as_raw_fd() as LibcFd
 }
 
-#[cfg(not(any(windows, target_os = "espidf", target_os = "redox")))]
+#[cfg(all(
+    feature = "global-allocator",
+    not(any(windows, target_os = "espidf", target_os = "redox"))
+))]
 #[inline]
 pub(super) fn owned_fd(fd: OwnedFd) -> LibcFd {
     fd.into_raw_fd() as LibcFd
@@ -133,7 +136,7 @@ pub(super) fn ret_discarded_fd(raw: LibcFd) -> io::Result<()> {
     }
 }
 
-#[cfg(not(any(windows, target_os = "wasi")))]
+#[cfg(all(feature = "global-allocator", not(any(windows, target_os = "wasi"))))]
 #[inline]
 pub(super) fn ret_discarded_char_ptr(raw: *mut c::c_char) -> io::Result<()> {
     if raw.is_null() {

--- a/src/backend/libc/event/mod.rs
+++ b/src/backend/libc/event/mod.rs
@@ -5,5 +5,5 @@ pub(crate) mod types;
 #[cfg_attr(windows, path = "windows_syscalls.rs")]
 pub(crate) mod syscalls;
 
-#[cfg(linux_kernel)]
+#[cfg(all(feature = "alloc", linux_kernel))]
 pub mod epoll;

--- a/src/backend/libc/fs/inotify.rs
+++ b/src/backend/libc/fs/inotify.rs
@@ -104,16 +104,17 @@ pub fn inotify_add_watch<P: crate::path::Arg>(
     path: P,
     flags: WatchFlags,
 ) -> io::Result<i32> {
-    let path = path.as_cow_c_str().unwrap();
-    // SAFETY: The fd and path we are passing is guaranteed valid by the type
-    // system.
-    unsafe {
-        ret_c_int(c::inotify_add_watch(
-            borrowed_fd(inot),
-            c_str(&path),
-            flags.bits(),
-        ))
-    }
+    path.into_with_c_str(|path| {
+        // SAFETY: The fd and path we are passing is guaranteed valid by the type
+        // system.
+        unsafe {
+            ret_c_int(c::inotify_add_watch(
+                borrowed_fd(inot),
+                c_str(&path),
+                flags.bits(),
+            ))
+        }
+    })
 }
 
 /// `inotify_rm_watch(self, wd)`—Removes a watch from this inotify

--- a/src/backend/libc/fs/mod.rs
+++ b/src/backend/libc/fs/mod.rs
@@ -1,7 +1,4 @@
-#[cfg(all(
-    feature = "global-allocator",
-    not(any(target_os = "espidf", target_os = "redox"))
-))]
+#[cfg(all(feature = "alloc", not(any(target_os = "espidf", target_os = "redox"))))]
 pub(crate) mod dir;
 #[cfg(linux_kernel)]
 pub mod inotify;

--- a/src/backend/libc/fs/mod.rs
+++ b/src/backend/libc/fs/mod.rs
@@ -1,4 +1,7 @@
-#[cfg(not(any(target_os = "espidf", target_os = "redox")))]
+#[cfg(all(
+    feature = "global-allocator",
+    not(any(target_os = "espidf", target_os = "redox"))
+))]
 pub(crate) mod dir;
 #[cfg(linux_kernel)]
 pub mod inotify;

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -248,7 +248,7 @@ pub(crate) fn statvfs(filename: &CStr) -> io::Result<StatVfs> {
     }
 }
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 #[inline]
 pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     unsafe {
@@ -258,7 +258,7 @@ pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     }
 }
 
-#[cfg(all(feature = "global-allocator", not(target_os = "redox")))]
+#[cfg(all(feature = "alloc", not(target_os = "redox")))]
 #[inline]
 pub(crate) fn readlinkat(
     dirfd: BorrowedFd<'_>,

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -248,6 +248,7 @@ pub(crate) fn statvfs(filename: &CStr) -> io::Result<StatVfs> {
     }
 }
 
+#[cfg(feature = "global-allocator")]
 #[inline]
 pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     unsafe {
@@ -257,7 +258,7 @@ pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     }
 }
 
-#[cfg(not(target_os = "redox"))]
+#[cfg(all(feature = "global-allocator", not(target_os = "redox")))]
 #[inline]
 pub(crate) fn readlinkat(
     dirfd: BorrowedFd<'_>,

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -7,7 +7,7 @@ use crate::backend::c;
 use crate::backend::conv::borrowed_fd;
 #[cfg(feature = "fs")]
 use crate::backend::conv::c_str;
-#[cfg(all(feature = "global-allocator", feature = "fs", not(target_os = "wasi")))]
+#[cfg(all(feature = "alloc", feature = "fs", not(target_os = "wasi")))]
 use crate::backend::conv::ret_discarded_char_ptr;
 #[cfg(not(any(
     target_os = "espidf",
@@ -20,7 +20,7 @@ use crate::backend::conv::ret_infallible;
 use crate::backend::conv::ret_pid_t;
 #[cfg(linux_kernel)]
 use crate::backend::conv::ret_u32;
-#[cfg(all(feature = "global-allocator", not(target_os = "wasi")))]
+#[cfg(all(feature = "alloc", not(target_os = "wasi")))]
 use crate::backend::conv::ret_usize;
 #[cfg(not(target_os = "fucshia"))]
 use crate::backend::conv::{ret, ret_c_int};
@@ -33,7 +33,7 @@ use crate::ffi::CStr;
 #[cfg(feature = "fs")]
 use crate::fs::Mode;
 use crate::io;
-#[cfg(all(feature = "global-allocator", not(target_os = "wasi")))]
+#[cfg(all(feature = "alloc", not(target_os = "wasi")))]
 use crate::process::Gid;
 #[cfg(not(target_os = "wasi"))]
 use crate::process::Pid;
@@ -80,7 +80,7 @@ pub(crate) fn chroot(path: &CStr) -> io::Result<()> {
     unsafe { ret(c::chroot(c_str(path))) }
 }
 
-#[cfg(all(feature = "global-allocator", feature = "fs"))]
+#[cfg(all(feature = "alloc", feature = "fs"))]
 #[cfg(not(target_os = "wasi"))]
 pub(crate) fn getcwd(buf: &mut [MaybeUninit<u8>]) -> io::Result<()> {
     unsafe { ret_discarded_char_ptr(c::getcwd(buf.as_mut_ptr().cast(), buf.len())) }
@@ -619,7 +619,7 @@ pub(crate) fn pidfd_getfd(
     }
 }
 
-#[cfg(all(feature = "global-allocator", not(target_os = "wasi")))]
+#[cfg(all(feature = "alloc", not(target_os = "wasi")))]
 pub(crate) fn getgroups(buf: &mut [Gid]) -> io::Result<usize> {
     let len = buf.len().try_into().map_err(|_| io::Errno::NOMEM)?;
 

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -7,7 +7,7 @@ use crate::backend::c;
 use crate::backend::conv::borrowed_fd;
 #[cfg(feature = "fs")]
 use crate::backend::conv::c_str;
-#[cfg(all(feature = "fs", not(target_os = "wasi")))]
+#[cfg(all(feature = "global-allocator", feature = "fs", not(target_os = "wasi")))]
 use crate::backend::conv::ret_discarded_char_ptr;
 #[cfg(not(any(
     target_os = "espidf",
@@ -16,12 +16,14 @@ use crate::backend::conv::ret_discarded_char_ptr;
     target_os = "wasi"
 )))]
 use crate::backend::conv::ret_infallible;
+#[cfg(not(target_os = "wasi"))]
+use crate::backend::conv::ret_pid_t;
 #[cfg(linux_kernel)]
 use crate::backend::conv::ret_u32;
+#[cfg(all(feature = "global-allocator", not(target_os = "wasi")))]
+use crate::backend::conv::ret_usize;
 #[cfg(not(target_os = "fucshia"))]
 use crate::backend::conv::{ret, ret_c_int};
-#[cfg(not(target_os = "wasi"))]
-use crate::backend::conv::{ret_pid_t, ret_usize};
 #[cfg(not(any(target_os = "wasi", target_os = "fuchsia")))]
 use crate::fd::BorrowedFd;
 #[cfg(target_os = "linux")]
@@ -31,12 +33,14 @@ use crate::ffi::CStr;
 #[cfg(feature = "fs")]
 use crate::fs::Mode;
 use crate::io;
+#[cfg(all(feature = "global-allocator", not(target_os = "wasi")))]
+use crate::process::Gid;
+#[cfg(not(target_os = "wasi"))]
+use crate::process::Pid;
 #[cfg(not(any(target_os = "espidf", target_os = "fuchsia", target_os = "wasi")))]
 use crate::process::Uid;
 #[cfg(linux_kernel)]
 use crate::process::{Cpuid, MembarrierCommand, MembarrierQuery};
-#[cfg(not(target_os = "wasi"))]
-use crate::process::{Gid, Pid};
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 use crate::process::{RawPid, Signal, WaitOptions, WaitStatus};
 #[cfg(not(any(
@@ -76,7 +80,7 @@ pub(crate) fn chroot(path: &CStr) -> io::Result<()> {
     unsafe { ret(c::chroot(c_str(path))) }
 }
 
-#[cfg(feature = "fs")]
+#[cfg(all(feature = "global-allocator", feature = "fs"))]
 #[cfg(not(target_os = "wasi"))]
 pub(crate) fn getcwd(buf: &mut [MaybeUninit<u8>]) -> io::Result<()> {
     unsafe { ret_discarded_char_ptr(c::getcwd(buf.as_mut_ptr().cast(), buf.len())) }
@@ -615,7 +619,7 @@ pub(crate) fn pidfd_getfd(
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
+#[cfg(all(feature = "global-allocator", not(target_os = "wasi")))]
 pub(crate) fn getgroups(buf: &mut [Gid]) -> io::Result<usize> {
     let len = buf.len().try_into().map_err(|_| io::Errno::NOMEM)?;
 

--- a/src/backend/libc/pty/syscalls.rs
+++ b/src/backend/libc/pty/syscalls.rs
@@ -5,7 +5,7 @@ use crate::backend::conv::{borrowed_fd, ret};
 use crate::fd::BorrowedFd;
 use crate::io;
 #[cfg(all(
-    feature = "global-allocator",
+    feature = "alloc",
     any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia")
 ))]
 use {
@@ -25,7 +25,7 @@ pub(crate) fn openpt(flags: OpenptFlags) -> io::Result<OwnedFd> {
 }
 
 #[cfg(all(
-    feature = "global-allocator",
+    feature = "alloc",
     any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia")
 ))]
 #[inline]

--- a/src/backend/libc/pty/syscalls.rs
+++ b/src/backend/libc/pty/syscalls.rs
@@ -4,7 +4,10 @@ use crate::backend::c;
 use crate::backend::conv::{borrowed_fd, ret};
 use crate::fd::BorrowedFd;
 use crate::io;
-#[cfg(any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(all(
+    feature = "global-allocator",
+    any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia")
+))]
 use {
     crate::ffi::{CStr, CString},
     crate::path::SMALL_PATH_BUFFER_SIZE,
@@ -21,7 +24,10 @@ pub(crate) fn openpt(flags: OpenptFlags) -> io::Result<OwnedFd> {
     unsafe { ret_owned_fd(c::posix_openpt(flags.bits() as _)) }
 }
 
-#[cfg(any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(all(
+    feature = "global-allocator",
+    any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia")
+))]
 #[inline]
 pub(crate) fn ptsname(fd: BorrowedFd, mut buffer: Vec<u8>) -> io::Result<CString> {
     // This code would benefit from having a better way to read into

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -9,7 +9,7 @@ use crate::backend::c;
 use crate::backend::conv::ret_pid_t;
 use crate::backend::conv::{borrowed_fd, ret};
 use crate::fd::BorrowedFd;
-#[cfg(all(feature = "global-allocator", feature = "procfs"))]
+#[cfg(all(feature = "alloc", feature = "procfs"))]
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 use crate::ffi::CStr;
 #[cfg(any(
@@ -347,7 +347,7 @@ pub(crate) fn isatty(fd: BorrowedFd<'_>) -> bool {
     unsafe { c::isatty(borrowed_fd(fd)) != 0 }
 }
 
-#[cfg(all(feature = "global-allocator", feature = "procfs"))]
+#[cfg(all(feature = "alloc", feature = "procfs"))]
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 pub(crate) fn ttyname(dirfd: BorrowedFd<'_>, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
     unsafe {

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -9,7 +9,7 @@ use crate::backend::c;
 use crate::backend::conv::ret_pid_t;
 use crate::backend::conv::{borrowed_fd, ret};
 use crate::fd::BorrowedFd;
-#[cfg(feature = "procfs")]
+#[cfg(all(feature = "global-allocator", feature = "procfs"))]
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 use crate::ffi::CStr;
 #[cfg(any(
@@ -347,7 +347,7 @@ pub(crate) fn isatty(fd: BorrowedFd<'_>) -> bool {
     unsafe { c::isatty(borrowed_fd(fd)) != 0 }
 }
 
-#[cfg(feature = "procfs")]
+#[cfg(all(feature = "global-allocator", feature = "procfs"))]
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 pub(crate) fn ttyname(dirfd: BorrowedFd<'_>, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
     unsafe {

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -581,7 +581,7 @@ impl<'a, Num: ArgNumber> From<crate::event::EventfdFlags> for ArgReg<'a, Num> {
     }
 }
 
-#[cfg(feature = "event")]
+#[cfg(all(feature = "alloc", feature = "event"))]
 impl<'a, Num: ArgNumber> From<crate::event::epoll::CreateFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::event::epoll::CreateFlags) -> Self {

--- a/src/backend/linux_raw/event/mod.rs
+++ b/src/backend/linux_raw/event/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "alloc")]
 pub mod epoll;
 pub(crate) mod poll_fd;
 pub(crate) mod syscalls;

--- a/src/backend/linux_raw/event/syscalls.rs
+++ b/src/backend/linux_raw/event/syscalls.rs
@@ -7,13 +7,17 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::c;
-use crate::backend::conv::{
-    by_ref, c_int, c_uint, pass_usize, raw_fd, ret, ret_owned_fd, ret_usize, slice_mut, zero,
-};
-use crate::event::{epoll, EventfdFlags, PollFd};
-use crate::fd::{BorrowedFd, OwnedFd};
+use crate::backend::conv::{c_int, c_uint, ret_owned_fd, ret_usize, slice_mut};
+use crate::event::{EventfdFlags, PollFd};
+use crate::fd::OwnedFd;
 use crate::io;
-use linux_raw_sys::general::{EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD};
+#[cfg(feature = "alloc")]
+use {
+    crate::backend::conv::{by_ref, pass_usize, raw_fd, ret, zero},
+    crate::event::epoll,
+    crate::fd::BorrowedFd,
+    linux_raw_sys::general::{EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD},
+};
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use {
     crate::backend::conv::{opt_ref, size_of},
@@ -49,11 +53,13 @@ pub(crate) fn poll(fds: &mut [PollFd<'_>], timeout: c::c_int) -> io::Result<usiz
     }
 }
 
+#[cfg(feature = "alloc")]
 #[inline]
 pub(crate) fn epoll_create(flags: epoll::CreateFlags) -> io::Result<OwnedFd> {
     unsafe { ret_owned_fd(syscall_readonly!(__NR_epoll_create1, flags)) }
 }
 
+#[cfg(feature = "alloc")]
 #[inline]
 pub(crate) unsafe fn epoll_add(
     epfd: BorrowedFd<'_>,
@@ -69,6 +75,7 @@ pub(crate) unsafe fn epoll_add(
     ))
 }
 
+#[cfg(feature = "alloc")]
 #[inline]
 pub(crate) unsafe fn epoll_mod(
     epfd: BorrowedFd<'_>,
@@ -84,6 +91,7 @@ pub(crate) unsafe fn epoll_mod(
     ))
 }
 
+#[cfg(feature = "alloc")]
 #[inline]
 pub(crate) unsafe fn epoll_del(epfd: BorrowedFd<'_>, fd: c::c_int) -> io::Result<()> {
     ret(syscall_readonly!(
@@ -95,6 +103,7 @@ pub(crate) unsafe fn epoll_del(epfd: BorrowedFd<'_>, fd: c::c_int) -> io::Result
     ))
 }
 
+#[cfg(feature = "alloc")]
 #[inline]
 pub(crate) fn epoll_wait(
     epfd: BorrowedFd<'_>,

--- a/src/backend/linux_raw/fs/inotify.rs
+++ b/src/backend/linux_raw/fs/inotify.rs
@@ -105,8 +105,7 @@ pub fn inotify_add_watch<P: crate::path::Arg>(
     path: P,
     flags: WatchFlags,
 ) -> io::Result<i32> {
-    let path = path.as_cow_c_str().unwrap();
-    syscalls::inotify_add_watch(inot, &path, flags)
+    path.into_with_c_str(|path| syscalls::inotify_add_watch(inot, path, flags))
 }
 
 /// `inotify_rm_watch(self, wd)`—Removes a watch from this inotify

--- a/src/backend/linux_raw/fs/mod.rs
+++ b/src/backend/linux_raw/fs/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 pub(crate) mod dir;
 pub mod inotify;
 pub(crate) mod makedev;

--- a/src/backend/linux_raw/fs/mod.rs
+++ b/src/backend/linux_raw/fs/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "global-allocator")]
 pub(crate) mod dir;
 pub mod inotify;
 pub(crate) mod makedev;

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -912,6 +912,7 @@ fn statfs_to_statvfs(statfs: StatFs) -> StatVfs {
     }
 }
 
+#[cfg(feature = "global-allocator")]
 #[inline]
 pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     let (buf_addr_mut, buf_len) = slice_mut(buf);
@@ -926,6 +927,7 @@ pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     }
 }
 
+#[cfg(feature = "global-allocator")]
 #[inline]
 pub(crate) fn readlinkat(
     dirfd: BorrowedFd<'_>,
@@ -1231,6 +1233,7 @@ pub(crate) fn mkdirat(dirfd: BorrowedFd<'_>, path: &CStr, mode: Mode) -> io::Res
     unsafe { ret(syscall_readonly!(__NR_mkdirat, dirfd, path, mode)) }
 }
 
+#[cfg(feature = "global-allocator")]
 #[inline]
 pub(crate) fn getdents(fd: BorrowedFd<'_>, dirent: &mut [u8]) -> io::Result<usize> {
     let (dirent_addr_mut, dirent_len) = slice_mut(dirent);

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -912,7 +912,7 @@ fn statfs_to_statvfs(statfs: StatFs) -> StatVfs {
     }
 }
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 #[inline]
 pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     let (buf_addr_mut, buf_len) = slice_mut(buf);
@@ -927,7 +927,7 @@ pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     }
 }
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 #[inline]
 pub(crate) fn readlinkat(
     dirfd: BorrowedFd<'_>,
@@ -1233,7 +1233,7 @@ pub(crate) fn mkdirat(dirfd: BorrowedFd<'_>, path: &CStr, mode: Mode) -> io::Res
     unsafe { ret(syscall_readonly!(__NR_mkdirat, dirfd, path, mode)) }
 }
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 #[inline]
 pub(crate) fn getdents(fd: BorrowedFd<'_>, dirent: &mut [u8]) -> io::Result<usize> {
     let (dirent_addr_mut, dirent_len) = slice_mut(dirent);

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -8,12 +8,12 @@
 
 use super::types::RawCpuSet;
 use crate::backend::c;
-#[cfg(feature = "fs")]
+#[cfg(all(feature = "global-allocator", feature = "fs"))]
 use crate::backend::conv::slice_mut;
 use crate::backend::conv::{
     by_mut, by_ref, c_int, c_uint, negative_pid, pass_usize, raw_fd, ret, ret_c_int,
     ret_c_int_infallible, ret_c_uint, ret_infallible, ret_owned_fd, ret_usize, size_of,
-    slice_just_addr, slice_just_addr_mut, zero,
+    slice_just_addr, zero,
 };
 use crate::fd::{AsRawFd, BorrowedFd, OwnedFd, RawFd};
 #[cfg(feature = "fs")]
@@ -21,8 +21,8 @@ use crate::ffi::CStr;
 use crate::io;
 use crate::pid::RawPid;
 use crate::process::{
-    Cpuid, Gid, MembarrierCommand, MembarrierQuery, Pid, PidfdFlags, PidfdGetfdFlags, Resource,
-    Rlimit, Uid, WaitId, WaitOptions, WaitStatus, WaitidOptions, WaitidStatus,
+    Cpuid, MembarrierCommand, MembarrierQuery, Pid, PidfdFlags, PidfdGetfdFlags, Resource, Rlimit,
+    Uid, WaitId, WaitOptions, WaitStatus, WaitidOptions, WaitidStatus,
 };
 use crate::signal::Signal;
 use crate::utils::as_mut_ptr;
@@ -34,6 +34,8 @@ use linux_raw_sys::general::{
 };
 #[cfg(feature = "fs")]
 use {crate::backend::conv::ret_c_uint_infallible, crate::fs::Mode};
+#[cfg(feature = "global-allocator")]
+use {crate::backend::conv::slice_just_addr_mut, crate::process::Gid};
 
 #[cfg(feature = "fs")]
 #[inline]
@@ -52,7 +54,7 @@ pub(crate) fn chroot(filename: &CStr) -> io::Result<()> {
     unsafe { ret(syscall_readonly!(__NR_chroot, filename)) }
 }
 
-#[cfg(feature = "fs")]
+#[cfg(all(feature = "global-allocator", feature = "fs"))]
 #[inline]
 pub(crate) fn getcwd(buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
     let (buf_addr_mut, buf_len) = slice_mut(buf);
@@ -609,6 +611,7 @@ pub(crate) fn pidfd_open(pid: Pid, flags: PidfdFlags) -> io::Result<OwnedFd> {
     unsafe { ret_owned_fd(syscall_readonly!(__NR_pidfd_open, pid, flags)) }
 }
 
+#[cfg(feature = "global-allocator")]
 #[inline]
 pub(crate) fn getgroups(buf: &mut [Gid]) -> io::Result<usize> {
     let len = buf.len().try_into().map_err(|_| io::Errno::NOMEM)?;

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -8,7 +8,7 @@
 
 use super::types::RawCpuSet;
 use crate::backend::c;
-#[cfg(all(feature = "global-allocator", feature = "fs"))]
+#[cfg(all(feature = "alloc", feature = "fs"))]
 use crate::backend::conv::slice_mut;
 use crate::backend::conv::{
     by_mut, by_ref, c_int, c_uint, negative_pid, pass_usize, raw_fd, ret, ret_c_int,
@@ -34,7 +34,7 @@ use linux_raw_sys::general::{
 };
 #[cfg(feature = "fs")]
 use {crate::backend::conv::ret_c_uint_infallible, crate::fs::Mode};
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 use {crate::backend::conv::slice_just_addr_mut, crate::process::Gid};
 
 #[cfg(feature = "fs")]
@@ -54,7 +54,7 @@ pub(crate) fn chroot(filename: &CStr) -> io::Result<()> {
     unsafe { ret(syscall_readonly!(__NR_chroot, filename)) }
 }
 
-#[cfg(all(feature = "global-allocator", feature = "fs"))]
+#[cfg(all(feature = "alloc", feature = "fs"))]
 #[inline]
 pub(crate) fn getcwd(buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
     let (buf_addr_mut, buf_len) = slice_mut(buf);
@@ -611,7 +611,7 @@ pub(crate) fn pidfd_open(pid: Pid, flags: PidfdFlags) -> io::Result<OwnedFd> {
     unsafe { ret_owned_fd(syscall_readonly!(__NR_pidfd_open, pid, flags)) }
 }
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 #[inline]
 pub(crate) fn getgroups(buf: &mut [Gid]) -> io::Result<usize> {
     let len = buf.len().try_into().map_err(|_| io::Errno::NOMEM)?;

--- a/src/backend/linux_raw/pty/syscalls.rs
+++ b/src/backend/linux_raw/pty/syscalls.rs
@@ -10,13 +10,13 @@ use crate::backend::conv::{by_ref, c_uint, ret};
 use crate::fd::BorrowedFd;
 use crate::io;
 use linux_raw_sys::ioctl::TIOCSPTLCK;
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 use {
     crate::backend::c, crate::ffi::CString, crate::path::DecInt, alloc::vec::Vec,
     core::mem::MaybeUninit, linux_raw_sys::ioctl::TIOCGPTN,
 };
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 #[inline]
 pub(crate) fn ptsname(fd: BorrowedFd, mut buffer: Vec<u8>) -> io::Result<CString> {
     unsafe {

--- a/src/backend/linux_raw/pty/syscalls.rs
+++ b/src/backend/linux_raw/pty/syscalls.rs
@@ -6,16 +6,17 @@
 #![allow(unsafe_code)]
 #![allow(clippy::undocumented_unsafe_blocks)]
 
-use crate::backend::c;
 use crate::backend::conv::{by_ref, c_uint, ret};
 use crate::fd::BorrowedFd;
-use crate::ffi::CString;
 use crate::io;
-use crate::path::DecInt;
-use alloc::vec::Vec;
-use core::mem::MaybeUninit;
-use linux_raw_sys::ioctl::{TIOCGPTN, TIOCSPTLCK};
+use linux_raw_sys::ioctl::TIOCSPTLCK;
+#[cfg(feature = "global-allocator")]
+use {
+    crate::backend::c, crate::ffi::CString, crate::path::DecInt, alloc::vec::Vec,
+    core::mem::MaybeUninit, linux_raw_sys::ioctl::TIOCGPTN,
+};
 
+#[cfg(feature = "global-allocator")]
 #[inline]
 pub(crate) fn ptsname(fd: BorrowedFd, mut buffer: Vec<u8>) -> io::Result<CString> {
     unsafe {

--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -11,13 +11,13 @@ use crate::backend::conv::{by_ref, c_uint, ret};
 use crate::fd::BorrowedFd;
 use crate::io;
 use crate::pid::Pid;
-#[cfg(all(feature = "global-allocator", feature = "procfs"))]
+#[cfg(all(feature = "alloc", feature = "procfs"))]
 use crate::procfs;
 use crate::termios::{
     Action, ControlModes, InputModes, LocalModes, OptionalActions, OutputModes, QueueSelector,
     SpecialCodeIndex, Termios, Winsize,
 };
-#[cfg(all(feature = "global-allocator", feature = "procfs"))]
+#[cfg(all(feature = "alloc", feature = "procfs"))]
 use crate::{ffi::CStr, fs::FileType, path::DecInt};
 use core::mem::MaybeUninit;
 use linux_raw_sys::general::IBSHIFT;
@@ -229,7 +229,7 @@ pub(crate) fn isatty(fd: BorrowedFd<'_>) -> bool {
     tcgetwinsize(fd).is_ok()
 }
 
-#[cfg(all(feature = "global-allocator", feature = "procfs"))]
+#[cfg(all(feature = "alloc", feature = "procfs"))]
 #[allow(unsafe_code)]
 pub(crate) fn ttyname(fd: BorrowedFd<'_>, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
     let fd_stat = crate::backend::fs::syscalls::fstat(fd)?;

--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -11,13 +11,13 @@ use crate::backend::conv::{by_ref, c_uint, ret};
 use crate::fd::BorrowedFd;
 use crate::io;
 use crate::pid::Pid;
-#[cfg(feature = "procfs")]
+#[cfg(all(feature = "global-allocator", feature = "procfs"))]
 use crate::procfs;
 use crate::termios::{
     Action, ControlModes, InputModes, LocalModes, OptionalActions, OutputModes, QueueSelector,
     SpecialCodeIndex, Termios, Winsize,
 };
-#[cfg(feature = "procfs")]
+#[cfg(all(feature = "global-allocator", feature = "procfs"))]
 use crate::{ffi::CStr, fs::FileType, path::DecInt};
 use core::mem::MaybeUninit;
 use linux_raw_sys::general::IBSHIFT;
@@ -229,7 +229,7 @@ pub(crate) fn isatty(fd: BorrowedFd<'_>) -> bool {
     tcgetwinsize(fd).is_ok()
 }
 
-#[cfg(feature = "procfs")]
+#[cfg(all(feature = "global-allocator", feature = "procfs"))]
 #[allow(unsafe_code)]
 pub(crate) fn ttyname(fd: BorrowedFd<'_>, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
     let fd_stat = crate::backend::fs::syscalls::fstat(fd)?;

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -13,7 +13,7 @@ mod poll;
 #[cfg(solarish)]
 pub mod port;
 
-#[cfg(linux_kernel)]
+#[cfg(all(feature = "alloc", linux_kernel))]
 pub use crate::backend::event::epoll;
 #[cfg(any(
     linux_kernel,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -9,8 +9,7 @@ pub use {
 
 // If we don't have std, we can depend on core and alloc having these features
 // in Rust 1.64+.
+#[cfg(all(feature = "global-allocator", not(feature = "std")))]
+pub use alloc::ffi::{CString, NulError};
 #[cfg(not(feature = "std"))]
-pub use {
-    alloc::ffi::{CString, NulError},
-    core::ffi::{c_char, CStr, FromBytesWithNulError},
-};
+pub use core::ffi::{c_char, CStr, FromBytesWithNulError};

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -9,7 +9,7 @@ pub use {
 
 // If we don't have std, we can depend on core and alloc having these features
 // in Rust 1.64+.
-#[cfg(all(feature = "global-allocator", not(feature = "std")))]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 pub use alloc::ffi::{CString, NulError};
 #[cfg(not(feature = "std"))]
 pub use core::ffi::{c_char, CStr, FromBytesWithNulError};

--- a/src/fs/abs.rs
+++ b/src/fs/abs.rs
@@ -17,7 +17,7 @@ use crate::fs::StatFs;
 use crate::fs::StatVfs;
 use crate::fs::{Mode, OFlags, Stat};
 use crate::{backend, io, path};
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 use {
     crate::ffi::{CStr, CString},
     crate::path::SMALL_PATH_BUFFER_SIZE,
@@ -104,13 +104,13 @@ pub fn lstat<P: path::Arg>(path: P) -> io::Result<Stat> {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/readlink.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/readlink.2.html
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 #[inline]
 pub fn readlink<P: path::Arg, B: Into<Vec<u8>>>(path: P, reuse: B) -> io::Result<CString> {
     path.into_with_c_str(|path| _readlink(path, reuse.into()))
 }
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 fn _readlink(path: &CStr, mut buffer: Vec<u8>) -> io::Result<CString> {
     // This code would benefit from having a better way to read into
     // uninitialized memory, but that requires `unsafe`.

--- a/src/fs/abs.rs
+++ b/src/fs/abs.rs
@@ -1,7 +1,6 @@
 //! POSIX-style filesystem functions which operate on bare paths.
 
 use crate::fd::OwnedFd;
-use crate::ffi::{CStr, CString};
 #[cfg(not(target_os = "espidf"))]
 use crate::fs::Access;
 #[cfg(not(any(
@@ -17,9 +16,13 @@ use crate::fs::StatFs;
 #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 use crate::fs::StatVfs;
 use crate::fs::{Mode, OFlags, Stat};
-use crate::path::SMALL_PATH_BUFFER_SIZE;
 use crate::{backend, io, path};
-use alloc::vec::Vec;
+#[cfg(feature = "global-allocator")]
+use {
+    crate::ffi::{CStr, CString},
+    crate::path::SMALL_PATH_BUFFER_SIZE,
+    alloc::vec::Vec,
+};
 
 /// `open(path, oflags, mode)`—Opens a file.
 ///
@@ -101,11 +104,13 @@ pub fn lstat<P: path::Arg>(path: P) -> io::Result<Stat> {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/readlink.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/readlink.2.html
+#[cfg(feature = "global-allocator")]
 #[inline]
 pub fn readlink<P: path::Arg, B: Into<Vec<u8>>>(path: P, reuse: B) -> io::Result<CString> {
     path.into_with_c_str(|path| _readlink(path, reuse.into()))
 }
 
+#[cfg(feature = "global-allocator")]
 fn _readlink(path: &CStr, mut buffer: Vec<u8>) -> io::Result<CString> {
     // This code would benefit from having a better way to read into
     // uninitialized memory, but that requires `unsafe`.

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -6,7 +6,6 @@
 //! [`cwd`]: crate::fs::cwd::CWD
 
 use crate::fd::OwnedFd;
-use crate::ffi::{CStr, CString};
 #[cfg(apple)]
 use crate::fs::CloneFlags;
 #[cfg(not(any(apple, target_os = "espidf", target_os = "wasi")))]
@@ -16,10 +15,15 @@ use crate::fs::RenameFlags;
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 use crate::fs::{Gid, Uid};
 use crate::fs::{Mode, OFlags};
-use crate::path::SMALL_PATH_BUFFER_SIZE;
 use crate::{backend, io, path};
-use alloc::vec::Vec;
-use backend::fd::{AsFd, BorrowedFd};
+use backend::fd::AsFd;
+#[cfg(feature = "global-allocator")]
+use {
+    crate::ffi::{CStr, CString},
+    crate::path::SMALL_PATH_BUFFER_SIZE,
+    alloc::vec::Vec,
+    backend::fd::BorrowedFd,
+};
 #[cfg(not(target_os = "espidf"))]
 use {
     crate::fs::{Access, AtFlags, Stat, Timestamps},
@@ -76,6 +80,7 @@ pub fn openat<P: path::Arg, Fd: AsFd>(
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/readlinkat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/readlinkat.2.html
+#[cfg(feature = "global-allocator")]
 #[inline]
 pub fn readlinkat<P: path::Arg, Fd: AsFd, B: Into<Vec<u8>>>(
     dirfd: Fd,
@@ -85,6 +90,7 @@ pub fn readlinkat<P: path::Arg, Fd: AsFd, B: Into<Vec<u8>>>(
     path.into_with_c_str(|path| _readlinkat(dirfd.as_fd(), path, reuse.into()))
 }
 
+#[cfg(feature = "global-allocator")]
 #[allow(unsafe_code)]
 fn _readlinkat(dirfd: BorrowedFd<'_>, path: &CStr, mut buffer: Vec<u8>) -> io::Result<CString> {
     buffer.clear();

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -17,7 +17,7 @@ use crate::fs::{Gid, Uid};
 use crate::fs::{Mode, OFlags};
 use crate::{backend, io, path};
 use backend::fd::AsFd;
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 use {
     crate::ffi::{CStr, CString},
     crate::path::SMALL_PATH_BUFFER_SIZE,
@@ -80,7 +80,7 @@ pub fn openat<P: path::Arg, Fd: AsFd>(
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/readlinkat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/readlinkat.2.html
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 #[inline]
 pub fn readlinkat<P: path::Arg, Fd: AsFd, B: Into<Vec<u8>>>(
     dirfd: Fd,
@@ -90,7 +90,7 @@ pub fn readlinkat<P: path::Arg, Fd: AsFd, B: Into<Vec<u8>>>(
     path.into_with_c_str(|path| _readlinkat(dirfd.as_fd(), path, reuse.into()))
 }
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 #[allow(unsafe_code)]
 fn _readlinkat(dirfd: BorrowedFd<'_>, path: &CStr, mut buffer: Vec<u8>) -> io::Result<CString> {
     buffer.clear();

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -9,7 +9,10 @@ mod copy_file_range;
 #[cfg(not(any(target_os = "espidf", target_os = "redox")))]
 #[cfg(not(target_os = "haiku"))] // Haiku needs <https://github.com/rust-lang/rust/pull/112371>
 mod cwd;
-#[cfg(not(any(target_os = "espidf", target_os = "redox")))]
+#[cfg(all(
+    feature = "global-allocator",
+    not(any(target_os = "espidf", target_os = "redox"))
+))]
 mod dir;
 #[cfg(not(any(
     apple,
@@ -71,7 +74,10 @@ pub use copy_file_range::copy_file_range;
 #[cfg(not(any(target_os = "espidf", target_os = "redox")))]
 #[cfg(not(target_os = "haiku"))] // Haiku needs <https://github.com/rust-lang/rust/pull/112371>
 pub use cwd::*;
-#[cfg(not(any(target_os = "espidf", target_os = "redox")))]
+#[cfg(all(
+    feature = "global-allocator",
+    not(any(target_os = "espidf", target_os = "redox"))
+))]
 pub use dir::{Dir, DirEntry};
 #[cfg(not(any(
     apple,

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -9,10 +9,7 @@ mod copy_file_range;
 #[cfg(not(any(target_os = "espidf", target_os = "redox")))]
 #[cfg(not(target_os = "haiku"))] // Haiku needs <https://github.com/rust-lang/rust/pull/112371>
 mod cwd;
-#[cfg(all(
-    feature = "global-allocator",
-    not(any(target_os = "espidf", target_os = "redox"))
-))]
+#[cfg(all(feature = "alloc", not(any(target_os = "espidf", target_os = "redox"))))]
 mod dir;
 #[cfg(not(any(
     apple,
@@ -74,10 +71,7 @@ pub use copy_file_range::copy_file_range;
 #[cfg(not(any(target_os = "espidf", target_os = "redox")))]
 #[cfg(not(target_os = "haiku"))] // Haiku needs <https://github.com/rust-lang/rust/pull/112371>
 pub use cwd::*;
-#[cfg(all(
-    feature = "global-allocator",
-    not(any(target_os = "espidf", target_os = "redox"))
-))]
+#[cfg(all(feature = "alloc", not(any(target_os = "espidf", target_os = "redox"))))]
 pub use dir::{Dir, DirEntry};
 #[cfg(not(any(
     apple,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,8 +104,8 @@
 #![cfg_attr(all(wasi_ext, target_os = "wasi", feature = "std"), feature(wasi_ext))]
 #![cfg_attr(core_ffi_c, feature(core_ffi_c))]
 #![cfg_attr(core_c_str, feature(core_c_str))]
-#![cfg_attr(alloc_c_string, feature(alloc_c_string))]
-#![cfg_attr(alloc_ffi, feature(alloc_ffi))]
+#![cfg_attr(all(feature = "alloc", alloc_c_string), feature(alloc_c_string))]
+#![cfg_attr(all(feature = "alloc", alloc_ffi), feature(alloc_ffi))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "rustc-dep-of-std", feature(ip))]
 #![cfg_attr(
@@ -122,7 +122,7 @@
 // conditionalizing all the `use`s for them.
 #![cfg_attr(any(target_os = "redox", target_os = "wasi"), allow(unused_imports))]
 
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(all(feature = "alloc", not(feature = "rustc-dep-of-std")))]
 extern crate alloc;
 
 // Use `static_assertions` macros if we have them, or a polyfill otherwise.

--- a/src/path/arg.rs
+++ b/src/path/arg.rs
@@ -10,7 +10,7 @@ use crate::io;
 #[cfg(feature = "itoa")]
 use crate::path::DecInt;
 use crate::path::SMALL_PATH_BUFFER_SIZE;
-#[cfg(all(feature = "global-allocator", feature = "itoa"))]
+#[cfg(all(feature = "alloc", feature = "itoa"))]
 use alloc::borrow::ToOwned;
 use core::mem::MaybeUninit;
 use core::{ptr, slice, str};
@@ -26,9 +26,9 @@ use std::os::vxworks::ext::ffi::{OsStrExt, OsStringExt};
 use std::os::wasi::ffi::{OsStrExt, OsStringExt};
 #[cfg(feature = "std")]
 use std::path::{Component, Components, Iter, Path, PathBuf};
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 use {crate::ffi::CString, alloc::borrow::Cow};
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 use {alloc::string::String, alloc::vec::Vec};
 
 /// A trait for passing path arguments.
@@ -68,16 +68,16 @@ pub trait Arg {
 
     /// Returns a potentially-lossy rendering of this string as a
     /// `Cow<'_, str>`.
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     fn to_string_lossy(&self) -> Cow<'_, str>;
 
     /// Returns a view of this string as a maybe-owned [`CStr`].
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>>;
 
     /// Consumes `self` and returns a view of this string as a maybe-owned
     /// [`CStr`].
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
         Self: 'b;
@@ -95,13 +95,13 @@ impl Arg for &str {
         Ok(self)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         Cow::Borrowed(self)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -109,7 +109,7 @@ impl Arg for &str {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -130,20 +130,20 @@ impl Arg for &str {
     }
 }
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 impl Arg for &String {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
         Ok(self)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         Cow::Borrowed(self)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -151,7 +151,7 @@ impl Arg for &String {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -170,20 +170,20 @@ impl Arg for &String {
     }
 }
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 impl Arg for String {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
         Ok(self)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         Cow::Borrowed(self)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -191,7 +191,7 @@ impl Arg for String {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -219,13 +219,13 @@ impl Arg for &OsStr {
         self.to_str().ok_or(io::Errno::INVAL)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         OsStr::to_string_lossy(self)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -233,7 +233,7 @@ impl Arg for &OsStr {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -261,13 +261,13 @@ impl Arg for &OsString {
         OsString::as_os_str(self).to_str().ok_or(io::Errno::INVAL)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         self.as_os_str().to_string_lossy()
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -276,7 +276,7 @@ impl Arg for &OsString {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -302,13 +302,13 @@ impl Arg for OsString {
         self.as_os_str().to_str().ok_or(io::Errno::INVAL)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         self.as_os_str().to_string_lossy()
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -316,7 +316,7 @@ impl Arg for OsString {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -344,13 +344,13 @@ impl Arg for &Path {
         self.as_os_str().to_str().ok_or(io::Errno::INVAL)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         Path::to_string_lossy(self)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -358,7 +358,7 @@ impl Arg for &Path {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -389,13 +389,13 @@ impl Arg for &PathBuf {
             .ok_or(io::Errno::INVAL)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         self.as_path().to_string_lossy()
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -404,7 +404,7 @@ impl Arg for &PathBuf {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -430,13 +430,13 @@ impl Arg for PathBuf {
         self.as_os_str().to_str().ok_or(io::Errno::INVAL)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         self.as_os_str().to_string_lossy()
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -444,7 +444,7 @@ impl Arg for PathBuf {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -474,19 +474,19 @@ impl Arg for &CStr {
         self.to_str().map_err(|_utf8_err| io::Errno::INVAL)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         CStr::to_string_lossy(self)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Borrowed(self))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -505,26 +505,26 @@ impl Arg for &CStr {
     }
 }
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 impl Arg for &CString {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
         unimplemented!()
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         unimplemented!()
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Borrowed(self))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -543,26 +543,26 @@ impl Arg for &CString {
     }
 }
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 impl Arg for CString {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
         self.to_str().map_err(|_utf8_err| io::Errno::INVAL)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         CStr::to_string_lossy(self)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Borrowed(self))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -581,20 +581,20 @@ impl Arg for CString {
     }
 }
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 impl<'a> Arg for Cow<'a, str> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
         Ok(self)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         Cow::Borrowed(self)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -602,7 +602,7 @@ impl<'a> Arg for Cow<'a, str> {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -628,20 +628,20 @@ impl<'a> Arg for Cow<'a, str> {
 }
 
 #[cfg(feature = "std")]
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 impl<'a> Arg for Cow<'a, OsStr> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
         (**self).to_str().ok_or(io::Errno::INVAL)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         (**self).to_string_lossy()
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -649,7 +649,7 @@ impl<'a> Arg for Cow<'a, OsStr> {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -674,27 +674,27 @@ impl<'a> Arg for Cow<'a, OsStr> {
     }
 }
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 impl<'a> Arg for Cow<'a, CStr> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
         self.to_str().map_err(|_utf8_err| io::Errno::INVAL)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         let borrow: &CStr = core::borrow::Borrow::borrow(self);
         borrow.to_string_lossy()
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Borrowed(self))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -720,13 +720,13 @@ impl<'a> Arg for Component<'a> {
         self.as_os_str().to_str().ok_or(io::Errno::INVAL)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         self.as_os_str().to_string_lossy()
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -734,7 +734,7 @@ impl<'a> Arg for Component<'a> {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -762,13 +762,13 @@ impl<'a> Arg for Components<'a> {
         self.as_path().to_str().ok_or(io::Errno::INVAL)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         self.as_path().to_string_lossy()
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -777,7 +777,7 @@ impl<'a> Arg for Components<'a> {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -806,13 +806,13 @@ impl<'a> Arg for Iter<'a> {
         self.as_path().to_str().ok_or(io::Errno::INVAL)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         self.as_path().to_string_lossy()
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -821,7 +821,7 @@ impl<'a> Arg for Iter<'a> {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -849,13 +849,13 @@ impl Arg for &[u8] {
         str::from_utf8(self).map_err(|_utf8_err| io::Errno::INVAL)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         String::from_utf8_lossy(self)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -863,7 +863,7 @@ impl Arg for &[u8] {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -884,20 +884,20 @@ impl Arg for &[u8] {
     }
 }
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 impl Arg for &Vec<u8> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
         str::from_utf8(self).map_err(|_utf8_err| io::Errno::INVAL)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         String::from_utf8_lossy(self)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -905,7 +905,7 @@ impl Arg for &Vec<u8> {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -926,20 +926,20 @@ impl Arg for &Vec<u8> {
     }
 }
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 impl Arg for Vec<u8> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
         str::from_utf8(self).map_err(|_utf8_err| io::Errno::INVAL)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         String::from_utf8_lossy(self)
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Owned(
@@ -947,7 +947,7 @@ impl Arg for Vec<u8> {
         ))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -975,19 +975,19 @@ impl Arg for DecInt {
         Ok(self.as_str())
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn to_string_lossy(&self) -> Cow<'_, str> {
         Cow::Borrowed(self.as_str())
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
         Ok(Cow::Borrowed(self.as_c_str()))
     }
 
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     #[inline]
     fn into_c_str<'b>(self) -> io::Result<Cow<'b, CStr>>
     where
@@ -1056,12 +1056,12 @@ fn with_c_str_slow_path<T, F>(bytes: &[u8], f: F) -> io::Result<T>
 where
     F: FnOnce(&CStr) -> io::Result<T>,
 {
-    #[cfg(feature = "global-allocator")]
+    #[cfg(feature = "alloc")]
     {
         f(&CString::new(bytes).map_err(|_cstr_err| io::Errno::INVAL)?)
     }
 
-    #[cfg(not(feature = "global-allocator"))]
+    #[cfg(not(feature = "alloc"))]
     {
         #[cfg(libc)]
         const LARGE_PATH_BUFFER_SIZE: usize = libc::PATH_MAX as usize;

--- a/src/process/chdir.rs
+++ b/src/process/chdir.rs
@@ -1,11 +1,13 @@
 #[cfg(not(target_os = "fuchsia"))]
 use crate::backend::fd::AsFd;
+#[cfg(feature = "fs")]
+use crate::path;
 #[cfg(any(feature = "fs", not(target_os = "fuchsia")))]
 use crate::{backend, io};
-#[cfg(feature = "fs")]
+#[cfg(all(feature = "global-allocator", feature = "fs"))]
 use {
     crate::ffi::{CStr, CString},
-    crate::path::{self, SMALL_PATH_BUFFER_SIZE},
+    crate::path::SMALL_PATH_BUFFER_SIZE,
     alloc::vec::Vec,
 };
 
@@ -48,7 +50,7 @@ pub fn fchdir<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getcwd.html
 /// [Linux]: https://man7.org/linux/man-pages/man3/getcwd.3.html
-#[cfg(feature = "fs")]
+#[cfg(all(feature = "global-allocator", feature = "fs"))]
 #[cfg(not(target_os = "wasi"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
 #[inline]
@@ -56,7 +58,7 @@ pub fn getcwd<B: Into<Vec<u8>>>(reuse: B) -> io::Result<CString> {
     _getcwd(reuse.into())
 }
 
-#[cfg(feature = "fs")]
+#[cfg(all(feature = "global-allocator", feature = "fs"))]
 #[allow(unsafe_code)]
 fn _getcwd(mut buffer: Vec<u8>) -> io::Result<CString> {
     buffer.clear();

--- a/src/process/chdir.rs
+++ b/src/process/chdir.rs
@@ -4,7 +4,7 @@ use crate::backend::fd::AsFd;
 use crate::path;
 #[cfg(any(feature = "fs", not(target_os = "fuchsia")))]
 use crate::{backend, io};
-#[cfg(all(feature = "global-allocator", feature = "fs"))]
+#[cfg(all(feature = "alloc", feature = "fs"))]
 use {
     crate::ffi::{CStr, CString},
     crate::path::SMALL_PATH_BUFFER_SIZE,
@@ -50,7 +50,7 @@ pub fn fchdir<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getcwd.html
 /// [Linux]: https://man7.org/linux/man-pages/man3/getcwd.3.html
-#[cfg(all(feature = "global-allocator", feature = "fs"))]
+#[cfg(all(feature = "alloc", feature = "fs"))]
 #[cfg(not(target_os = "wasi"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
 #[inline]
@@ -58,7 +58,7 @@ pub fn getcwd<B: Into<Vec<u8>>>(reuse: B) -> io::Result<CString> {
     _getcwd(reuse.into())
 }
 
-#[cfg(all(feature = "global-allocator", feature = "fs"))]
+#[cfg(all(feature = "alloc", feature = "fs"))]
 #[allow(unsafe_code)]
 fn _getcwd(mut buffer: Vec<u8>) -> io::Result<CString> {
     buffer.clear();

--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -8,7 +8,7 @@
 #![allow(unsafe_code)]
 
 use crate::{backend, io};
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 #[cfg(linux_kernel)]
 use backend::process::types::RawCpuid;
@@ -209,7 +209,7 @@ pub fn setsid() -> io::Result<Pid> {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getgroups.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getgroups.2.html
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 pub fn getgroups() -> io::Result<Vec<Gid>> {
     let mut buffer = Vec::new();
 

--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -8,6 +8,7 @@
 #![allow(unsafe_code)]
 
 use crate::{backend, io};
+#[cfg(feature = "global-allocator")]
 use alloc::vec::Vec;
 #[cfg(linux_kernel)]
 use backend::process::types::RawCpuid;
@@ -208,6 +209,7 @@ pub fn setsid() -> io::Result<Pid> {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getgroups.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getgroups.2.html
+#[cfg(feature = "global-allocator")]
 pub fn getgroups() -> io::Result<Vec<Gid>> {
     let mut buffer = Vec::new();
 

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -12,7 +12,7 @@ use crate::fd::{AsFd, OwnedFd};
 use crate::fs::OFlags;
 use crate::{backend, io};
 #[cfg(all(
-    feature = "global-allocator",
+    feature = "alloc",
     any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia")
 ))]
 use {crate::ffi::CString, alloc::vec::Vec};
@@ -114,7 +114,7 @@ pub fn openpt(flags: OpenptFlags) -> io::Result<OwnedFd> {
 /// [Linux]: https://man7.org/linux/man-pages/man3/ptsname.3.html
 /// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Allocation.html#index-ptsname
 #[cfg(all(
-    feature = "global-allocator",
+    feature = "alloc",
     any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia")
 ))]
 #[inline]

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -11,7 +11,10 @@ use crate::backend::c;
 use crate::fd::{AsFd, OwnedFd};
 use crate::fs::OFlags;
 use crate::{backend, io};
-#[cfg(any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(all(
+    feature = "global-allocator",
+    any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia")
+))]
 use {crate::ffi::CString, alloc::vec::Vec};
 
 #[cfg(target_os = "linux")]
@@ -110,9 +113,12 @@ pub fn openpt(flags: OpenptFlags) -> io::Result<OwnedFd> {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/ptsname.html
 /// [Linux]: https://man7.org/linux/man-pages/man3/ptsname.3.html
 /// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Allocation.html#index-ptsname
+#[cfg(all(
+    feature = "global-allocator",
+    any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia")
+))]
 #[inline]
 #[doc(alias = "ptsname_r")]
-#[cfg(any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia"))]
 pub fn ptsname<Fd: AsFd, B: Into<Vec<u8>>>(fd: Fd, reuse: B) -> io::Result<CString> {
     backend::pty::syscalls::ptsname(fd.as_fd(), reuse.into())
 }

--- a/src/termios/tty.rs
+++ b/src/termios/tty.rs
@@ -2,7 +2,7 @@
 
 use crate::backend;
 use backend::fd::AsFd;
-#[cfg(feature = "procfs")]
+#[cfg(all(feature = "global-allocator", feature = "procfs"))]
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 use {
     crate::ffi::CString, crate::io, crate::path::SMALL_PATH_BUFFER_SIZE, alloc::vec::Vec,
@@ -33,7 +33,7 @@ pub fn isatty<Fd: AsFd>(fd: Fd) -> bool {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/ttyname.html
 /// [Linux]: https://man7.org/linux/man-pages/man3/ttyname.3.html
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
-#[cfg(feature = "procfs")]
+#[cfg(all(feature = "global-allocator", feature = "procfs"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
 #[doc(alias = "ttyname_r")]
 #[inline]
@@ -42,7 +42,7 @@ pub fn ttyname<Fd: AsFd, B: Into<Vec<u8>>>(dirfd: Fd, reuse: B) -> io::Result<CS
 }
 
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
-#[cfg(feature = "procfs")]
+#[cfg(all(feature = "global-allocator", feature = "procfs"))]
 #[allow(unsafe_code)]
 fn _ttyname(dirfd: BorrowedFd<'_>, mut buffer: Vec<u8>) -> io::Result<CString> {
     buffer.clear();

--- a/src/termios/tty.rs
+++ b/src/termios/tty.rs
@@ -2,7 +2,7 @@
 
 use crate::backend;
 use backend::fd::AsFd;
-#[cfg(all(feature = "global-allocator", feature = "procfs"))]
+#[cfg(all(feature = "alloc", feature = "procfs"))]
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 use {
     crate::ffi::CString, crate::io, crate::path::SMALL_PATH_BUFFER_SIZE, alloc::vec::Vec,
@@ -33,7 +33,7 @@ pub fn isatty<Fd: AsFd>(fd: Fd) -> bool {
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/ttyname.html
 /// [Linux]: https://man7.org/linux/man-pages/man3/ttyname.3.html
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
-#[cfg(all(feature = "global-allocator", feature = "procfs"))]
+#[cfg(all(feature = "alloc", feature = "procfs"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
 #[doc(alias = "ttyname_r")]
 #[inline]
@@ -42,7 +42,7 @@ pub fn ttyname<Fd: AsFd, B: Into<Vec<u8>>>(dirfd: Fd, reuse: B) -> io::Result<CS
 }
 
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
-#[cfg(all(feature = "global-allocator", feature = "procfs"))]
+#[cfg(all(feature = "alloc", feature = "procfs"))]
 #[allow(unsafe_code)]
 fn _ttyname(dirfd: BorrowedFd<'_>, mut buffer: Vec<u8>) -> io::Result<CString> {
     buffer.clear();

--- a/src/thread/prctl.rs
+++ b/src/thread/prctl.rs
@@ -19,7 +19,9 @@ use bitflags::bitflags;
 
 use crate::backend::c::{c_int, c_uint, c_void};
 use crate::backend::prctl::syscalls;
-use crate::ffi::{CStr, CString};
+use crate::ffi::CStr;
+#[cfg(feature = "global-allocator")]
+use crate::ffi::CString;
 use crate::io;
 use crate::pid::Pid;
 use crate::prctl::{
@@ -61,6 +63,7 @@ pub fn set_keep_capabilities(enable: bool) -> io::Result<()> {
 // PR_GET_NAME/PR_SET_NAME
 //
 
+#[cfg(feature = "global-allocator")]
 const PR_GET_NAME: c_int = 16;
 
 /// Get the name of the calling thread.
@@ -70,6 +73,7 @@ const PR_GET_NAME: c_int = 16;
 ///
 /// [`prctl(PR_GET_NAME,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[cfg(feature = "global-allocator")]
 pub fn name() -> io::Result<CString> {
     let mut buffer = [0_u8; 16];
     unsafe { prctl_2args(PR_GET_NAME, buffer.as_mut_ptr().cast())? };

--- a/src/thread/prctl.rs
+++ b/src/thread/prctl.rs
@@ -20,7 +20,7 @@ use bitflags::bitflags;
 use crate::backend::c::{c_int, c_uint, c_void};
 use crate::backend::prctl::syscalls;
 use crate::ffi::CStr;
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 use crate::ffi::CString;
 use crate::io;
 use crate::pid::Pid;
@@ -63,7 +63,7 @@ pub fn set_keep_capabilities(enable: bool) -> io::Result<()> {
 // PR_GET_NAME/PR_SET_NAME
 //
 
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 const PR_GET_NAME: c_int = 16;
 
 /// Get the name of the calling thread.
@@ -73,7 +73,7 @@ const PR_GET_NAME: c_int = 16;
 ///
 /// [`prctl(PR_GET_NAME,...)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
-#[cfg(feature = "global-allocator")]
+#[cfg(feature = "alloc")]
 pub fn name() -> io::Result<CString> {
     let mut buffer = [0_u8; 16];
     unsafe { prctl_2args(PR_GET_NAME, buffer.as_mut_ptr().cast())? };


### PR DESCRIPTION
Put features that use global allocation, such as `ttyname`, that return owned strings, or `getgroups` that returns owned `Vec`s, behind a "global-allocator" cargo feature, which is enabled by default and with "std", but can be disabled with `default-features = false`.