### PR TITLE
Fix bug in pr_get_auxv

### DIFF
--- a/src/backend/linux_raw/param/auxv.rs
+++ b/src/backend/linux_raw/param/auxv.rs
@@ -150,7 +150,9 @@ fn pr_get_auxv() -> crate::io::Result<Vec<u8>> {
             __NR_prctl,
             c_int(PR_GET_AUXV),
             buffer.as_ptr(),
-            pass_usize(buffer.len())
+            pass_usize(buffer.len()),
+            pass_usize(0),
+            pass_usize(0)
         ))?
     };
     if len <= buffer.len() {
@@ -163,7 +165,9 @@ fn pr_get_auxv() -> crate::io::Result<Vec<u8>> {
             __NR_prctl,
             c_int(PR_GET_AUXV),
             buffer.as_ptr(),
-            pass_usize(buffer.len())
+            pass_usize(buffer.len()),
+            pass_usize(0),
+            pass_usize(0)
         ))?
     };
     assert_eq!(len, buffer.len());


### PR DESCRIPTION
PR_GET_AUXV's arg4 and arg5 must be zero.
https://github.com/torvalds/linux/blob/ddc65971bb677aa9f6a4c21f76d3133e106f88eb/kernel/sys.c#L2532

Currently, we are passing up to arg3, which means that arg4 and arg5 will be undefined values and will cause the pr_get_auxv to sometimes fail with EINVAL.

https://github.com/bytecodealliance/rustix/blob/7f3c973e7ae762a9e5133907a0d94a91c18d03ff/src/backend/linux_raw/param/auxv.rs#L149-L154

Tested locally by adding dbg to code (and adjusting some cfg) on aarch64 linux kernel 6.4.13.

before:

```
[src/backend/linux_raw/param/auxv.rs:154] ret_usize(syscall_always_asm!(__NR_prctl, c_int(PR_GET_AUXV), buffer.as_ptr(),
        pass_usize(buffer.len()))) = Err(
    Os {
        code: 22,
        kind: InvalidInput,
        message: "Invalid argument",
    },
)
```

after:

```
[src/backend/linux_raw/param/auxv.rs:154] ret_usize(syscall_always_asm!(__NR_prctl, c_int(PR_GET_AUXV), buffer.as_ptr(),
        pass_usize(buffer.len()), pass_usize(0), pass_usize(0))) = Ok(
    400,
)
```