### PR TITLE
Add `IORING_ENTER_REGISTERED_RING` flag

### DIFF
--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -121,6 +121,9 @@ bitflags::bitflags! {
         /// `IORING_ENTER_EXT_ARG`
         const EXT_ARG = sys::IORING_ENTER_EXT_ARG;
 
+        /// `IORING_ENTER_REGISTERED_RING`
+        const REGISTERED_RING = sys::IORING_ENTER_REGISTERED_RING;
+
         /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
         const _ = !0;
     }


### PR DESCRIPTION
Adds the `IORING_ENTER_REGISTERED_RING` flag to `rustix::io_uring::IoringEnterFlags`.

Resources: [`io_uring_enter(2)`](https://man7.org/linux/man-pages/man2/io_uring_enter.2.html), [liburing](https://github.com/axboe/liburing/blob/master/src/include/liburing/io_uring.h#L457)