### PR TITLE
Adjust sockaddr lengths for illumos in more more place.

### DIFF
--- a/src/backend/libc/net/read_sockaddr.rs
+++ b/src/backend/libc/net/read_sockaddr.rs
@@ -167,10 +167,10 @@ pub(crate) unsafe fn read_sockaddr(
                 // Otherwise we expect a NUL-terminated filesystem path.
 
                 // Trim off unused bytes from the end of `path_bytes`.
-                let path_bytes = if cfg!(target_os = "freebsd") {
-                    // FreeBSD sometimes sets the length to longer than the
-                    // length of the NUL-terminated string. Find the NUL and
-                    // truncate the string accordingly.
+                let path_bytes = if cfg!(any(solarish, target_os = "freebsd")) {
+                    // FreeBSD and illumos sometimes set the length to longer
+                    // than the length of the NUL-terminated string. Find the
+                    // NUL and truncate the string accordingly.
                     &decode.sun_path[..decode
                         .sun_path
                         .iter()

--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -205,11 +205,17 @@ fn test_sockopts_tcp(s: &OwnedFd) {
         assert!(sockopt::get_tcp_keepintvl(&s).is_ok());
     }
 
-    // Set the nodelay flag;
+    // Set the nodelay flag.
     sockopt::set_tcp_nodelay(&s, true).unwrap();
 
     // Check that the nodelay flag is set.
     assert!(sockopt::get_tcp_nodelay(&s).unwrap());
+
+    // Clear the nodelay flag.
+    sockopt::set_tcp_nodelay(&s, false).unwrap();
+
+    // Check that the nodelay flag is cleared.
+    assert!(!sockopt::get_tcp_nodelay(&s).unwrap());
 
     #[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
     {


### PR DESCRIPTION
Following up on #900, add illumos to the platforms that may return a Unix-domain socket address with a shorter string than the socklen value.

And following up on #901, a another test for TCP_NODELAY.