### PR TITLE
Implement `rustix::process::sched_getcpu`.

### DIFF
--- a/src/backend/libc/process/mod.rs
+++ b/src/backend/libc/process/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
+#[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 pub(crate) mod cpu_set;
 #[cfg(not(windows))]
 pub(crate) mod syscalls;

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -1,6 +1,6 @@
 //! libc syscalls supporting `rustix::process`.
 
-#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
+#[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 use super::types::RawCpuSet;
 use crate::backend::c;
 #[cfg(not(any(target_os = "wasi", target_os = "fuchsia")))]
@@ -71,6 +71,14 @@ use core::mem::MaybeUninit;
 use {
     super::super::conv::ret_owned_fd, crate::process::PidfdFlags, crate::process::PidfdGetfdFlags,
 };
+
+#[cfg(any(linux_kernel, target_os = "dragonfly"))]
+#[inline]
+pub(crate) fn sched_getcpu() -> usize {
+    let r = unsafe { libc::sched_getcpu() };
+    debug_assert!(r >= 0);
+    r as usize
+}
 
 #[cfg(feature = "fs")]
 #[cfg(not(target_os = "wasi"))]
@@ -181,7 +189,7 @@ pub(crate) fn getpgrp() -> Pid {
     }
 }
 
-#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
+#[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 #[inline]
 pub(crate) fn sched_getaffinity(pid: Option<Pid>, cpuset: &mut RawCpuSet) -> io::Result<()> {
     unsafe {
@@ -193,7 +201,7 @@ pub(crate) fn sched_getaffinity(pid: Option<Pid>, cpuset: &mut RawCpuSet) -> io:
     }
 }
 
-#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
+#[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 #[inline]
 pub(crate) fn sched_setaffinity(pid: Option<Pid>, cpuset: &RawCpuSet) -> io::Result<()> {
     unsafe {

--- a/src/backend/libc/process/types.rs
+++ b/src/backend/libc/process/types.rs
@@ -155,10 +155,12 @@ pub type RawCpuid = u32;
 #[cfg(freebsdlike)]
 pub type RawId = c::id_t;
 
-#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 pub(crate) type RawCpuSet = c::cpu_set_t;
+#[cfg(freebsdlike)]
+pub(crate) type RawCpuSet = c::cpuset_t;
 
-#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
+#[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 #[inline]
 pub(crate) fn raw_cpu_set_new() -> RawCpuSet {
     let mut set = unsafe { core::mem::zeroed() };
@@ -166,7 +168,5 @@ pub(crate) fn raw_cpu_set_new() -> RawCpuSet {
     set
 }
 
-#[cfg(any(linux_kernel, target_os = "fuchsia"))]
+#[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 pub(crate) const CPU_SETSIZE: usize = c::CPU_SETSIZE as usize;
-#[cfg(target_os = "dragonfly")]
-pub(crate) const CPU_SETSIZE: usize = 256;

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -32,7 +32,7 @@ mod procctl;
     target_os = "wasi"
 )))]
 mod rlimit;
-#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
+#[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 mod sched;
 mod sched_yield;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have umask.
@@ -71,7 +71,7 @@ pub use procctl::*;
     target_os = "wasi"
 )))]
 pub use rlimit::*;
-#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
+#[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 pub use sched::*;
 pub use sched_yield::sched_yield;
 #[cfg(not(target_os = "wasi"))]

--- a/src/process/sched.rs
+++ b/src/process/sched.rs
@@ -108,3 +108,18 @@ pub fn sched_getaffinity(pid: Option<Pid>) -> io::Result<CpuSet> {
     let mut cpuset = CpuSet::new();
     backend::process::syscalls::sched_getaffinity(pid, &mut cpuset.cpu_set).and(Ok(cpuset))
 }
+
+/// `sched_getcpu()`—Get the CPU that the current thread is currently on.
+///
+/// # References
+///  - [Linux]
+///  - [DragonFly BSD]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/sched_getcpu.2.html
+/// [DragonFly BSD]: https://man.dragonflybsd.org/?command=sched_getcpu&section=2
+// FreeBSD added `sched_getcpu` in 13.0.
+#[cfg(any(linux_kernel, target_os = "dragonfly"))]
+#[inline]
+pub fn sched_getcpu() -> usize {
+    backend::process::syscalls::sched_getcpu()
+}

--- a/tests/process/main.rs
+++ b/tests/process/main.rs
@@ -19,7 +19,7 @@ mod priority;
 mod procctl;
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 mod rlimit;
-mod sched_yield;
+mod sched;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have umask.
 mod umask;
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have waitpid.

--- a/tests/process/sched.rs
+++ b/tests/process/sched.rs
@@ -1,0 +1,14 @@
+use rustix::process::sched_yield;
+
+#[test]
+fn test_sched_yield() {
+    // Just make sure we can call it.
+    sched_yield();
+}
+
+#[cfg(any(linux_kernel, target_os = "dragonfly"))]
+#[test]
+fn test_sched_getcpu() {
+    let n = rustix::process::sched_getcpu();
+    assert!(n < rustix::process::CpuSet::MAX_CPU);
+}

--- a/tests/process/sched_yield.rs
+++ b/tests/process/sched_yield.rs
@@ -1,7 +1,0 @@
-use rustix::process::sched_yield;
-
-#[test]
-fn test_sched_yield() {
-    // Just make sure we can call it.
-    sched_yield();
-}


### PR DESCRIPTION
On some architectures, there is a `getcpu` entry in the vDSO, so use that if available, and use the syscall otherwise.