### PR TITLE
Fix no_std compilation on AIX.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -213,10 +213,13 @@ jobs:
     - run: cargo check -Z build-std --target=riscv32imc-esp-espidf --features=all-apis
     - run: cargo check -Z build-std --target=aarch64-unknown-nto-qnx710 --features=all-apis
     - run: cargo check -Z build-std --target=x86_64-pc-nto-qnx710 --features=all-apis
+    # `std` doesn't appear to build on AIX yet, so test in `no_std` mode.
+    - run: cargo check -Zbuild-std=core,alloc --target=powerpc64-ibm-aix --features=all-apis --no-default-features
     # Disable MIPS entirely for now as it fails with errors like
     # "Undefined temporary symbol $BB342_17".
     #- run: cargo check -Z build-std --target=mipsel-unknown-linux-gnu --features=all-apis
     #- run: cargo check -Z build-std --target=mips64el-unknown-linux-gnuabi64 --features=all-apis
+
 
   test:
     name: Test

--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -113,13 +113,15 @@ pub(super) use libc::open64 as open;
 pub(super) use libc::posix_fallocate64 as posix_fallocate;
 #[cfg(any(all(linux_like, not(target_os = "android")), target_os = "aix"))]
 pub(super) use libc::{blkcnt64_t as blkcnt_t, rlim64_t as rlim_t};
+// TODO: AIX has `stat64x`, `fstat64x`, `lstat64x`, and `stat64xat`; add them
+// to the upstream libc crate and implement rustix's `statat` etc. with them.
 #[cfg(target_os = "aix")]
 pub(super) use libc::{
     blksize64_t as blksize_t, fstat64 as fstat, fstatfs64 as fstatfs, fstatvfs64 as fstatvfs,
     ftruncate64 as ftruncate, getrlimit64 as getrlimit, ino_t, lseek64 as lseek, mmap,
     off64_t as off_t, openat, posix_fadvise64 as posix_fadvise, preadv, pwritev,
-    rlimit64 as rlimit, setrlimit64 as setrlimit, stat64at as fstatat, statfs64 as statfs,
-    statvfs64 as statvfs, RLIM_INFINITY,
+    rlimit64 as rlimit, setrlimit64 as setrlimit, statfs64 as statfs, statvfs64 as statvfs,
+    RLIM_INFINITY,
 };
 #[cfg(linux_like)]
 pub(super) use libc::{

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -618,7 +618,7 @@ pub(crate) fn lstat(path: &CStr) -> io::Result<Stat> {
     }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "redox")))]
+#[cfg(not(any(target_os = "aix", target_os = "espidf", target_os = "redox")))]
 pub(crate) fn statat(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io::Result<Stat> {
     // See the comments in `fstat` about using `crate::fs::statx` here.
     #[cfg(all(

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -523,6 +523,7 @@ impl FileType {
     /// Construct a `FileType` from the `d_type` field of a `c::dirent`.
     #[cfg(not(any(
         solarish,
+        target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",

--- a/src/backend/libc/net/syscalls.rs
+++ b/src/backend/libc/net/syscalls.rs
@@ -525,6 +525,7 @@ pub(crate) mod sockopt {
         apple,
         solarish,
         windows,
+        target_os = "aix",
         target_os = "dragonfly",
         target_os = "emscripten",
         target_os = "espidf",

--- a/src/clockid.rs
+++ b/src/clockid.rs
@@ -11,9 +11,8 @@ use crate::fd::BorrowedFd;
 /// [`clock_gettime`]: crate::time::clock_gettime
 #[cfg(not(any(apple, target_os = "wasi")))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(not(any(target_os = "aix", target_os = "dragonfly")), repr(i32))]
+#[cfg_attr(not(target_os = "dragonfly"), repr(i32))]
 #[cfg_attr(target_os = "dragonfly", repr(u64))]
-#[cfg_attr(target_os = "aix", repr(i64))]
 #[non_exhaustive]
 pub enum ClockId {
     /// `CLOCK_REALTIME`

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -12,6 +12,8 @@ use crate::fs::CloneFlags;
 use crate::fs::FileType;
 #[cfg(linux_kernel)]
 use crate::fs::RenameFlags;
+#[cfg(not(any(target_os = "aix", target_os = "espidf")))]
+use crate::fs::Stat;
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 use crate::fs::{Gid, Uid};
 use crate::fs::{Mode, OFlags};
@@ -26,7 +28,7 @@ use {
 };
 #[cfg(not(target_os = "espidf"))]
 use {
-    crate::fs::{Access, AtFlags, Stat, Timestamps},
+    crate::fs::{Access, AtFlags, Timestamps},
     crate::timespec::Nsecs,
 };
 
@@ -288,7 +290,8 @@ pub fn symlinkat<P: path::Arg, Q: path::Arg, Fd: AsFd>(
 /// [Linux]: https://man7.org/linux/man-pages/man2/fstatat.2.html
 /// [`Mode::from_raw_mode`]: crate::fs::Mode::from_raw_mode
 /// [`FileType::from_raw_mode`]: crate::fs::FileType::from_raw_mode
-#[cfg(not(target_os = "espidf"))]
+// TODO: Add `stat64xat` to upstream libc bindings and reenable this for AIX.
+#[cfg(not(any(target_os = "aix", target_os = "espidf")))]
 #[inline]
 #[doc(alias = "fstatat")]
 pub fn statat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, flags: AtFlags) -> io::Result<Stat> {

--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -318,8 +318,9 @@ type _RawOpcode = c::c_int;
 #[cfg(any(apple, bsd, target_os = "redox", target_os = "haiku"))]
 type _RawOpcode = c::c_ulong;
 
-// Solaris, Fuchsia, Emscripten and WASI use an int
+// AIX, Solaris, Fuchsia, Emscripten and WASI use an int
 #[cfg(any(
+    target_os = "aix",
     target_os = "solaris",
     target_os = "illumos",
     target_os = "fuchsia",

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -10,6 +10,7 @@
     apple,
     solarish,
     windows,
+    target_os = "aix",
     target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "espidf",

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -7,7 +7,7 @@ mod chroot;
 mod exit;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have get[gpu]id.
 mod id;
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "aix", target_os = "espidf")))]
 mod ioctl;
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 mod kill;
@@ -45,7 +45,7 @@ pub use chroot::*;
 pub use exit::*;
 #[cfg(not(target_os = "wasi"))]
 pub use id::*;
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "aix", target_os = "espidf")))]
 pub use ioctl::*;
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 pub use kill::*;


### PR DESCRIPTION
`std` doesn't appear to build on AIX currently, but `-Z build-std=core,alloc` does, so add that as a CI check, and fix the errors it turns up.

AIX has `stat64xat` and others which we could use, but they're not in the upstream `libc` crate bindings yet, so disable `statat` on AIX for now.