### PR TITLE
Add support for armv7-sony-vita-newlibeabihf.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -214,6 +214,7 @@ jobs:
     - run: cargo check -Z build-std --target=riscv32imc-esp-espidf --features=all-apis
     - run: cargo check -Z build-std --target=aarch64-unknown-nto-qnx710 --features=all-apis
     - run: cargo check -Z build-std --target=x86_64-pc-nto-qnx710 --features=all-apis
+    - run: cargo check -Z build-std --target=armv7-sony-vita-newlibeabihf --features=all-apis
     # `std` doesn't appear to build on AIX yet, so test in `no_std` mode.
     - run: cargo check -Zbuild-std=core,alloc --target=powerpc64-ibm-aix --features=all-apis --no-default-features
     # Disable MIPS entirely for now as it fails with errors like

--- a/src/backend/libc/conv.rs
+++ b/src/backend/libc/conv.rs
@@ -16,7 +16,7 @@ pub(super) fn c_str(c: &CStr) -> *const c::c_char {
     c.as_ptr()
 }
 
-#[cfg(not(any(windows, target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(windows, target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 #[inline]
 pub(super) fn no_fd() -> LibcFd {
     -1
@@ -192,7 +192,13 @@ pub(super) fn msg_iov_len(len: usize) -> c::size_t {
 
 /// Convert the value to the `msg_iovlen` field of a `msghdr` struct.
 #[cfg(all(
-    not(any(windows, target_os = "espidf", target_os = "redox", target_os = "wasi")),
+    not(any(
+        windows,
+        target_os = "espidf",
+        target_os = "redox",
+        target_os = "vita",
+        target_os = "wasi"
+    )),
     not(any(
         target_os = "android",
         all(target_os = "linux", not(target_env = "musl"))
@@ -232,6 +238,7 @@ pub(crate) fn msg_control_len(len: usize) -> c::socklen_t {
     target_os = "haiku",
     target_os = "nto",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 #[inline]

--- a/src/backend/libc/fs/mod.rs
+++ b/src/backend/libc/fs/mod.rs
@@ -6,6 +6,7 @@ pub mod inotify;
     target_os = "espidf",
     target_os = "haiku",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 pub(crate) mod makedev;

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -1,7 +1,7 @@
 use crate::backend::c;
 use bitflags::bitflags;
 
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
 bitflags! {
     /// `*_OK` constants for use with [`accessat`].
     ///
@@ -92,63 +92,63 @@ bitflags! {
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct Mode: RawMode {
         /// `S_IRWXU`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const RWXU = c::S_IRWXU as RawMode;
 
         /// `S_IRUSR`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const RUSR = c::S_IRUSR as RawMode;
 
         /// `S_IWUSR`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const WUSR = c::S_IWUSR as RawMode;
 
         /// `S_IXUSR`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const XUSR = c::S_IXUSR as RawMode;
 
         /// `S_IRWXG`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const RWXG = c::S_IRWXG as RawMode;
 
         /// `S_IRGRP`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const RGRP = c::S_IRGRP as RawMode;
 
         /// `S_IWGRP`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const WGRP = c::S_IWGRP as RawMode;
 
         /// `S_IXGRP`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const XGRP = c::S_IXGRP as RawMode;
 
         /// `S_IRWXO`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const RWXO = c::S_IRWXO as RawMode;
 
         /// `S_IROTH`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const ROTH = c::S_IROTH as RawMode;
 
         /// `S_IWOTH`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const WOTH = c::S_IWOTH as RawMode;
 
         /// `S_IXOTH`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const XOTH = c::S_IXOTH as RawMode;
 
         /// `S_ISUID`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const SUID = c::S_ISUID as RawMode;
 
         /// `S_ISGID`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const SGID = c::S_ISGID as RawMode;
 
         /// `S_ISVTX`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const SVTX = c::S_ISVTX as RawMode;
 
         /// <https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags>
@@ -231,7 +231,7 @@ bitflags! {
         const DIRECTORY = bitcast!(c::O_DIRECTORY);
 
         /// `O_DSYNC`
-        #[cfg(not(any(target_os = "dragonfly", target_os = "espidf", target_os = "l4re", target_os = "redox")))]
+        #[cfg(not(any(target_os = "dragonfly", target_os = "espidf", target_os = "l4re", target_os = "redox", target_os = "vita")))]
         const DSYNC = bitcast!(c::O_DSYNC);
 
         /// `O_EXCL`
@@ -263,7 +263,7 @@ bitflags! {
         const RDWR = bitcast!(c::O_RDWR);
 
         /// `O_NOCTTY`
-        #[cfg(not(any(target_os = "espidf", target_os = "l4re", target_os = "redox")))]
+        #[cfg(not(any(target_os = "espidf", target_os = "l4re", target_os = "redox", target_os = "vita")))]
         const NOCTTY = bitcast!(c::O_NOCTTY);
 
         /// `O_RSYNC`
@@ -527,7 +527,8 @@ impl FileType {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
-        target_os = "redox"
+        target_os = "redox",
+        target_os = "vita"
     )))]
     #[inline]
     pub(crate) const fn from_dirent_d_type(d_type: u8) -> Self {
@@ -558,6 +559,7 @@ impl FileType {
     target_os = "espidf",
     target_os = "haiku",
     target_os = "redox",
+    target_os = "vita",
 )))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u32)]
@@ -783,7 +785,8 @@ bitflags! {
     target_os = "aix",
     target_os = "espidf",
     target_os = "nto",
-    target_os = "redox"
+    target_os = "redox",
+    target_os = "vita"
 )))]
 bitflags! {
     /// `FALLOC_FL_*` constants for use with [`fallocate`].
@@ -901,11 +904,11 @@ bitflags! {
         const NOEXEC = c::ST_NOEXEC as u64;
 
         /// `ST_NOSUID`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const NOSUID = c::ST_NOSUID as u64;
 
         /// `ST_RDONLY`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const RDONLY = c::ST_RDONLY as u64;
 
         /// `ST_RELATIME`
@@ -925,7 +928,7 @@ bitflags! {
 ///
 /// [`flock`]: crate::fs::flock
 /// [`fcntl_lock`]: crate::fs::fcntl_lock
-#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u32)]
 pub enum FlockOperation {
@@ -1004,6 +1007,7 @@ pub struct Stat {
     target_os = "netbsd",
     target_os = "nto",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 #[allow(clippy::module_name_repetitions)]

--- a/src/backend/libc/io/errno.rs
+++ b/src/backend/libc/io/errno.rs
@@ -54,6 +54,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const ADV: Self = Self(c::EADV);
@@ -77,6 +78,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const BADE: Self = Self(c::EBADE);
@@ -91,6 +93,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const BADFD: Self = Self(c::EBADFD);
@@ -106,6 +109,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const BADR: Self = Self(c::EBADR);
@@ -121,6 +125,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const BADRQC: Self = Self(c::EBADRQC);
@@ -133,6 +138,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const BADSLT: Self = Self(c::EBADSLT);
@@ -145,6 +151,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const BFONT: Self = Self(c::EBFONT);
@@ -168,6 +175,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi"
     )))]
     pub const CHRNG: Self = Self(c::ECHRNG);
@@ -180,6 +188,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const COMM: Self = Self(c::ECOMM);
@@ -201,6 +210,7 @@ impl Errno {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "hurd",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const DEADLOCK: Self = Self(c::EDEADLOCK);
@@ -227,6 +237,7 @@ impl Errno {
         target_os = "hurd",
         target_os = "l4re",
         target_os = "nto",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const DOTDOT: Self = Self(c::EDOTDOT);
@@ -261,6 +272,7 @@ impl Errno {
         target_os = "l4re",
         target_os = "nto",
         target_os = "redox",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const HWPOISON: Self = Self(c::EHWPOISON);
@@ -308,6 +320,7 @@ impl Errno {
         target_os = "hurd",
         target_os = "l4re",
         target_os = "nto",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const ISNAM: Self = Self(c::EISNAM);
@@ -322,6 +335,7 @@ impl Errno {
         target_os = "hurd",
         target_os = "l4re",
         target_os = "nto",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const KEYEXPIRED: Self = Self(c::EKEYEXPIRED);
@@ -336,6 +350,7 @@ impl Errno {
         target_os = "hurd",
         target_os = "l4re",
         target_os = "nto",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const KEYREJECTED: Self = Self(c::EKEYREJECTED);
@@ -350,6 +365,7 @@ impl Errno {
         target_os = "hurd",
         target_os = "l4re",
         target_os = "nto",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const KEYREVOKED: Self = Self(c::EKEYREVOKED);
@@ -361,6 +377,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi"
     )))]
     pub const L2HLT: Self = Self(c::EL2HLT);
@@ -372,6 +389,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi"
     )))]
     pub const L2NSYNC: Self = Self(c::EL2NSYNC);
@@ -383,6 +401,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi"
     )))]
     pub const L3HLT: Self = Self(c::EL3HLT);
@@ -394,6 +413,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi"
     )))]
     pub const L3RST: Self = Self(c::EL3RST);
@@ -406,6 +426,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const LIBACC: Self = Self(c::ELIBACC);
@@ -418,6 +439,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const LIBBAD: Self = Self(c::ELIBBAD);
@@ -429,6 +451,7 @@ impl Errno {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const LIBEXEC: Self = Self(c::ELIBEXEC);
@@ -441,6 +464,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const LIBMAX: Self = Self(c::ELIBMAX);
@@ -453,6 +477,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const LIBSCN: Self = Self(c::ELIBSCN);
@@ -464,6 +489,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi"
     )))]
     pub const LNRNG: Self = Self(c::ELNRNG);
@@ -480,6 +506,7 @@ impl Errno {
         target_os = "hurd",
         target_os = "l4re",
         target_os = "nto",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const MEDIUMTYPE: Self = Self(c::EMEDIUMTYPE);
@@ -507,6 +534,7 @@ impl Errno {
         target_os = "hurd",
         target_os = "l4re",
         target_os = "nto",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const NAVAIL: Self = Self(c::ENAVAIL);
@@ -532,6 +560,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const NOANO: Self = Self(c::ENOANO);
@@ -549,6 +578,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi"
     )))]
     pub const NOCSI: Self = Self(c::ENOCSI);
@@ -581,6 +611,7 @@ impl Errno {
         target_os = "hurd",
         target_os = "l4re",
         target_os = "nto",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const NOKEY: Self = Self(c::ENOKEY);
@@ -601,6 +632,7 @@ impl Errno {
         target_os = "hurd",
         target_os = "l4re",
         target_os = "nto",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const NOMEDIUM: Self = Self(c::ENOMEDIUM);
@@ -622,6 +654,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const NONET: Self = Self(c::ENONET);
@@ -634,6 +667,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const NOPKG: Self = Self(c::ENOPKG);
@@ -667,7 +701,13 @@ impl Errno {
     #[cfg(not(windows))]
     pub const NOSYS: Self = Self(c::ENOSYS);
     /// `ENOTBLK`
-    #[cfg(not(any(windows, target_os = "espidf", target_os = "haiku", target_os = "wasi")))]
+    #[cfg(not(any(
+        windows,
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "vita",
+        target_os = "wasi"
+    )))]
     pub const NOTBLK: Self = Self(c::ENOTBLK);
     /// `ENOTCAPABLE`
     #[cfg(any(target_os = "freebsd", target_os = "wasi"))]
@@ -690,6 +730,7 @@ impl Errno {
         target_os = "hurd",
         target_os = "l4re",
         target_os = "nto",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const NOTNAM: Self = Self(c::ENOTNAM);
@@ -720,6 +761,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const NOTUNIQ: Self = Self(c::ENOTUNIQ);
@@ -788,6 +830,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const REMCHG: Self = Self(c::EREMCHG);
@@ -796,6 +839,7 @@ impl Errno {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi"
     )))]
     pub const REMOTE: Self = Self(c::EREMOTE);
@@ -810,6 +854,7 @@ impl Errno {
         target_os = "hurd",
         target_os = "l4re",
         target_os = "nto",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const REMOTEIO: Self = Self(c::EREMOTEIO);
@@ -821,6 +866,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi"
     )))]
     pub const RESTART: Self = Self(c::ERESTART);
@@ -837,6 +883,7 @@ impl Errno {
         target_os = "l4re",
         target_os = "nto",
         target_os = "redox",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const RFKILL: Self = Self(c::ERFKILL);
@@ -847,13 +894,19 @@ impl Errno {
     #[cfg(bsd)]
     pub const RPCMISMATCH: Self = Self(c::ERPCMISMATCH);
     /// `ESHUTDOWN`
-    #[cfg(not(any(target_os = "espidf", target_os = "l4re", target_os = "wasi")))]
+    #[cfg(not(any(
+        target_os = "espidf",
+        target_os = "l4re",
+        target_os = "vita",
+        target_os = "wasi"
+    )))]
     pub const SHUTDOWN: Self = Self(c::ESHUTDOWN);
     /// `ESOCKTNOSUPPORT`
     #[cfg(not(any(
         target_os = "espidf",
         target_os = "haiku",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi"
     )))]
     pub const SOCKTNOSUPPORT: Self = Self(c::ESOCKTNOSUPPORT);
@@ -872,6 +925,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const SRMNT: Self = Self(c::ESRMNT);
@@ -886,6 +940,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const STRPIPE: Self = Self(c::ESTRPIPE);
@@ -921,6 +976,7 @@ impl Errno {
         target_os = "hurd",
         target_os = "l4re",
         target_os = "nto",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const UCLEAN: Self = Self(c::EUCLEAN);
@@ -932,6 +988,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi"
     )))]
     pub const UNATCH: Self = Self(c::EUNATCH);
@@ -940,6 +997,7 @@ impl Errno {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi"
     )))]
     pub const USERS: Self = Self(c::EUSERS);
@@ -957,6 +1015,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "l4re",
+        target_os = "vita",
         target_os = "wasi",
     )))]
     pub const XFULL: Self = Self(c::EXFULL);

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -9,6 +9,7 @@ use crate::fd::{AsFd, BorrowedFd, OwnedFd, RawFd};
     target_os = "aix",
     target_os = "espidf",
     target_os = "nto",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 use crate::io::DupFlags;
@@ -51,8 +52,8 @@ pub(crate) fn pread(fd: BorrowedFd<'_>, buf: &mut [u8], offset: u64) -> io::Resu
     // Silently cast; we'll get `EINVAL` if the value is negative.
     let offset = offset as i64;
 
-    // ESP-IDF doesn't support 64-bit offsets.
-    #[cfg(target_os = "espidf")]
+    // ESP-IDF and Vita don't support 64-bit offsets.
+    #[cfg(any(target_os = "espidf", target_os = "vita"))]
     let offset: i32 = offset.try_into().map_err(|_| io::Errno::OVERFLOW)?;
 
     unsafe {
@@ -71,8 +72,8 @@ pub(crate) fn pwrite(fd: BorrowedFd<'_>, buf: &[u8], offset: u64) -> io::Result<
     // Silently cast; we'll get `EINVAL` if the value is negative.
     let offset = offset as i64;
 
-    // ESP-IDF doesn't support 64-bit offsets.
-    #[cfg(target_os = "espidf")]
+    // ESP-IDF and Vita don't support 64-bit offsets.
+    #[cfg(any(target_os = "espidf", target_os = "vita"))]
     let offset: i32 = offset.try_into().map_err(|_| io::Errno::OVERFLOW)?;
 
     unsafe { ret_usize(c::pwrite(borrowed_fd(fd), buf.as_ptr().cast(), len, offset)) }
@@ -105,7 +106,8 @@ pub(crate) fn writev(fd: BorrowedFd<'_>, bufs: &[IoSlice<'_>]) -> io::Result<usi
     target_os = "haiku",
     target_os = "nto",
     target_os = "redox",
-    target_os = "solaris"
+    target_os = "solaris",
+    target_os = "vita"
 )))]
 pub(crate) fn preadv(
     fd: BorrowedFd<'_>,
@@ -129,7 +131,8 @@ pub(crate) fn preadv(
     target_os = "haiku",
     target_os = "nto",
     target_os = "redox",
-    target_os = "solaris"
+    target_os = "solaris",
+    target_os = "vita"
 )))]
 pub(crate) fn pwritev(fd: BorrowedFd<'_>, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
     // Silently cast; we'll get `EINVAL` if the value is negative.
@@ -316,6 +319,7 @@ pub(crate) fn dup2(fd: BorrowedFd<'_>, new: &mut OwnedFd) -> io::Result<()> {
     target_os = "haiku",
     target_os = "nto",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 pub(crate) fn dup3(fd: BorrowedFd<'_>, new: &mut OwnedFd, flags: DupFlags) -> io::Result<()> {

--- a/src/backend/libc/mod.rs
+++ b/src/backend/libc/mod.rs
@@ -111,7 +111,7 @@ pub(crate) mod io;
 #[cfg(linux_kernel)]
 #[cfg(feature = "io_uring")]
 pub(crate) mod io_uring;
-#[cfg(not(any(windows, target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(windows, target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 #[cfg(feature = "mm")]
 pub(crate) mod mm;
 #[cfg(linux_kernel)]
@@ -148,7 +148,7 @@ pub(crate) mod rand;
 #[cfg(not(target_os = "wasi"))]
 #[cfg(feature = "system")]
 pub(crate) mod system;
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "vita")))]
 #[cfg(feature = "termios")]
 pub(crate) mod termios;
 #[cfg(not(windows))]
@@ -188,6 +188,7 @@ pub(crate) mod prctl;
     windows,
     target_os = "android",
     target_os = "espidf",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 #[cfg(feature = "shm")]

--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -210,13 +210,7 @@ pub type SocketAddrStorage = c::sockaddr_storage;
 #[inline]
 pub(crate) fn offsetof_sun_path() -> usize {
     let z = c::sockaddr_un {
-        #[cfg(any(
-            bsd,
-            target_os = "aix",
-            target_os = "espidf",
-            target_os = "haiku",
-            target_os = "nto",
-        ))]
+        #[cfg(any(bsd, target_os = "aix", target_os = "haiku", target_os = "nto"))]
         sun_len: 0_u8,
         #[cfg(target_os = "vita")]
         ss_len: 0,

--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -78,6 +78,8 @@ impl SocketAddrUnix {
         c::sockaddr_un {
             #[cfg(any(bsd, target_os = "aix", target_os = "haiku", target_os = "nto"))]
             sun_len: 0,
+            #[cfg(target_os = "vita")]
+            ss_len: 0,
             sun_family: c::AF_UNIX as _,
             #[cfg(any(bsd, target_os = "nto"))]
             sun_path: [0; 104],
@@ -208,14 +210,23 @@ pub type SocketAddrStorage = c::sockaddr_storage;
 #[inline]
 pub(crate) fn offsetof_sun_path() -> usize {
     let z = c::sockaddr_un {
-        #[cfg(any(bsd, target_os = "aix", target_os = "haiku", target_os = "nto"))]
-        sun_len: 0_u8,
         #[cfg(any(
             bsd,
             target_os = "aix",
             target_os = "espidf",
             target_os = "haiku",
-            target_os = "nto"
+            target_os = "nto",
+        ))]
+        sun_len: 0_u8,
+        #[cfg(target_os = "vita")]
+        ss_len: 0,
+        #[cfg(any(
+            bsd,
+            target_os = "aix",
+            target_os = "espidf",
+            target_os = "haiku",
+            target_os = "nto",
+            target_os = "vita"
         ))]
         sun_family: 0_u8,
         #[cfg(not(any(
@@ -223,7 +234,8 @@ pub(crate) fn offsetof_sun_path() -> usize {
             target_os = "aix",
             target_os = "espidf",
             target_os = "haiku",
-            target_os = "nto"
+            target_os = "nto",
+            target_os = "vita"
         )))]
         sun_family: 0_u16,
         #[cfg(any(bsd, target_os = "nto"))]

--- a/src/backend/libc/net/ext.rs
+++ b/src/backend/libc/net/ext.rs
@@ -83,7 +83,8 @@ pub(crate) const fn sockaddr_in6_new(
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
-        target_os = "nto"
+        target_os = "nto",
+        target_os = "vita"
     ))]
     sin6_len: u8,
     sin6_family: c::sa_family_t,
@@ -98,7 +99,8 @@ pub(crate) const fn sockaddr_in6_new(
             target_os = "aix",
             target_os = "espidf",
             target_os = "haiku",
-            target_os = "nto"
+            target_os = "nto",
+            target_os = "vita"
         ))]
         sin6_len,
         sin6_family,
@@ -108,6 +110,8 @@ pub(crate) const fn sockaddr_in6_new(
         sin6_scope_id,
         #[cfg(solarish)]
         __sin6_src_id: 0,
+        #[cfg(target_os = "vita")]
+        sin6_vport: 0,
     }
 }
 

--- a/src/backend/libc/net/mod.rs
+++ b/src/backend/libc/net/mod.rs
@@ -1,6 +1,12 @@
 pub(crate) mod addr;
 pub(crate) mod ext;
-#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 pub(crate) mod msghdr;
 pub(crate) mod read_sockaddr;
 pub(crate) mod send_recv;

--- a/src/backend/libc/net/read_sockaddr.rs
+++ b/src/backend/libc/net/read_sockaddr.rs
@@ -14,11 +14,32 @@ use core::mem::size_of;
 // This must match the header of `sockaddr`.
 #[repr(C)]
 struct sockaddr_header {
-    #[cfg(any(bsd, target_os = "haiku"))]
+    #[cfg(any(
+        bsd,
+        target_os = "aix",
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "nto",
+        target_os = "vita"
+    ))]
     sa_len: u8,
-    #[cfg(any(bsd, target_os = "haiku"))]
+    #[cfg(any(
+        bsd,
+        target_os = "aix",
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "nto",
+        target_os = "vita"
+    ))]
     ss_family: u8,
-    #[cfg(not(any(bsd, target_os = "haiku")))]
+    #[cfg(not(any(
+        bsd,
+        target_os = "aix",
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "nto",
+        target_os = "vita"
+    )))]
     ss_family: u16,
 }
 
@@ -31,7 +52,8 @@ unsafe fn read_ss_family(storage: *const c::sockaddr_storage) -> u16 {
             target_os = "aix",
             target_os = "espidf",
             target_os = "haiku",
-            target_os = "nto"
+            target_os = "nto",
+            target_os = "vita"
         ))]
         sa_len: 0_u8,
         #[cfg(any(
@@ -39,7 +61,8 @@ unsafe fn read_ss_family(storage: *const c::sockaddr_storage) -> u16 {
             target_os = "aix",
             target_os = "espidf",
             target_os = "haiku",
-            target_os = "nto"
+            target_os = "nto",
+            target_os = "vita"
         ))]
         sa_family: 0_u8,
         #[cfg(not(any(
@@ -47,7 +70,8 @@ unsafe fn read_ss_family(storage: *const c::sockaddr_storage) -> u16 {
             target_os = "aix",
             target_os = "espidf",
             target_os = "haiku",
-            target_os = "nto"
+            target_os = "nto",
+            target_os = "vita"
         )))]
         sa_family: 0_u16,
         #[cfg(not(target_os = "haiku"))]

--- a/src/backend/libc/net/send_recv.rs
+++ b/src/backend/libc/net/send_recv.rs
@@ -19,6 +19,7 @@ bitflags! {
             target_os = "espidf",
             target_os = "nto",
             target_os = "haiku",
+            target_os = "vita",
         )))]
         const CONFIRM = bitcast!(c::MSG_CONFIRM);
         /// `MSG_DONTROUTE`
@@ -37,9 +38,10 @@ bitflags! {
             target_os = "aix",
             target_os = "haiku",
             target_os = "nto",
+            target_os = "vita",
         )))]
         const MORE = bitcast!(c::MSG_MORE);
-        #[cfg(not(any(apple, windows)))]
+        #[cfg(not(any(apple, windows, target_os = "vita")))]
         /// `MSG_NOSIGNAL`
         const NOSIGNAL = bitcast!(c::MSG_NOSIGNAL);
         /// `MSG_OOB`
@@ -67,6 +69,7 @@ bitflags! {
             target_os = "espidf",
             target_os = "haiku",
             target_os = "nto",
+            target_os = "vita",
         )))]
         /// `MSG_CMSG_CLOEXEC`
         const CMSG_CLOEXEC = bitcast!(c::MSG_CMSG_CLOEXEC);
@@ -82,6 +85,7 @@ bitflags! {
             target_os = "espidf",
             target_os = "haiku",
             target_os = "nto",
+            target_os = "vita",
         )))]
         const ERRQUEUE = bitcast!(c::MSG_ERRQUEUE);
         /// `MSG_OOB`

--- a/src/backend/libc/net/sockopt.rs
+++ b/src/backend/libc/net/sockopt.rs
@@ -24,6 +24,7 @@ use crate::net::sockopt::Timeout;
     target_os = "haiku",
     target_os = "netbsd",
     target_os = "nto",
+    target_os = "vita",
 )))]
 use crate::net::AddressFamily;
 #[cfg(any(
@@ -366,6 +367,7 @@ pub(crate) fn get_socket_send_buffer_size(fd: BorrowedFd<'_>) -> io::Result<usiz
     target_os = "haiku",
     target_os = "netbsd",
     target_os = "nto",
+    target_os = "vita",
 )))]
 pub(crate) fn get_socket_domain(fd: BorrowedFd<'_>) -> io::Result<AddressFamily> {
     let domain: c::c_int = getsockopt(fd, c::SOL_SOCKET, c::SO_DOMAIN)?;
@@ -787,13 +789,25 @@ pub(crate) fn get_ipv6_original_dst(fd: BorrowedFd<'_>) -> io::Result<SocketAddr
     }
 }
 
-#[cfg(not(any(solarish, windows, target_os = "espidf", target_os = "haiku")))]
+#[cfg(not(any(
+    solarish,
+    windows,
+    target_os = "espidf",
+    target_os = "haiku",
+    target_os = "vita"
+)))]
 #[inline]
 pub(crate) fn set_ipv6_tclass(fd: BorrowedFd<'_>, value: u32) -> io::Result<()> {
     setsockopt(fd, c::IPPROTO_IPV6, c::IPV6_TCLASS, value)
 }
 
-#[cfg(not(any(solarish, windows, target_os = "espidf", target_os = "haiku")))]
+#[cfg(not(any(
+    solarish,
+    windows,
+    target_os = "espidf",
+    target_os = "haiku",
+    target_os = "vita"
+)))]
 #[inline]
 pub(crate) fn get_ipv6_tclass(fd: BorrowedFd<'_>) -> io::Result<u32> {
     getsockopt(fd, c::IPPROTO_IPV6, c::IPV6_TCLASS)

--- a/src/backend/libc/net/syscalls.rs
+++ b/src/backend/libc/net/syscalls.rs
@@ -9,7 +9,13 @@ use crate::io;
 use crate::net::{SocketAddrAny, SocketAddrV4, SocketAddrV6};
 use crate::utils::as_ptr;
 use core::mem::{size_of, MaybeUninit};
-#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 use {
     super::msghdr::{with_noaddr_msghdr, with_recv_msghdr, with_v4_msghdr, with_v6_msghdr},
     crate::io::{IoSlice, IoSliceMut},
@@ -255,7 +261,13 @@ pub(crate) fn accept(sockfd: BorrowedFd<'_>) -> io::Result<OwnedFd> {
     }
 }
 
-#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 pub(crate) fn recvmsg(
     sockfd: BorrowedFd<'_>,
     iov: &mut [IoSliceMut<'_>],
@@ -287,7 +299,13 @@ pub(crate) fn recvmsg(
     })
 }
 
-#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 pub(crate) fn sendmsg(
     sockfd: BorrowedFd<'_>,
     iov: &[IoSlice<'_>],
@@ -303,7 +321,13 @@ pub(crate) fn sendmsg(
     })
 }
 
-#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 pub(crate) fn sendmsg_v4(
     sockfd: BorrowedFd<'_>,
     addr: &SocketAddrV4,
@@ -320,7 +344,13 @@ pub(crate) fn sendmsg_v4(
     })
 }
 
-#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 pub(crate) fn sendmsg_v6(
     sockfd: BorrowedFd<'_>,
     addr: &SocketAddrV6,
@@ -337,7 +367,10 @@ pub(crate) fn sendmsg_v6(
     })
 }
 
-#[cfg(all(unix, not(any(target_os = "espidf", target_os = "redox"))))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "espidf", target_os = "redox", target_os = "vita"))
+))]
 pub(crate) fn sendmsg_unix(
     sockfd: BorrowedFd<'_>,
     addr: &SocketAddrUnix,
@@ -362,6 +395,7 @@ pub(crate) fn sendmsg_unix(
     target_os = "haiku",
     target_os = "redox",
     target_os = "nto",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 pub(crate) fn accept_with(sockfd: BorrowedFd<'_>, flags: SocketFlags) -> io::Result<OwnedFd> {
@@ -401,6 +435,7 @@ pub(crate) fn acceptfrom(sockfd: BorrowedFd<'_>) -> io::Result<(OwnedFd, Option<
     target_os = "haiku",
     target_os = "nto",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 pub(crate) fn acceptfrom_with(
@@ -431,7 +466,8 @@ pub(crate) fn acceptfrom_with(
     target_os = "aix",
     target_os = "espidf",
     target_os = "haiku",
-    target_os = "nto"
+    target_os = "nto",
+    target_os = "vita",
 ))]
 pub(crate) fn accept_with(sockfd: BorrowedFd<'_>, _flags: SocketFlags) -> io::Result<OwnedFd> {
     accept(sockfd)
@@ -445,7 +481,8 @@ pub(crate) fn accept_with(sockfd: BorrowedFd<'_>, _flags: SocketFlags) -> io::Re
     target_os = "aix",
     target_os = "espidf",
     target_os = "haiku",
-    target_os = "nto"
+    target_os = "nto",
+    target_os = "vita",
 ))]
 pub(crate) fn acceptfrom_with(
     sockfd: BorrowedFd<'_>,

--- a/src/backend/libc/net/write_sockaddr.rs
+++ b/src/backend/libc/net/write_sockaddr.rs
@@ -29,15 +29,20 @@ pub(crate) fn encode_sockaddr_v4(v4: &SocketAddrV4) -> c::sockaddr_in {
             target_os = "espidf",
             target_os = "haiku",
             target_os = "nto",
+            target_os = "vita",
         ))]
         sin_len: size_of::<c::sockaddr_in>() as _,
         sin_family: c::AF_INET as _,
         sin_port: u16::to_be(v4.port()),
         sin_addr: in_addr_new(u32::from_ne_bytes(v4.ip().octets())),
-        #[cfg(not(target_os = "haiku"))]
+        #[cfg(not(any(target_os = "haiku", target_os = "vita")))]
         sin_zero: [0; 8_usize],
         #[cfg(target_os = "haiku")]
         sin_zero: [0; 24_usize],
+        #[cfg(target_os = "vita")]
+        sin_zero: [0; 6_usize],
+        #[cfg(target_os = "vita")]
+        sin_vport: 0,
     }
 }
 
@@ -54,6 +59,7 @@ pub(crate) fn encode_sockaddr_v6(v6: &SocketAddrV6) -> c::sockaddr_in6 {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita"
     ))]
     {
         sockaddr_in6_new(
@@ -70,7 +76,8 @@ pub(crate) fn encode_sockaddr_v6(v6: &SocketAddrV6) -> c::sockaddr_in6 {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
-        target_os = "nto"
+        target_os = "nto",
+        target_os = "vita"
     )))]
     {
         sockaddr_in6_new(

--- a/src/backend/libc/param/auxv.rs
+++ b/src/backend/libc/param/auxv.rs
@@ -17,7 +17,7 @@ pub(crate) fn page_size() -> usize {
     unsafe { c::sysconf(c::_SC_PAGESIZE) as usize }
 }
 
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "vita", target_os = "wasi")))]
 #[inline]
 pub(crate) fn clock_ticks_per_second() -> u64 {
     unsafe { c::sysconf(c::_SC_CLK_TCK) as u64 }

--- a/src/backend/libc/pipe/types.rs
+++ b/src/backend/libc/pipe/types.rs
@@ -21,6 +21,7 @@ bitflags! {
             target_os = "nto",
             target_os = "openbsd",
             target_os = "redox",
+            target_os = "vita",
         )))]
         const DIRECT = bitcast!(c::O_DIRECT);
         /// `O_NONBLOCK`

--- a/src/backend/libc/process/mod.rs
+++ b/src/backend/libc/process/mod.rs
@@ -3,5 +3,5 @@ pub(crate) mod cpu_set;
 #[cfg(not(windows))]
 pub(crate) mod syscalls;
 pub(crate) mod types;
-#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 pub(crate) mod wait;

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -13,6 +13,7 @@ use crate::backend::conv::ret_discarded_char_ptr;
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 use crate::backend::conv::ret_infallible;
@@ -36,16 +37,24 @@ use crate::io;
 use crate::process::Gid;
 #[cfg(not(target_os = "wasi"))]
 use crate::process::Pid;
-#[cfg(not(any(target_os = "espidf", target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
+use crate::process::Signal;
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 use crate::process::Uid;
 #[cfg(linux_kernel)]
 use crate::process::{Cpuid, MembarrierCommand, MembarrierQuery};
-#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
-use crate::process::{RawPid, Signal, WaitOptions, WaitStatus};
+#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+use crate::process::{RawPid, WaitOptions, WaitStatus};
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 use crate::process::{Resource, Rlimit};
@@ -53,6 +62,7 @@ use crate::process::{Resource, Rlimit};
     target_os = "espidf",
     target_os = "redox",
     target_os = "openbsd",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 use crate::process::{WaitId, WaitidOptions, WaitidStatus};
@@ -209,7 +219,7 @@ pub(crate) fn umask(mask: Mode) -> Mode {
     unsafe { Mode::from_bits_retain(c::umask(mask.bits() as c::mode_t).into()) }
 }
 
-#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "vita", target_os = "wasi")))]
 #[inline]
 pub(crate) fn nice(inc: i32) -> io::Result<i32> {
     libc_errno::set_errno(libc_errno::Errno(0));
@@ -221,7 +231,12 @@ pub(crate) fn nice(inc: i32) -> io::Result<i32> {
     }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 #[inline]
 pub(crate) fn getpriority_user(uid: Uid) -> io::Result<i32> {
     libc_errno::set_errno(libc_errno::Errno(0));
@@ -233,7 +248,12 @@ pub(crate) fn getpriority_user(uid: Uid) -> io::Result<i32> {
     }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 #[inline]
 pub(crate) fn getpriority_pgrp(pgid: Option<Pid>) -> io::Result<i32> {
     libc_errno::set_errno(libc_errno::Errno(0));
@@ -245,7 +265,12 @@ pub(crate) fn getpriority_pgrp(pgid: Option<Pid>) -> io::Result<i32> {
     }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 #[inline]
 pub(crate) fn getpriority_process(pid: Option<Pid>) -> io::Result<i32> {
     libc_errno::set_errno(libc_errno::Errno(0));
@@ -257,13 +282,23 @@ pub(crate) fn getpriority_process(pid: Option<Pid>) -> io::Result<i32> {
     }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 #[inline]
 pub(crate) fn setpriority_user(uid: Uid, priority: i32) -> io::Result<()> {
     unsafe { ret(c::setpriority(c::PRIO_USER, uid.as_raw() as _, priority)) }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 #[inline]
 pub(crate) fn setpriority_pgrp(pgid: Option<Pid>, priority: i32) -> io::Result<()> {
     unsafe {
@@ -275,7 +310,12 @@ pub(crate) fn setpriority_pgrp(pgid: Option<Pid>, priority: i32) -> io::Result<(
     }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 #[inline]
 pub(crate) fn setpriority_process(pid: Option<Pid>, priority: i32) -> io::Result<()> {
     unsafe {
@@ -291,6 +331,7 @@ pub(crate) fn setpriority_process(pid: Option<Pid>, priority: i32) -> io::Result
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 #[inline]
@@ -306,6 +347,7 @@ pub(crate) fn getrlimit(limit: Resource) -> Rlimit {
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 #[inline]
@@ -335,6 +377,7 @@ pub(crate) fn prlimit(pid: Option<Pid>, limit: Resource, new: Rlimit) -> io::Res
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 fn rlimit_from_libc(lim: c::rlimit) -> Rlimit {
@@ -356,6 +399,7 @@ fn rlimit_from_libc(lim: c::rlimit) -> Rlimit {
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 fn rlimit_to_libc(lim: Rlimit) -> io::Result<c::rlimit> {
@@ -371,13 +415,13 @@ fn rlimit_to_libc(lim: Rlimit) -> io::Result<c::rlimit> {
     Ok(c::rlimit { rlim_cur, rlim_max })
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 #[inline]
 pub(crate) fn wait(waitopts: WaitOptions) -> io::Result<Option<(Pid, WaitStatus)>> {
     _waitpid(!0, waitopts)
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 #[inline]
 pub(crate) fn waitpid(
     pid: Option<Pid>,
@@ -386,13 +430,13 @@ pub(crate) fn waitpid(
     _waitpid(Pid::as_raw(pid), waitopts)
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 #[inline]
 pub(crate) fn waitpgid(pgid: Pid, waitopts: WaitOptions) -> io::Result<Option<(Pid, WaitStatus)>> {
     _waitpid(-pgid.as_raw_nonzero().get(), waitopts)
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 #[inline]
 pub(crate) fn _waitpid(
     pid: RawPid,
@@ -409,6 +453,7 @@ pub(crate) fn _waitpid(
     target_os = "espidf",
     target_os = "redox",
     target_os = "openbsd",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 #[inline]
@@ -429,6 +474,7 @@ pub(crate) fn waitid(id: WaitId<'_>, options: WaitidOptions) -> io::Result<Optio
     target_os = "espidf",
     target_os = "redox",
     target_os = "openbsd",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 #[inline]
@@ -452,6 +498,7 @@ fn _waitid_all(options: WaitidOptions) -> io::Result<Option<WaitidStatus>> {
     target_os = "espidf",
     target_os = "redox",
     target_os = "openbsd",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 #[inline]
@@ -475,6 +522,7 @@ fn _waitid_pid(pid: Pid, options: WaitidOptions) -> io::Result<Option<WaitidStat
     target_os = "espidf",
     target_os = "redox",
     target_os = "openbsd",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 #[inline]
@@ -522,6 +570,7 @@ fn _waitid_pidfd(fd: BorrowedFd<'_>, options: WaitidOptions) -> io::Result<Optio
     target_os = "espidf",
     target_os = "openbsd",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 #[inline]

--- a/src/backend/libc/process/types.rs
+++ b/src/backend/libc/process/types.rs
@@ -1,4 +1,4 @@
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
 use crate::backend::c;
 
 /// A command for use with [`membarrier`] and [`membarrier_cpu`].
@@ -45,6 +45,7 @@ pub enum MembarrierCommand {
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/backend/libc/system/syscalls.rs
+++ b/src/backend/libc/system/syscalls.rs
@@ -13,6 +13,7 @@ use core::mem::MaybeUninit;
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 use {crate::backend::conv::ret, crate::io};
@@ -48,6 +49,7 @@ pub(crate) fn sysinfo() -> Sysinfo {
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 pub(crate) fn sethostname(name: &[u8]) -> io::Result<()> {

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -24,6 +24,7 @@ use {
     target_os = "haiku",
     target_os = "openbsd",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 use {crate::thread::ClockId, core::ptr::null_mut};
@@ -42,6 +43,7 @@ weak!(fn __nanosleep64(*const LibcTimespec, *mut LibcTimespec) -> c::c_int);
     target_os = "haiku",
     target_os = "openbsd",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 #[inline]
@@ -92,7 +94,12 @@ pub(crate) fn clock_nanosleep_relative(id: ClockId, request: &Timespec) -> Nanos
 
 #[cfg(all(
     fix_y2038,
-    not(any(apple, target_os = "emscripten", target_os = "haiku"))
+    not(any(
+        apple,
+        target_os = "emscripten",
+        target_os = "haiku",
+        target_os = "vita"
+    ))
 ))]
 fn clock_nanosleep_relative_old(id: ClockId, request: &Timespec) -> NanosleepRelativeResult {
     let tv_sec = match request.tv_sec.try_into() {
@@ -137,6 +144,7 @@ fn clock_nanosleep_relative_old(id: ClockId, request: &Timespec) -> NanosleepRel
     target_os = "haiku",
     target_os = "openbsd",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 #[inline]
@@ -180,7 +188,12 @@ pub(crate) fn clock_nanosleep_absolute(id: ClockId, request: &Timespec) -> io::R
 
 #[cfg(all(
     fix_y2038,
-    not(any(apple, target_os = "emscripten", target_os = "haiku"))
+    not(any(
+        apple,
+        target_os = "emscripten",
+        target_os = "haiku",
+        target_os = "vita"
+    ))
 ))]
 fn clock_nanosleep_absolute_old(id: ClockId, request: &Timespec) -> io::Result<()> {
     let flags = c::TIMER_ABSTIME;

--- a/src/clockid.rs
+++ b/src/clockid.rs
@@ -16,21 +16,31 @@ use crate::fd::BorrowedFd;
 #[non_exhaustive]
 pub enum ClockId {
     /// `CLOCK_REALTIME`
-    Realtime = c::CLOCK_REALTIME,
+    Realtime = bitcast!(c::CLOCK_REALTIME),
 
     /// `CLOCK_MONOTONIC`
-    Monotonic = c::CLOCK_MONOTONIC,
+    Monotonic = bitcast!(c::CLOCK_MONOTONIC),
 
     /// `CLOCK_UPTIME`
     #[cfg(any(freebsdlike, target_os = "openbsd"))]
     Uptime = c::CLOCK_UPTIME,
 
     /// `CLOCK_PROCESS_CPUTIME_ID`
-    #[cfg(not(any(solarish, target_os = "netbsd", target_os = "redox")))]
+    #[cfg(not(any(
+        solarish,
+        target_os = "netbsd",
+        target_os = "redox",
+        target_os = "vita"
+    )))]
     ProcessCPUTime = c::CLOCK_PROCESS_CPUTIME_ID,
 
     /// `CLOCK_THREAD_CPUTIME_ID`
-    #[cfg(not(any(solarish, target_os = "netbsd", target_os = "redox")))]
+    #[cfg(not(any(
+        solarish,
+        target_os = "netbsd",
+        target_os = "redox",
+        target_os = "vita"
+    )))]
     ThreadCPUTime = c::CLOCK_THREAD_CPUTIME_ID,
 
     /// `CLOCK_REALTIME_COARSE`

--- a/src/fs/abs.rs
+++ b/src/fs/abs.rs
@@ -1,7 +1,7 @@
 //! POSIX-style filesystem functions which operate on bare paths.
 
 use crate::fd::OwnedFd;
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
 use crate::fs::Access;
 #[cfg(not(any(
     solarish,
@@ -10,6 +10,7 @@ use crate::fs::Access;
     target_os = "netbsd",
     target_os = "nto",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 use crate::fs::StatFs;
@@ -236,7 +237,7 @@ pub fn mkdir<P: path::Arg>(path: P, mode: Mode) -> io::Result<()> {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/access.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/access.2.html
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
 #[inline]
 pub fn access<P: path::Arg>(path: P, access: Access) -> io::Result<()> {
     path.into_with_c_str(|path| backend::fs::syscalls::access(path, access))
@@ -258,6 +259,7 @@ pub fn access<P: path::Arg>(path: P, access: Access) -> io::Result<()> {
     target_os = "netbsd",
     target_os = "nto",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 #[inline]

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -6,9 +6,13 @@
 //! [`cwd`]: crate::fs::CWD
 
 use crate::fd::OwnedFd;
+#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+use crate::fs::Access;
+#[cfg(not(target_os = "espidf"))]
+use crate::fs::AtFlags;
 #[cfg(apple)]
 use crate::fs::CloneFlags;
-#[cfg(not(any(apple, target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(apple, target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 use crate::fs::FileType;
 #[cfg(linux_kernel)]
 use crate::fs::RenameFlags;
@@ -26,24 +30,21 @@ use {
     alloc::vec::Vec,
     backend::fd::BorrowedFd,
 };
-#[cfg(not(target_os = "espidf"))]
-use {
-    crate::fs::{Access, AtFlags, Timestamps},
-    crate::timespec::Nsecs,
-};
+#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+use {crate::fs::Timestamps, crate::timespec::Nsecs};
 
 pub use backend::fs::types::{Dev, RawMode};
 
 /// `UTIME_NOW` for use with [`utimensat`].
 ///
 /// [`utimensat`]: crate::fs::utimensat
-#[cfg(not(any(target_os = "espidf", target_os = "redox")))]
+#[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "vita")))]
 pub const UTIME_NOW: Nsecs = backend::c::UTIME_NOW as Nsecs;
 
 /// `UTIME_OMIT` for use with [`utimensat`].
 ///
 /// [`utimensat`]: crate::fs::utimensat
-#[cfg(not(any(target_os = "espidf", target_os = "redox")))]
+#[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "vita")))]
 pub const UTIME_OMIT: Nsecs = backend::c::UTIME_OMIT as Nsecs;
 
 /// `openat(dirfd, path, oflags, mode)`—Opens a file.
@@ -314,7 +315,7 @@ pub fn statat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, flags: AtFlags) -> io:
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/faccessat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/faccessat.2.html
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
 #[inline]
 #[doc(alias = "faccessat")]
 pub fn accessat<P: path::Arg, Fd: AsFd>(
@@ -334,7 +335,7 @@ pub fn accessat<P: path::Arg, Fd: AsFd>(
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/utimensat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/utimensat.2.html
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
 #[inline]
 pub fn utimensat<P: path::Arg, Fd: AsFd>(
     dirfd: Fd,
@@ -396,7 +397,7 @@ pub fn fclonefileat<Fd: AsFd, DstFd: AsFd, P: path::Arg>(
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/mknodat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/mknodat.2.html
-#[cfg(not(any(apple, target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(apple, target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 #[inline]
 pub fn mknodat<P: path::Arg, Fd: AsFd>(
     dirfd: Fd,

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -3,7 +3,7 @@
 use crate::backend;
 
 pub use crate::io::FdFlags;
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
 pub use backend::fs::types::Access;
 pub use backend::fs::types::{Dev, Mode, OFlags};
 

--- a/src/fs/fcntl.rs
+++ b/src/fs/fcntl.rs
@@ -8,6 +8,7 @@
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 use crate::fs::FlockOperation;
@@ -100,6 +101,7 @@ pub fn fcntl_add_seals<Fd: AsFd>(fd: Fd, seals: SealFlags) -> io::Result<()> {
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 #[inline]

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -8,7 +8,7 @@ use crate::fs::{OFlags, SeekFrom, Timespec};
 use crate::{backend, io};
 use backend::fd::{AsFd, BorrowedFd};
 
-#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 pub use backend::fs::types::FlockOperation;
 
 #[cfg(not(any(
@@ -19,6 +19,7 @@ pub use backend::fs::types::FlockOperation;
     target_os = "espidf",
     target_os = "nto",
     target_os = "redox",
+    target_os = "vita",
 )))]
 pub use backend::fs::types::FallocateFlags;
 
@@ -31,6 +32,7 @@ pub use backend::fs::types::Stat;
     target_os = "netbsd",
     target_os = "nto",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 pub use backend::fs::types::StatFs;
@@ -170,6 +172,7 @@ pub fn fstat<Fd: AsFd>(fd: Fd) -> io::Result<Stat> {
     target_os = "netbsd",
     target_os = "nto",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 #[inline]
@@ -205,7 +208,7 @@ pub fn fstatvfs<Fd: AsFd>(fd: Fd) -> io::Result<StatVfs> {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/futimens.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/utimensat.2.html
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
 #[inline]
 pub fn futimens<Fd: AsFd>(fd: Fd, times: &Timestamps) -> io::Result<()> {
     backend::fs::syscalls::futimens(fd.as_fd(), times)
@@ -234,6 +237,7 @@ pub fn futimens<Fd: AsFd>(fd: Fd, times: &Timestamps) -> io::Result<()> {
     target_os = "espidf",
     target_os = "nto",
     target_os = "redox",
+    target_os = "vita",
 )))] // not implemented in libc for netbsd yet
 #[inline]
 #[doc(alias = "posix_fallocate")]
@@ -304,6 +308,7 @@ pub fn fsync<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     target_os = "espidf",
     target_os = "haiku",
     target_os = "redox",
+    target_os = "vita",
 )))]
 #[inline]
 pub fn fdatasync<Fd: AsFd>(fd: Fd) -> io::Result<()> {
@@ -329,7 +334,12 @@ pub fn ftruncate<Fd: AsFd>(fd: Fd, length: u64) -> io::Result<()> {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/flock.2.html
-#[cfg(not(any(target_os = "espidf", target_os = "solaris", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "solaris",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 #[inline]
 pub fn flock<Fd: AsFd>(fd: Fd, operation: FlockOperation) -> io::Result<()> {
     backend::fs::syscalls::flock(fd.as_fd(), operation)

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -19,6 +19,7 @@ mod dir;
     target_os = "espidf",
     target_os = "haiku",
     target_os = "redox",
+    target_os = "vita",
 )))]
 mod fadvise;
 pub(crate) mod fcntl;
@@ -38,6 +39,7 @@ mod ioctl;
     target_os = "espidf",
     target_os = "haiku",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 mod makedev;
@@ -55,7 +57,12 @@ mod seek_from;
 mod sendfile;
 #[cfg(linux_kernel)]
 mod statx;
-#[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 mod sync;
 #[cfg(any(apple, linux_kernel))]
 mod xattr;
@@ -81,6 +88,7 @@ pub use dir::{Dir, DirEntry};
     target_os = "espidf",
     target_os = "haiku",
     target_os = "redox",
+    target_os = "vita",
 )))]
 pub use fadvise::{fadvise, Advice};
 pub use fcntl::*;
@@ -100,6 +108,7 @@ pub use ioctl::*;
     target_os = "espidf",
     target_os = "haiku",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 pub use makedev::*;
@@ -117,7 +126,12 @@ pub use seek_from::SeekFrom;
 pub use sendfile::sendfile;
 #[cfg(linux_kernel)]
 pub use statx::{statx, Statx, StatxFlags, StatxTimestamp};
-#[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 pub use sync::sync;
 #[cfg(any(apple, linux_kernel))]
 pub use xattr::*;

--- a/src/io/dup.rs
+++ b/src/io/dup.rs
@@ -115,6 +115,7 @@ pub fn dup2<Fd: AsFd>(fd: Fd, new: &mut OwnedFd) -> io::Result<()> {
     target_os = "aix",
     target_os = "espidf",
     target_os = "nto",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 #[inline]

--- a/src/io/ioctl.rs
+++ b/src/io/ioctl.rs
@@ -73,7 +73,7 @@ pub fn ioctl_fionbio<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 /// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=ioctl&sektion=2#GENERIC%09IOCTLS
 /// [NetBSD]: https://man.netbsd.org/ioctl.2#GENERIC%20IOCTLS
 /// [OpenBSD]: https://man.openbsd.org/ioctl.2#GENERIC_IOCTLS
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
 #[inline]
 #[doc(alias = "FIONREAD")]
 pub fn ioctl_fionread<Fd: AsFd>(fd: Fd) -> io::Result<u64> {

--- a/src/io/read_write.rs
+++ b/src/io/read_write.rs
@@ -192,7 +192,8 @@ pub fn writev<Fd: AsFd>(fd: Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
     target_os = "haiku",
     target_os = "nto",
     target_os = "redox",
-    target_os = "solaris"
+    target_os = "solaris",
+    target_os = "vita"
 )))]
 #[inline]
 pub fn preadv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
@@ -225,7 +226,8 @@ pub fn preadv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io:
     target_os = "haiku",
     target_os = "nto",
     target_os = "redox",
-    target_os = "solaris"
+    target_os = "solaris",
+    target_os = "vita"
 )))]
 #[inline]
 pub fn pwritev<Fd: AsFd>(fd: Fd, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {

--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -325,8 +325,14 @@ type _RawOpcode = c::c_int;
 #[cfg(all(not(linux_raw), target_os = "android"))]
 type _RawOpcode = c::c_int;
 
-// BSD, Haiku, Hurd, and Redox use `unsigned long`.
-#[cfg(any(bsd, target_os = "redox", target_os = "haiku", target_os = "hurd"))]
+// BSD, Haiku, Hurd, Redox, and Vita use `unsigned long`.
+#[cfg(any(
+    bsd,
+    target_os = "redox",
+    target_os = "haiku",
+    target_os = "hurd",
+    target_os = "vita"
+))]
 type _RawOpcode = c::c_ulong;
 
 // AIX, Emscripten, Fuchsia, Solaris, and WASI use a `int`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ pub mod io;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "io_uring")))]
 pub mod io_uring;
 pub mod ioctl;
-#[cfg(not(any(windows, target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(windows, target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 #[cfg(feature = "mm")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "mm")))]
 pub mod mm;
@@ -250,6 +250,7 @@ pub mod rand;
     windows,
     target_os = "android",
     target_os = "espidf",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 #[cfg(feature = "shm")]
@@ -263,7 +264,7 @@ pub mod stdio;
 #[cfg(not(any(windows, target_os = "wasi")))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "system")))]
 pub mod system;
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "vita")))]
 #[cfg(feature = "termios")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "termios")))]
 pub mod termios;

--- a/src/net/send_recv/mod.rs
+++ b/src/net/send_recv/mod.rs
@@ -8,10 +8,22 @@ use backend::fd::{AsFd, BorrowedFd};
 
 pub use backend::net::send_recv::{RecvFlags, SendFlags};
 
-#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 mod msg;
 
-#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 pub use msg::*;
 
 /// `recv(fd, buf, flags)`—Reads data from a socket.

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -153,6 +153,7 @@
     target_os = "haiku",
     target_os = "netbsd",
     target_os = "nto",
+    target_os = "vita",
 )))]
 use crate::net::AddressFamily;
 #[cfg(any(
@@ -441,6 +442,7 @@ pub fn get_socket_send_buffer_size<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
     target_os = "haiku",
     target_os = "netbsd",
     target_os = "nto",
+    target_os = "vita",
 )))]
 #[inline]
 #[doc(alias = "SO_DOMAIN")]
@@ -1098,7 +1100,13 @@ pub fn get_ipv6_original_dst<Fd: AsFd>(fd: Fd) -> io::Result<SocketAddrV6> {
 /// See the [module-level documentation] for more.
 ///
 /// [module-level documentation]: self#references-for-get_ipv6_-and-set_ipv6_-functions
-#[cfg(not(any(solarish, windows, target_os = "espidf", target_os = "haiku")))]
+#[cfg(not(any(
+    solarish,
+    windows,
+    target_os = "espidf",
+    target_os = "haiku",
+    target_os = "vita"
+)))]
 #[inline]
 #[doc(alias = "IPV6_TCLASS")]
 pub fn set_ipv6_tclass<Fd: AsFd>(fd: Fd, value: u32) -> io::Result<()> {
@@ -1110,7 +1118,13 @@ pub fn set_ipv6_tclass<Fd: AsFd>(fd: Fd, value: u32) -> io::Result<()> {
 /// See the [module-level documentation] for more.
 ///
 /// [module-level documentation]: self#references-for-get_ipv6_-and-set_ipv6_-functions
-#[cfg(not(any(solarish, windows, target_os = "espidf", target_os = "haiku")))]
+#[cfg(not(any(
+    solarish,
+    windows,
+    target_os = "espidf",
+    target_os = "haiku",
+    target_os = "vita"
+)))]
 #[inline]
 #[doc(alias = "IPV6_TCLASS")]
 pub fn get_ipv6_tclass<Fd: AsFd>(fd: Fd) -> io::Result<u32> {

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -92,6 +92,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const NETLINK: Self = Self(c::AF_NETLINK as _);
     /// `AF_UNIX`, aka `AF_LOCAL`
@@ -106,16 +107,18 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const AX25: Self = Self(c::AF_AX25 as _);
     /// `AF_IPX`
     #[cfg(not(any(
-        target_os = "espidf",
         target_os = "aix",
+        target_os = "espidf",
+        target_os = "vita",
     )))]
     pub const IPX: Self = Self(c::AF_IPX as _);
     /// `AF_APPLETALK`
-    #[cfg(not(target_os = "espidf"))]
+    #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
     pub const APPLETALK: Self = Self(c::AF_APPLETALK as _);
     /// `AF_NETROM`
     #[cfg(not(any(
@@ -126,6 +129,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const NETROM: Self = Self(c::AF_NETROM as _);
     /// `AF_BRIDGE`
@@ -137,6 +141,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const BRIDGE: Self = Self(c::AF_BRIDGE as _);
     /// `AF_ATMPVC`
@@ -148,6 +153,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const ATMPVC: Self = Self(c::AF_ATMPVC as _);
     /// `AF_X25`
@@ -158,6 +164,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const X25: Self = Self(c::AF_X25 as _);
     /// `AF_ROSE`
@@ -169,10 +176,11 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const ROSE: Self = Self(c::AF_ROSE as _);
     /// `AF_DECnet`
-    #[cfg(not(any(target_os = "espidf", target_os = "haiku")))]
+    #[cfg(not(any(target_os = "espidf", target_os = "haiku", target_os = "vita")))]
     pub const DECnet: Self = Self(c::AF_DECnet as _);
     /// `AF_NETBEUI`
     #[cfg(not(any(
@@ -183,6 +191,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const NETBEUI: Self = Self(c::AF_NETBEUI as _);
     /// `AF_SECURITY`
@@ -194,6 +203,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const SECURITY: Self = Self(c::AF_SECURITY as _);
     /// `AF_KEY`
@@ -204,6 +214,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const KEY: Self = Self(c::AF_KEY as _);
     /// `AF_PACKET`
@@ -219,6 +230,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const PACKET: Self = Self(c::AF_PACKET as _);
     /// `AF_ASH`
@@ -230,6 +242,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const ASH: Self = Self(c::AF_ASH as _);
     /// `AF_ECONET`
@@ -241,6 +254,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const ECONET: Self = Self(c::AF_ECONET as _);
     /// `AF_ATMSVC`
@@ -252,6 +266,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const ATMSVC: Self = Self(c::AF_ATMSVC as _);
     /// `AF_RDS`
@@ -263,10 +278,11 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const RDS: Self = Self(c::AF_RDS as _);
     /// `AF_SNA`
-    #[cfg(not(any(target_os = "espidf", target_os = "haiku")))]
+    #[cfg(not(any(target_os = "espidf", target_os = "haiku", target_os = "vita")))]
     pub const SNA: Self = Self(c::AF_SNA as _);
     /// `AF_IRDA`
     #[cfg(not(any(
@@ -276,6 +292,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const IRDA: Self = Self(c::AF_IRDA as _);
     /// `AF_PPPOX`
@@ -287,6 +304,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const PPPOX: Self = Self(c::AF_PPPOX as _);
     /// `AF_WANPIPE`
@@ -298,6 +316,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const WANPIPE: Self = Self(c::AF_WANPIPE as _);
     /// `AF_LLC`
@@ -309,6 +328,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const LLC: Self = Self(c::AF_LLC as _);
     /// `AF_CAN`
@@ -320,6 +340,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const CAN: Self = Self(c::AF_CAN as _);
     /// `AF_TIPC`
@@ -331,6 +352,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const TIPC: Self = Self(c::AF_TIPC as _);
     /// `AF_BLUETOOTH`
@@ -340,6 +362,7 @@ impl AddressFamily {
         windows,
         target_os = "aix",
         target_os = "espidf",
+        target_os = "vita",
     )))]
     pub const BLUETOOTH: Self = Self(c::AF_BLUETOOTH as _);
     /// `AF_IUCV`
@@ -351,6 +374,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const IUCV: Self = Self(c::AF_IUCV as _);
     /// `AF_RXRPC`
@@ -362,6 +386,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const RXRPC: Self = Self(c::AF_RXRPC as _);
     /// `AF_ISDN`
@@ -371,6 +396,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "vita",
     )))]
     pub const ISDN: Self = Self(c::AF_ISDN as _);
     /// `AF_PHONET`
@@ -382,6 +408,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const PHONET: Self = Self(c::AF_PHONET as _);
     /// `AF_IEEE802154`
@@ -393,6 +420,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const IEEE802154: Self = Self(c::AF_IEEE802154 as _);
     /// `AF_802`
@@ -610,26 +638,58 @@ pub mod ipproto {
     /// `IPPROTO_ICMP`
     pub const ICMP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_ICMP as _));
     /// `IPPROTO_IGMP`
-    #[cfg(not(any(solarish, target_os = "espidf", target_os = "haiku")))]
+    #[cfg(not(any(
+        solarish,
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "vita"
+    )))]
     pub const IGMP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_IGMP as _));
     /// `IPPROTO_IPIP`
-    #[cfg(not(any(solarish, windows, target_os = "espidf", target_os = "haiku")))]
+    #[cfg(not(any(
+        solarish,
+        windows,
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "vita"
+    )))]
     pub const IPIP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_IPIP as _));
     /// `IPPROTO_TCP`
     pub const TCP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_TCP as _));
     /// `IPPROTO_EGP`
-    #[cfg(not(any(solarish, target_os = "espidf", target_os = "haiku")))]
+    #[cfg(not(any(
+        solarish,
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "vita"
+    )))]
     pub const EGP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_EGP as _));
     /// `IPPROTO_PUP`
-    #[cfg(not(any(solarish, target_os = "espidf", target_os = "haiku")))]
+    #[cfg(not(any(
+        solarish,
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "vita"
+    )))]
     pub const PUP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_PUP as _));
     /// `IPPROTO_UDP`
     pub const UDP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_UDP as _));
     /// `IPPROTO_IDP`
-    #[cfg(not(any(solarish, target_os = "espidf", target_os = "haiku")))]
+    #[cfg(not(any(
+        solarish,
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "vita"
+    )))]
     pub const IDP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_IDP as _));
     /// `IPPROTO_TP`
-    #[cfg(not(any(solarish, windows, target_os = "espidf", target_os = "haiku")))]
+    #[cfg(not(any(
+        solarish,
+        windows,
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "vita"
+    )))]
     pub const TP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_TP as _));
     /// `IPPROTO_DCCP`
     #[cfg(not(any(
@@ -642,21 +702,44 @@ pub mod ipproto {
         target_os = "haiku",
         target_os = "nto",
         target_os = "openbsd",
+        target_os = "vita",
     )))]
     pub const DCCP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_DCCP as _));
     /// `IPPROTO_IPV6`
     pub const IPV6: Protocol = Protocol(new_raw_protocol(c::IPPROTO_IPV6 as _));
     /// `IPPROTO_RSVP`
-    #[cfg(not(any(solarish, windows, target_os = "espidf", target_os = "haiku")))]
+    #[cfg(not(any(
+        solarish,
+        windows,
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "vita"
+    )))]
     pub const RSVP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_RSVP as _));
     /// `IPPROTO_GRE`
-    #[cfg(not(any(solarish, windows, target_os = "espidf", target_os = "haiku")))]
+    #[cfg(not(any(
+        solarish,
+        windows,
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "vita"
+    )))]
     pub const GRE: Protocol = Protocol(new_raw_protocol(c::IPPROTO_GRE as _));
     /// `IPPROTO_ESP`
-    #[cfg(not(any(solarish, target_os = "espidf", target_os = "haiku")))]
+    #[cfg(not(any(
+        solarish,
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "vita"
+    )))]
     pub const ESP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_ESP as _));
     /// `IPPROTO_AH`
-    #[cfg(not(any(solarish, target_os = "espidf", target_os = "haiku")))]
+    #[cfg(not(any(
+        solarish,
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "vita"
+    )))]
     pub const AH: Protocol = Protocol(new_raw_protocol(c::IPPROTO_AH as _));
     /// `IPPROTO_MTP`
     #[cfg(not(any(
@@ -667,6 +750,7 @@ pub mod ipproto {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const MTP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_MTP as _));
     /// `IPPROTO_BEETPH`
@@ -677,7 +761,8 @@ pub mod ipproto {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
-        target_os = "nto"
+        target_os = "nto",
+        target_os = "vita",
     )))]
     pub const BEETPH: Protocol = Protocol(new_raw_protocol(c::IPPROTO_BEETPH as _));
     /// `IPPROTO_ENCAP`
@@ -687,10 +772,17 @@ pub mod ipproto {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "vita",
     )))]
     pub const ENCAP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_ENCAP as _));
     /// `IPPROTO_PIM`
-    #[cfg(not(any(solarish, target_os = "aix", target_os = "espidf", target_os = "haiku")))]
+    #[cfg(not(any(
+        solarish,
+        target_os = "aix",
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "vita"
+    )))]
     pub const PIM: Protocol = Protocol(new_raw_protocol(c::IPPROTO_PIM as _));
     /// `IPPROTO_COMP`
     #[cfg(not(any(
@@ -700,7 +792,8 @@ pub mod ipproto {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
-        target_os = "nto"
+        target_os = "nto",
+        target_os = "vita",
     )))]
     pub const COMP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_COMP as _));
     /// `IPPROTO_SCTP`
@@ -709,7 +802,8 @@ pub mod ipproto {
         target_os = "dragonfly",
         target_os = "espidf",
         target_os = "haiku",
-        target_os = "openbsd"
+        target_os = "openbsd",
+        target_os = "vita",
     )))]
     pub const SCTP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_SCTP as _));
     /// `IPPROTO_UDPLITE`
@@ -723,6 +817,7 @@ pub mod ipproto {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const UDPLITE: Protocol = Protocol(new_raw_protocol(c::IPPROTO_UDPLITE as _));
     /// `IPPROTO_MPLS`
@@ -736,13 +831,14 @@ pub mod ipproto {
         target_os = "haiku",
         target_os = "netbsd",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const MPLS: Protocol = Protocol(new_raw_protocol(c::IPPROTO_MPLS as _));
     /// `IPPROTO_ETHERNET`
     #[cfg(linux_kernel)]
     pub const ETHERNET: Protocol = Protocol(new_raw_protocol(c::IPPROTO_ETHERNET as _));
     /// `IPPROTO_RAW`
-    #[cfg(not(target_os = "espidf"))]
+    #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
     pub const RAW: Protocol = Protocol(new_raw_protocol(c::IPPROTO_RAW as _));
     /// `IPPROTO_MPTCP`
     #[cfg(not(any(
@@ -755,10 +851,16 @@ pub mod ipproto {
         target_os = "fuchsia",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const MPTCP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_MPTCP as _));
     /// `IPPROTO_FRAGMENT`
-    #[cfg(not(any(solarish, target_os = "espidf", target_os = "haiku")))]
+    #[cfg(not(any(
+        solarish,
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "vita"
+    )))]
     pub const FRAGMENT: Protocol = Protocol(new_raw_protocol(c::IPPROTO_FRAGMENT as _));
     /// `IPPROTO_ICMPV6`
     pub const ICMPV6: Protocol = Protocol(new_raw_protocol(c::IPPROTO_ICMPV6 as _));
@@ -772,10 +874,16 @@ pub mod ipproto {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
     )))]
     pub const MH: Protocol = Protocol(new_raw_protocol(c::IPPROTO_MH as _));
     /// `IPPROTO_ROUTING`
-    #[cfg(not(any(solarish, target_os = "espidf", target_os = "haiku")))]
+    #[cfg(not(any(
+        solarish,
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "vita"
+    )))]
     pub const ROUTING: Protocol = Protocol(new_raw_protocol(c::IPPROTO_ROUTING as _));
 }
 
@@ -1323,6 +1431,7 @@ bitflags! {
             target_os = "espidf",
             target_os = "haiku",
             target_os = "nto",
+            target_os = "vita",
         )))]
         const NONBLOCK = bitcast!(c::SOCK_NONBLOCK);
 

--- a/src/param/auxv.rs
+++ b/src/param/auxv.rs
@@ -36,7 +36,7 @@ pub fn page_size() -> usize {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/sysconf.html
 /// [Linux]: https://man7.org/linux/man-pages/man3/sysconf.3.html
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "vita", target_os = "wasi")))]
 #[inline]
 #[doc(alias = "_SC_CLK_TCK")]
 pub fn clock_ticks_per_second() -> u64 {

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -14,6 +14,7 @@ use crate::{backend, io};
     target_os = "espidf",
     target_os = "haiku",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 use backend::c;
@@ -41,6 +42,7 @@ pub use backend::pipe::types::{IoSliceRaw, SpliceFlags};
     target_os = "haiku",
     target_os = "hurd",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 pub const PIPE_BUF: usize = c::PIPE_BUF;

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -7,7 +7,7 @@ mod chroot;
 mod exit;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have get[gpu]id.
 mod id;
-#[cfg(not(any(target_os = "aix", target_os = "espidf")))]
+#[cfg(not(any(target_os = "aix", target_os = "espidf", target_os = "vita")))]
 mod ioctl;
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 mod kill;
@@ -19,7 +19,8 @@ mod pidfd;
 mod pidfd_getfd;
 #[cfg(linux_kernel)]
 mod prctl;
-#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))] // WASI doesn't have [gs]etpriority.
+#[cfg(not(any(target_os = "fuchsia", target_os = "vita", target_os = "wasi")))]
+// WASI doesn't have [gs]etpriority.
 mod priority;
 #[cfg(freebsdlike)]
 mod procctl;
@@ -27,6 +28,7 @@ mod procctl;
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 mod rlimit;
@@ -35,7 +37,7 @@ mod sched;
 mod sched_yield;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have umask.
 mod umask;
-#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 mod wait;
 
 #[cfg(not(target_os = "wasi"))]
@@ -45,7 +47,7 @@ pub use chroot::*;
 pub use exit::*;
 #[cfg(not(target_os = "wasi"))]
 pub use id::*;
-#[cfg(not(any(target_os = "aix", target_os = "espidf")))]
+#[cfg(not(any(target_os = "aix", target_os = "espidf", target_os = "vita")))]
 pub use ioctl::*;
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 pub use kill::*;
@@ -57,7 +59,7 @@ pub use pidfd::*;
 pub use pidfd_getfd::*;
 #[cfg(linux_kernel)]
 pub use prctl::*;
-#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "vita", target_os = "wasi")))]
 pub use priority::*;
 #[cfg(freebsdlike)]
 pub use procctl::*;
@@ -65,6 +67,7 @@ pub use procctl::*;
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 pub use rlimit::*;
@@ -73,5 +76,5 @@ pub use sched::*;
 pub use sched_yield::sched_yield;
 #[cfg(not(target_os = "wasi"))]
 pub use umask::*;
-#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 pub use wait::*;

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -30,7 +30,7 @@ bitflags! {
 
 #[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "wasi")))]
 bitflags! {
-    /// Options for modifying the behavior of waitid
+    /// Options for modifying the behavior of [`waitid`].
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct WaitidOptions: u32 {

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -31,7 +31,7 @@ bitflags::bitflags! {
         const RDWR = c::O_RDWR as c::c_uint;
 
         /// `O_NOCTTY`
-        #[cfg(not(any(target_os = "espidf", target_os = "l4re", target_os = "redox")))]
+        #[cfg(not(any(target_os = "espidf", target_os = "l4re", target_os = "redox", target_os = "vita")))]
         const NOCTTY = c::O_NOCTTY as c::c_uint;
 
         /// `O_CLOEXEC`

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -30,10 +30,12 @@ pub enum Signal {
     /// `SIGKILL`
     Kill = c::SIGKILL,
     /// `SIGUSR1`
+    #[cfg(not(target_os = "vita"))]
     Usr1 = c::SIGUSR1,
     /// `SIGSEGV`
     Segv = c::SIGSEGV,
     /// `SIGUSR2`
+    #[cfg(not(target_os = "vita"))]
     Usr2 = c::SIGUSR2,
     /// `SIGPIPE`
     Pipe = c::SIGPIPE,
@@ -49,6 +51,7 @@ pub enum Signal {
         target_os = "aix",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "vita",
         all(
             linux_kernel,
             any(
@@ -63,37 +66,49 @@ pub enum Signal {
     )))]
     Stkflt = c::SIGSTKFLT,
     /// `SIGCHLD`
+    #[cfg(not(target_os = "vita"))]
     #[doc(alias = "Chld")]
     Child = c::SIGCHLD,
     /// `SIGCONT`
+    #[cfg(not(target_os = "vita"))]
     Cont = c::SIGCONT,
     /// `SIGSTOP`
+    #[cfg(not(target_os = "vita"))]
     Stop = c::SIGSTOP,
     /// `SIGTSTP`
+    #[cfg(not(target_os = "vita"))]
     Tstp = c::SIGTSTP,
     /// `SIGTTIN`
+    #[cfg(not(target_os = "vita"))]
     Ttin = c::SIGTTIN,
     /// `SIGTTOU`
+    #[cfg(not(target_os = "vita"))]
     Ttou = c::SIGTTOU,
     /// `SIGURG`
+    #[cfg(not(target_os = "vita"))]
     Urg = c::SIGURG,
     /// `SIGXCPU`
+    #[cfg(not(target_os = "vita"))]
     Xcpu = c::SIGXCPU,
     /// `SIGXFSZ`
+    #[cfg(not(target_os = "vita"))]
     Xfsz = c::SIGXFSZ,
     /// `SIGVTALRM`
+    #[cfg(not(target_os = "vita"))]
     #[doc(alias = "Vtalrm")]
     Vtalarm = c::SIGVTALRM,
     /// `SIGPROF`
+    #[cfg(not(target_os = "vita"))]
     Prof = c::SIGPROF,
     /// `SIGWINCH`
+    #[cfg(not(target_os = "vita"))]
     Winch = c::SIGWINCH,
     /// `SIGIO`, aka `SIGPOLL`
     #[doc(alias = "Poll")]
-    #[cfg(not(target_os = "haiku"))]
+    #[cfg(not(any(target_os = "haiku", target_os = "vita")))]
     Io = c::SIGIO,
     /// `SIGPWR`
-    #[cfg(not(any(bsd, target_os = "haiku")))]
+    #[cfg(not(any(bsd, target_os = "haiku", target_os = "vita")))]
     #[doc(alias = "Pwr")]
     Power = c::SIGPWR,
     /// `SIGSYS`, aka `SIGUNUSED`
@@ -143,8 +158,10 @@ impl Signal {
             c::SIGBUS => Some(Self::Bus),
             c::SIGFPE => Some(Self::Fpe),
             c::SIGKILL => Some(Self::Kill),
+            #[cfg(not(target_os = "vita"))]
             c::SIGUSR1 => Some(Self::Usr1),
             c::SIGSEGV => Some(Self::Segv),
+            #[cfg(not(target_os = "vita"))]
             c::SIGUSR2 => Some(Self::Usr2),
             c::SIGPIPE => Some(Self::Pipe),
             c::SIGALRM => Some(Self::Alarm),
@@ -155,6 +172,7 @@ impl Signal {
                 target_os = "aix",
                 target_os = "haiku",
                 target_os = "nto",
+                target_os = "vita",
                 all(
                     linux_kernel,
                     any(
@@ -168,21 +186,33 @@ impl Signal {
                 )
             )))]
             c::SIGSTKFLT => Some(Self::Stkflt),
+            #[cfg(not(target_os = "vita"))]
             c::SIGCHLD => Some(Self::Child),
+            #[cfg(not(target_os = "vita"))]
             c::SIGCONT => Some(Self::Cont),
+            #[cfg(not(target_os = "vita"))]
             c::SIGSTOP => Some(Self::Stop),
+            #[cfg(not(target_os = "vita"))]
             c::SIGTSTP => Some(Self::Tstp),
+            #[cfg(not(target_os = "vita"))]
             c::SIGTTIN => Some(Self::Ttin),
+            #[cfg(not(target_os = "vita"))]
             c::SIGTTOU => Some(Self::Ttou),
+            #[cfg(not(target_os = "vita"))]
             c::SIGURG => Some(Self::Urg),
+            #[cfg(not(target_os = "vita"))]
             c::SIGXCPU => Some(Self::Xcpu),
+            #[cfg(not(target_os = "vita"))]
             c::SIGXFSZ => Some(Self::Xfsz),
+            #[cfg(not(target_os = "vita"))]
             c::SIGVTALRM => Some(Self::Vtalarm),
+            #[cfg(not(target_os = "vita"))]
             c::SIGPROF => Some(Self::Prof),
+            #[cfg(not(target_os = "vita"))]
             c::SIGWINCH => Some(Self::Winch),
-            #[cfg(not(target_os = "haiku"))]
+            #[cfg(not(any(target_os = "haiku", target_os = "vita")))]
             c::SIGIO => Some(Self::Io),
-            #[cfg(not(any(bsd, target_os = "haiku")))]
+            #[cfg(not(any(bsd, target_os = "haiku", target_os = "vita")))]
             c::SIGPWR => Some(Self::Power),
             c::SIGSYS => Some(Self::Sys),
             #[cfg(any(

--- a/src/system.rs
+++ b/src/system.rs
@@ -10,7 +10,7 @@ use crate::backend;
 #[cfg(target_os = "linux")]
 use crate::backend::c;
 use crate::ffi::CStr;
-#[cfg(not(any(target_os = "espidf", target_os = "emscripten")))]
+#[cfg(not(any(target_os = "espidf", target_os = "emscripten", target_os = "vita")))]
 use crate::io;
 use core::fmt;
 
@@ -150,6 +150,7 @@ pub fn sysinfo() -> Sysinfo {
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi"
 )))]
 #[inline]

--- a/src/thread/clock.rs
+++ b/src/thread/clock.rs
@@ -9,6 +9,7 @@ pub use crate::timespec::Timespec;
     target_os = "freebsd", // FreeBSD 12 has clock_nanosleep, but libc targets FreeBSD 11.
     target_os = "openbsd",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 pub use crate::clockid::ClockId;
@@ -34,6 +35,7 @@ pub use crate::clockid::ClockId;
     target_os = "haiku",
     target_os = "openbsd",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 #[inline]
@@ -62,6 +64,7 @@ pub fn clock_nanosleep_relative(id: ClockId, request: &Timespec) -> NanosleepRel
     target_os = "haiku",
     target_os = "openbsd",
     target_os = "redox",
+    target_os = "vita",
     target_os = "wasi",
 )))]
 #[inline]


### PR DESCRIPTION
Add `target_os = "vita"` checks as needed for rustix to compile on armv7-sony-vita-newlibeabihf.

This excludes support for `mm`, `termios`, and a few other things for now, where the libc bindings seem to be missing key types and constants.

Fixes #881.