### PR TITLE
Miscellaneous cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ once_cell = { version = "1.5.2", optional = true }
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
 linux-raw-sys = { version = "0.4.7", default-features = false, features = ["general", "errno", "ioctl", "no_std", "elf"] }
 libc_errno = { package = "errno", version = "0.3.1", default-features = false, optional = true }
-libc = { version = "0.2.147", default-features = false, features = ["extra_traits"], optional = true }
+libc = { version = "0.2.148", default-features = false, features = ["extra_traits"], optional = true }
 
 # Dependencies for platforms where only libc is supported:
 #
@@ -46,7 +46,7 @@ libc = { version = "0.2.147", default-features = false, features = ["extra_trait
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.1", default-features = false }
-libc = { version = "0.2.147", default-features = false, features = ["extra_traits"] }
+libc = { version = "0.2.148", default-features = false, features = ["extra_traits"] }
 
 # Additional dependencies for Linux with the libc backend:
 #
@@ -74,7 +74,7 @@ default-features = false
 
 [dev-dependencies]
 tempfile = "3.5.0"
-libc = "0.2.147"
+libc = "0.2.148"
 libc_errno = { package = "errno", version = "0.3.1", default-features = false }
 serial_test = "2.0.0"
 memoffset = "0.9.0"

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -125,7 +125,7 @@ mod suite {
             b.iter(|| {
                 let mut s = std::mem::MaybeUninit::<libc::stat>::uninit();
                 unsafe {
-                    assert_eq!(libc::fstat(libc::STDIN_FILENO, s.as_mut_ptr(),), 0);
+                    assert_eq!(libc::fstat(libc::STDIN_FILENO, s.as_mut_ptr()), 0);
                 }
             })
         });

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -92,63 +92,63 @@ bitflags! {
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct Mode: RawMode {
         /// `S_IRWXU`
-        #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have Unix-style mode flags.
+        #[cfg(not(target_os = "espidf"))]
         const RWXU = c::S_IRWXU as RawMode;
 
         /// `S_IRUSR`
-        #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have Unix-style mode flags.
+        #[cfg(not(target_os = "espidf"))]
         const RUSR = c::S_IRUSR as RawMode;
 
         /// `S_IWUSR`
-        #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have Unix-style mode flags.
+        #[cfg(not(target_os = "espidf"))]
         const WUSR = c::S_IWUSR as RawMode;
 
         /// `S_IXUSR`
-        #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have Unix-style mode flags.
+        #[cfg(not(target_os = "espidf"))]
         const XUSR = c::S_IXUSR as RawMode;
 
         /// `S_IRWXG`
-        #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have Unix-style mode flags.
+        #[cfg(not(target_os = "espidf"))]
         const RWXG = c::S_IRWXG as RawMode;
 
         /// `S_IRGRP`
-        #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have Unix-style mode flags.
+        #[cfg(not(target_os = "espidf"))]
         const RGRP = c::S_IRGRP as RawMode;
 
         /// `S_IWGRP`
-        #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have Unix-style mode flags.
+        #[cfg(not(target_os = "espidf"))]
         const WGRP = c::S_IWGRP as RawMode;
 
         /// `S_IXGRP`
-        #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have Unix-style mode flags.
+        #[cfg(not(target_os = "espidf"))]
         const XGRP = c::S_IXGRP as RawMode;
 
         /// `S_IRWXO`
-        #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have Unix-style mode flags.
+        #[cfg(not(target_os = "espidf"))]
         const RWXO = c::S_IRWXO as RawMode;
 
         /// `S_IROTH`
-        #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have Unix-style mode flags.
+        #[cfg(not(target_os = "espidf"))]
         const ROTH = c::S_IROTH as RawMode;
 
         /// `S_IWOTH`
-        #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have Unix-style mode flags.
+        #[cfg(not(target_os = "espidf"))]
         const WOTH = c::S_IWOTH as RawMode;
 
         /// `S_IXOTH`
-        #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have Unix-style mode flags.
+        #[cfg(not(target_os = "espidf"))]
         const XOTH = c::S_IXOTH as RawMode;
 
         /// `S_ISUID`
-        #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have Unix-style mode flags.
+        #[cfg(not(target_os = "espidf"))]
         const SUID = c::S_ISUID as RawMode;
 
         /// `S_ISGID`
-        #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have Unix-style mode flags.
+        #[cfg(not(target_os = "espidf"))]
         const SGID = c::S_ISGID as RawMode;
 
         /// `S_ISVTX`
-        #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have Unix-style mode flags.
+        #[cfg(not(target_os = "espidf"))]
         const SVTX = c::S_ISVTX as RawMode;
 
         /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>

--- a/src/backend/libc/net/syscalls.rs
+++ b/src/backend/libc/net/syscalls.rs
@@ -523,7 +523,6 @@ pub(crate) mod sockopt {
     use crate::net::sockopt::Timeout;
     #[cfg(not(any(
         apple,
-        solarish,
         windows,
         target_os = "aix",
         target_os = "dragonfly",
@@ -532,7 +531,6 @@ pub(crate) mod sockopt {
         target_os = "haiku",
         target_os = "netbsd",
         target_os = "nto",
-        target_os = "openbsd"
     )))]
     use crate::net::AddressFamily;
     use crate::net::{Ipv4Addr, Ipv6Addr, SocketType};
@@ -835,7 +833,6 @@ pub(crate) mod sockopt {
     #[inline]
     #[cfg(not(any(
         apple,
-        solarish,
         windows,
         target_os = "aix",
         target_os = "dragonfly",
@@ -844,7 +841,6 @@ pub(crate) mod sockopt {
         target_os = "haiku",
         target_os = "netbsd",
         target_os = "nto",
-        target_os = "openbsd"
     )))]
     pub(crate) fn get_socket_domain(fd: BorrowedFd<'_>) -> io::Result<AddressFamily> {
         let domain: c::c_int = getsockopt(fd, c::SOL_SOCKET as _, c::SO_DOMAIN)?;

--- a/src/backend/linux_raw/arch/x86.rs
+++ b/src/backend/linux_raw/arch/x86.rs
@@ -163,7 +163,6 @@ pub(in crate::backend) unsafe fn indirect_syscall5(
     FromAsm::from_asm(r0)
 }
 
-#[allow(clippy::too_many_arguments)]
 #[inline]
 pub(in crate::backend) unsafe fn indirect_syscall6(
     callee: SyscallType,

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -40,7 +40,6 @@ pub(crate) use linux_raw_sys::general::{
     XATTR_REPLACE,
 };
 
-#[allow(unused)]
 pub(crate) use linux_raw_sys::ioctl::{BLKPBSZGET, BLKSSZGET, FICLONE};
 
 #[cfg(feature = "io_uring")]

--- a/src/backend/linux_raw/event/syscalls.rs
+++ b/src/backend/linux_raw/event/syscalls.rs
@@ -3,8 +3,7 @@
 //! # Safety
 //!
 //! See the `rustix::backend` module documentation for details.
-#![allow(unsafe_code)]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::c;
 use crate::backend::conv::{c_int, c_uint, ret_owned_fd, ret_usize, slice_mut};

--- a/src/backend/linux_raw/io_uring/syscalls.rs
+++ b/src/backend/linux_raw/io_uring/syscalls.rs
@@ -3,8 +3,7 @@
 //! # Safety
 //!
 //! See the `rustix::backend::syscalls` module documentation for details.
-#![allow(unsafe_code)]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::conv::{by_mut, c_uint, pass_usize, ret_c_uint, ret_owned_fd};
 use crate::fd::{BorrowedFd, OwnedFd};

--- a/src/backend/linux_raw/net/syscalls.rs
+++ b/src/backend/linux_raw/net/syscalls.rs
@@ -3,8 +3,7 @@
 //! # Safety
 //!
 //! See the `rustix::backend` module documentation for details.
-#![allow(unsafe_code)]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
 use super::msghdr::{
     with_noaddr_msghdr, with_recv_msghdr, with_unix_msghdr, with_v4_msghdr, with_v6_msghdr,

--- a/src/backend/linux_raw/pid/syscalls.rs
+++ b/src/backend/linux_raw/pid/syscalls.rs
@@ -3,8 +3,7 @@
 //! # Safety
 //!
 //! See the `rustix::backend` module documentation for details.
-#![allow(unsafe_code)]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::conv::ret_usize_infallible;
 use crate::pid::{Pid, RawPid};

--- a/src/backend/linux_raw/pipe/syscalls.rs
+++ b/src/backend/linux_raw/pipe/syscalls.rs
@@ -3,8 +3,7 @@
 //! # Safety
 //!
 //! See the `rustix::backend` module documentation for details.
-#![allow(unsafe_code)]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::conv::{c_int, c_uint, opt_mut, pass_usize, ret, ret_usize, slice};
 use crate::backend::{c, MAX_IOV};

--- a/src/backend/linux_raw/prctl/syscalls.rs
+++ b/src/backend/linux_raw/prctl/syscalls.rs
@@ -3,8 +3,7 @@
 //! # Safety
 //!
 //! See the `rustix::backend` module documentation for details.
-#![allow(unsafe_code)]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::c;
 use crate::backend::conv::{c_int, ret_c_int};

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -3,8 +3,7 @@
 //! # Safety
 //!
 //! See the `rustix::backend` module documentation for details.
-#![allow(unsafe_code)]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
 use super::types::RawCpuSet;
 use crate::backend::c;

--- a/src/backend/linux_raw/pty/syscalls.rs
+++ b/src/backend/linux_raw/pty/syscalls.rs
@@ -3,8 +3,7 @@
 //! # Safety
 //!
 //! See the `rustix::backend` module documentation for details.
-#![allow(unsafe_code)]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::conv::{by_ref, c_uint, ret};
 use crate::fd::BorrowedFd;

--- a/src/backend/linux_raw/rand/syscalls.rs
+++ b/src/backend/linux_raw/rand/syscalls.rs
@@ -3,8 +3,7 @@
 //! # Safety
 //!
 //! See the `rustix::backend` module documentation for details.
-#![allow(unsafe_code)]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::conv::{ret_usize, slice_mut};
 use crate::io;

--- a/src/backend/linux_raw/runtime/syscalls.rs
+++ b/src/backend/linux_raw/runtime/syscalls.rs
@@ -3,8 +3,7 @@
 //! # Safety
 //!
 //! See the `rustix::backend` module documentation for details.
-#![allow(unsafe_code)]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::c;
 #[cfg(target_arch = "x86")]

--- a/src/backend/linux_raw/system/syscalls.rs
+++ b/src/backend/linux_raw/system/syscalls.rs
@@ -3,8 +3,7 @@
 //! # Safety
 //!
 //! See the `rustix::backend` module documentation for details.
-#![allow(unsafe_code)]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
 use super::types::RawUname;
 use crate::backend::conv::{ret, ret_infallible, slice};

--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -3,8 +3,7 @@
 //! # Safety
 //!
 //! See the `rustix::backend` module documentation for details.
-#![allow(unsafe_code)]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::c;
 use crate::backend::conv::{by_ref, c_uint, ret};
@@ -230,7 +229,6 @@ pub(crate) fn isatty(fd: BorrowedFd<'_>) -> bool {
 }
 
 #[cfg(all(feature = "alloc", feature = "procfs"))]
-#[allow(unsafe_code)]
 pub(crate) fn ttyname(fd: BorrowedFd<'_>, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
     let fd_stat = crate::backend::fs::syscalls::fstat(fd)?;
 

--- a/src/backend/linux_raw/thread/syscalls.rs
+++ b/src/backend/linux_raw/thread/syscalls.rs
@@ -3,8 +3,7 @@
 //! # Safety
 //!
 //! See the `rustix::backend` module documentation for details.
-#![allow(unsafe_code)]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::c;
 use crate::backend::conv::{

--- a/src/backend/linux_raw/time/syscalls.rs
+++ b/src/backend/linux_raw/time/syscalls.rs
@@ -3,8 +3,7 @@
 //! # Safety
 //!
 //! See the `rustix::backend` module documentation for details.
-#![allow(unsafe_code)]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::conv::{ret, ret_infallible};
 use crate::clockid::ClockId;

--- a/src/backend/linux_raw/ugid/syscalls.rs
+++ b/src/backend/linux_raw/ugid/syscalls.rs
@@ -3,8 +3,7 @@
 //! # Safety
 //!
 //! See the `rustix::backend` module documentation for details.
-#![allow(unsafe_code)]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::c;
 use crate::backend::conv::ret_usize_infallible;

--- a/src/bitcast.rs
+++ b/src/bitcast.rs
@@ -1,6 +1,7 @@
+#![allow(unused_macros)]
+
 // Ensure that the source and destination types are both primitive integer
 // types and the same size, and then bitcast.
-#[allow(unused_macros)]
 macro_rules! bitcast {
     ($x:expr) => {{
         if false {
@@ -24,7 +25,6 @@ macro_rules! bitcast {
 
 /// Return a [`bitcast`] of the value of `$x.bits()`, where `$x` is a
 /// `bitflags` type.
-#[allow(unused_macros)]
 macro_rules! bitflags_bits {
     ($x:expr) => {{
         bitcast!($x.bits())

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -256,7 +256,7 @@ pub(crate) fn _is_file_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)
     let mode = backend::fs::syscalls::fcntl_getfl(fd)?;
 
     // Check for `O_PATH`.
-    #[cfg(any(linux_kernel, target_os = "fuchsia", target_os = "emscripten"))]
+    #[cfg(any(linux_kernel, target_os = "emscripten", target_os = "fuchsia"))]
     if mode.contains(OFlags::PATH) {
         return Ok((false, false));
     }

--- a/src/ioctl/patterns.rs
+++ b/src/ioctl/patterns.rs
@@ -166,37 +166,37 @@ impl<const OPCODE: RawOpcode> CompileTimeOpcode for BadOpcode<OPCODE> {
 }
 
 /// Provides a read code at compile time.
-#[cfg(any(linux_kernel, apple, bsd))]
+#[cfg(any(linux_kernel, bsd))]
 pub struct ReadOpcode<const GROUP: u8, const NUM: u8, Data>(Data);
 
-#[cfg(any(linux_kernel, apple, bsd))]
+#[cfg(any(linux_kernel, bsd))]
 impl<const GROUP: u8, const NUM: u8, Data> CompileTimeOpcode for ReadOpcode<GROUP, NUM, Data> {
     const OPCODE: Opcode = Opcode::read::<Data>(GROUP, NUM);
 }
 
 /// Provides a write code at compile time.
-#[cfg(any(linux_kernel, apple, bsd))]
+#[cfg(any(linux_kernel, bsd))]
 pub struct WriteOpcode<const GROUP: u8, const NUM: u8, Data>(Data);
 
-#[cfg(any(linux_kernel, apple, bsd))]
+#[cfg(any(linux_kernel, bsd))]
 impl<const GROUP: u8, const NUM: u8, Data> CompileTimeOpcode for WriteOpcode<GROUP, NUM, Data> {
     const OPCODE: Opcode = Opcode::write::<Data>(GROUP, NUM);
 }
 
 /// Provides a read/write code at compile time.
-#[cfg(any(linux_kernel, apple, bsd))]
+#[cfg(any(linux_kernel, bsd))]
 pub struct ReadWriteOpcode<const GROUP: u8, const NUM: u8, Data>(Data);
 
-#[cfg(any(linux_kernel, apple, bsd))]
+#[cfg(any(linux_kernel, bsd))]
 impl<const GROUP: u8, const NUM: u8, Data> CompileTimeOpcode for ReadWriteOpcode<GROUP, NUM, Data> {
     const OPCODE: Opcode = Opcode::read_write::<Data>(GROUP, NUM);
 }
 
 /// Provides a `None` code at compile time.
-#[cfg(any(linux_kernel, apple, bsd))]
+#[cfg(any(linux_kernel, bsd))]
 pub struct NoneOpcode<const GROUP: u8, const NUM: u8, Data>(Data);
 
-#[cfg(any(linux_kernel, apple, bsd))]
+#[cfg(any(linux_kernel, bsd))]
 impl<const GROUP: u8, const NUM: u8, Data> CompileTimeOpcode for NoneOpcode<GROUP, NUM, Data> {
     const OPCODE: Opcode = Opcode::none::<Data>(GROUP, NUM);
 }

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -8,7 +8,6 @@
 
 #[cfg(not(any(
     apple,
-    solarish,
     windows,
     target_os = "aix",
     target_os = "dragonfly",
@@ -17,7 +16,6 @@
     target_os = "haiku",
     target_os = "netbsd",
     target_os = "nto",
-    target_os = "openbsd"
 )))]
 use crate::net::AddressFamily;
 use crate::net::{Ipv4Addr, Ipv6Addr, SocketType};
@@ -796,10 +794,8 @@ pub fn get_socket_send_buffer_size<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
 /// [illumos]: https://illumos.org/man/3SOCKET/getsockopt
 /// [glibc `getsockopt`]: https://www.gnu.org/software/libc/manual/html_node/Socket-Option-Functions.html
 /// [glibc `SOL_SOCKET` options]: https://www.gnu.org/software/libc/manual/html_node/Socket_002dLevel-Options.html
-// TODO: OpenBSD and Solarish support submitted upstream: https://github.com/rust-lang/libc/pull/3316
 #[cfg(not(any(
     apple,
-    solarish,
     windows,
     target_os = "aix",
     target_os = "dragonfly",
@@ -808,7 +804,6 @@ pub fn get_socket_send_buffer_size<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
     target_os = "haiku",
     target_os = "netbsd",
     target_os = "nto",
-    target_os = "openbsd"
 )))]
 #[inline]
 #[doc(alias = "SO_DOMAIN")]

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -176,7 +176,7 @@ impl WaitidStatus {
     /// Returns the number of the signal that stopped the process,
     /// if the process was stopped by a signal.
     #[inline]
-    #[cfg(not(any(target_os = "netbsd", target_os = "fuchsia", target_os = "emscripten")))]
+    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
     pub fn stopping_signal(&self) -> Option<u32> {
         if self.stopped() {
             Some(self.si_status() as _)
@@ -188,7 +188,7 @@ impl WaitidStatus {
     /// Returns the number of the signal that trapped the process,
     /// if the process was trapped by a signal.
     #[inline]
-    #[cfg(not(any(target_os = "netbsd", target_os = "fuchsia", target_os = "emscripten")))]
+    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
     pub fn trapping_signal(&self) -> Option<u32> {
         if self.trapped() {
             Some(self.si_status() as _)
@@ -200,7 +200,7 @@ impl WaitidStatus {
     /// Returns the exit status number returned by the process,
     /// if it exited normally.
     #[inline]
-    #[cfg(not(any(target_os = "netbsd", target_os = "fuchsia", target_os = "emscripten")))]
+    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
     pub fn exit_status(&self) -> Option<u32> {
         if self.exited() {
             Some(self.si_status() as _)
@@ -212,7 +212,7 @@ impl WaitidStatus {
     /// Returns the number of the signal that terminated the process,
     /// if the process was terminated by a signal.
     #[inline]
-    #[cfg(not(any(target_os = "netbsd", target_os = "fuchsia", target_os = "emscripten")))]
+    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
     pub fn terminating_signal(&self) -> Option<u32> {
         if self.killed() || self.dumped() {
             Some(self.si_status() as _)
@@ -237,7 +237,7 @@ impl WaitidStatus {
         self.0.si_code
     }
 
-    #[cfg(not(any(target_os = "netbsd", target_os = "fuchsia", target_os = "emscripten")))]
+    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
     #[allow(unsafe_code)]
     fn si_status(&self) -> backend::c::c_int {
         // SAFETY: POSIX [specifies] that the `siginfo_t` returned by a

--- a/tests/io/main.rs
+++ b/tests/io/main.rs
@@ -10,5 +10,4 @@ mod from_into;
 mod ioctl;
 #[cfg(not(windows))]
 #[cfg(not(target_os = "redox"))] // redox doesn't have cwd/openat
-#[cfg(not(target_os = "wasi"))] // wasi support for `S_IRUSR` etc. submitted to libc in #2264
 mod read_write;

--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -51,7 +51,6 @@ fn test_sockopts_ipv4() {
     );
     #[cfg(not(any(
         apple,
-        solarish,
         windows,
         target_os = "dragonfly",
         target_os = "emscripten",
@@ -59,7 +58,6 @@ fn test_sockopts_ipv4() {
         target_os = "haiku",
         target_os = "netbsd",
         target_os = "nto",
-        target_os = "openbsd"
     )))]
     assert_eq!(
         rustix::net::sockopt::get_socket_domain(&s).unwrap(),

--- a/tests/process/wait.rs
+++ b/tests/process/wait.rs
@@ -47,7 +47,7 @@ fn test_waitid() {
         .unwrap();
 
     assert!(status.stopped());
-    #[cfg(not(any(target_os = "netbsd", target_os = "fuchsia")))]
+    #[cfg(not(any(target_os = "fuchsia", target_os = "netbsd")))]
     assert_eq!(status.stopping_signal(), Some(SIGSTOP as _));
 
     unsafe { kill(child.id() as _, SIGCONT) };
@@ -76,7 +76,7 @@ fn test_waitid() {
     .unwrap();
 
     assert!(status.killed());
-    #[cfg(not(any(target_os = "netbsd", target_os = "fuchsia")))]
+    #[cfg(not(any(target_os = "fuchsia", target_os = "netbsd")))]
     assert_eq!(status.terminating_signal(), Some(SIGKILL as _));
 
     let status = process::waitid(process::WaitId::Pid(pid), process::WaitidOptions::EXITED)
@@ -84,6 +84,6 @@ fn test_waitid() {
         .unwrap();
 
     assert!(status.killed());
-    #[cfg(not(any(target_os = "netbsd", target_os = "fuchsia")))]
+    #[cfg(not(any(target_os = "fuchsia", target_os = "netbsd")))]
     assert_eq!(status.terminating_signal(), Some(SIGKILL as _));
 }


### PR DESCRIPTION
 - Update to libc 0.2.148, which has `SO_DOMAIN` for OpenBSD and Solarish.
 - Enable `Mode` constants on WASI, which now defines them.
 - Simplify some `cfg`s and `allow`s.