### PR TITLE
Updated deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,17 @@ rust-version = "1.63"
 
 [dependencies]
 bitflags = { version = "2.4.0", default-features = false }
-itoa = { version = "1.0.1", default-features = false, optional = true }
+itoa = { version = "1.0.9", default-features = false, optional = true }
 
 # Special dependencies used in rustc-dep-of-std mode.
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
-compiler_builtins = { version = '0.1.49', optional = true }
+compiler_builtins = { version = "0.1.101", optional = true }
 
 # The procfs feature needs once_cell.
 # With Rust 1.70.0, we can switch to `core::cell::OnceCell`.
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
-once_cell = { version = "1.5.2", optional = true }
+once_cell = { version = "1.18.0", optional = true }
 
 # Dependencies for platforms where linux_raw is supported, in addition to libc:
 #
@@ -36,8 +36,8 @@ once_cell = { version = "1.5.2", optional = true }
 # libc backend can be selected via adding `--cfg=rustix_use_libc` to
 # `RUSTFLAGS` or enabling the `use-libc` cargo feature.
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
-linux-raw-sys = { version = "0.4.7", default-features = false, features = ["general", "errno", "ioctl", "no_std", "elf"] }
-libc_errno = { package = "errno", version = "0.3.1", default-features = false, optional = true }
+linux-raw-sys = { version = "0.5.2", default-features = false, features = ["general", "errno", "ioctl", "no_std", "elf"] }
+libc_errno = { package = "errno", version = "0.3.3", default-features = false, optional = true }
 libc = { version = "0.2.147", default-features = false, features = ["extra_traits"], optional = true }
 
 # Dependencies for platforms where only libc is supported:
@@ -45,7 +45,7 @@ libc = { version = "0.2.147", default-features = false, features = ["extra_trait
 # On all other Unix-family platforms, and under Miri, we always use the libc
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
-libc_errno = { package = "errno", version = "0.3.1", default-features = false }
+libc_errno = { package = "errno", version = "0.3.3", default-features = false }
 libc = { version = "0.2.147", default-features = false, features = ["extra_traits"] }
 
 # Additional dependencies for Linux with the libc backend:
@@ -53,7 +53,7 @@ libc = { version = "0.2.147", default-features = false, features = ["extra_trait
 # Some syscalls do not have libc wrappers, such as in `io_uring`. For these,
 # the libc backend uses the linux-raw-sys ABI and `libc::syscall`.
 [target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
-linux-raw-sys = { version = "0.4.3", default-features = false, features = ["general", "ioctl", "no_std"] }
+linux-raw-sys = { version = "0.5.2", default-features = false, features = ["general", "ioctl", "no_std"] }
 
 # For the libc backend on Windows, use the Winsock2 API in windows-sys.
 [target.'cfg(windows)'.dependencies.windows-sys]
@@ -68,14 +68,14 @@ features = [
 # For the libc backend on Windows, also use the errno crate, which has Windows
 # support.
 [target.'cfg(windows)'.dependencies.libc_errno]
-version = "0.3.1"
+version = "0.3.3"
 package = "errno"
 default-features = false
 
 [dev-dependencies]
-tempfile = "3.5.0"
+tempfile = "3.8.0"
 libc = "0.2.147"
-libc_errno = { package = "errno", version = "0.3.1", default-features = false }
+libc_errno = { package = "errno", version = "0.3.3", default-features = false }
 serial_test = "2.0.0"
 memoffset = "0.9.0"
 flate2 = "1.0"
@@ -85,7 +85,7 @@ static_assertions = "1.1.0"
 criterion = "0.4"
 
 [target.'cfg(windows)'.dev-dependencies]
-ctor = "0.2.0"
+ctor = "0.2.4"
 
 # Add Criterion configuration, as described here:
 # <https://bheisler.github.io/criterion.rs/book/getting_started.html#step-1---add-dependency-to-cargotoml>

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -1285,7 +1285,6 @@ pub struct io_uring_buf_reg {
     pub ring_addr: u64,
     pub ring_entries: u32,
     pub bgid: u16,
-    pub pad: u16,
     pub resv: [u64; 3_usize],
 }
 
@@ -1455,6 +1454,6 @@ fn io_uring_layouts() {
     check_struct!(io_uring_getevents_arg, sigmask, sigmask_sz, pad, ts);
     check_struct!(iovec, iov_base, iov_len);
     check_struct!(open_how, flags, mode, resolve);
-    check_struct!(io_uring_buf_reg, ring_addr, ring_entries, bgid, pad, resv);
+    check_struct!(io_uring_buf_reg, ring_addr, ring_entries, bgid, resv);
     check_struct!(io_uring_buf, addr, len, bid, resv);
 }


### PR DESCRIPTION
Bump linux-raw-sys from 0.4.7 to 0.5.2
Bump itoa from 1.0.1 to 1.0.9
Bump tempfile from 3.5.0 to 3.8.0
Bump once_cell from 1.5.2 to 1.18.0
Bump libc_errno from 0.3.1 to 0.3.3
Bump ctor from 0.2.0 to 0.2.4