### PR TITLE
Work around a Rust 1.69 doc bug.

### DIFF
--- a/src/backend/libc/io/errno.rs
+++ b/src/backend/libc/io/errno.rs
@@ -6,10 +6,32 @@
 use crate::backend::c;
 use libc_errno::errno;
 
-/// The error type for `rustix` APIs.
+/// `errno`—An error code.
 ///
-/// This is similar to `std::io::Error`, but only holds an OS error code,
-/// and no extra error value.
+/// The error type for `rustix` APIs. This is similar to [`std::io::Error`],
+//// but only holds an OS error code, and no extra error value.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///  - [Winsock2]
+///  - [FreeBSD]
+///  - [NetBSD]
+///  - [OpenBSD]
+///  - [DragonFly BSD]
+///  - [illumos]
+///  - [glibc]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/errno.html
+/// [Linux]: https://man7.org/linux/man-pages/man3/errno.3.html
+/// [Winsock2]: https://learn.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?errno
+/// [NetBSD]: https://man.netbsd.org/errno.2
+/// [OpenBSD]: https://man.openbsd.org/errno.2
+/// [DragonFly BSD]: https://man.dragonflybsd.org/?command=errno&section=2
+/// [illumos]: https://illumos.org/man/3C/errno
+/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Error-Codes.html
+/// [`std::io::Error`]: Result
 #[repr(transparent)]
 #[doc(alias = "errno")]
 #[derive(Eq, PartialEq, Hash, Copy, Clone)]

--- a/src/backend/linux_raw/io/errno.rs
+++ b/src/backend/linux_raw/io/errno.rs
@@ -16,10 +16,32 @@ use crate::backend::reg::{RetNumber, RetReg};
 use crate::io;
 use linux_raw_sys::errno;
 
-/// The error type for `rustix` APIs.
+/// `errno`—An error code.
 ///
-/// This is similar to `std::io::Error`, but only holds an OS error code,
-/// and no extra error value.
+/// The error type for `rustix` APIs. This is similar to [`std::io::Error`],
+//// but only holds an OS error code, and no extra error value.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///  - [Winsock2]
+///  - [FreeBSD]
+///  - [NetBSD]
+///  - [OpenBSD]
+///  - [DragonFly BSD]
+///  - [illumos]
+///  - [glibc]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/errno.html
+/// [Linux]: https://man7.org/linux/man-pages/man3/errno.3.html
+/// [Winsock2]: https://learn.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?errno
+/// [NetBSD]: https://man.netbsd.org/errno.2
+/// [OpenBSD]: https://man.openbsd.org/errno.2
+/// [DragonFly BSD]: https://man.dragonflybsd.org/?command=errno&section=2
+/// [illumos]: https://illumos.org/man/3C/errno
+/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Error-Codes.html
+/// [`std::io::Error`]: Result
 #[repr(transparent)]
 #[doc(alias = "errno")]
 #[derive(Eq, PartialEq, Hash, Copy, Clone)]

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -3,7 +3,7 @@
 //! The `dirfd` argument to these functions may be a file descriptor for a
 //! directory, or the special value [`CWD`].
 //!
-//! [`cwd`]: crate::fs::cwd::CWD
+//! [`cwd`]: crate::fs::CWD
 
 use crate::fd::OwnedFd;
 #[cfg(apple)]

--- a/src/io/errno.rs
+++ b/src/io/errno.rs
@@ -12,31 +12,6 @@ use std::error;
 /// A specialized [`Result`] type for `rustix` APIs.
 pub type Result<T> = result::Result<T, Errno>;
 
-/// `errno`—An error code.
-///
-/// The error type for `rustix` APIs. This is similar to [`std::io::Error`],
-/// but only holds an OS error code, and no extra error value.
-///
-/// # References
-///  - [POSIX]
-///  - [Linux]
-///  - [Winsock2]
-///  - [FreeBSD]
-///  - [NetBSD]
-///  - [OpenBSD]
-///  - [DragonFly BSD]
-///  - [illumos]
-///  - [glibc]
-///
-/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/errno.html
-/// [Linux]: https://man7.org/linux/man-pages/man3/errno.3.html
-/// [Winsock2]: https://learn.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2
-/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?errno
-/// [NetBSD]: https://man.netbsd.org/errno.2
-/// [OpenBSD]: https://man.openbsd.org/errno.2
-/// [DragonFly BSD]: https://man.dragonflybsd.org/?command=errno&section=2
-/// [illumos]: https://illumos.org/man/3C/errno
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Error-Codes.html
 pub use backend::io::errno::Errno;
 
 impl Errno {

--- a/src/rand/getrandom.rs
+++ b/src/rand/getrandom.rs
@@ -1,6 +1,5 @@
 use crate::{backend, io};
 
-/// `GRND_*` constants for use with [`getrandom`].
 pub use backend::rand::types::GetRandomFlags;
 
 /// `getrandom(buf, flags)`—Reads a sequence of random bytes.


### PR DESCRIPTION
Don't add documentation to public type aliases `Errno` and `GetRandomFlags`; just document the underlying types instead. This avoids a compiler abort in Rust 1.69.

Fixes #818.