### PR TITLE
Remove redundant checks for `linux_kernel` in the linux_raw backend.

### DIFF
--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -622,7 +622,6 @@ impl<'a, Num: ArgNumber> From<crate::backend::mm::types::MlockFlags> for ArgReg<
 }
 
 #[cfg(feature = "mm")]
-#[cfg(any(linux_kernel, freebsdlike, netbsdlike))]
 impl<'a, Num: ArgNumber> From<crate::backend::mm::types::MlockAllFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::backend::mm::types::MlockAllFlags) -> Self {

--- a/src/backend/linux_raw/fs/mod.rs
+++ b/src/backend/linux_raw/fs/mod.rs
@@ -6,8 +6,8 @@ pub(crate) mod syscalls;
 pub(crate) mod types;
 
 // TODO: Fix linux-raw-sys to define ioctl codes for sparc.
-#[cfg(all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64")))]
+#[cfg(any(target_arch = "sparc", target_arch = "sparc64"))]
 pub(crate) const EXT4_IOC_RESIZE_FS: u32 = 0x8008_6610;
 
-#[cfg(all(linux_kernel, not(any(target_arch = "sparc", target_arch = "sparc64"))))]
+#[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))]
 pub(crate) use linux_raw_sys::ioctl::EXT4_IOC_RESIZE_FS;

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -961,7 +961,7 @@ pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     }
 }
 
-#[cfg(any(feature = "alloc", all(linux_kernel, feature = "procfs")))]
+#[cfg(any(feature = "alloc", feature = "procfs"))]
 #[inline]
 pub(crate) fn readlinkat(
     dirfd: BorrowedFd<'_>,

--- a/src/backend/linux_raw/mm/syscalls.rs
+++ b/src/backend/linux_raw/mm/syscalls.rs
@@ -6,7 +6,6 @@
 #![allow(unsafe_code)]
 #![allow(clippy::undocumented_unsafe_blocks)]
 
-#[cfg(any(linux_kernel, freebsdlike, netbsdlike))]
 use super::types::MlockAllFlags;
 use super::types::{
     Advice, MapFlags, MlockFlags, MprotectFlags, MremapFlags, MsyncFlags, ProtFlags,
@@ -221,7 +220,6 @@ pub(crate) unsafe fn userfaultfd(flags: UserfaultfdFlags) -> io::Result<OwnedFd>
 /// returns successfully; the pages are guaranteed to stay in RAM until later
 /// unlocked.
 #[inline]
-#[cfg(any(linux_kernel, freebsdlike, netbsdlike))]
 pub(crate) fn mlockall(flags: MlockAllFlags) -> io::Result<()> {
     // When `mlockall` is used with `MCL_ONFAULT | MCL_FUTURE`, the ordering
     // of `mlockall` with respect to arbitrary loads may be significant,
@@ -235,7 +233,6 @@ pub(crate) fn mlockall(flags: MlockAllFlags) -> io::Result<()> {
 
 /// Unlocks all pages mapped into the address space of the calling process.
 #[inline]
-#[cfg(any(linux_kernel, freebsdlike, netbsdlike))]
 pub(crate) fn munlockall() -> io::Result<()> {
     unsafe { ret(syscall_readonly!(__NR_munlockall)) }
 }

--- a/src/backend/linux_raw/mm/types.rs
+++ b/src/backend/linux_raw/mm/types.rs
@@ -263,7 +263,6 @@ bitflags! {
     }
 }
 
-#[cfg(any(linux_kernel, freebsdlike, netbsdlike))]
 bitflags! {
     /// `MCL_*` flags for use with [`mlockall`].
     ///


### PR DESCRIPTION
As noted in #920, `cfg(linux_kernel` is redundant within src/backend/linux_raw.