### PR TITLE
On PowerPC, when handling QEMU's `TCGETS2`, handle `B0`.

### DIFF
--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -63,7 +63,11 @@ pub(crate) fn tcgetattr(fd: BorrowedFd<'_>) -> io::Result<Termios> {
             if result.input_speed == 0
                 && ((result.control_modes.bits() & c::CIBAUD) >> c::IBSHIFT) != c::BOTHER
             {
-                if let Some(input_speed) =
+                // For input speeds, `B0` is special-cased to mean the input
+                // speed is the same as the output speed.
+                if ((result.control_modes.bits() & c::CIBAUD) >> c::IBSHIFT) == c::B0 {
+                    result.input_speed = result.output_speed;
+                } else if let Some(input_speed) =
                     speed::decode((result.control_modes.bits() & c::CIBAUD) >> c::IBSHIFT)
                 {
                     result.input_speed = input_speed;


### PR DESCRIPTION
Linux uses an input speed of `B0` to mean that the input speed is the same as the output speed. Add that logic to rustix's code to work around QEMU's handling of `TCGETS2` on PowerPC.