### PR TITLE
Mark a few more system calls as readonly.

### DIFF
--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -843,9 +843,10 @@ pub(crate) fn statx(
 pub(crate) fn is_statx_available() -> bool {
     unsafe {
         // Call `statx` with null pointers so that if it fails for any reason
-        // other than `EFAULT`, we know it's not supported.
+        // other than `EFAULT`, we know it's not supported. This can use
+        // "readonly" because we don't pass it a buffer to mutate.
         matches!(
-            ret(syscall!(
+            ret(syscall_readonly!(
                 __NR_statx,
                 raw_fd(AT_FDCWD),
                 zero(),

--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -166,7 +166,7 @@ pub(crate) fn tcgetsid(fd: BorrowedFd<'_>) -> io::Result<Pid> {
 #[inline]
 pub(crate) fn tcsetwinsize(fd: BorrowedFd<'_>, winsize: Winsize) -> io::Result<()> {
     unsafe {
-        ret(syscall!(
+        ret(syscall_readonly!(
             __NR_ioctl,
             fd,
             c_uint(TIOCSWINSZ),

--- a/src/backend/linux_raw/time/syscalls.rs
+++ b/src/backend/linux_raw/time/syscalls.rs
@@ -104,7 +104,7 @@ unsafe fn clock_settime_old(which_clock: ClockId, timespec: Timespec) -> io::Res
 #[cfg(feature = "time")]
 #[inline]
 pub(crate) fn timerfd_create(clockid: TimerfdClockId, flags: TimerfdFlags) -> io::Result<OwnedFd> {
-    unsafe { ret_owned_fd(syscall!(__NR_timerfd_create, clockid, flags)) }
+    unsafe { ret_owned_fd(syscall_readonly!(__NR_timerfd_create, clockid, flags)) }
 }
 
 #[cfg(feature = "time")]


### PR DESCRIPTION
Mark the `TIOCSWINSZ` ioctl, `timerfd_create`, and the feature-test call to `statx` as "readonly", since they don't mutate memory.