### PR TITLE
Provide {get,set}_socket_nosigpipe on NetBSD and DragonFly BSD

### DIFF
--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -86,6 +86,11 @@ pub(crate) const XCASE: tcflag_t = linux_raw_sys::general::XCASE as _;
 #[cfg(target_os = "aix")]
 pub(crate) const MSG_DONTWAIT: c_int = libc::MSG_NONBLOCK;
 
+// TODO: Remove once https://github.com/rust-lang/libc/pull/3377 is merged and released.
+#[cfg(target_os = "netbsd")]
+#[cfg(feature = "net")]
+pub(crate) const SO_NOSIGPIPE: c_int = 0x0800;
+
 // On PowerPC, the regular `termios` has the `termios2` fields and there is no
 // `termios2`. linux-raw-sys has aliases `termios2` to `termios` to cover this
 // difference, but we still need to manually import it since `libc` doesn't

--- a/src/backend/libc/net/sockopt.rs
+++ b/src/backend/libc/net/sockopt.rs
@@ -301,13 +301,13 @@ pub(crate) fn get_socket_timeout(fd: BorrowedFd<'_>, id: Timeout) -> io::Result<
     }
 }
 
-#[cfg(any(apple, target_os = "freebsd"))]
+#[cfg(any(apple, freebsdlike, target_os = "netbsd"))]
 #[inline]
 pub(crate) fn get_socket_nosigpipe(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_NOSIGPIPE).map(to_bool)
 }
 
-#[cfg(any(apple, target_os = "freebsd"))]
+#[cfg(any(apple, freebsdlike, target_os = "netbsd"))]
 #[inline]
 pub(crate) fn set_socket_nosigpipe(fd: BorrowedFd<'_>, val: bool) -> io::Result<()> {
     setsockopt(fd, c::SOL_SOCKET, c::SO_NOSIGPIPE, from_bool(val))

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -341,7 +341,7 @@ pub fn get_socket_error<Fd: AsFd>(fd: Fd) -> io::Result<Result<(), io::Errno>> {
 /// See the [module-level documentation] for more.
 ///
 /// [module-level documentation]: self#references-for-get_socket_-and-set_socket_-functions
-#[cfg(any(apple, target_os = "freebsd"))]
+#[cfg(any(apple, freebsdlike, target_os = "netbsd"))]
 #[doc(alias = "SO_NOSIGPIPE")]
 #[inline]
 pub fn get_socket_nosigpipe<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
@@ -353,7 +353,7 @@ pub fn get_socket_nosigpipe<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
 /// See the [module-level documentation] for more.
 ///
 /// [module-level documentation]: self#references-for-get_socket_-and-set_socket_-functions
-#[cfg(any(apple, target_os = "freebsd"))]
+#[cfg(any(apple, freebsdlike, target_os = "netbsd"))]
 #[doc(alias = "SO_NOSIGPIPE")]
 #[inline]
 pub fn set_socket_nosigpipe<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {


### PR DESCRIPTION
- https://man.netbsd.org/setsockopt.2
- https://github.com/DragonFlyBSD/DragonFlyBSD/commit/89233cfd97300c5309bc96594ef1b873b24d60c2

libc 0.2.149 doesn't provide SO_NOSIGPIPE in NetBSD, so I opened https://github.com/rust-lang/libc/pull/3377 and added our own constant in src/backend/libc/c.rs for now.

(BTW, AFAIK, OpenBSD doesn't have SO_NOSIGPIPE: https://github.com/search?q=repo%3Aopenbsd%2Fsrc%20%2FSO_NOSIGPIPE%2F&type=code)