### PR TITLE
Fix procfs on /proc/self with user namespaces

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -1,7 +1,12 @@
 //! libc syscalls supporting `rustix::fs`.
 
 use crate::backend::c;
-#[cfg(any(apple, linux_kernel, feature = "alloc"))]
+#[cfg(any(
+    apple,
+    linux_kernel,
+    feature = "alloc",
+    all(linux_kernel, feature = "procfs")
+))]
 use crate::backend::conv::ret_usize;
 use crate::backend::conv::{borrowed_fd, c_str, ret, ret_c_int, ret_off_t, ret_owned_fd};
 use crate::fd::{BorrowedFd, OwnedFd};
@@ -258,7 +263,10 @@ pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     }
 }
 
-#[cfg(all(any(feature = "alloc", feature = "procfs"), not(target_os = "redox")))]
+#[cfg(all(
+    any(feature = "alloc", all(linux_kernel, feature = "procfs")),
+    not(target_os = "redox")
+))]
 #[inline]
 pub(crate) fn readlinkat(
     dirfd: BorrowedFd<'_>,

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -258,7 +258,7 @@ pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     }
 }
 
-#[cfg(all(feature = "alloc", not(target_os = "redox")))]
+#[cfg(all(any(feature = "alloc", feature = "procfs"), not(target_os = "redox")))]
 #[inline]
 pub(crate) fn readlinkat(
     dirfd: BorrowedFd<'_>,

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -951,7 +951,7 @@ pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     }
 }
 
-#[cfg(any(feature = "alloc", feature = "procfs"))]
+#[cfg(any(feature = "alloc", all(linux_kernel, feature = "procfs")))]
 #[inline]
 pub(crate) fn readlinkat(
     dirfd: BorrowedFd<'_>,

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -951,7 +951,7 @@ pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", feature = "procfs"))]
 #[inline]
 pub(crate) fn readlinkat(
     dirfd: BorrowedFd<'_>,

--- a/src/fs/raw_dir.rs
+++ b/src/fs/raw_dir.rs
@@ -43,10 +43,11 @@ impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
     /// ```
     /// # use std::mem::MaybeUninit;
     /// # use rustix::fs::{CWD, Mode, OFlags, openat, RawDir};
+    /// # use rustix::cstr;
     ///
     /// let fd = openat(
     ///     CWD,
-    ///     ".",
+    ///     cstr!("."),
     ///     OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
     ///     Mode::empty(),
     /// )
@@ -65,10 +66,11 @@ impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
     /// ```
     /// # use std::mem::MaybeUninit;
     /// # use rustix::fs::{CWD, Mode, OFlags, openat, RawDir};
+    /// # use rustix::cstr;
     ///
     /// let fd = openat(
     ///     CWD,
-    ///     ".",
+    ///     cstr!("."),
     ///     OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
     ///     Mode::empty(),
     /// )
@@ -92,10 +94,11 @@ impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
     /// # use std::mem::MaybeUninit;
     /// # use rustix::fs::{CWD, Mode, OFlags, openat, RawDir};
     /// # use rustix::io::Errno;
+    /// # use rustix::cstr;
     ///
     /// let fd = openat(
     ///     CWD,
-    ///     ".",
+    ///     cstr!("."),
     ///     OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
     ///     Mode::empty(),
     /// )


### PR DESCRIPTION
Use `readlink` on the /proc/self symlink instead of `getpid`, so that we get the pid relative to the procfs's pid namespace rather than the process' pid namespace.

Fixes #854.