### PR TITLE
Add a way to way to wait for process groups.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ To keep compile times low, most features in rustix's API are behind cargo
 features. A special feature, `all-apis` enables all APIs, which is useful
 for testing.
 
-```
+```console
 cargo test --features=all-apis
 ```
 
@@ -17,7 +17,7 @@ And, rustix has two backends, linux_raw and libc, and only one is used in
 any given build. To test with the libc backend explicitly, additionally
 enable the `use-libc` feature:
 
-```
+```console
 cargo test --features=all-apis,use-libc
 ```
 

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -90,7 +90,7 @@ pub(crate) const EXIT_SIGNALED_SIGABRT: c_int = 128 + linux_raw_sys::general::SI
 pub(crate) use linux_raw_sys::{
     general::{
         CLD_CONTINUED, CLD_DUMPED, CLD_EXITED, CLD_KILLED, CLD_STOPPED, CLD_TRAPPED,
-        O_NONBLOCK as PIDFD_NONBLOCK, P_ALL, P_PID, P_PIDFD,
+        O_NONBLOCK as PIDFD_NONBLOCK, P_ALL, P_PGID, P_PID, P_PIDFD,
     },
     ioctl::TIOCSCTTY,
 };


### PR DESCRIPTION
When the `Pid` type changed to only accept positive pid values, the `waitpid` function became unable to wait for process groups, because that involves negative pids. Fully fixing this will require a semver bump, but for now, we can add a new `waitpgid` function to add support for waiting for a process group.

Also add a `Pgid` arm to `WaitId`, to support waiting for process groups from `waitid` as well.