### PR TITLE
On Linux, require Linux >= 3.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,23 @@ safety types rather than `RawFd`, and the flags parameters to functions such as
 ## Minimum Supported Rust Version (MSRV)
 
 This crate currently works on the version of [Rust on Debian stable], which is
-currently Rust 1.63. This policy may change in the future, in minor version
+currently [Rust 1.63]. This policy may change in the future, in minor version
 releases, so users using a fixed version of Rust should pin to a specific
 version of this crate.
 
+## Minimum Linux Version
+
+On Linux platforms, rustix requires at least Linux 3.2. This is at most the
+oldest Linux version supported by:
+ - [any current Rust target], or
+ - [kernel.org] at the time of rustix's [MSRV] release.
+The specifics of this policy may change in the future, but we intend it to
+always reflect “very old” Linux versions.
+
+[MSRV]: #minimum-supported-rust-version-msrv
+[Rust 1.63]: https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html
+[any current Rust target]: https://doc.rust-lang.org/nightly/rustc/platform-support.html
+[kernel.org]: https://www.kernel.org/releases.html
 [Rust on Debian stable]: https://packages.debian.org/stable/rust/rustc
 [`nix`]: https://crates.io/crates/nix
 [`unix`]: https://crates.io/crates/unix

--- a/src/backend/libc/mm/types.rs
+++ b/src/backend/libc/mm/types.rs
@@ -383,10 +383,10 @@ pub enum Advice {
     /// `MADV_UNMERGEABLE`
     #[cfg(linux_kernel)]
     LinuxUnmergeable = bitcast!(c::MADV_UNMERGEABLE),
-    /// `MADV_HUGEPAGE` (since Linux 2.6.38)
+    /// `MADV_HUGEPAGE`
     #[cfg(linux_kernel)]
     LinuxHugepage = bitcast!(c::MADV_HUGEPAGE),
-    /// `MADV_NOHUGEPAGE` (since Linux 2.6.38)
+    /// `MADV_NOHUGEPAGE`
     #[cfg(linux_kernel)]
     LinuxNoHugepage = bitcast!(c::MADV_NOHUGEPAGE),
     /// `MADV_DONTDUMP` (since Linux 3.4)

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -268,13 +268,13 @@ pub(crate) const CLOCK_THREAD_CPUTIME_ID: c_int =
     linux_raw_sys::general::CLOCK_THREAD_CPUTIME_ID as _;
 pub(crate) const CLOCK_PROCESS_CPUTIME_ID: c_int =
     linux_raw_sys::general::CLOCK_PROCESS_CPUTIME_ID as _;
-#[cfg(all(feature = "time", feature = "linux_4_11"))]
+#[cfg(any(feature = "thread", feature = "time", target_arch = "x86"))]
 pub(crate) const CLOCK_BOOTTIME: c_int = linux_raw_sys::general::CLOCK_BOOTTIME as _;
-#[cfg(all(feature = "time", feature = "linux_4_11"))]
+#[cfg(any(feature = "thread", feature = "time", target_arch = "x86"))]
 pub(crate) const CLOCK_BOOTTIME_ALARM: c_int = linux_raw_sys::general::CLOCK_BOOTTIME_ALARM as _;
-#[cfg(all(feature = "time", feature = "linux_4_11"))]
+#[cfg(any(feature = "thread", feature = "time", target_arch = "x86"))]
 pub(crate) const CLOCK_TAI: c_int = linux_raw_sys::general::CLOCK_TAI as _;
-#[cfg(all(feature = "time", feature = "linux_4_11"))]
+#[cfg(any(feature = "thread", feature = "time", target_arch = "x86"))]
 pub(crate) const CLOCK_REALTIME_ALARM: c_int = linux_raw_sys::general::CLOCK_REALTIME_ALARM as _;
 
 #[cfg(feature = "system")]

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -197,13 +197,13 @@ bitflags! {
         /// `O_DIRECTORY`
         const DIRECTORY = linux_raw_sys::general::O_DIRECTORY;
 
-        /// `O_DSYNC`. Linux 2.6.32 only supports `O_SYNC`.
+        /// `O_DSYNC`.
         const DSYNC = linux_raw_sys::general::O_SYNC;
 
         /// `O_EXCL`
         const EXCL = linux_raw_sys::general::O_EXCL;
 
-        /// `O_FSYNC`. Linux 2.6.32 only supports `O_SYNC`.
+        /// `O_FSYNC`.
         const FSYNC = linux_raw_sys::general::O_SYNC;
 
         /// `O_NOFOLLOW`
@@ -226,7 +226,7 @@ bitflags! {
         /// `O_NOCTTY`
         const NOCTTY = linux_raw_sys::general::O_NOCTTY;
 
-        /// `O_RSYNC`. Linux 2.6.32 only supports `O_SYNC`.
+        /// `O_RSYNC`.
         const RSYNC = linux_raw_sys::general::O_SYNC;
 
         /// `O_SYNC`

--- a/src/backend/linux_raw/mm/types.rs
+++ b/src/backend/linux_raw/mm/types.rs
@@ -212,9 +212,9 @@ pub enum Advice {
     LinuxMergeable = linux_raw_sys::general::MADV_MERGEABLE,
     /// `MADV_UNMERGEABLE`
     LinuxUnmergeable = linux_raw_sys::general::MADV_UNMERGEABLE,
-    /// `MADV_HUGEPAGE` (since Linux 2.6.38)
+    /// `MADV_HUGEPAGE`
     LinuxHugepage = linux_raw_sys::general::MADV_HUGEPAGE,
-    /// `MADV_NOHUGEPAGE` (since Linux 2.6.38)
+    /// `MADV_NOHUGEPAGE`
     LinuxNoHugepage = linux_raw_sys::general::MADV_NOHUGEPAGE,
     /// `MADV_DONTDUMP` (since Linux 3.4)
     LinuxDontDump = linux_raw_sys::general::MADV_DONTDUMP,

--- a/src/backend/linux_raw/vdso_wrappers.rs
+++ b/src/backend/linux_raw/vdso_wrappers.rs
@@ -75,14 +75,10 @@ pub(crate) fn clock_gettime_dynamic(which_clock: DynamicClockId<'_>) -> io::Resu
             ((!fd.as_raw_fd() << 3) | CLOCKFD) as __kernel_clockid_t
         }
 
-        DynamicClockId::RealtimeAlarm => {
-            linux_raw_sys::general::CLOCK_REALTIME_ALARM as __kernel_clockid_t
-        }
-        DynamicClockId::Tai => linux_raw_sys::general::CLOCK_TAI as __kernel_clockid_t,
-        DynamicClockId::Boottime => linux_raw_sys::general::CLOCK_BOOTTIME as __kernel_clockid_t,
-        DynamicClockId::BoottimeAlarm => {
-            linux_raw_sys::general::CLOCK_BOOTTIME_ALARM as __kernel_clockid_t
-        }
+        DynamicClockId::RealtimeAlarm => c::CLOCK_REALTIME_ALARM as __kernel_clockid_t,
+        DynamicClockId::Tai => c::CLOCK_TAI as __kernel_clockid_t,
+        DynamicClockId::Boottime => c::CLOCK_BOOTTIME as __kernel_clockid_t,
+        DynamicClockId::BoottimeAlarm => c::CLOCK_BOOTTIME_ALARM as __kernel_clockid_t,
     };
 
     // SAFETY: `CLOCK_GETTIME` contains either null or the address of a

--- a/src/clockid.rs
+++ b/src/clockid.rs
@@ -56,8 +56,8 @@ pub enum ClockId {
     #[cfg(linux_kernel)]
     MonotonicRaw = c::CLOCK_MONOTONIC_RAW,
 
-    /// `CLOCK_REALTIME_ALARM`, available on Linux >= 3.0
-    #[cfg(all(linux_kernel, feature = "linux_4_11"))]
+    /// `CLOCK_REALTIME_ALARM`
+    #[cfg(linux_kernel)]
     #[doc(alias = "CLOCK_REALTIME_ALARM")]
     RealtimeAlarm = bitcast!(c::CLOCK_REALTIME_ALARM),
 
@@ -66,20 +66,16 @@ pub enum ClockId {
     #[doc(alias = "CLOCK_TAI")]
     Tai = bitcast!(c::CLOCK_TAI),
 
-    /// `CLOCK_BOOTTIME`, available on Linux >= 2.6.39
+    /// `CLOCK_BOOTTIME`
     ///
     /// On FreeBSD, use [`Self::Uptime`], as `CLOCK_BOOTTIME` is an alias for
     /// `CLOCK_UPTIME`.
-    #[cfg(any(
-        all(linux_kernel, feature = "linux_4_11"),
-        target_os = "fuchsia",
-        target_os = "openbsd"
-    ))]
+    #[cfg(any(linux_kernel, target_os = "fuchsia", target_os = "openbsd"))]
     #[doc(alias = "CLOCK_BOOTTIME")]
     Boottime = bitcast!(c::CLOCK_BOOTTIME),
 
-    /// `CLOCK_BOOTTIME_ALARM`, available on Linux >= 2.6.39
-    #[cfg(any(all(linux_kernel, feature = "linux_4_11"), target_os = "fuchsia"))]
+    /// `CLOCK_BOOTTIME_ALARM`
+    #[cfg(any(linux_kernel, target_os = "fuchsia"))]
     #[doc(alias = "CLOCK_BOOTTIME_ALARM")]
     BoottimeAlarm = bitcast!(c::CLOCK_BOOTTIME_ALARM),
 }
@@ -127,7 +123,7 @@ pub enum DynamicClockId<'a> {
     /// Linux dynamic clocks.
     Dynamic(BorrowedFd<'a>),
 
-    /// `CLOCK_REALTIME_ALARM`, available on Linux >= 3.0
+    /// `CLOCK_REALTIME_ALARM`
     #[cfg(linux_kernel)]
     RealtimeAlarm,
 
@@ -135,7 +131,7 @@ pub enum DynamicClockId<'a> {
     #[cfg(linux_kernel)]
     Tai,
 
-    /// `CLOCK_BOOTTIME`, available on Linux >= 2.6.39
+    /// `CLOCK_BOOTTIME`
     #[cfg(any(
         freebsdlike,
         linux_kernel,
@@ -144,7 +140,7 @@ pub enum DynamicClockId<'a> {
     ))]
     Boottime,
 
-    /// `CLOCK_BOOTTIME_ALARM`, available on Linux >= 2.6.39
+    /// `CLOCK_BOOTTIME_ALARM`
     #[cfg(any(linux_kernel, target_os = "fuchsia"))]
     BoottimeAlarm,
 }

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -226,8 +226,8 @@ fn is_mountpoint(file: BorrowedFd<'_>) -> bool {
 
 /// Open a directory in `/proc`, mapping all errors to `io::Errno::NOTSUP`.
 fn proc_opendirat<P: crate::path::Arg, Fd: AsFd>(dirfd: Fd, path: P) -> io::Result<OwnedFd> {
-    // We could add `PATH`|`NOATIME` here but Linux 2.6.32 doesn't support it.
-    // Also for `NOATIME` see the comment in `open_and_check_file`.
+    // We don't add `PATH` here because that disables `DIRECTORY`. And we don't
+    // add `NOATIME` for the same reason as the comment in `open_and_check_file`.
     let oflags = OFlags::NOFOLLOW | OFlags::DIRECTORY | OFlags::CLOEXEC | OFlags::NOCTTY;
     openat(dirfd, path, oflags, Mode::empty()).map_err(|_err| io::Errno::NOTSUP)
 }


### PR DESCRIPTION
Add a Minimum Linux Version policy, which is currently Linux 3.2, and enable `ClockId::Boottime` and other values without extra feature gates.

Fixes #905.
Fixes #907.