### PR TITLE
Ignore a null `AT_BASE` value.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -231,7 +231,7 @@ jobs:
       RUSTFLAGS: --cfg rustix_use_experimental_features
     strategy:
       matrix:
-        build: [ubuntu, ubuntu-20.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.63, i686-linux-1.63, aarch64-linux-1.63, riscv64-linux-1.63, s390x-linux-1.63, powerpc64le-linux-1.63, arm-linux-1.63, macos-latest, macos-11, windows, windows-2019]
+        build: [ubuntu, ubuntu-20.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.63, i686-linux-1.63, aarch64-linux-1.63, riscv64-linux-1.63, s390x-linux-1.63, powerpc64le-linux-1.63, arm-linux-1.63, macos-latest, macos-11, windows, windows-2019, musl]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -413,6 +413,12 @@ jobs:
           - build: windows-2019
             os: windows-2019
             rust: nightly
+          - build: musl
+            os: ubuntu-latest
+            rust: stable
+            target: x86_64-unknown-linux-musl
+            gcc_package: musl-tools
+            gcc: musl-gcc
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -417,8 +417,6 @@ jobs:
             os: ubuntu-latest
             rust: stable
             target: x86_64-unknown-linux-musl
-            gcc_package: musl-tools
-            gcc: musl-gcc
     steps:
     - uses: actions/checkout@v3
       with:

--- a/src/backend/linux_raw/param/auxv.rs
+++ b/src/backend/linux_raw/param/auxv.rs
@@ -307,7 +307,11 @@ unsafe fn init_from_aux_iter(aux_iter: impl Iterator<Item = Elf_auxv_t>) -> Opti
             AT_SYSINFO_EHDR => sysinfo_ehdr = check_elf_base(a_val as *mut _)?.as_ptr(),
 
             AT_BASE => {
-                let _ = check_elf_base(a_val.cast())?;
+                // The `AT_BASE` value can be NULL in a static executable that
+                // doesn't use a dynamic linker. If so, ignore it.
+                if !a_val.is_null() {
+                    let _ = check_elf_base(a_val.cast())?;
+                }
             }
 
             #[cfg(feature = "runtime")]


### PR DESCRIPTION
When processing AUX values, don't check whether `AT_BASE` is valid if it is NULL, as NULL indicates a static executable that doesn't have a dynamic linker.

Fixes #933.