### PR TITLE
Relax a test to accept `EAGAIN` from `preadv2` on a socket.

### DIFF
--- a/tests/io/read_write.rs
+++ b/tests/io/read_write.rs
@@ -226,6 +226,7 @@ fn test_preadv2_nowait() {
         ReadWriteFlags::NOWAIT,
     ) {
         Err(rustix::io::Errno::OPNOTSUPP | rustix::io::Errno::NOSYS) => {}
+        Err(rustix::io::Errno::AGAIN) => {}
         Ok(_) => panic!("preadv2 unexpectedly succeeded"),
         Err(e) => panic!("preadv2 failed with an unexpected error: {:?}", e),
     }


### PR DESCRIPTION
Following up on #812, accept `Errno::AGAIN` from a `NOWAIT` read on a socket too.