### PR TITLE
Fix Linux custom ioctl opcode computation

### DIFF
--- a/src/ioctl/linux.rs
+++ b/src/ioctl/linux.rs
@@ -10,7 +10,7 @@ pub(super) const fn compose_opcode(
     num: RawOpcode,
     size: RawOpcode,
 ) -> RawOpcode {
-    macro_rules! shift_and_mask {
+    macro_rules! mask_and_shift {
         ($val:expr, $shift:expr, $mask:expr) => {{
             ($val & $mask) << $shift
         }};
@@ -23,10 +23,10 @@ pub(super) const fn compose_opcode(
         Direction::ReadWrite => READ | WRITE,
     };
 
-    shift_and_mask!(group, GROUP_SHIFT, GROUP_MASK)
-        | shift_and_mask!(num, NUM_SHIFT, NUM_MASK)
-        | shift_and_mask!(size, SIZE_SHIFT, SIZE_MASK)
-        | shift_and_mask!(dir, DIR_SHIFT, DIR_MASK)
+    mask_and_shift!(group, GROUP_SHIFT, GROUP_MASK)
+        | mask_and_shift!(num, NUM_SHIFT, NUM_MASK)
+        | mask_and_shift!(size, SIZE_SHIFT, SIZE_MASK)
+        | mask_and_shift!(dir, DIR_SHIFT, DIR_MASK)
 }
 
 const NUM_BITS: RawOpcode = 8;

--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -205,6 +205,8 @@ impl Opcode {
     }
 
     /// Create a new opcode from a direction, group, number and size.
+    ///
+    /// This corresponds to the C macro `_IOC(direction, group, number, size)`
     #[cfg(any(linux_kernel, bsd))]
     #[inline]
     pub const fn from_components(
@@ -227,6 +229,8 @@ impl Opcode {
 
     /// Create a new non-mutating opcode from a group, a number and the type of
     /// data.
+    ///
+    /// This corresponds to the C macro `_IO(group, number)` when `T` is zero sized.
     #[cfg(any(linux_kernel, bsd))]
     #[inline]
     pub const fn none<T>(group: u8, number: u8) -> Self {
@@ -235,6 +239,8 @@ impl Opcode {
 
     /// Create a new reading opcode from a group, a number and the type of
     /// data.
+    ///
+    /// This corresponds to the C macro `_IOR(group, number, T)`.
     #[cfg(any(linux_kernel, bsd))]
     #[inline]
     pub const fn read<T>(group: u8, number: u8) -> Self {
@@ -243,6 +249,8 @@ impl Opcode {
 
     /// Create a new writing opcode from a group, a number and the type of
     /// data.
+    ///
+    /// This corresponds to the C macro `_IOW(group, number, T)`.
     #[cfg(any(linux_kernel, bsd))]
     #[inline]
     pub const fn write<T>(group: u8, number: u8) -> Self {
@@ -251,6 +259,8 @@ impl Opcode {
 
     /// Create a new reading and writing opcode from a group, a number and the
     /// type of data.
+    ///
+    /// This corresponds to the C macro `_IOWR(group, number, T)`.
     #[cfg(any(linux_kernel, bsd))]
     #[inline]
     pub const fn read_write<T>(group: u8, number: u8) -> Self {

--- a/src/ioctl/patterns.rs
+++ b/src/ioctl/patterns.rs
@@ -166,6 +166,8 @@ impl<const OPCODE: RawOpcode> CompileTimeOpcode for BadOpcode<OPCODE> {
 }
 
 /// Provides a read code at compile time.
+///
+/// This corresponds to the C macro `_IOR(GROUP, NUM, Data)`.
 #[cfg(any(linux_kernel, bsd))]
 pub struct ReadOpcode<const GROUP: u8, const NUM: u8, Data>(Data);
 
@@ -175,6 +177,8 @@ impl<const GROUP: u8, const NUM: u8, Data> CompileTimeOpcode for ReadOpcode<GROU
 }
 
 /// Provides a write code at compile time.
+///
+/// This corresponds to the C macro `_IOW(GROUP, NUM, Data)`.
 #[cfg(any(linux_kernel, bsd))]
 pub struct WriteOpcode<const GROUP: u8, const NUM: u8, Data>(Data);
 
@@ -184,6 +188,8 @@ impl<const GROUP: u8, const NUM: u8, Data> CompileTimeOpcode for WriteOpcode<GRO
 }
 
 /// Provides a read/write code at compile time.
+///
+/// This corresponds to the C macro `_IOWR(GROUP, NUM, Data)`.
 #[cfg(any(linux_kernel, bsd))]
 pub struct ReadWriteOpcode<const GROUP: u8, const NUM: u8, Data>(Data);
 
@@ -193,6 +199,8 @@ impl<const GROUP: u8, const NUM: u8, Data> CompileTimeOpcode for ReadWriteOpcode
 }
 
 /// Provides a `None` code at compile time.
+///
+/// This corresponds to the C macro `_IO(GROUP, NUM)` when `Data` is zero sized.
 #[cfg(any(linux_kernel, bsd))]
 pub struct NoneOpcode<const GROUP: u8, const NUM: u8, Data>(Data);
 


### PR DESCRIPTION
When attempting to use the recently added [custom ioctl APIs](https://github.com/bytecodealliance/rustix/pull/788) I was getting `Inappropriate ioctl for device` errors and found that the ioctl opcodes being passed to the kernel were equal to just the `NUM` part with the other components ignored. This seems to be because the shift and the mask were performed in the wrong order when combining the components.

I also added:
  * a test comparing a few computed opcodes to known opcodes from `linux_raw_sys` as a sanity check
  * documentation referring to the C macros where you would find the values to use with these functions / types.

By the way, I noticed that this library is itself using only `BadOpcode` with constants from `linux_raw_sys` rather than the `ReadOpcode` / `WriteOpcode` types. Is there any reason to prefer `ReadOpcode` / `WriteOpcode` over using an opcode found in `linux_raw_sys`?

The name `Bad` made it seem like something I shouldn't be using, but taking the value by name from `linux_raw_sys` seems less error prone than looking up these components in a C header file and hard-coding them.

cc @notgull 

