### PR TITLE
Fix ioctl numbers on BSDs

### DIFF
--- a/src/ioctl/bsd.rs
+++ b/src/ioctl/bsd.rs
@@ -18,7 +18,10 @@ pub(super) const fn compose_opcode(
     dir | num | (group << 8) | ((size & IOCPARAM_MASK) << 16)
 }
 
+// `IOC_VOID`
 pub const NONE: RawOpcode = 0x2000_0000;
-pub const WRITE: RawOpcode = 0x4000_0000;
-pub const READ: RawOpcode = 0x8000_0000;
+// `IOC_OUT` ("out" is from the perspective of the kernel)
+pub const READ: RawOpcode = 0x4000_0000;
+// `IOC_IN`
+pub const WRITE: RawOpcode = 0x8000_0000;
 pub const IOCPARAM_MASK: RawOpcode = 0x1FFF;


### PR DESCRIPTION
`<sys/ioccom.h>` defines `IOC_OUT` as `0x40000000UL`. But this is "out" from the perspective of the kernel, not the application. So this corresponds to `READ` rather than `WRITE`.

Tested on FreeBSD with https://github.com/Smithay/drm-rs/pull/180. This also seems to be correct for NetBSD and OpenBSD.