### PR TITLE
io-uring API updates.

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -933,7 +933,11 @@ fn utimensat_old(
                 .tv_sec
                 .try_into()
                 .map_err(|_| io::Errno::OVERFLOW)?,
-            tv_nsec: times.last_access.tv_nsec,
+            tv_nsec: times
+                .last_access
+                .tv_nsec
+                .try_into()
+                .map_err(|_| io::Errno::OVERFLOW)?,
         },
         c::timespec {
             tv_sec: times
@@ -941,7 +945,11 @@ fn utimensat_old(
                 .tv_sec
                 .try_into()
                 .map_err(|_| io::Errno::OVERFLOW)?,
-            tv_nsec: times.last_modification.tv_nsec,
+            tv_nsec: times
+                .last_modification
+                .tv_nsec
+                .try_into()
+                .map_err(|_| io::Errno::OVERFLOW)?,
         },
     ];
     unsafe {
@@ -1515,7 +1523,11 @@ fn futimens_old(fd: BorrowedFd<'_>, times: &Timestamps) -> io::Result<()> {
                 .tv_sec
                 .try_into()
                 .map_err(|_| io::Errno::OVERFLOW)?,
-            tv_nsec: times.last_access.tv_nsec,
+            tv_nsec: times
+                .last_access
+                .tv_nsec
+                .try_into()
+                .map_err(|_| io::Errno::OVERFLOW)?,
         },
         c::timespec {
             tv_sec: times
@@ -1523,7 +1535,11 @@ fn futimens_old(fd: BorrowedFd<'_>, times: &Timestamps) -> io::Result<()> {
                 .tv_sec
                 .try_into()
                 .map_err(|_| io::Errno::OVERFLOW)?,
-            tv_nsec: times.last_modification.tv_nsec,
+            tv_nsec: times
+                .last_modification
+                .tv_nsec
+                .try_into()
+                .map_err(|_| io::Errno::OVERFLOW)?,
         },
     ];
 


### PR DESCRIPTION
Add the `addr_len` field to `splice_fd_in_or_file_index_union`, define the `io_uring_sync_cancel_reg` struct, and export the various flags types used in the public API from the `io_uring` module so that users don't need to enable "fs" or "net" themselves just to work with `io_uring`.