### PR TITLE
Add more clocks to `ClockId` under `linux_4_11`

### DIFF
--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -266,6 +266,14 @@ pub(crate) const CLOCK_THREAD_CPUTIME_ID: c_int =
     linux_raw_sys::general::CLOCK_THREAD_CPUTIME_ID as _;
 pub(crate) const CLOCK_PROCESS_CPUTIME_ID: c_int =
     linux_raw_sys::general::CLOCK_PROCESS_CPUTIME_ID as _;
+#[cfg(all(feature = "time", feature = "linux_4_11"))]
+pub(crate) const CLOCK_BOOTTIME: c_int = linux_raw_sys::general::CLOCK_BOOTTIME as _;
+#[cfg(all(feature = "time", feature = "linux_4_11"))]
+pub(crate) const CLOCK_BOOTTIME_ALARM: c_int = linux_raw_sys::general::CLOCK_BOOTTIME_ALARM as _;
+#[cfg(all(feature = "time", feature = "linux_4_11"))]
+pub(crate) const CLOCK_TAI: c_int = linux_raw_sys::general::CLOCK_TAI as _;
+#[cfg(all(feature = "time", feature = "linux_4_11"))]
+pub(crate) const CLOCK_REALTIME_ALARM: c_int = linux_raw_sys::general::CLOCK_REALTIME_ALARM as _;
 
 #[cfg(feature = "system")]
 mod reboot_symbols {

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -8,9 +8,11 @@
 
 use crate::backend::c;
 use crate::backend::conv::fs::oflags_for_open_how;
+#[cfg(not(feature = "linux_4_11"))]
+use crate::backend::conv::zero;
 use crate::backend::conv::{
     by_ref, c_int, c_uint, dev_t, opt_mut, pass_usize, raw_fd, ret, ret_c_int, ret_c_uint,
-    ret_infallible, ret_owned_fd, ret_usize, size_of, slice, slice_mut, zero,
+    ret_infallible, ret_owned_fd, ret_usize, size_of, slice, slice_mut,
 };
 #[cfg(target_pointer_width = "64")]
 use crate::backend::conv::{loff_t, loff_t_from_u64, ret_u64};
@@ -839,6 +841,7 @@ pub(crate) fn statx(
     }
 }
 
+#[cfg(not(feature = "linux_4_11"))]
 #[inline]
 pub(crate) fn is_statx_available() -> bool {
     unsafe {

--- a/src/clockid.rs
+++ b/src/clockid.rs
@@ -54,6 +54,31 @@ pub enum ClockId {
     /// `CLOCK_MONOTONIC_RAW`
     #[cfg(linux_kernel)]
     MonotonicRaw = c::CLOCK_MONOTONIC_RAW,
+
+    /// `CLOCK_REALTIME_ALARM`, available on Linux >= 3.0
+    #[cfg(all(linux_kernel, feature = "linux_4_11"))]
+    #[doc(alias = "CLOCK_REALTIME_ALARM")]
+    RealtimeAlarm = bitcast!(c::CLOCK_REALTIME_ALARM),
+
+    /// `CLOCK_TAI`, available on Linux >= 3.10
+    #[cfg(all(linux_kernel, feature = "linux_4_11"))]
+    #[doc(alias = "CLOCK_TAI")]
+    Tai = bitcast!(c::CLOCK_TAI),
+
+    /// `CLOCK_BOOTTIME`, available on Linux >= 2.6.39
+    #[cfg(any(
+        freebsdlike,
+        all(linux_kernel, feature = "linux_4_11"),
+        target_os = "fuchsia",
+        target_os = "openbsd"
+    ))]
+    #[doc(alias = "CLOCK_BOOTTIME")]
+    Boottime = bitcast!(c::CLOCK_BOOTTIME),
+
+    /// `CLOCK_BOOTTIME_ALARM`, available on Linux >= 2.6.39
+    #[cfg(any(all(linux_kernel, feature = "linux_4_11"), target_os = "fuchsia"))]
+    #[doc(alias = "CLOCK_BOOTTIME_ALARM")]
+    BoottimeAlarm = bitcast!(c::CLOCK_BOOTTIME_ALARM),
 }
 
 /// `CLOCK_*` constants for use with [`clock_gettime`].

--- a/src/clockid.rs
+++ b/src/clockid.rs
@@ -66,8 +66,10 @@ pub enum ClockId {
     Tai = bitcast!(c::CLOCK_TAI),
 
     /// `CLOCK_BOOTTIME`, available on Linux >= 2.6.39
+    ///
+    /// On FreeBSD, use [`Self::Uptime`], as `CLOCK_BOOTTIME` is an alias for
+    /// `CLOCK_UPTIME`.
     #[cfg(any(
-        freebsdlike,
         all(linux_kernel, feature = "linux_4_11"),
         target_os = "fuchsia",
         target_os = "openbsd"

--- a/tests/time/clocks.rs
+++ b/tests/time/clocks.rs
@@ -58,12 +58,7 @@ fn test_boottime_clock() {
 
 /// Attempt to test that the boot alarm clock is monotonic. Time may or may not
 /// advance, but it shouldn't regress.
-#[cfg(any(
-    freebsdlike,
-    linux_kernel,
-    target_os = "fuchsia",
-    target_os = "openbsd"
-))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[test]
 fn test_boottime_alarm_clock() {
     use rustix::time::{clock_gettime_dynamic, DynamicClockId};


### PR DESCRIPTION
Add several more clocks to `ClockId` for use with the infallible `clock_gettiem` when the `linux_4_11` feature is enabled.