### PR TITLE
Don't truncate the last character in ttyname

### DIFF
--- a/src/termios/tty.rs
+++ b/src/termios/tty.rs
@@ -54,9 +54,9 @@ fn _ttyname(dirfd: BorrowedFd<'_>, mut buffer: Vec<u8>) -> io::Result<CString> {
                 buffer.reserve(buffer.capacity() + 1); // use `Vec` reallocation strategy to grow capacity exponentially
             }
             Ok(len) => {
-                // SAFETY: assume the backend returns the length of the string
+                // SAFETY: assume the backend returns the length of the string excluding the NUL.
                 unsafe {
-                    buffer.set_len(len);
+                    buffer.set_len(len + 1);
                 }
 
                 // SAFETY:


### PR DESCRIPTION
CStr::len(), as used in backend::libc::termios::syscalls::ttyname, does not include the trailing NUL.  But CString::from_vec_with_nul_unchecked requires the NUL to be present.  Without it, it drops off the last character from the string.  This led to it returning paths like "/dev/pts/" instead of "/dev/pts/8".

Tested on FreeBSD and Linux x86_64