### PR TITLE
Use `nostack` for the `noreturn` syscall asm.

### DIFF
--- a/src/backend/linux_raw/arch/asm/aarch64.rs
+++ b/src/backend/linux_raw/arch/asm/aarch64.rs
@@ -53,7 +53,7 @@ pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: Ar
         "svc 0",
         in("x8") nr.to_asm(),
         in("x0") a0.to_asm(),
-        options(noreturn)
+        options(nostack, noreturn)
     )
 }
 

--- a/src/backend/linux_raw/arch/asm/arm.rs
+++ b/src/backend/linux_raw/arch/asm/arm.rs
@@ -50,7 +50,7 @@ pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: Ar
         "svc 0",
         in("r7") nr.to_asm(),
         in("r0") a0.to_asm(),
-        options(noreturn)
+        options(nostack, noreturn)
     )
 }
 

--- a/src/backend/linux_raw/arch/asm/mips.rs
+++ b/src/backend/linux_raw/arch/asm/mips.rs
@@ -103,7 +103,7 @@ pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: Ar
         "syscall",
         in("$2" /*$v0*/) nr.to_asm(),
         in("$4" /*$a0*/) a0.to_asm(),
-        options(noreturn)
+        options(nostack, noreturn)
     )
 }
 

--- a/src/backend/linux_raw/arch/asm/mips32r6.rs
+++ b/src/backend/linux_raw/arch/asm/mips32r6.rs
@@ -103,7 +103,7 @@ pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: Ar
         "syscall",
         in("$2" /*$v0*/) nr.to_asm(),
         in("$4" /*$a0*/) a0.to_asm(),
-        options(noreturn)
+        options(nostack, noreturn)
     )
 }
 

--- a/src/backend/linux_raw/arch/asm/mips64.rs
+++ b/src/backend/linux_raw/arch/asm/mips64.rs
@@ -103,7 +103,7 @@ pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: Ar
         "syscall",
         in("$2" /*$v0*/) nr.to_asm(),
         in("$4" /*$a0*/) a0.to_asm(),
-        options(noreturn)
+        options(nostack, noreturn)
     )
 }
 

--- a/src/backend/linux_raw/arch/asm/mips64r6.rs
+++ b/src/backend/linux_raw/arch/asm/mips64r6.rs
@@ -107,7 +107,7 @@ pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: Ar
         "syscall",
         in("$2" /*$v0*/) nr.to_asm(),
         in("$4" /*$a0*/) a0.to_asm(),
-        options(noreturn)
+        options(nostack, noreturn)
     )
 }
 

--- a/src/backend/linux_raw/arch/asm/powerpc64.rs
+++ b/src/backend/linux_raw/arch/asm/powerpc64.rs
@@ -98,7 +98,7 @@ pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: Ar
         "sc",
         in("r0") nr.to_asm(),
         in("r3") a0.to_asm(),
-        options(noreturn)
+        options(nostack, noreturn)
     )
 }
 

--- a/src/backend/linux_raw/arch/asm/riscv64.rs
+++ b/src/backend/linux_raw/arch/asm/riscv64.rs
@@ -50,7 +50,7 @@ pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: Ar
         "ecall",
         in("a7") nr.to_asm(),
         in("a0") a0.to_asm(),
-        options(noreturn)
+        options(nostack, noreturn)
     );
 }
 

--- a/src/backend/linux_raw/arch/asm/thumb.rs
+++ b/src/backend/linux_raw/arch/asm/thumb.rs
@@ -67,7 +67,7 @@ pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: Ar
         "svc 0",
         nr = in(reg) nr.to_asm(),
         in("r0") a0.to_asm(),
-        options(noreturn)
+        options(nostack, noreturn)
     )
 }
 

--- a/src/backend/linux_raw/arch/asm/x86.rs
+++ b/src/backend/linux_raw/arch/asm/x86.rs
@@ -248,7 +248,7 @@ pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: Ar
         "int $$0x80",
         in("eax") nr.to_asm(),
         in("ebx") a0.to_asm(),
-        options(noreturn)
+        options(nostack, noreturn)
     )
 }
 

--- a/src/backend/linux_raw/arch/asm/x86_64.rs
+++ b/src/backend/linux_raw/arch/asm/x86_64.rs
@@ -58,7 +58,7 @@ pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: Ar
         "syscall",
         in("rax") nr.to_asm(),
         in("rdi") a0.to_asm(),
-        options(noreturn)
+        options(nostack, noreturn)
     )
 }
 


### PR DESCRIPTION
In `syscall1_noreturn` on platforms where it's just a syscall instruction and register moves, enable the `nostack` option, since those instructions don't push data to the stack, write to the stack red-zone, or make a function call.

This allows the compiler to avoid instructions to align the stack in functions that just do a noreturn syscall.