### PR TITLE
Add a `readlinkat_raw` function.

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -1,7 +1,11 @@
 //! libc syscalls supporting `rustix::fs`.
 
 use crate::backend::c;
-#[cfg(any(not(target_os = "redox"), all(linux_kernel, feature = "procfs")))]
+#[cfg(any(
+    not(target_os = "redox"),
+    feature = "alloc",
+    all(linux_kernel, feature = "procfs")
+))]
 use crate::backend::conv::ret_usize;
 use crate::backend::conv::{borrowed_fd, c_str, ret, ret_c_int, ret_off_t, ret_owned_fd};
 use crate::fd::{BorrowedFd, OwnedFd};

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -1,12 +1,7 @@
 //! libc syscalls supporting `rustix::fs`.
 
 use crate::backend::c;
-#[cfg(any(
-    apple,
-    linux_kernel,
-    feature = "alloc",
-    all(linux_kernel, feature = "procfs")
-))]
+#[cfg(any(not(target_os = "redox"), all(linux_kernel, feature = "procfs")))]
 use crate::backend::conv::ret_usize;
 use crate::backend::conv::{borrowed_fd, c_str, ret, ret_c_int, ret_off_t, ret_owned_fd};
 use crate::fd::{BorrowedFd, OwnedFd};

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -275,10 +275,7 @@ pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     }
 }
 
-#[cfg(all(
-    any(feature = "alloc", all(linux_kernel, feature = "procfs")),
-    not(target_os = "redox")
-))]
+#[cfg(not(target_os = "redox"))]
 #[inline]
 pub(crate) fn readlinkat(
     dirfd: BorrowedFd<'_>,

--- a/src/backend/libc/process/mod.rs
+++ b/src/backend/libc/process/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
+#[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 pub(crate) mod cpu_set;
 #[cfg(not(windows))]
 pub(crate) mod syscalls;

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -1,6 +1,6 @@
 //! libc syscalls supporting `rustix::process`.
 
-#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
+#[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 use super::types::RawCpuSet;
 use crate::backend::c;
 #[cfg(not(any(target_os = "wasi", target_os = "fuchsia")))]
@@ -71,6 +71,14 @@ use core::mem::MaybeUninit;
 use {
     super::super::conv::ret_owned_fd, crate::process::PidfdFlags, crate::process::PidfdGetfdFlags,
 };
+
+#[cfg(any(linux_kernel, target_os = "dragonfly"))]
+#[inline]
+pub(crate) fn sched_getcpu() -> usize {
+    let r = unsafe { libc::sched_getcpu() };
+    debug_assert!(r >= 0);
+    r as usize
+}
 
 #[cfg(feature = "fs")]
 #[cfg(not(target_os = "wasi"))]
@@ -181,7 +189,7 @@ pub(crate) fn getpgrp() -> Pid {
     }
 }
 
-#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
+#[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 #[inline]
 pub(crate) fn sched_getaffinity(pid: Option<Pid>, cpuset: &mut RawCpuSet) -> io::Result<()> {
     unsafe {
@@ -193,7 +201,7 @@ pub(crate) fn sched_getaffinity(pid: Option<Pid>, cpuset: &mut RawCpuSet) -> io:
     }
 }
 
-#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
+#[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 #[inline]
 pub(crate) fn sched_setaffinity(pid: Option<Pid>, cpuset: &RawCpuSet) -> io::Result<()> {
     unsafe {

--- a/src/backend/libc/process/types.rs
+++ b/src/backend/libc/process/types.rs
@@ -155,10 +155,12 @@ pub type RawCpuid = u32;
 #[cfg(freebsdlike)]
 pub type RawId = c::id_t;
 
-#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 pub(crate) type RawCpuSet = c::cpu_set_t;
+#[cfg(freebsdlike)]
+pub(crate) type RawCpuSet = c::cpuset_t;
 
-#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
+#[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 #[inline]
 pub(crate) fn raw_cpu_set_new() -> RawCpuSet {
     let mut set = unsafe { core::mem::zeroed() };
@@ -166,7 +168,5 @@ pub(crate) fn raw_cpu_set_new() -> RawCpuSet {
     set
 }
 
-#[cfg(any(linux_kernel, target_os = "fuchsia"))]
+#[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 pub(crate) const CPU_SETSIZE: usize = c::CPU_SETSIZE as usize;
-#[cfg(target_os = "dragonfly")]
-pub(crate) const CPU_SETSIZE: usize = 256;

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -961,7 +961,6 @@ pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     }
 }
 
-#[cfg(any(feature = "alloc", feature = "procfs"))]
 #[inline]
 pub(crate) fn readlinkat(
     dirfd: BorrowedFd<'_>,

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -6,6 +6,7 @@
 //! [`cwd`]: crate::fs::CWD
 
 use crate::fd::OwnedFd;
+use crate::ffi::CStr;
 #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
 use crate::fs::Access;
 #[cfg(not(target_os = "espidf"))]
@@ -22,16 +23,11 @@ use crate::fs::{Dev, FileType};
 use crate::fs::{Gid, Uid};
 use crate::fs::{Mode, OFlags};
 use crate::{backend, io, path};
-use backend::fd::AsFd;
+use backend::fd::{AsFd, BorrowedFd};
 use core::mem::MaybeUninit;
 use core::slice;
 #[cfg(feature = "alloc")]
-use {
-    crate::ffi::{CStr, CString},
-    crate::path::SMALL_PATH_BUFFER_SIZE,
-    alloc::vec::Vec,
-    backend::fd::BorrowedFd,
-};
+use {crate::ffi::CString, crate::path::SMALL_PATH_BUFFER_SIZE, alloc::vec::Vec};
 #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
 use {crate::fs::Timestamps, crate::timespec::Nsecs};
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -32,7 +32,7 @@ mod procctl;
     target_os = "wasi"
 )))]
 mod rlimit;
-#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
+#[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 mod sched;
 mod sched_yield;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have umask.
@@ -71,7 +71,7 @@ pub use procctl::*;
     target_os = "wasi"
 )))]
 pub use rlimit::*;
-#[cfg(any(linux_kernel, target_os = "dragonfly", target_os = "fuchsia"))]
+#[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 pub use sched::*;
 pub use sched_yield::sched_yield;
 #[cfg(not(target_os = "wasi"))]

--- a/src/process/sched.rs
+++ b/src/process/sched.rs
@@ -108,3 +108,18 @@ pub fn sched_getaffinity(pid: Option<Pid>) -> io::Result<CpuSet> {
     let mut cpuset = CpuSet::new();
     backend::process::syscalls::sched_getaffinity(pid, &mut cpuset.cpu_set).and(Ok(cpuset))
 }
+
+/// `sched_getcpu()`—Get the CPU that the current thread is currently on.
+///
+/// # References
+///  - [Linux]
+///  - [DragonFly BSD]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/sched_getcpu.2.html
+/// [DragonFly BSD]: https://man.dragonflybsd.org/?command=sched_getcpu&section=2
+// FreeBSD added `sched_getcpu` in 13.0.
+#[cfg(any(linux_kernel, target_os = "dragonfly"))]
+#[inline]
+pub fn sched_getcpu() -> usize {
+    backend::process::syscalls::sched_getcpu()
+}

--- a/tests/fs/readlinkat.rs
+++ b/tests/fs/readlinkat.rs
@@ -50,3 +50,49 @@ fn test_readlinkat() {
     let target = readlinkat(&dir, "another", Vec::new()).unwrap();
     assert_eq!(target.to_string_lossy(), "link");
 }
+
+#[cfg(not(target_os = "redox"))]
+#[test]
+fn test_readlinkat_raw() {
+    use core::mem::MaybeUninit;
+    use rustix::fs::{openat, readlinkat_raw, symlinkat, Mode, OFlags, CWD};
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = openat(CWD, tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
+
+    let _ = openat(&dir, "foo", OFlags::CREATE | OFlags::WRONLY, Mode::RUSR).unwrap();
+    symlinkat("foo", &dir, "link").unwrap();
+
+    let mut some = [MaybeUninit::<u8>::new(0); 32];
+    let mut short = [MaybeUninit::<u8>::new(0); 2];
+    readlinkat_raw(&dir, "absent", &mut some).unwrap_err();
+    readlinkat_raw(&dir, "foo", &mut some).unwrap_err();
+
+    let (yes, no) = readlinkat_raw(&dir, "link", &mut some).unwrap();
+    assert_eq!(OsStr::from_bytes(yes).to_string_lossy(), "foo");
+    assert!(!no.is_empty());
+
+    let (yes, no) = readlinkat_raw(&dir, "link", &mut short).unwrap();
+    assert_eq!(yes, &[b'f', b'o']);
+    assert!(no.is_empty());
+
+    symlinkat("link", &dir, "another").unwrap();
+
+    let (yes, no) = readlinkat_raw(&dir, "link", &mut some).unwrap();
+    assert_eq!(OsStr::from_bytes(yes).to_string_lossy(), "foo");
+    assert!(!no.is_empty());
+
+    let (yes, no) = readlinkat_raw(&dir, "link", &mut short).unwrap();
+    assert_eq!(yes, &[b'f', b'o']);
+    assert!(no.is_empty());
+
+    let (yes, no) = readlinkat_raw(&dir, "another", &mut some).unwrap();
+    assert_eq!(OsStr::from_bytes(yes).to_string_lossy(), "link");
+    assert!(!no.is_empty());
+
+    let (yes, no) = readlinkat_raw(&dir, "another", &mut short).unwrap();
+    assert_eq!(yes, &[b'l', b'i']);
+    assert!(no.is_empty());
+}

--- a/tests/process/main.rs
+++ b/tests/process/main.rs
@@ -19,7 +19,7 @@ mod priority;
 mod procctl;
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "wasi")))]
 mod rlimit;
-mod sched_yield;
+mod sched;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have umask.
 mod umask;
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))] // WASI doesn't have waitpid.

--- a/tests/process/sched.rs
+++ b/tests/process/sched.rs
@@ -1,0 +1,14 @@
+use rustix::process::sched_yield;
+
+#[test]
+fn test_sched_yield() {
+    // Just make sure we can call it.
+    sched_yield();
+}
+
+#[cfg(any(linux_kernel, target_os = "dragonfly"))]
+#[test]
+fn test_sched_getcpu() {
+    let n = rustix::process::sched_getcpu();
+    assert!(n < rustix::process::CpuSet::MAX_CPU);
+}

--- a/tests/process/sched_yield.rs
+++ b/tests/process/sched_yield.rs
@@ -1,7 +1,0 @@
-use rustix::process::sched_yield;
-
-#[test]
-fn test_sched_yield() {
-    // Just make sure we can call it.
-    sched_yield();
-}


### PR DESCRIPTION
This is similar to `readlinkat`, but instead of returning an owned and allocated `CString`, takes a `&mut [MaybeUninit<u8>]` and returns a `&mut [u8]` containing the written bytes, which may have been truncated. This is trickier to use, and most users should still just use `readlinkat`, but it is usable in contexts that can't do dynamic allocation.