### PR TITLE
build.rs: fix mips32r6 detection for libc feature switch

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -94,8 +94,7 @@ fn main() {
         || !inline_asm_name_present
         || is_unsupported_abi
         || miri
-        || ((arch == "powerpc64" || arch == "mips" || arch == "mips64" || arch == "mips64r6")
-            && !rustix_use_experimental_asm);
+        || ((arch == "powerpc64" || arch.starts_with("mips")) && !rustix_use_experimental_asm);
     if libc {
         // Use the libc backend.
         use_feature("libc");


### PR DESCRIPTION
and simplify the logic since inline assembly support for all variants of MIPS is experimental only.