### PR TITLE
Add a `runtime::entry` function.

### DIFF
--- a/src/backend/linux_raw/param/auxv.rs
+++ b/src/backend/linux_raw/param/auxv.rs
@@ -259,11 +259,15 @@ unsafe fn init_from_aux_iter(aux_iter: impl Iterator<Item = Elf_auxv_t>) -> Opti
     let mut clktck = 0;
     let mut hwcap = 0;
     let mut hwcap2 = 0;
-    let mut phdr = null_mut();
-    let mut phnum = 0;
     let mut execfn = null_mut();
     let mut sysinfo_ehdr = null_mut();
+    #[cfg(feature = "runtime")]
+    let mut phdr = null_mut();
+    #[cfg(feature = "runtime")]
+    let mut phnum = 0;
+    #[cfg(feature = "runtime")]
     let mut phent = 0;
+    #[cfg(feature = "runtime")]
     let mut entry = 0;
 
     for Elf_auxv_t { a_type, a_val } in aux_iter {

--- a/src/backend/linux_raw/param/auxv.rs
+++ b/src/backend/linux_raw/param/auxv.rs
@@ -17,13 +17,15 @@ use alloc::vec::Vec;
 use core::ffi::c_void;
 use core::mem::size_of;
 use core::ptr::{null_mut, read_unaligned, NonNull};
-#[cfg(feature = "runtime")]
-use core::slice;
 use core::sync::atomic::Ordering::Relaxed;
 use core::sync::atomic::{AtomicPtr, AtomicUsize};
 use linux_raw_sys::general::{
-    AT_BASE, AT_CLKTCK, AT_EXECFN, AT_HWCAP, AT_HWCAP2, AT_NULL, AT_PAGESZ, AT_PHDR, AT_PHENT,
-    AT_PHNUM, AT_SYSINFO_EHDR,
+    AT_BASE, AT_CLKTCK, AT_EXECFN, AT_HWCAP, AT_HWCAP2, AT_NULL, AT_PAGESZ, AT_SYSINFO_EHDR,
+};
+#[cfg(feature = "runtime")]
+use {
+    core::slice,
+    linux_raw_sys::general::{AT_ENTRY, AT_PHDR, AT_PHENT, AT_PHNUM},
 };
 
 #[cfg(feature = "param")]
@@ -121,14 +123,31 @@ pub(in super::super) fn sysinfo_ehdr() -> *const Elf_Ehdr {
     ehdr
 }
 
+#[cfg(feature = "runtime")]
+#[inline]
+pub(crate) fn entry() -> usize {
+    let mut entry = ENTRY.load(Relaxed);
+
+    if entry == 0 {
+        init_auxv();
+        entry = ENTRY.load(Relaxed);
+    }
+
+    entry
+}
+
 static PAGE_SIZE: AtomicUsize = AtomicUsize::new(0);
 static CLOCK_TICKS_PER_SECOND: AtomicUsize = AtomicUsize::new(0);
 static HWCAP: AtomicUsize = AtomicUsize::new(0);
 static HWCAP2: AtomicUsize = AtomicUsize::new(0);
-static SYSINFO_EHDR: AtomicPtr<Elf_Ehdr> = AtomicPtr::new(null_mut());
-static PHDR: AtomicPtr<Elf_Phdr> = AtomicPtr::new(null_mut());
-static PHNUM: AtomicUsize = AtomicUsize::new(0);
 static EXECFN: AtomicPtr<c::c_char> = AtomicPtr::new(null_mut());
+static SYSINFO_EHDR: AtomicPtr<Elf_Ehdr> = AtomicPtr::new(null_mut());
+#[cfg(feature = "runtime")]
+static PHDR: AtomicPtr<Elf_Phdr> = AtomicPtr::new(null_mut());
+#[cfg(feature = "runtime")]
+static PHNUM: AtomicUsize = AtomicUsize::new(0);
+#[cfg(feature = "runtime")]
+static ENTRY: AtomicUsize = AtomicUsize::new(0);
 
 #[cfg(feature = "alloc")]
 fn pr_get_auxv() -> crate::io::Result<Vec<u8>> {
@@ -245,6 +264,7 @@ unsafe fn init_from_aux_iter(aux_iter: impl Iterator<Item = Elf_auxv_t>) -> Opti
     let mut execfn = null_mut();
     let mut sysinfo_ehdr = null_mut();
     let mut phent = 0;
+    let mut entry = 0;
 
     for Elf_auxv_t { a_type, a_val } in aux_iter {
         match a_type as _ {
@@ -252,12 +272,20 @@ unsafe fn init_from_aux_iter(aux_iter: impl Iterator<Item = Elf_auxv_t>) -> Opti
             AT_CLKTCK => clktck = a_val as usize,
             AT_HWCAP => hwcap = a_val as usize,
             AT_HWCAP2 => hwcap2 = a_val as usize,
-            AT_PHDR => phdr = check_raw_pointer::<Elf_Phdr>(a_val as *mut _)?.as_ptr(),
-            AT_PHNUM => phnum = a_val as usize,
-            AT_PHENT => phent = a_val as usize,
             AT_EXECFN => execfn = check_raw_pointer::<c::c_char>(a_val as *mut _)?.as_ptr(),
-            AT_BASE => check_interpreter_base(a_val.cast())?,
             AT_SYSINFO_EHDR => sysinfo_ehdr = check_vdso_base(a_val as *mut _)?.as_ptr(),
+
+            AT_BASE => check_interpreter_base(a_val.cast())?,
+
+            #[cfg(feature = "runtime")]
+            AT_PHDR => phdr = check_raw_pointer::<Elf_Phdr>(a_val as *mut _)?.as_ptr(),
+            #[cfg(feature = "runtime")]
+            AT_PHNUM => phnum = a_val as usize,
+            #[cfg(feature = "runtime")]
+            AT_PHENT => phent = a_val as usize,
+            #[cfg(feature = "runtime")]
+            AT_ENTRY => entry = a_val as usize,
+
             AT_NULL => break,
             _ => (),
         }
@@ -275,6 +303,7 @@ unsafe fn init_from_aux_iter(aux_iter: impl Iterator<Item = Elf_auxv_t>) -> Opti
     PHNUM.store(phnum, Relaxed);
     EXECFN.store(execfn, Relaxed);
     SYSINFO_EHDR.store(sysinfo_ehdr, Relaxed);
+    ENTRY.store(entry, Relaxed);
 
     Some(())
 }

--- a/src/backend/linux_raw/param/auxv.rs
+++ b/src/backend/linux_raw/param/auxv.rs
@@ -299,10 +299,13 @@ unsafe fn init_from_aux_iter(aux_iter: impl Iterator<Item = Elf_auxv_t>) -> Opti
     CLOCK_TICKS_PER_SECOND.store(clktck, Relaxed);
     HWCAP.store(hwcap, Relaxed);
     HWCAP2.store(hwcap2, Relaxed);
-    PHDR.store(phdr, Relaxed);
-    PHNUM.store(phnum, Relaxed);
     EXECFN.store(execfn, Relaxed);
     SYSINFO_EHDR.store(sysinfo_ehdr, Relaxed);
+    #[cfg(feature = "runtime")]
+    PHDR.store(phdr, Relaxed);
+    #[cfg(feature = "runtime")]
+    PHNUM.store(phnum, Relaxed);
+    #[cfg(feature = "runtime")]
     ENTRY.store(entry, Relaxed);
 
     Some(())

--- a/src/backend/linux_raw/param/auxv.rs
+++ b/src/backend/linux_raw/param/auxv.rs
@@ -295,6 +295,7 @@ unsafe fn init_from_aux_iter(aux_iter: impl Iterator<Item = Elf_auxv_t>) -> Opti
         }
     }
 
+    #[cfg(feature = "runtime")]
     assert_eq!(phent, size_of::<Elf_Phdr>());
 
     // The base and sysinfo_ehdr (if present) matches our platform. Accept

--- a/src/backend/linux_raw/param/libc_auxv.rs
+++ b/src/backend/linux_raw/param/libc_auxv.rs
@@ -26,8 +26,12 @@ extern "C" {
     fn getauxval(type_: c::c_ulong) -> *mut c::c_void;
 }
 
+#[cfg(feature = "runtime")]
 const AT_PHDR: c::c_ulong = 3;
+#[cfg(feature = "runtime")]
 const AT_PHNUM: c::c_ulong = 5;
+#[cfg(feature = "runtime")]
+const AT_ENTRY: c::c_ulong = 9;
 const AT_HWCAP: c::c_ulong = 16;
 const AT_HWCAP2: c::c_ulong = 26;
 const AT_EXECFN: c::c_ulong = 31;
@@ -52,12 +56,16 @@ const _SC_CLK_TCK: c::c_int = 2;
 fn test_abi() {
     const_assert_eq!(self::_SC_PAGESIZE, ::libc::_SC_PAGESIZE);
     const_assert_eq!(self::_SC_CLK_TCK, ::libc::_SC_CLK_TCK);
-    const_assert_eq!(self::AT_PHDR, ::libc::AT_PHDR);
-    const_assert_eq!(self::AT_PHNUM, ::libc::AT_PHNUM);
     const_assert_eq!(self::AT_HWCAP, ::libc::AT_HWCAP);
     const_assert_eq!(self::AT_HWCAP2, ::libc::AT_HWCAP2);
     const_assert_eq!(self::AT_EXECFN, ::libc::AT_EXECFN);
     const_assert_eq!(self::AT_SYSINFO_EHDR, ::libc::AT_SYSINFO_EHDR);
+    #[cfg(feature = "runtime")]
+    const_assert_eq!(self::AT_PHDR, ::libc::AT_PHDR);
+    #[cfg(feature = "runtime")]
+    const_assert_eq!(self::AT_PHNUM, ::libc::AT_PHNUM);
+    #[cfg(feature = "runtime")]
+    const_assert_eq!(self::AT_ENTRY, ::libc::AT_ENTRY);
 }
 
 #[cfg(feature = "param")]
@@ -149,4 +157,10 @@ pub(in super::super) fn sysinfo_ehdr() -> *const Elf_Ehdr {
     unsafe {
         getauxval(AT_SYSINFO_EHDR) as *const Elf_Ehdr
     }
+}
+
+#[cfg(feature = "runtime")]
+#[inline]
+pub(crate) fn entry() -> usize {
+    unsafe { getauxval(AT_ENTRY) as usize }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -187,6 +187,15 @@ pub fn exe_phdrs() -> (*const c_void, usize) {
 
 /// `getauxval(AT_ENTRY)`—Returns the address of the program entrypoint.
 ///
+/// Most code interested in the program entrypoint address should instead use a
+/// symbol reference to `_start`. That will be properly PC-relative or
+/// relocated if needed, and will come with appropriate pointer type and
+/// pointer provenance.
+///
+/// This function is intended only for use in code that implements those
+/// relocations, to compute the ASLR offset. It has type `usize`, so it doesn't
+/// carry any provenance, and it shouldn't be used to dereference memory.
+///
 /// # References
 ///  - [Linux]
 ///

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -185,6 +185,17 @@ pub fn exe_phdrs() -> (*const c_void, usize) {
     backend::param::auxv::exe_phdrs()
 }
 
+/// `getauxval(AT_ENTRY)`—Returns the address of the program entrypoint.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man3/getauxval.3.html
+#[inline]
+pub fn entry() -> usize {
+    backend::param::auxv::entry()
+}
+
 #[cfg(linux_raw)]
 pub use backend::runtime::tls::StartupTlsInfo;
 


### PR DESCRIPTION
This returns the program entrypoint, which is needed in origin. It's in the undocumented `runtime` module.