### PR TITLE
Fix the `test_ttyname_ok` test when /dev/stdin is inaccessable.

### DIFF
--- a/tests/termios/ttyname.rs
+++ b/tests/termios/ttyname.rs
@@ -4,7 +4,11 @@ use std::fs::File;
 
 #[test]
 fn test_ttyname_ok() {
-    let file = File::open("/dev/stdin").unwrap();
+    let file = match File::open("/dev/stdin") {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => return,
+        Err(err) => Err(err).unwrap(),
+    };
     if isatty(&file) {
         assert!(ttyname(&file, Vec::new())
             .unwrap()


### PR DESCRIPTION
/dev/stdin may be inaccessible in some sandboxed configurations, so just gracefully return if opening it fails.