### PR TITLE
Fix `prctl` calls in the `runtime` module to pass 5 arguments.

### DIFF
--- a/src/backend/linux_raw/runtime/syscalls.rs
+++ b/src/backend/linux_raw/runtime/syscalls.rs
@@ -93,7 +93,10 @@ pub(crate) mod tls {
         ret_infallible(syscall_readonly!(
             __NR_arch_prctl,
             c_uint(ARCH_SET_FS),
-            data
+            data,
+            zero(),
+            zero(),
+            zero()
         ))
     }
 
@@ -105,7 +108,14 @@ pub(crate) mod tls {
 
     #[inline]
     pub(crate) unsafe fn set_thread_name(name: &CStr) -> io::Result<()> {
-        ret(syscall_readonly!(__NR_prctl, c_uint(PR_SET_NAME), name))
+        ret(syscall_readonly!(
+            __NR_prctl,
+            c_uint(PR_SET_NAME),
+            name,
+            zero(),
+            zero(),
+            zero()
+        ))
     }
 
     #[inline]


### PR DESCRIPTION
Similar to #814, fix a few `prctl` calls in the `runtime` module to pass all 5 arguments too.