### PR TITLE
Relax a test to accept `EAGAIN` from `preadv2` on a `pipe`.

### DIFF
--- a/tests/io/read_write.rs
+++ b/tests/io/read_write.rs
@@ -237,6 +237,7 @@ fn test_preadv2_nowait() {
         ReadWriteFlags::NOWAIT,
     ) {
         Err(rustix::io::Errno::OPNOTSUPP | rustix::io::Errno::NOSYS) => {}
+        Err(rustix::io::Errno::AGAIN) => {}
         Ok(_) => panic!("preadv2 unexpectedly succeeded"),
         Err(e) => panic!("preadv2 failed with an unexpected error: {:?}", e),
     }


### PR DESCRIPTION
It appears with Linux 6.4, pipes can now return `EAGAIN` on `preadv2` with the `NOWAIT` flag, so relax a test to accept that value.