### PR TITLE
Add a `rustix::runtime::linux_secure` function

### DIFF
--- a/src/backend/linux_raw/param/libc_auxv.rs
+++ b/src/backend/linux_raw/param/libc_auxv.rs
@@ -34,6 +34,7 @@ const AT_PHNUM: c::c_ulong = 5;
 const AT_ENTRY: c::c_ulong = 9;
 const AT_HWCAP: c::c_ulong = 16;
 const AT_HWCAP2: c::c_ulong = 26;
+const AT_SECURE: c::c_ulong = 23;
 const AT_EXECFN: c::c_ulong = 31;
 const AT_SYSINFO_EHDR: c::c_ulong = 33;
 
@@ -59,6 +60,7 @@ fn test_abi() {
     const_assert_eq!(self::AT_HWCAP, ::libc::AT_HWCAP);
     const_assert_eq!(self::AT_HWCAP2, ::libc::AT_HWCAP2);
     const_assert_eq!(self::AT_EXECFN, ::libc::AT_EXECFN);
+    const_assert_eq!(self::AT_SECURE, ::libc::AT_SECURE);
     const_assert_eq!(self::AT_SYSINFO_EHDR, ::libc::AT_SYSINFO_EHDR);
     #[cfg(feature = "runtime")]
     const_assert_eq!(self::AT_PHDR, ::libc::AT_PHDR);
@@ -118,6 +120,12 @@ pub(crate) fn linux_execfn() -> &'static CStr {
     unsafe {
         CStr::from_ptr(getauxval(AT_EXECFN).cast())
     }
+}
+
+#[cfg(feature = "runtime")]
+#[inline]
+pub(crate) fn linux_secure() -> bool {
+    unsafe { getauxval(AT_SECURE) as usize != 0 }
 }
 
 #[cfg(feature = "runtime")]

--- a/src/param/auxv.rs
+++ b/src/param/auxv.rs
@@ -1,12 +1,9 @@
 use crate::backend;
 #[cfg(any(
     linux_raw,
-    all(
-        libc,
-        any(
-            all(target_os = "android", target_pointer_width = "64"),
-            target_os = "linux",
-        )
+    any(
+        all(target_os = "android", target_pointer_width = "64"),
+        target_os = "linux",
     )
 ))]
 use crate::ffi::CStr;
@@ -58,12 +55,9 @@ pub fn clock_ticks_per_second() -> u64 {
 /// [Linux]: https://man7.org/linux/man-pages/man3/getauxval.3.html
 #[cfg(any(
     linux_raw,
-    all(
-        libc,
-        any(
-            all(target_os = "android", target_pointer_width = "64"),
-            target_os = "linux",
-        )
+    any(
+        all(target_os = "android", target_pointer_width = "64"),
+        target_os = "linux",
     )
 ))]
 #[inline]
@@ -82,12 +76,9 @@ pub fn linux_hwcap() -> (usize, usize) {
 /// [Linux]: https://man7.org/linux/man-pages/man3/getauxval.3.html
 #[cfg(any(
     linux_raw,
-    all(
-        libc,
-        any(
-            all(target_os = "android", target_pointer_width = "64"),
-            target_os = "linux",
-        )
+    any(
+        all(target_os = "android", target_pointer_width = "64"),
+        target_os = "linux",
     )
 ))]
 #[inline]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -485,3 +485,28 @@ pub unsafe fn sigwaitinfo(set: &Sigset) -> io::Result<Siginfo> {
 pub unsafe fn sigtimedwait(set: &Sigset, timeout: Option<Timespec>) -> io::Result<Siginfo> {
     backend::runtime::syscalls::sigtimedwait(set, timeout)
 }
+
+/// `getauxval(AT_SECURE)`—Returns the Linux "secure execution" mode.
+///
+/// Return a boolean value indicating whether "secure execution" mode was
+/// requested, due the the process having elevated privileges. This includes
+/// whether the `AT_SECURE` AUX value is set, and whether the initial real
+/// UID and GID differ from the initial effective UID and GID.
+///
+/// The meaning of "secure execution" mode is beyond the scope of this comment.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man3/getauxval.3.html
+#[cfg(any(
+    linux_raw,
+    any(
+        all(target_os = "android", target_pointer_width = "64"),
+        target_os = "linux",
+    )
+))]
+#[inline]
+pub fn linux_secure() -> bool {
+    backend::param::auxv::linux_secure()
+}


### PR DESCRIPTION
This function tests for "secure execution" mode which isn't as comprehensive as it first sounds, but it is something that libc implementations are expected to check in a few places, so add it to the "runtime" module for c-scape to use.