### PR TITLE
Fix the `set`/`get_socket_timeout` timeout on linux_raw

### DIFF
--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -93,6 +93,22 @@ fn test_sockopts_ipv4() {
         );
     }
 
+    // Set a timeout with more than a million nanoseconds.
+    rustix::net::sockopt::set_socket_timeout(
+        &s,
+        rustix::net::sockopt::Timeout::Recv,
+        Some(Duration::new(1, 10000000)),
+    )
+    .unwrap();
+
+    // Check that we have a timeout of at least the time we set.
+    assert!(
+        rustix::net::sockopt::get_socket_timeout(&s, rustix::net::sockopt::Timeout::Recv)
+            .unwrap()
+            .unwrap()
+            >= Duration::new(1, 10000000)
+    );
+
     // Set the reuse address flag
     rustix::net::sockopt::set_socket_reuseaddr(&s, true).unwrap();
 


### PR DESCRIPTION
Fix the linux_raw backend to use `__kernel_sock_timeval` and `__kernel_old_timeval` for the send and recieve timeout socket options.