### PR TITLE
Fix p{read,write}v{,v2}'s encoding of the offset argument on Linux. (…

### DIFF
--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -102,25 +102,16 @@ pub(crate) fn preadv(
 ) -> io::Result<usize> {
     let (bufs_addr, bufs_len) = slice(&bufs[..cmp::min(bufs.len(), max_iov())]);
 
-    #[cfg(target_pointer_width = "32")]
+    // Unlike the plain "p" functions, the "pv" functions pass their offset in
+    // an endian-independent way, and always in two registers.
     unsafe {
         ret_usize(syscall!(
             __NR_preadv,
             fd,
             bufs_addr,
             bufs_len,
-            hi(pos),
-            lo(pos)
-        ))
-    }
-    #[cfg(target_pointer_width = "64")]
-    unsafe {
-        ret_usize(syscall!(
-            __NR_preadv,
-            fd,
-            bufs_addr,
-            bufs_len,
-            loff_t_from_u64(pos)
+            pass_usize(pos as usize),
+            pass_usize((pos >> 32) as usize)
         ))
     }
 }
@@ -134,26 +125,16 @@ pub(crate) fn preadv2(
 ) -> io::Result<usize> {
     let (bufs_addr, bufs_len) = slice(&bufs[..cmp::min(bufs.len(), max_iov())]);
 
-    #[cfg(target_pointer_width = "32")]
+    // Unlike the plain "p" functions, the "pv" functions pass their offset in
+    // an endian-independent way, and always in two registers.
     unsafe {
         ret_usize(syscall!(
             __NR_preadv2,
             fd,
             bufs_addr,
             bufs_len,
-            hi(pos),
-            lo(pos),
-            flags
-        ))
-    }
-    #[cfg(target_pointer_width = "64")]
-    unsafe {
-        ret_usize(syscall!(
-            __NR_preadv2,
-            fd,
-            bufs_addr,
-            bufs_len,
-            loff_t_from_u64(pos),
+            pass_usize(pos as usize),
+            pass_usize((pos >> 32) as usize),
             flags
         ))
     }
@@ -223,25 +204,16 @@ pub(crate) fn writev(fd: BorrowedFd<'_>, bufs: &[IoSlice<'_>]) -> io::Result<usi
 pub(crate) fn pwritev(fd: BorrowedFd<'_>, bufs: &[IoSlice<'_>], pos: u64) -> io::Result<usize> {
     let (bufs_addr, bufs_len) = slice(&bufs[..cmp::min(bufs.len(), max_iov())]);
 
-    #[cfg(target_pointer_width = "32")]
+    // Unlike the plain "p" functions, the "pv" functions pass their offset in
+    // an endian-independent way, and always in two registers.
     unsafe {
         ret_usize(syscall_readonly!(
             __NR_pwritev,
             fd,
             bufs_addr,
             bufs_len,
-            hi(pos),
-            lo(pos)
-        ))
-    }
-    #[cfg(target_pointer_width = "64")]
-    unsafe {
-        ret_usize(syscall_readonly!(
-            __NR_pwritev,
-            fd,
-            bufs_addr,
-            bufs_len,
-            loff_t_from_u64(pos)
+            pass_usize(pos as usize),
+            pass_usize((pos >> 32) as usize)
         ))
     }
 }
@@ -255,26 +227,16 @@ pub(crate) fn pwritev2(
 ) -> io::Result<usize> {
     let (bufs_addr, bufs_len) = slice(&bufs[..cmp::min(bufs.len(), max_iov())]);
 
-    #[cfg(target_pointer_width = "32")]
+    // Unlike the plain "p" functions, the "pv" functions pass their offset in
+    // an endian-independent way, and always in two registers.
     unsafe {
         ret_usize(syscall_readonly!(
             __NR_pwritev2,
             fd,
             bufs_addr,
             bufs_len,
-            hi(pos),
-            lo(pos),
-            flags
-        ))
-    }
-    #[cfg(target_pointer_width = "64")]
-    unsafe {
-        ret_usize(syscall_readonly!(
-            __NR_pwritev2,
-            fd,
-            bufs_addr,
-            bufs_len,
-            loff_t_from_u64(pos),
+            pass_usize(pos as usize),
+            pass_usize((pos >> 32) as usize),
             flags
         ))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,8 @@
 )]
 #![cfg_attr(asm_experimental_arch, feature(asm_experimental_arch))]
 #![cfg_attr(not(feature = "all-apis"), allow(dead_code))]
+// On the release branch, don't worry about unused-import warnings.
+#![allow(unused_imports)]
 
 #[cfg(not(feature = "rustc-dep-of-std"))]
 extern crate alloc;

--- a/tests/fs/seek.rs
+++ b/tests/fs/seek.rs
@@ -1,0 +1,80 @@
+/// Test seek positions related to file "holes".
+#[cfg(any(apple, freebsdlike, linux_kernel, solarish))]
+#[test]
+fn test_seek_holes() {
+    use rustix::fs::{fstat, openat, seek, Mode, OFlags, SeekFrom, CWD};
+    use std::io::Write;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = openat(CWD, tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+    let foo = openat(
+        &dir,
+        "foo",
+        OFlags::RDWR | OFlags::CREATE | OFlags::TRUNC,
+        Mode::RUSR | Mode::WUSR,
+    )
+    .unwrap();
+    let mut foo = std::fs::File::from(foo);
+
+    let stat = fstat(&foo).unwrap();
+    let hole_size = stat.st_blksize as u64;
+
+    #[cfg(any(solarish, freebsdlike, netbsdlike))]
+    let hole_size = unsafe {
+        use std::os::unix::io::AsRawFd;
+
+        let r = libc::fpathconf(foo.as_raw_fd(), libc::_PC_MIN_HOLE_SIZE);
+
+        if r < 0 {
+            // Holes not supported.
+            return;
+        }
+
+        // Holes are supported.
+        core::cmp::max(hole_size, r as u64)
+    };
+
+    foo.write_all(b"prefix").unwrap();
+    assert_eq!(
+        seek(&foo, SeekFrom::Start(hole_size * 2)),
+        Ok(hole_size * 2)
+    );
+    foo.write_all(b"suffix").unwrap();
+    assert_eq!(seek(&foo, SeekFrom::Start(0)), Ok(0));
+    assert_eq!(seek(&foo, SeekFrom::Current(0)), Ok(0));
+    assert_eq!(seek(&foo, SeekFrom::Hole(0)), Ok(hole_size));
+    assert_eq!(seek(&foo, SeekFrom::Hole(hole_size as i64)), Ok(hole_size));
+    assert_eq!(
+        seek(&foo, SeekFrom::Hole(hole_size as i64 * 2)),
+        Ok(hole_size * 2 + 6)
+    );
+    assert_eq!(seek(&foo, SeekFrom::Data(0)), Ok(0));
+    assert_eq!(
+        seek(&foo, SeekFrom::Data(hole_size as i64)),
+        Ok(hole_size * 2)
+    );
+    assert_eq!(
+        seek(&foo, SeekFrom::Data(hole_size as i64 * 2)),
+        Ok(hole_size * 2)
+    );
+}
+
+#[test]
+fn test_seek_offsets() {
+    use rustix::fs::{openat, seek, Mode, OFlags, SeekFrom, CWD};
+
+    let f = openat(CWD, "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
+
+    match seek(&f, SeekFrom::Start(0)) {
+        Ok(_) => {}
+        Err(e) => panic!("seek failed with an unexpected error: {:?}", e),
+    }
+    for invalid_offset in &[i32::MIN as u64, !1 as u64, i64::MIN as u64] {
+        let invalid_offset = *invalid_offset;
+        match seek(&f, SeekFrom::Start(invalid_offset)) {
+            Err(rustix::io::Errno::INVAL) => {}
+            Ok(_) => panic!("seek unexpectedly succeeded"),
+            Err(e) => panic!("seek failed with an unexpected error: {:?}", e),
+        }
+    }
+}


### PR DESCRIPTION
…#896)

Unlike with `p{read,write}`, Linux's `p{read,write}v` syscall's offset argument is not passed in an endian-specific order. And, the expectation is for syscall wrappers to always pass both the high and low halves of the offset as separate arguments, even though on 64-bit architectures the low half is passed throgh as a 64-bit value containing the full offset and the kernel doesn't mask it.

And `p{read,write}v2` follow the behavior of `p{read,write}`.