### PR TITLE
Add MCL_ONFAULT constant to libc backend

### DIFF
--- a/src/backend/libc/mm/types.rs
+++ b/src/backend/libc/mm/types.rs
@@ -451,8 +451,17 @@ bitflags! {
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MlockAllFlags: u32 {
-        // libc doesn't define `MCL_ONFAULT` yet.
-        // const ONFAULT = libc::MCL_ONFAULT;
+        /// Used together with `MCL_CURRENT`, `MCL_FUTURE`, or both. Mark all
+        /// current (with `MCL_CURRENT`) or future (with `MCL_FUTURE`) mappings
+        /// to lock pages when they are faulted in. When used with
+        /// `MCL_CURRENT`, all present pages are locked, but `mlockall` will
+        /// not fault in non-present pages. When used with `MCL_FUTURE`, all
+        /// future mappings will be marked to lock pages when they are faulted
+        /// in, but they will not be populated by the lock when the mapping is
+        /// created. `MCL_ONFAULT` must be used with either `MCL_CURRENT` or
+        /// `MCL_FUTURE` or both.
+        #[cfg(linux_kernel)]
+        const ONFAULT = bitcast!(libc::MCL_ONFAULT);
         /// Lock all pages which will become mapped into the address space of
         /// the process in the future. These could be, for instance, new pages
         /// required by a growing heap and stack as well as new memory-mapped


### PR DESCRIPTION
The constant was added in libc v0.2.150.