### PR TITLE
Use `default-features = false` with libc in no-std mode.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ once_cell = { version = "1.5.2", optional = true }
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
 linux-raw-sys = { version = "0.4.3", default-features = false, features = ["general", "errno", "ioctl", "no_std"] }
 libc_errno = { package = "errno", version = "0.3.1", default-features = false, optional = true }
-libc = { version = "0.2.147", features = ["extra_traits"], optional = true }
+libc = { version = "0.2.147", default-features = false, features = ["extra_traits"], optional = true }
 
 # Dependencies for platforms where only libc is supported:
 #
@@ -46,7 +46,7 @@ libc = { version = "0.2.147", features = ["extra_traits"], optional = true }
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.1", default-features = false }
-libc = { version = "0.2.147", features = ["extra_traits"] }
+libc = { version = "0.2.147", default-features = false, features = ["extra_traits"] }
 
 # Additional dependencies for Linux with the libc backend:
 #
@@ -123,7 +123,7 @@ default = ["std", "use-libc-auxv"]
 
 # This enables use of std. Disabling this enables `#![no_std], and requires
 # Rust 1.64 or newer.
-std = ["bitflags/std", "alloc"]
+std = ["bitflags/std", "alloc", "libc?/std", "libc_errno?/std"]
 
 # Enable this to request the libc backend.
 use-libc = ["libc_errno", "libc"]


### PR DESCRIPTION
Use the `?` syntax, which is new in Rust 1.60, to enable "libc/std" only if "libc" is already enabled. This syntax is documented [here].

[here]: https://doc.rust-lang.org/stable/cargo/reference/features.html#dependency-features