### PR TITLE
Miscellaneous fixes for the rustc-dep-of-std build.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
 
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.
-      RUSTFLAGS: -D warnings --cfg criterion
+      RUSTFLAGS: -D warnings -D elided-lifetimes-in-paths --cfg criterion
     steps:
     - uses: actions/checkout@v3
       with:
@@ -131,7 +131,7 @@ jobs:
 
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.
-      RUSTFLAGS: -D warnings
+      RUSTFLAGS: -D warnings -D elided-lifetimes-in-paths
     steps:
     - uses: actions/checkout@v3
       with:
@@ -538,7 +538,7 @@ jobs:
             qemu_target: arm-linux-user
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.
-      RUSTFLAGS: -D warnings
+      RUSTFLAGS: -D warnings -D elided-lifetimes-in-paths
       QEMU_BUILD_VERSION: 8.0.2
     steps:
     - uses: actions/checkout@v3
@@ -625,7 +625,7 @@ jobs:
             qemu_target: ppc64le-linux-user
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.
-      RUSTFLAGS: --cfg rustix_use_experimental_asm -D warnings
+      RUSTFLAGS: --cfg rustix_use_experimental_asm -D warnings -D elided-lifetimes-in-paths
       RUSTDOCFLAGS: --cfg rustix_use_experimental_asm
       CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_experimental_asm
       QEMU_BUILD_VERSION: 8.0.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,7 @@ rustc-dep-of-std = [
     "dep:compiler_builtins",
     "linux-raw-sys/rustc-dep-of-std",
     "bitflags/rustc-dep-of-std",
+    "compiler_builtins?/rustc-dep-of-std",
 ]
 
 # Obsolete and deprecated.

--- a/build.rs
+++ b/build.rs
@@ -34,6 +34,9 @@ fn main() {
     // enable the libc backend even if rustix is depended on transitively.
     let cfg_use_libc = var("CARGO_CFG_RUSTIX_USE_LIBC").is_ok();
 
+    // Check for `--features=rustc-dep-of-std`.
+    let rustc_dep_of_std = var("CARGO_FEATURE_RUSTC_DEP_OF_STD").is_ok();
+
     // Check for eg. `RUSTFLAGS=--cfg=rustix_use_experimental_features`. This
     // is a rustc flag rather than a cargo feature flag because it's
     // experimental and not something we want accidentally enabled via
@@ -52,7 +55,10 @@ fn main() {
 
     // If experimental features are enabled, auto-detect and use available
     // features.
-    if rustix_use_experimental_features {
+    if rustc_dep_of_std {
+        use_feature("rustc_attrs");
+        use_feature("core_intrinsics");
+    } else if rustix_use_experimental_features {
         use_feature_or_nothing("rustc_attrs");
         use_feature_or_nothing("core_intrinsics");
     }

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -2040,12 +2040,12 @@ pub(crate) fn fcntl_fullfsync(fd: BorrowedFd<'_>) -> io::Result<()> {
 }
 
 #[cfg(apple)]
-pub(crate) fn fcntl_nocache(fd: BorrowedFd, value: bool) -> io::Result<()> {
+pub(crate) fn fcntl_nocache(fd: BorrowedFd<'_>, value: bool) -> io::Result<()> {
     unsafe { ret(c::fcntl(borrowed_fd(fd), c::F_NOCACHE, value as c::c_int)) }
 }
 
 #[cfg(apple)]
-pub(crate) fn fcntl_global_nocache(fd: BorrowedFd, value: bool) -> io::Result<()> {
+pub(crate) fn fcntl_global_nocache(fd: BorrowedFd<'_>, value: bool) -> io::Result<()> {
     unsafe {
         ret(c::fcntl(
             borrowed_fd(fd),

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -79,7 +79,7 @@ pub(crate) fn pwrite(fd: BorrowedFd<'_>, buf: &[u8], offset: u64) -> io::Result<
 }
 
 #[cfg(not(target_os = "espidf"))]
-pub(crate) fn readv(fd: BorrowedFd<'_>, bufs: &mut [IoSliceMut]) -> io::Result<usize> {
+pub(crate) fn readv(fd: BorrowedFd<'_>, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
     unsafe {
         ret_usize(c::readv(
             borrowed_fd(fd),
@@ -90,7 +90,7 @@ pub(crate) fn readv(fd: BorrowedFd<'_>, bufs: &mut [IoSliceMut]) -> io::Result<u
 }
 
 #[cfg(not(target_os = "espidf"))]
-pub(crate) fn writev(fd: BorrowedFd<'_>, bufs: &[IoSlice]) -> io::Result<usize> {
+pub(crate) fn writev(fd: BorrowedFd<'_>, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
     unsafe {
         ret_usize(c::writev(
             borrowed_fd(fd),
@@ -109,7 +109,7 @@ pub(crate) fn writev(fd: BorrowedFd<'_>, bufs: &[IoSlice]) -> io::Result<usize> 
 )))]
 pub(crate) fn preadv(
     fd: BorrowedFd<'_>,
-    bufs: &mut [IoSliceMut],
+    bufs: &mut [IoSliceMut<'_>],
     offset: u64,
 ) -> io::Result<usize> {
     // Silently cast; we'll get `EINVAL` if the value is negative.
@@ -131,7 +131,7 @@ pub(crate) fn preadv(
     target_os = "redox",
     target_os = "solaris"
 )))]
-pub(crate) fn pwritev(fd: BorrowedFd<'_>, bufs: &[IoSlice], offset: u64) -> io::Result<usize> {
+pub(crate) fn pwritev(fd: BorrowedFd<'_>, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
     // Silently cast; we'll get `EINVAL` if the value is negative.
     let offset = offset as i64;
     unsafe {
@@ -147,7 +147,7 @@ pub(crate) fn pwritev(fd: BorrowedFd<'_>, bufs: &[IoSlice], offset: u64) -> io::
 #[cfg(linux_kernel)]
 pub(crate) fn preadv2(
     fd: BorrowedFd<'_>,
-    bufs: &mut [IoSliceMut],
+    bufs: &mut [IoSliceMut<'_>],
     offset: u64,
     flags: ReadWriteFlags,
 ) -> io::Result<usize> {
@@ -167,7 +167,7 @@ pub(crate) fn preadv2(
 #[cfg(linux_kernel)]
 pub(crate) fn pwritev2(
     fd: BorrowedFd<'_>,
-    bufs: &[IoSlice],
+    bufs: &[IoSlice<'_>],
     offset: u64,
     flags: ReadWriteFlags,
 ) -> io::Result<usize> {

--- a/src/backend/libc/pipe/syscalls.rs
+++ b/src/backend/libc/pipe/syscalls.rs
@@ -55,9 +55,9 @@ pub(crate) fn pipe_with(flags: PipeFlags) -> io::Result<(OwnedFd, OwnedFd)> {
 #[cfg(linux_kernel)]
 #[inline]
 pub fn splice(
-    fd_in: BorrowedFd,
+    fd_in: BorrowedFd<'_>,
     off_in: Option<&mut u64>,
-    fd_out: BorrowedFd,
+    fd_out: BorrowedFd<'_>,
     off_out: Option<&mut u64>,
     len: usize,
     flags: SpliceFlags,
@@ -80,8 +80,8 @@ pub fn splice(
 #[cfg(linux_kernel)]
 #[inline]
 pub unsafe fn vmsplice(
-    fd: BorrowedFd,
-    bufs: &[IoSliceRaw],
+    fd: BorrowedFd<'_>,
+    bufs: &[IoSliceRaw<'_>],
     flags: SpliceFlags,
 ) -> io::Result<usize> {
     ret_usize(c::vmsplice(
@@ -95,8 +95,8 @@ pub unsafe fn vmsplice(
 #[cfg(linux_kernel)]
 #[inline]
 pub fn tee(
-    fd_in: BorrowedFd,
-    fd_out: BorrowedFd,
+    fd_in: BorrowedFd<'_>,
+    fd_out: BorrowedFd<'_>,
     len: usize,
     flags: SpliceFlags,
 ) -> io::Result<usize> {

--- a/src/backend/libc/pty/syscalls.rs
+++ b/src/backend/libc/pty/syscalls.rs
@@ -29,7 +29,7 @@ pub(crate) fn openpt(flags: OpenptFlags) -> io::Result<OwnedFd> {
     any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia")
 ))]
 #[inline]
-pub(crate) fn ptsname(fd: BorrowedFd, mut buffer: Vec<u8>) -> io::Result<CString> {
+pub(crate) fn ptsname(fd: BorrowedFd<'_>, mut buffer: Vec<u8>) -> io::Result<CString> {
     // This code would benefit from having a better way to read into
     // uninitialized memory, but that requires `unsafe`.
     buffer.clear();
@@ -93,12 +93,12 @@ pub(crate) fn ptsname(fd: BorrowedFd, mut buffer: Vec<u8>) -> io::Result<CString
 }
 
 #[inline]
-pub(crate) fn unlockpt(fd: BorrowedFd) -> io::Result<()> {
+pub(crate) fn unlockpt(fd: BorrowedFd<'_>) -> io::Result<()> {
     unsafe { ret(c::unlockpt(borrowed_fd(fd))) }
 }
 
 #[cfg(not(linux_kernel))]
 #[inline]
-pub(crate) fn grantpt(fd: BorrowedFd) -> io::Result<()> {
+pub(crate) fn grantpt(fd: BorrowedFd<'_>) -> io::Result<()> {
     unsafe { ret(c::grantpt(borrowed_fd(fd))) }
 }

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -92,7 +92,7 @@ pub(crate) fn tcsetpgrp(fd: BorrowedFd<'_>, pid: Pid) -> io::Result<()> {
 
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 pub(crate) fn tcsetattr(
-    fd: BorrowedFd,
+    fd: BorrowedFd<'_>,
     optional_actions: OptionalActions,
     termios: &Termios,
 ) -> io::Result<()> {
@@ -165,27 +165,27 @@ pub(crate) fn tcsetattr(
 }
 
 #[cfg(not(target_os = "wasi"))]
-pub(crate) fn tcsendbreak(fd: BorrowedFd) -> io::Result<()> {
+pub(crate) fn tcsendbreak(fd: BorrowedFd<'_>) -> io::Result<()> {
     unsafe { ret(c::tcsendbreak(borrowed_fd(fd), 0)) }
 }
 
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
-pub(crate) fn tcdrain(fd: BorrowedFd) -> io::Result<()> {
+pub(crate) fn tcdrain(fd: BorrowedFd<'_>) -> io::Result<()> {
     unsafe { ret(c::tcdrain(borrowed_fd(fd))) }
 }
 
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
-pub(crate) fn tcflush(fd: BorrowedFd, queue_selector: QueueSelector) -> io::Result<()> {
+pub(crate) fn tcflush(fd: BorrowedFd<'_>, queue_selector: QueueSelector) -> io::Result<()> {
     unsafe { ret(c::tcflush(borrowed_fd(fd), queue_selector as _)) }
 }
 
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
-pub(crate) fn tcflow(fd: BorrowedFd, action: Action) -> io::Result<()> {
+pub(crate) fn tcflow(fd: BorrowedFd<'_>, action: Action) -> io::Result<()> {
     unsafe { ret(c::tcflow(borrowed_fd(fd), action as _)) }
 }
 
 #[cfg(not(target_os = "wasi"))]
-pub(crate) fn tcgetsid(fd: BorrowedFd) -> io::Result<Pid> {
+pub(crate) fn tcgetsid(fd: BorrowedFd<'_>) -> io::Result<Pid> {
     unsafe {
         let pid = ret_pid_t(c::tcgetsid(borrowed_fd(fd)))?;
         Ok(Pid::from_raw_unchecked(pid))
@@ -193,12 +193,12 @@ pub(crate) fn tcgetsid(fd: BorrowedFd) -> io::Result<Pid> {
 }
 
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
-pub(crate) fn tcsetwinsize(fd: BorrowedFd, winsize: Winsize) -> io::Result<()> {
+pub(crate) fn tcsetwinsize(fd: BorrowedFd<'_>, winsize: Winsize) -> io::Result<()> {
     unsafe { ret(c::ioctl(borrowed_fd(fd), c::TIOCSWINSZ, &winsize)) }
 }
 
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
-pub(crate) fn tcgetwinsize(fd: BorrowedFd) -> io::Result<Winsize> {
+pub(crate) fn tcgetwinsize(fd: BorrowedFd<'_>) -> io::Result<Winsize> {
     unsafe {
         let mut buf = MaybeUninit::<Winsize>::uninit();
         ret(c::ioctl(

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -280,7 +280,7 @@ pub(crate) fn gettid() -> Pid {
 
 #[cfg(linux_kernel)]
 #[inline]
-pub(crate) fn setns(fd: BorrowedFd, nstype: c::c_int) -> io::Result<c::c_int> {
+pub(crate) fn setns(fd: BorrowedFd<'_>, nstype: c::c_int) -> io::Result<c::c_int> {
     // `setns` wasn't supported in glibc until 2.14, and musl until 0.9.5,
     // so use `syscall`.
     weak_or_syscall! {

--- a/src/backend/linux_raw/arch/powerpc64.rs
+++ b/src/backend/linux_raw/arch/powerpc64.rs
@@ -15,7 +15,7 @@ use crate::backend::reg::{
 use core::arch::asm;
 
 #[inline]
-pub(in crate::backend) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
+pub(in crate::backend) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
     let r0;
     asm!(
         "sc",

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -186,45 +186,45 @@ pub(super) fn no_fd<'a, Num: ArgNumber>() -> ArgReg<'a, Num> {
 }
 
 #[inline]
-pub(super) fn slice_just_addr<T: Sized, Num: ArgNumber>(v: &[T]) -> ArgReg<Num> {
+pub(super) fn slice_just_addr<T: Sized, Num: ArgNumber>(v: &[T]) -> ArgReg<'_, Num> {
     let mut_ptr = v.as_ptr() as *mut T;
     raw_arg(mut_ptr.cast())
 }
 
 #[inline]
-pub(super) fn slice_just_addr_mut<T: Sized, Num: ArgNumber>(v: &mut [T]) -> ArgReg<Num> {
+pub(super) fn slice_just_addr_mut<T: Sized, Num: ArgNumber>(v: &mut [T]) -> ArgReg<'_, Num> {
     raw_arg(v.as_mut_ptr().cast())
 }
 
 #[inline]
 pub(super) fn slice<T: Sized, Num0: ArgNumber, Num1: ArgNumber>(
     v: &[T],
-) -> (ArgReg<Num0>, ArgReg<Num1>) {
+) -> (ArgReg<'_, Num0>, ArgReg<'_, Num1>) {
     (slice_just_addr(v), pass_usize(v.len()))
 }
 
 #[inline]
 pub(super) fn slice_mut<T: Sized, Num0: ArgNumber, Num1: ArgNumber>(
     v: &mut [T],
-) -> (ArgReg<Num0>, ArgReg<Num1>) {
+) -> (ArgReg<'_, Num0>, ArgReg<'_, Num1>) {
     (raw_arg(v.as_mut_ptr().cast()), pass_usize(v.len()))
 }
 
 #[inline]
-pub(super) fn by_ref<T: Sized, Num: ArgNumber>(t: &T) -> ArgReg<Num> {
+pub(super) fn by_ref<T: Sized, Num: ArgNumber>(t: &T) -> ArgReg<'_, Num> {
     let mut_ptr = as_ptr(t) as *mut T;
     raw_arg(mut_ptr.cast())
 }
 
 #[inline]
-pub(super) fn by_mut<T: Sized, Num: ArgNumber>(t: &mut T) -> ArgReg<Num> {
+pub(super) fn by_mut<T: Sized, Num: ArgNumber>(t: &mut T) -> ArgReg<'_, Num> {
     raw_arg(as_mut_ptr(t).cast())
 }
 
 /// Convert an optional mutable reference into a `usize` for passing to a
 /// syscall.
 #[inline]
-pub(super) fn opt_mut<T: Sized, Num: ArgNumber>(t: Option<&mut T>) -> ArgReg<Num> {
+pub(super) fn opt_mut<T: Sized, Num: ArgNumber>(t: Option<&mut T>) -> ArgReg<'_, Num> {
     // This optimizes into the equivalent of `transmute(t)`, and has the
     // advantage of not requiring `unsafe`.
     match t {
@@ -237,7 +237,7 @@ pub(super) fn opt_mut<T: Sized, Num: ArgNumber>(t: Option<&mut T>) -> ArgReg<Num
 /// syscall.
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 #[inline]
-pub(super) fn opt_ref<T: Sized, Num: ArgNumber>(t: Option<&T>) -> ArgReg<Num> {
+pub(super) fn opt_ref<T: Sized, Num: ArgNumber>(t: Option<&T>) -> ArgReg<'_, Num> {
     // This optimizes into the equivalent of `transmute(t)`, and has the
     // advantage of not requiring `unsafe`.
     match t {

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -10,12 +10,7 @@
 use crate::backend::conv::loff_t_from_u64;
 #[cfg(all(
     target_pointer_width = "32",
-    any(
-        target_arch = "arm",
-        target_arch = "mips",
-        target_arch = "mips32r6",
-        target_arch = "power"
-    ),
+    any(target_arch = "arm", target_arch = "mips", target_arch = "mips32r6"),
 ))]
 use crate::backend::conv::zero;
 use crate::backend::conv::{
@@ -47,12 +42,7 @@ pub(crate) fn pread(fd: BorrowedFd<'_>, buf: &mut [u8], pos: u64) -> io::Result<
     // <https://github.com/torvalds/linux/blob/fcadab740480e0e0e9fa9bd272acd409884d431a/arch/arm64/kernel/sys32.c#L75>
     #[cfg(all(
         target_pointer_width = "32",
-        any(
-            target_arch = "arm",
-            target_arch = "mips",
-            target_arch = "mips32r6",
-            target_arch = "power"
-        ),
+        any(target_arch = "arm", target_arch = "mips", target_arch = "mips32r6"),
     ))]
     unsafe {
         ret_usize(syscall!(
@@ -67,12 +57,7 @@ pub(crate) fn pread(fd: BorrowedFd<'_>, buf: &mut [u8], pos: u64) -> io::Result<
     }
     #[cfg(all(
         target_pointer_width = "32",
-        not(any(
-            target_arch = "arm",
-            target_arch = "mips",
-            target_arch = "mips32r6",
-            target_arch = "power"
-        )),
+        not(any(target_arch = "arm", target_arch = "mips", target_arch = "mips32r6")),
     ))]
     unsafe {
         ret_usize(syscall!(
@@ -182,12 +167,7 @@ pub(crate) fn pwrite(fd: BorrowedFd<'_>, buf: &[u8], pos: u64) -> io::Result<usi
     // <https://github.com/torvalds/linux/blob/fcadab740480e0e0e9fa9bd272acd409884d431a/arch/arm64/kernel/sys32.c#L81-L83>
     #[cfg(all(
         target_pointer_width = "32",
-        any(
-            target_arch = "arm",
-            target_arch = "mips",
-            target_arch = "mips32r6",
-            target_arch = "power"
-        ),
+        any(target_arch = "arm", target_arch = "mips", target_arch = "mips32r6"),
     ))]
     unsafe {
         ret_usize(syscall_readonly!(
@@ -202,12 +182,7 @@ pub(crate) fn pwrite(fd: BorrowedFd<'_>, buf: &[u8], pos: u64) -> io::Result<usi
     }
     #[cfg(all(
         target_pointer_width = "32",
-        not(any(
-            target_arch = "arm",
-            target_arch = "mips",
-            target_arch = "mips32r6",
-            target_arch = "power"
-        )),
+        not(any(target_arch = "arm", target_arch = "mips", target_arch = "mips32r6")),
     ))]
     unsafe {
         ret_usize(syscall_readonly!(

--- a/src/backend/linux_raw/net/syscalls.rs
+++ b/src/backend/linux_raw/net/syscalls.rs
@@ -51,7 +51,7 @@ pub(crate) fn socket(
         ret_owned_fd(syscall_readonly!(
             __NR_socketcall,
             x86_sys(SYS_SOCKET),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 family.into(),
                 type_.into(),
                 protocol.into(),
@@ -81,7 +81,7 @@ pub(crate) fn socket_with(
         ret_owned_fd(syscall_readonly!(
             __NR_socketcall,
             x86_sys(SYS_SOCKET),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 family.into(),
                 (type_, flags).into(),
                 protocol.into(),
@@ -116,7 +116,7 @@ pub(crate) fn socketpair(
         ret(syscall!(
             __NR_socketcall,
             x86_sys(SYS_SOCKETPAIR),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 family.into(),
                 (type_, flags).into(),
                 protocol.into(),
@@ -140,7 +140,7 @@ pub(crate) fn accept(fd: BorrowedFd<'_>) -> io::Result<OwnedFd> {
         let fd = ret_owned_fd(syscall_readonly!(
             __NR_socketcall,
             x86_sys(SYS_ACCEPT),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[fd.into(), zero(), zero()])
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[fd.into(), zero(), zero()])
         ))?;
         Ok(fd)
     }
@@ -158,7 +158,7 @@ pub(crate) fn accept_with(fd: BorrowedFd<'_>, flags: SocketFlags) -> io::Result<
         let fd = ret_owned_fd(syscall_readonly!(
             __NR_socketcall,
             x86_sys(SYS_ACCEPT4),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[fd.into(), zero(), zero(), flags.into()])
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[fd.into(), zero(), zero(), flags.into()])
         ))?;
         Ok(fd)
     }
@@ -188,7 +188,7 @@ pub(crate) fn acceptfrom(fd: BorrowedFd<'_>) -> io::Result<(OwnedFd, Option<Sock
         let fd = ret_owned_fd(syscall!(
             __NR_socketcall,
             x86_sys(SYS_ACCEPT),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
                 (&mut storage).into(),
                 by_mut(&mut addrlen),
@@ -229,7 +229,7 @@ pub(crate) fn acceptfrom_with(
         let fd = ret_owned_fd(syscall!(
             __NR_socketcall,
             x86_sys(SYS_ACCEPT4),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
                 (&mut storage).into(),
                 by_mut(&mut addrlen),
@@ -262,7 +262,7 @@ pub(crate) fn recvmsg(
             ret_usize(syscall!(
                 __NR_socketcall,
                 x86_sys(SYS_RECVMSG),
-                slice_just_addr::<ArgReg<SocketArg>, _>(&[
+                slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                     sockfd.into(),
                     by_mut(msghdr),
                     msg_flags.into(),
@@ -301,7 +301,7 @@ pub(crate) fn sendmsg(
             ret_usize(syscall!(
                 __NR_socketcall,
                 x86_sys(SYS_SENDMSG),
-                slice_just_addr::<ArgReg<SocketArg>, _>(&[
+                slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                     sockfd.into(),
                     by_ref(&msghdr),
                     msg_flags.into()
@@ -331,7 +331,7 @@ pub(crate) fn sendmsg_v4(
             ret_usize(syscall!(
                 __NR_socketcall,
                 x86_sys(SYS_SENDMSG),
-                slice_just_addr::<ArgReg<SocketArg>, _>(&[
+                slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                     sockfd.into(),
                     by_ref(&msghdr),
                     msg_flags.into(),
@@ -361,7 +361,7 @@ pub(crate) fn sendmsg_v6(
             ret_usize(syscall!(
                 __NR_socketcall,
                 x86_sys(SYS_SENDMSG),
-                slice_just_addr::<ArgReg<SocketArg>, _>(&[
+                slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                     sockfd.into(),
                     by_ref(&msghdr),
                     msg_flags.into()
@@ -391,7 +391,7 @@ pub(crate) fn sendmsg_unix(
             ret_usize(syscall!(
                 __NR_socketcall,
                 x86_sys(SYS_SENDMSG),
-                slice_just_addr::<ArgReg<SocketArg>, _>(&[
+                slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                     sockfd.into(),
                     by_ref(&msghdr),
                     msg_flags.into()
@@ -418,7 +418,7 @@ pub(crate) fn shutdown(fd: BorrowedFd<'_>, how: Shutdown) -> io::Result<()> {
         ret(syscall_readonly!(
             __NR_socketcall,
             x86_sys(SYS_SHUTDOWN),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[fd.into(), c_uint(how as c::c_uint)])
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[fd.into(), c_uint(how as c::c_uint)])
         ))
     }
 }
@@ -461,7 +461,12 @@ pub(crate) fn send(fd: BorrowedFd<'_>, buf: &[u8], flags: SendFlags) -> io::Resu
         ret_usize(syscall_readonly!(
             __NR_socketcall,
             x86_sys(SYS_SEND),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[fd.into(), buf_addr, buf_len, flags.into()])
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
+                fd.into(),
+                buf_addr,
+                buf_len,
+                flags.into()
+            ])
         ))
     }
 }
@@ -492,7 +497,7 @@ pub(crate) fn sendto_v4(
         ret_usize(syscall_readonly!(
             __NR_socketcall,
             x86_sys(SYS_SENDTO),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
                 buf_addr,
                 buf_len,
@@ -530,7 +535,7 @@ pub(crate) fn sendto_v6(
         ret_usize(syscall_readonly!(
             __NR_socketcall,
             x86_sys(SYS_SENDTO),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
                 buf_addr,
                 buf_len,
@@ -568,7 +573,7 @@ pub(crate) fn sendto_unix(
         ret_usize(syscall_readonly!(
             __NR_socketcall,
             x86_sys(SYS_SENDTO),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
                 buf_addr,
                 buf_len,
@@ -618,7 +623,7 @@ pub(crate) fn recv(fd: BorrowedFd<'_>, buf: &mut [u8], flags: RecvFlags) -> io::
         ret_usize(syscall!(
             __NR_socketcall,
             x86_sys(SYS_RECV),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
                 buf_addr_mut,
                 buf_len,
@@ -659,7 +664,7 @@ pub(crate) fn recvfrom(
         let nread = ret_usize(syscall!(
             __NR_socketcall,
             x86_sys(SYS_RECVFROM),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
                 buf_addr_mut,
                 buf_len,
@@ -700,7 +705,7 @@ pub(crate) fn getpeername(fd: BorrowedFd<'_>) -> io::Result<Option<SocketAddrAny
         ret(syscall!(
             __NR_socketcall,
             x86_sys(SYS_GETPEERNAME),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
                 (&mut storage).into(),
                 by_mut(&mut addrlen),
@@ -737,7 +742,7 @@ pub(crate) fn getsockname(fd: BorrowedFd<'_>) -> io::Result<SocketAddrAny> {
         ret(syscall!(
             __NR_socketcall,
             x86_sys(SYS_GETSOCKNAME),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
                 (&mut storage).into(),
                 by_mut(&mut addrlen),
@@ -766,7 +771,7 @@ pub(crate) fn bind_v4(fd: BorrowedFd<'_>, addr: &SocketAddrV4) -> io::Result<()>
         ret(syscall_readonly!(
             __NR_socketcall,
             x86_sys(SYS_BIND),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
                 by_ref(&encode_sockaddr_v4(addr)),
                 size_of::<sockaddr_in, _>(),
@@ -791,7 +796,7 @@ pub(crate) fn bind_v6(fd: BorrowedFd<'_>, addr: &SocketAddrV6) -> io::Result<()>
         ret(syscall_readonly!(
             __NR_socketcall,
             x86_sys(SYS_BIND),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
                 by_ref(&encode_sockaddr_v6(addr)),
                 size_of::<sockaddr_in6, _>(),
@@ -816,7 +821,7 @@ pub(crate) fn bind_unix(fd: BorrowedFd<'_>, addr: &SocketAddrUnix) -> io::Result
         ret(syscall_readonly!(
             __NR_socketcall,
             x86_sys(SYS_BIND),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
                 by_ref(&addr.unix),
                 socklen_t(addr.addr_len()),
@@ -841,7 +846,7 @@ pub(crate) fn connect_v4(fd: BorrowedFd<'_>, addr: &SocketAddrV4) -> io::Result<
         ret(syscall_readonly!(
             __NR_socketcall,
             x86_sys(SYS_CONNECT),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
                 by_ref(&encode_sockaddr_v4(addr)),
                 size_of::<sockaddr_in, _>(),
@@ -866,7 +871,7 @@ pub(crate) fn connect_v6(fd: BorrowedFd<'_>, addr: &SocketAddrV6) -> io::Result<
         ret(syscall_readonly!(
             __NR_socketcall,
             x86_sys(SYS_CONNECT),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
                 by_ref(&encode_sockaddr_v6(addr)),
                 size_of::<sockaddr_in6, _>(),
@@ -891,7 +896,7 @@ pub(crate) fn connect_unix(fd: BorrowedFd<'_>, addr: &SocketAddrUnix) -> io::Res
         ret(syscall_readonly!(
             __NR_socketcall,
             x86_sys(SYS_CONNECT),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
                 by_ref(&addr.unix),
                 socklen_t(addr.addr_len()),
@@ -911,7 +916,7 @@ pub(crate) fn listen(fd: BorrowedFd<'_>, backlog: c::c_int) -> io::Result<()> {
         ret(syscall_readonly!(
             __NR_socketcall,
             x86_sys(SYS_LISTEN),
-            slice_just_addr::<ArgReg<SocketArg>, _>(&[fd.into(), c_int(backlog)])
+            slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[fd.into(), c_int(backlog)])
         ))
     }
 }
@@ -960,7 +965,7 @@ pub(crate) mod sockopt {
             ret(syscall!(
                 __NR_socketcall,
                 x86_sys(SYS_GETSOCKOPT),
-                slice_just_addr::<ArgReg<SocketArg>, _>(&[
+                slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                     fd.into(),
                     c_uint(level),
                     c_uint(optname),
@@ -1008,7 +1013,7 @@ pub(crate) mod sockopt {
             ret(syscall_readonly!(
                 __NR_socketcall,
                 x86_sys(SYS_SETSOCKOPT),
-                slice_just_addr::<ArgReg<SocketArg>, _>(&[
+                slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                     fd.into(),
                     c_uint(level),
                     c_uint(optname),

--- a/src/backend/linux_raw/pipe/syscalls.rs
+++ b/src/backend/linux_raw/pipe/syscalls.rs
@@ -59,9 +59,9 @@ pub(crate) fn pipe_with(flags: PipeFlags) -> io::Result<(OwnedFd, OwnedFd)> {
 
 #[inline]
 pub fn splice(
-    fd_in: BorrowedFd,
+    fd_in: BorrowedFd<'_>,
     off_in: Option<&mut u64>,
-    fd_out: BorrowedFd,
+    fd_out: BorrowedFd<'_>,
     off_out: Option<&mut u64>,
     len: usize,
     flags: SpliceFlags,
@@ -81,8 +81,8 @@ pub fn splice(
 
 #[inline]
 pub unsafe fn vmsplice(
-    fd: BorrowedFd,
-    bufs: &[IoSliceRaw],
+    fd: BorrowedFd<'_>,
+    bufs: &[IoSliceRaw<'_>],
     flags: SpliceFlags,
 ) -> io::Result<usize> {
     let (bufs_addr, bufs_len) = slice(&bufs[..cmp::min(bufs.len(), MAX_IOV)]);
@@ -91,8 +91,8 @@ pub unsafe fn vmsplice(
 
 #[inline]
 pub fn tee(
-    fd_in: BorrowedFd,
-    fd_out: BorrowedFd,
+    fd_in: BorrowedFd<'_>,
+    fd_out: BorrowedFd<'_>,
     len: usize,
     flags: SpliceFlags,
 ) -> io::Result<usize> {

--- a/src/backend/linux_raw/pty/syscalls.rs
+++ b/src/backend/linux_raw/pty/syscalls.rs
@@ -18,7 +18,7 @@ use {
 
 #[cfg(feature = "alloc")]
 #[inline]
-pub(crate) fn ptsname(fd: BorrowedFd, mut buffer: Vec<u8>) -> io::Result<CString> {
+pub(crate) fn ptsname(fd: BorrowedFd<'_>, mut buffer: Vec<u8>) -> io::Result<CString> {
     unsafe {
         let mut n = MaybeUninit::<c::c_int>::uninit();
         ret(syscall!(__NR_ioctl, fd, c_uint(TIOCGPTN), &mut n))?;
@@ -32,7 +32,7 @@ pub(crate) fn ptsname(fd: BorrowedFd, mut buffer: Vec<u8>) -> io::Result<CString
 }
 
 #[inline]
-pub(crate) fn unlockpt(fd: BorrowedFd) -> io::Result<()> {
+pub(crate) fn unlockpt(fd: BorrowedFd<'_>) -> io::Result<()> {
     unsafe {
         ret(syscall_readonly!(
             __NR_ioctl,

--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -55,7 +55,7 @@ pub(crate) fn tcgetpgrp(fd: BorrowedFd<'_>) -> io::Result<Pid> {
 
 #[inline]
 pub(crate) fn tcsetattr(
-    fd: BorrowedFd,
+    fd: BorrowedFd<'_>,
     optional_actions: OptionalActions,
     termios: &Termios,
 ) -> io::Result<()> {
@@ -83,17 +83,17 @@ pub(crate) fn tcsetattr(
 }
 
 #[inline]
-pub(crate) fn tcsendbreak(fd: BorrowedFd) -> io::Result<()> {
+pub(crate) fn tcsendbreak(fd: BorrowedFd<'_>) -> io::Result<()> {
     unsafe { ret(syscall_readonly!(__NR_ioctl, fd, c_uint(TCSBRK), c_uint(0))) }
 }
 
 #[inline]
-pub(crate) fn tcdrain(fd: BorrowedFd) -> io::Result<()> {
+pub(crate) fn tcdrain(fd: BorrowedFd<'_>) -> io::Result<()> {
     unsafe { ret(syscall_readonly!(__NR_ioctl, fd, c_uint(TCSBRK), c_uint(1))) }
 }
 
 #[inline]
-pub(crate) fn tcflush(fd: BorrowedFd, queue_selector: QueueSelector) -> io::Result<()> {
+pub(crate) fn tcflush(fd: BorrowedFd<'_>, queue_selector: QueueSelector) -> io::Result<()> {
     unsafe {
         ret(syscall_readonly!(
             __NR_ioctl,
@@ -105,7 +105,7 @@ pub(crate) fn tcflush(fd: BorrowedFd, queue_selector: QueueSelector) -> io::Resu
 }
 
 #[inline]
-pub(crate) fn tcflow(fd: BorrowedFd, action: Action) -> io::Result<()> {
+pub(crate) fn tcflow(fd: BorrowedFd<'_>, action: Action) -> io::Result<()> {
     unsafe {
         ret(syscall_readonly!(
             __NR_ioctl,
@@ -117,7 +117,7 @@ pub(crate) fn tcflow(fd: BorrowedFd, action: Action) -> io::Result<()> {
 }
 
 #[inline]
-pub(crate) fn tcgetsid(fd: BorrowedFd) -> io::Result<Pid> {
+pub(crate) fn tcgetsid(fd: BorrowedFd<'_>) -> io::Result<Pid> {
     unsafe {
         let mut result = MaybeUninit::<c::pid_t>::uninit();
         ret(syscall!(__NR_ioctl, fd, c_uint(TIOCGSID), &mut result))?;
@@ -127,7 +127,7 @@ pub(crate) fn tcgetsid(fd: BorrowedFd) -> io::Result<Pid> {
 }
 
 #[inline]
-pub(crate) fn tcsetwinsize(fd: BorrowedFd, winsize: Winsize) -> io::Result<()> {
+pub(crate) fn tcsetwinsize(fd: BorrowedFd<'_>, winsize: Winsize) -> io::Result<()> {
     unsafe {
         ret(syscall!(
             __NR_ioctl,

--- a/src/backend/linux_raw/thread/syscalls.rs
+++ b/src/backend/linux_raw/thread/syscalls.rs
@@ -274,7 +274,7 @@ unsafe fn futex_old(
 }
 
 #[inline]
-pub(crate) fn setns(fd: BorrowedFd, nstype: c::c_int) -> io::Result<c::c_int> {
+pub(crate) fn setns(fd: BorrowedFd<'_>, nstype: c::c_int) -> io::Result<c::c_int> {
     unsafe { ret_c_int(syscall_readonly!(__NR_setns, fd, c_int(nstype))) }
 }
 

--- a/src/fs/raw_dir.rs
+++ b/src/fs/raw_dir.rs
@@ -193,7 +193,7 @@ impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
     /// with GAT support once one becomes available.
     #[allow(unsafe_code)]
     #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> Option<io::Result<RawDirEntry>> {
+    pub fn next(&mut self) -> Option<io::Result<RawDirEntry<'_>>> {
         if self.is_buffer_empty() {
             match getdents_uninit(self.fd.as_fd(), self.buf) {
                 Ok(0) => return None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,7 @@
 #![cfg_attr(all(feature = "alloc", alloc_ffi), feature(alloc_ffi))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "rustc-dep-of-std", feature(ip))]
+#![cfg_attr(feature = "rustc-dep-of-std", allow(internal_features))]
 #![cfg_attr(
     any(feature = "rustc-dep-of-std", core_intrinsics),
     feature(core_intrinsics)

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -165,7 +165,7 @@ pub fn splice<FdIn: AsFd, FdOut: AsFd>(
 #[inline]
 pub unsafe fn vmsplice<PipeFd: AsFd>(
     fd: PipeFd,
-    bufs: &[IoSliceRaw],
+    bufs: &[IoSliceRaw<'_>],
     flags: SpliceFlags,
 ) -> io::Result<usize> {
     backend::pipe::syscalls::vmsplice(fd.as_fd(), bufs, flags)

--- a/src/process/prctl.rs
+++ b/src/process/prctl.rs
@@ -673,7 +673,7 @@ pub unsafe fn set_virtual_memory_map_address(
 #[inline]
 #[doc(alias = "PR_SET_MM")]
 #[doc(alias = "PR_SET_MM_EXE_FILE")]
-pub fn set_executable_file(fd: BorrowedFd) -> io::Result<()> {
+pub fn set_executable_file(fd: BorrowedFd<'_>) -> io::Result<()> {
     let fd = usize::try_from(fd.as_raw_fd()).map_err(|_r| io::Errno::RANGE)?;
     unsafe { prctl_3args(PR_SET_MM, PR_SET_MM_EXE_FILE as *mut _, fd as *mut _) }.map(|_r| ())
 }

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -417,7 +417,7 @@ fn proc_self_file(name: &CStr) -> io::Result<OwnedFd> {
 
 /// Open a procfs file within in `dir` and check it for bind mounts.
 #[cfg(feature = "alloc")]
-fn open_and_check_file(dir: BorrowedFd, dir_stat: &Stat, name: &CStr) -> io::Result<OwnedFd> {
+fn open_and_check_file(dir: BorrowedFd<'_>, dir_stat: &Stat, name: &CStr) -> io::Result<OwnedFd> {
     let (_, proc_stat) = proc()?;
 
     // Don't use `NOATIME`, because it [requires us to own the file], and when

--- a/src/thread/setns.rs
+++ b/src/thread/setns.rs
@@ -102,7 +102,7 @@ bitflags! {
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/setns.2.html
 pub fn move_into_link_name_space(
-    fd: BorrowedFd,
+    fd: BorrowedFd<'_>,
     allowed_type: Option<LinkNameSpaceType>,
 ) -> io::Result<()> {
     let allowed_type = allowed_type.map_or(0, |t| t as c_int);
@@ -119,7 +119,7 @@ pub fn move_into_link_name_space(
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/setns.2.html
 pub fn move_into_thread_name_spaces(
-    fd: BorrowedFd,
+    fd: BorrowedFd<'_>,
     allowed_types: ThreadNameSpaceType,
 ) -> io::Result<()> {
     syscalls::setns(fd, allowed_types.bits() as c_int).map(|_r| ())

--- a/tests/fs/readdir.rs
+++ b/tests/fs/readdir.rs
@@ -60,7 +60,7 @@ fn test_raw_dir(buf: &mut [MaybeUninit<u8>]) {
     use rustix::fd::AsFd;
     use rustix::fs::RawDir;
 
-    fn read_raw_entries<Fd: AsFd>(dir: &mut RawDir<Fd>) -> HashSet<String> {
+    fn read_raw_entries<Fd: AsFd>(dir: &mut RawDir<'_, Fd>) -> HashSet<String> {
         let mut out = HashSet::new();
         while let Some(entry) = dir.next() {
             let entry = entry.expect("non-error entry");

--- a/tests/path/arg.rs
+++ b/tests/path/arg.rs
@@ -63,19 +63,19 @@ fn test_arg() {
     );
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
 
-    let t: Components = Path::new("hello").components();
+    let t: Components<'_> = Path::new("hello").components();
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
 
-    let t: Component = Path::new("hello").components().next().unwrap();
+    let t: Component<'_> = Path::new("hello").components().next().unwrap();
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
 
-    let t: Iter = Path::new("hello").iter();
+    let t: Iter<'_> = Path::new("hello").iter();
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));


### PR DESCRIPTION
 - Fix `-D elided-lifetimes-in-paths` diagnostics
 - Fix incorrect target_arch name "power"
 - Add a `try_clone_to_owned` function to the no_std polyfill's `BorrowedFd`.