### PR TITLE
Add support for NO_SOCKET_INHERIT

### DIFF
--- a/src/backend/libc/net/syscalls.rs
+++ b/src/backend/libc/net/syscalls.rs
@@ -9,6 +9,8 @@ use crate::io;
 use crate::net::{SocketAddrAny, SocketAddrV4, SocketAddrV6};
 use crate::utils::as_ptr;
 use core::mem::{size_of, MaybeUninit};
+#[cfg(windows)]
+use windows_sys::Win32::Networking::WinSock;
 #[cfg(not(any(
     windows,
     target_os = "espidf",
@@ -29,8 +31,6 @@ use {
     crate::net::{AddressFamily, Protocol, Shutdown, SocketFlags, SocketType},
     core::ptr::null_mut,
 };
-#[cfg(windows)]
-use windows_sys::Win32::Networking::WinSock;
 
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn recv(fd: BorrowedFd<'_>, buf: &mut [u8], flags: RecvFlags) -> io::Result<usize> {
@@ -203,7 +203,7 @@ pub(crate) fn socket_with(
             raw_protocol as c::c_int,
             core::ptr::null_mut(),
             0,
-            flags.bits() as c::c_uint
+            flags.bits() as c::c_uint,
         ))
     }
 }

--- a/src/backend/libc/winsock_c.rs
+++ b/src/backend/libc/winsock_c.rs
@@ -60,4 +60,3 @@ pub(crate) use WinSock::{
     WSAEWOULDBLOCK as EWOULDBLOCK, WSAEWOULDBLOCK as EAGAIN, WSAPOLLFD as pollfd,
     WSA_E_CANCELLED as ECANCELED, *,
 };
-

--- a/src/backend/libc/winsock_c.rs
+++ b/src/backend/libc/winsock_c.rs
@@ -27,6 +27,9 @@ pub(crate) const AF_INET: i32 = WinSock::AF_INET as _;
 pub(crate) const AF_INET6: i32 = WinSock::AF_INET6 as _;
 pub(crate) const AF_UNSPEC: i32 = WinSock::AF_UNSPEC as _;
 
+// WSA_FLAG_NO_HANDLE_INHERIT is the Windows equivalent of CLOEXEC.
+pub(crate) const SOCK_CLOEXEC: u32 = WinSock::WSA_FLAG_NO_HANDLE_INHERIT;
+
 // Include the contents of `WinSock`, renaming as needed to match POSIX.
 //
 // Use `WSA_E_CANCELLED` for `ECANCELED` instead of `WSAECANCELLED`, because
@@ -57,3 +60,4 @@ pub(crate) use WinSock::{
     WSAEWOULDBLOCK as EWOULDBLOCK, WSAEWOULDBLOCK as EAGAIN, WSAPOLLFD as pollfd,
     WSA_E_CANCELLED as ECANCELED, *,
 };
+

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1436,7 +1436,7 @@ bitflags! {
         const NONBLOCK = bitcast!(c::SOCK_NONBLOCK);
 
         /// `SOCK_CLOEXEC`
-        #[cfg(not(any(apple, windows, target_os = "aix", target_os = "haiku")))]
+        #[cfg(not(any(apple, target_os = "aix", target_os = "haiku")))]
         const CLOEXEC = bitcast!(c::SOCK_CLOEXEC);
 
         // This deliberately lacks a `const _ = !0`, so that users can use


### PR DESCRIPTION
Closes #888 by making `CLOEXEC` in `SocketFlags` use the no-inherit socket property in Windows. `accept_with` seems complicated so I haven't implemented it yet.