### PR TITLE
Support MIPS R6 targets in ioctl/linux.rs

### DIFF
--- a/src/ioctl/linux.rs
+++ b/src/ioctl/linux.rs
@@ -64,7 +64,9 @@ mod consts {
 
 #[cfg(any(
     target_arch = "mips",
+    target_arch = "mips32r6",
     target_arch = "mips64",
+    target_arch = "mips64r6",
     target_arch = "powerpc",
     target_arch = "powerpc64",
     target_arch = "sparc",


### PR DESCRIPTION
To fix a regression introduced by this new piece of code on these tier-3 targets.