### PR TITLE
Make `cmsg_space!` usable in const contexts.

### DIFF
--- a/tests/net/main.rs
+++ b/tests/net/main.rs
@@ -12,6 +12,8 @@ mod poll;
 mod sockopt;
 #[cfg(unix)]
 mod unix;
+#[cfg(unix)]
+mod unix_alloc;
 mod v4;
 mod v6;
 


### PR DESCRIPTION
Make `cmsg_space!` usable in const contexts, so that it can be used as a buffer size argument, and add a version of tests/net/unix.rs that uses stack-allocated buffers instead of `Vec`s.

This exposes an alignment sublety, that buffers must be aligned to the needed alignment of `cmsghdr`; handle this by auto-aligning the provided buffer to the needed boundary.