### PR TITLE
Add wrappers for `SO_PEERCRED` and `SCM_CREDENTIALS`

### DIFF
--- a/src/backend/libc/net/sockopt.rs
+++ b/src/backend/libc/net/sockopt.rs
@@ -44,11 +44,11 @@ use crate::net::Protocol;
     target_env = "newlib"
 ))]
 use crate::net::RawProtocol;
-#[cfg(linux_kernel)]
-use crate::net::SocketAddrV6;
 use crate::net::{Ipv4Addr, Ipv6Addr, SocketType};
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 use crate::net::{SocketAddrAny, SocketAddrStorage, SocketAddrV4};
+#[cfg(linux_kernel)]
+use crate::net::{SocketAddrV6, UCred};
 use crate::utils::as_mut_ptr;
 #[cfg(feature = "alloc")]
 #[cfg(any(
@@ -946,6 +946,12 @@ pub(crate) fn set_tcp_cork(fd: BorrowedFd<'_>, value: bool) -> io::Result<()> {
 #[inline]
 pub(crate) fn get_tcp_cork(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::IPPROTO_TCP, c::TCP_CORK).map(to_bool)
+}
+
+#[cfg(linux_kernel)]
+#[inline]
+pub(crate) fn get_socket_peercred(fd: BorrowedFd<'_>) -> io::Result<UCred> {
+    getsockopt(fd, c::SOL_SOCKET as _, c::SO_PEERCRED)
 }
 
 #[inline]

--- a/src/backend/linux_raw/net/sockopt.rs
+++ b/src/backend/linux_raw/net/sockopt.rs
@@ -12,6 +12,7 @@ use crate::fd::BorrowedFd;
 use crate::ffi::CStr;
 use crate::io;
 use crate::net::sockopt::Timeout;
+use crate::net::UCred;
 use crate::net::{
     AddressFamily, Ipv4Addr, Ipv6Addr, Protocol, RawProtocol, SocketAddrAny, SocketAddrStorage,
     SocketAddrV4, SocketAddrV6, SocketType,
@@ -793,6 +794,12 @@ pub(crate) fn set_tcp_cork(fd: BorrowedFd<'_>, value: bool) -> io::Result<()> {
 pub(crate) fn get_tcp_cork(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::IPPROTO_TCP, c::TCP_CORK).map(to_bool)
 }
+
+#[inline]
+pub(crate) fn get_socket_peercred(fd: BorrowedFd<'_>) -> io::Result<UCred> {
+    getsockopt(fd, c::SOL_SOCKET as _, linux_raw_sys::net::SO_PEERCRED)
+}
+
 #[inline]
 fn to_ip_mreq(multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> c::ip_mreq {
     c::ip_mreq {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,8 @@ mod clockid;
     feature = "runtime",
     feature = "termios",
     feature = "thread",
-    all(bsd, feature = "event")
+    all(bsd, feature = "event"),
+    all(linux_kernel, feature = "net")
 ))]
 mod pid;
 #[cfg(any(feature = "process", feature = "thread"))]
@@ -378,6 +379,7 @@ mod timespec;
             feature = "time",
             target_arch = "x86",
         )
-    )
+    ),
+    all(linux_kernel, feature = "net")
 ))]
 mod ugid;

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -1346,6 +1346,18 @@ pub fn get_tcp_cork<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
     backend::net::sockopt::get_tcp_cork(fd.as_fd())
 }
 
+/// Get credentials of Unix domain socket peer process
+///
+/// # References
+///  - [Linux `unix`]
+///
+/// [Linux `unix`]: https://man7.org/linux/man-pages/man7/unix.7.html
+#[cfg(linux_kernel)]
+#[doc(alias = "SO_PEERCRED")]
+pub fn get_socket_peercred<Fd: AsFd>(fd: Fd) -> io::Result<super::UCred> {
+    backend::net::sockopt::get_socket_peercred(fd.as_fd())
+}
+
 #[test]
 fn test_sizes() {
     use c::c_int;

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1336,6 +1336,25 @@ bitflags! {
     }
 }
 
+/// UNIX credentials of socket peer, for use with [`get_socket_peercred`]
+/// [`SendAncillaryMessage::ScmCredentials`] and
+/// [`RecvAncillaryMessage::ScmCredentials`].
+///
+/// [`get_socket_peercred`]: crate::net::sockopt::get_socket_peercred
+/// [`SendAncillaryMessage::ScmCredentials`]: crate::net::SendAncillaryMessage::ScmCredentials
+/// [`RecvAncillaryMessage::ScmCredentials`]: crate::net::RecvAncillaryMessage::ScmCredentials
+#[cfg(linux_kernel)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[repr(C)]
+pub struct UCred {
+    /// Process ID of peer
+    pub pid: crate::pid::Pid,
+    /// User ID of peer
+    pub uid: crate::ugid::Uid,
+    /// Group ID of peer
+    pub gid: crate::ugid::Gid,
+}
+
 #[test]
 fn test_sizes() {
     use c::c_int;
@@ -1361,4 +1380,7 @@ fn test_sizes() {
         let t: Option<Protocol> = Some(Protocol::from_raw(RawProtocol::new(4567).unwrap()));
         assert_eq!(4567_u32, transmute::<Option<Protocol>, u32>(t));
     }
+
+    #[cfg(linux_kernel)]
+    assert_eq_size!(UCred, libc::ucred);
 }


### PR DESCRIPTION
I still need to test this to make  sure it works properly. Particularly the `SCM_CREDENTIALS` part.

Apparently [FreeBSD](https://man.freebsd.org/cgi/man.cgi?query=unix&sektion=4), macOS, and DragonFlyBSD have `LOCAL_PEERCRED` which similar to `SO_PEERCRED` but with an array of groups. And likewise FreeBSD lists `SCM_CREDS` with a similar difference... There's also `getpeereid` on all BSDs but not Linux that gets uid and gid but not pid. 