### PR TITLE
Fix p{read,write}v{,v2}'s encoding of the offset argument on Linux.

### DIFF
--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -14,8 +14,8 @@ use crate::backend::conv::loff_t_from_u64;
 ))]
 use crate::backend::conv::zero;
 use crate::backend::conv::{
-    c_uint, raw_fd, ret, ret_c_int, ret_c_uint, ret_discarded_fd, ret_owned_fd, ret_usize, slice,
-    slice_mut,
+    c_uint, pass_usize, raw_fd, ret, ret_c_int, ret_c_uint, ret_discarded_fd, ret_owned_fd,
+    ret_usize, slice, slice_mut,
 };
 #[cfg(target_pointer_width = "32")]
 use crate::backend::conv::{hi, lo};
@@ -96,25 +96,16 @@ pub(crate) fn preadv(
 ) -> io::Result<usize> {
     let (bufs_addr, bufs_len) = slice(&bufs[..cmp::min(bufs.len(), MAX_IOV)]);
 
-    #[cfg(target_pointer_width = "32")]
+    // Unlike the plain "p" functions, the "pv" functions pass their offset in
+    // an endian-independent way, and always in two registers.
     unsafe {
         ret_usize(syscall!(
             __NR_preadv,
             fd,
             bufs_addr,
             bufs_len,
-            hi(pos),
-            lo(pos)
-        ))
-    }
-    #[cfg(target_pointer_width = "64")]
-    unsafe {
-        ret_usize(syscall!(
-            __NR_preadv,
-            fd,
-            bufs_addr,
-            bufs_len,
-            loff_t_from_u64(pos)
+            pass_usize(pos as usize),
+            pass_usize((pos >> 32) as usize)
         ))
     }
 }
@@ -128,26 +119,16 @@ pub(crate) fn preadv2(
 ) -> io::Result<usize> {
     let (bufs_addr, bufs_len) = slice(&bufs[..cmp::min(bufs.len(), MAX_IOV)]);
 
-    #[cfg(target_pointer_width = "32")]
+    // Unlike the plain "p" functions, the "pv" functions pass their offset in
+    // an endian-independent way, and always in two registers.
     unsafe {
         ret_usize(syscall!(
             __NR_preadv2,
             fd,
             bufs_addr,
             bufs_len,
-            hi(pos),
-            lo(pos),
-            flags
-        ))
-    }
-    #[cfg(target_pointer_width = "64")]
-    unsafe {
-        ret_usize(syscall!(
-            __NR_preadv2,
-            fd,
-            bufs_addr,
-            bufs_len,
-            loff_t_from_u64(pos),
+            pass_usize(pos as usize),
+            pass_usize((pos >> 32) as usize),
             flags
         ))
     }
@@ -217,25 +198,16 @@ pub(crate) fn writev(fd: BorrowedFd<'_>, bufs: &[IoSlice<'_>]) -> io::Result<usi
 pub(crate) fn pwritev(fd: BorrowedFd<'_>, bufs: &[IoSlice<'_>], pos: u64) -> io::Result<usize> {
     let (bufs_addr, bufs_len) = slice(&bufs[..cmp::min(bufs.len(), MAX_IOV)]);
 
-    #[cfg(target_pointer_width = "32")]
+    // Unlike the plain "p" functions, the "pv" functions pass their offset in
+    // an endian-independent way, and always in two registers.
     unsafe {
         ret_usize(syscall_readonly!(
             __NR_pwritev,
             fd,
             bufs_addr,
             bufs_len,
-            hi(pos),
-            lo(pos)
-        ))
-    }
-    #[cfg(target_pointer_width = "64")]
-    unsafe {
-        ret_usize(syscall_readonly!(
-            __NR_pwritev,
-            fd,
-            bufs_addr,
-            bufs_len,
-            loff_t_from_u64(pos)
+            pass_usize(pos as usize),
+            pass_usize((pos >> 32) as usize)
         ))
     }
 }
@@ -249,26 +221,16 @@ pub(crate) fn pwritev2(
 ) -> io::Result<usize> {
     let (bufs_addr, bufs_len) = slice(&bufs[..cmp::min(bufs.len(), MAX_IOV)]);
 
-    #[cfg(target_pointer_width = "32")]
+    // Unlike the plain "p" functions, the "pv" functions pass their offset in
+    // an endian-independent way, and always in two registers.
     unsafe {
         ret_usize(syscall_readonly!(
             __NR_pwritev2,
             fd,
             bufs_addr,
             bufs_len,
-            hi(pos),
-            lo(pos),
-            flags
-        ))
-    }
-    #[cfg(target_pointer_width = "64")]
-    unsafe {
-        ret_usize(syscall_readonly!(
-            __NR_pwritev2,
-            fd,
-            bufs_addr,
-            bufs_len,
-            loff_t_from_u64(pos),
+            pass_usize(pos as usize),
+            pass_usize((pos >> 32) as usize),
             flags
         ))
     }

--- a/tests/fs/seek.rs
+++ b/tests/fs/seek.rs
@@ -58,3 +58,22 @@ fn test_seek_holes() {
         Ok(hole_size * 2)
     );
 }
+
+#[test]
+fn test_seek_offsets() {
+    use rustix::fs::{openat, seek, Mode, OFlags, SeekFrom, CWD};
+
+    let f = openat(CWD, "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
+
+    match seek(&f, SeekFrom::Start(0)) {
+        Ok(_) => {}
+        Err(e) => panic!("seek failed with an unexpected error: {:?}", e),
+    }
+    for invalid_offset in [i32::MIN as u64, !1 as u64, i64::MIN as u64] {
+        match seek(&f, SeekFrom::Start(invalid_offset)) {
+            Err(rustix::io::Errno::INVAL) => {}
+            Ok(_) => panic!("seek unexpectedly succeeded"),
+            Err(e) => panic!("seek failed with an unexpected error: {:?}", e),
+        }
+    }
+}

--- a/tests/io/read_write.rs
+++ b/tests/io/read_write.rs
@@ -244,3 +244,119 @@ fn test_preadv2_nowait() {
         Err(e) => panic!("preadv2 failed with an unexpected error: {:?}", e),
     }
 }
+
+#[cfg(all(feature = "net", feature = "pipe"))]
+#[cfg(not(target_os = "espidf"))] // no preadv/pwritev
+#[cfg(not(target_os = "solaris"))] // no preadv/pwritev
+#[cfg(not(target_os = "haiku"))] // no preadv/pwritev
+#[test]
+fn test_p_offsets() {
+    use rustix::fs::{openat, Mode, OFlags, CWD};
+    use rustix::io::{pread, preadv, pwrite, pwritev};
+    #[cfg(linux_kernel)]
+    use rustix::io::{preadv2, pwritev2, ReadWriteFlags};
+
+    let mut buf = [0_u8; 5];
+
+    let tmp = tempfile::tempdir().unwrap();
+    let f = openat(
+        CWD,
+        tmp.path().join("file"),
+        OFlags::RDWR | OFlags::CREATE | OFlags::TRUNC,
+        Mode::RUSR | Mode::WUSR,
+    )
+    .unwrap();
+
+    // Test that offset 0 works.
+    match pread(&f, &mut buf, 0_u64) {
+        Err(rustix::io::Errno::OPNOTSUPP | rustix::io::Errno::NOSYS) => {}
+        Ok(_) => {}
+        Err(e) => panic!("pread failed with an unexpected error: {:?}", e),
+    }
+    match pwrite(&f, &buf, 0_u64) {
+        Err(rustix::io::Errno::OPNOTSUPP | rustix::io::Errno::NOSYS) => {}
+        Ok(_) => {}
+        Err(e) => panic!("pwrite failed with an unexpected error: {:?}", e),
+    }
+    match preadv(&f, &mut [IoSliceMut::new(&mut buf)], 0_u64) {
+        Err(rustix::io::Errno::OPNOTSUPP | rustix::io::Errno::NOSYS) => {}
+        Ok(_) => {}
+        Err(e) => panic!("preadv failed with an unexpected error: {:?}", e),
+    }
+    match pwritev(&f, &[IoSlice::new(&buf)], 0_u64) {
+        Err(rustix::io::Errno::OPNOTSUPP | rustix::io::Errno::NOSYS) => {}
+        Ok(_) => {}
+        Err(e) => panic!("pwritev failed with an unexpected error: {:?}", e),
+    }
+    #[cfg(linux_kernel)]
+    {
+        match preadv2(
+            &f,
+            &mut [IoSliceMut::new(&mut buf)],
+            0_u64,
+            ReadWriteFlags::empty(),
+        ) {
+            Err(rustix::io::Errno::OPNOTSUPP | rustix::io::Errno::NOSYS) => {}
+            Ok(_) => {}
+            Err(e) => panic!("preadv2 failed with an unexpected error: {:?}", e),
+        }
+        match pwritev2(&f, &[IoSlice::new(&buf)], 0_u64, ReadWriteFlags::empty()) {
+            Err(rustix::io::Errno::OPNOTSUPP | rustix::io::Errno::NOSYS) => {}
+            Ok(_) => {}
+            Err(e) => panic!("pwritev2 failed with an unexpected error: {:?}", e),
+        }
+    }
+
+    // Test that negative offsets fail with `INVAL`.
+    for invalid_offset in [i32::MIN as u64, !1 as u64, i64::MIN as u64] {
+        match pread(&f, &mut buf, invalid_offset) {
+            Err(rustix::io::Errno::OPNOTSUPP | rustix::io::Errno::NOSYS) => {}
+            Err(rustix::io::Errno::INVAL) => {}
+            Ok(_) => panic!("pread unexpectedly succeeded"),
+            Err(e) => panic!("pread failed with an unexpected error: {:?}", e),
+        }
+        match pwrite(&f, &buf, invalid_offset) {
+            Err(rustix::io::Errno::OPNOTSUPP | rustix::io::Errno::NOSYS) => {}
+            Err(rustix::io::Errno::INVAL) => {}
+            Ok(_) => panic!("pwrite unexpectedly succeeded"),
+            Err(e) => panic!("pwrite failed with an unexpected error: {:?}", e),
+        }
+        match preadv(&f, &mut [IoSliceMut::new(&mut buf)], invalid_offset) {
+            Err(rustix::io::Errno::OPNOTSUPP | rustix::io::Errno::NOSYS) => {}
+            Err(rustix::io::Errno::INVAL) => {}
+            Ok(_) => panic!("preadv unexpectedly succeeded"),
+            Err(e) => panic!("preadv failed with an unexpected error: {:?}", e),
+        }
+        match pwritev(&f, &[IoSlice::new(&buf)], invalid_offset) {
+            Err(rustix::io::Errno::OPNOTSUPP | rustix::io::Errno::NOSYS) => {}
+            Err(rustix::io::Errno::INVAL) => {}
+            Ok(_) => panic!("pwritev unexpectedly succeeded"),
+            Err(e) => panic!("pwritev failed with an unexpected error: {:?}", e),
+        }
+        #[cfg(linux_kernel)]
+        {
+            match preadv2(
+                &f,
+                &mut [IoSliceMut::new(&mut buf)],
+                invalid_offset,
+                ReadWriteFlags::empty(),
+            ) {
+                Err(rustix::io::Errno::OPNOTSUPP | rustix::io::Errno::NOSYS) => {}
+                Err(rustix::io::Errno::INVAL) => {}
+                Ok(_) => panic!("preadv2 unexpectedly succeeded"),
+                Err(e) => panic!("preadv2 failed with an unexpected error: {:?}", e),
+            }
+            match pwritev2(
+                &f,
+                &[IoSlice::new(&buf)],
+                invalid_offset,
+                ReadWriteFlags::empty(),
+            ) {
+                Err(rustix::io::Errno::OPNOTSUPP | rustix::io::Errno::NOSYS) => {}
+                Err(rustix::io::Errno::INVAL) => {}
+                Ok(_) => panic!("pwritev2 unexpectedly succeeded"),
+                Err(e) => panic!("pwritev2 failed with an unexpected error: {:?}", e),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Unlike with `p{read,write}`, Linux's `p{read,write}v` syscall's offset argument is not passed in an endian-specific order. And, the expectation is for syscall wrappers to always pass both the high and low halves of the offset as separate arguments, even though on 64-bit architectures the low half is passed throgh as a 64-bit value containing the full offset and the kernel doesn't mask it.

And `p{read,write}v2` follow the behavior of `p{read,write}`.