### PR TITLE
Implement `runtime::brk`.

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -510,3 +510,14 @@ pub unsafe fn sigtimedwait(set: &Sigset, timeout: Option<Timespec>) -> io::Resul
 pub fn linux_secure() -> bool {
     backend::param::auxv::linux_secure()
 }
+
+/// `brk(addr)`—Change the location of the “program break”.
+///
+/// # Safety
+///
+/// Be a good sport and don't break the allocator.
+#[cfg(linux_raw)]
+#[inline]
+pub unsafe fn brk(addr: *mut c_void) -> io::Result<*mut c_void> {
+    backend::runtime::syscalls::brk(addr)
+}


### PR DESCRIPTION
`brk` is used by some `malloc` implementations.