### PR TITLE
Make `kevent` safe, using `BorrowedFd` for `changelist`

### DIFF
--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -9,7 +9,11 @@ use crate::event::PollFd;
 use crate::fd::OwnedFd;
 use crate::io;
 #[cfg(any(bsd, solarish))]
-use {crate::backend::conv::borrowed_fd, crate::fd::BorrowedFd, core::mem::MaybeUninit};
+use {
+    crate::backend::conv::borrowed_fd,
+    crate::fd::{BorrowedFd, RawFd},
+    core::mem::MaybeUninit,
+};
 #[cfg(solarish)]
 use {
     crate::backend::conv::ret, crate::event::port::Event, crate::utils::as_mut_ptr,
@@ -69,8 +73,8 @@ pub(crate) fn kqueue() -> io::Result<OwnedFd> {
 #[cfg(all(feature = "alloc", bsd))]
 pub(crate) unsafe fn kevent(
     kq: BorrowedFd<'_>,
-    changelist: &[Event],
-    eventlist: &mut [MaybeUninit<Event>],
+    changelist: &[Event<BorrowedFd>],
+    eventlist: &mut [MaybeUninit<Event<RawFd>>],
     timeout: Option<&c::timespec>,
 ) -> io::Result<c::c_int> {
     ret_c_int(c::kevent(


### PR DESCRIPTION
It looks like https://github.com/bytecodealliance/rustix/pull/488 initially used something like this, but there was concern about the safety if an fd is closed while it is in a kqueue. But it doesn't seem to have been established that this actually violates io safety.

`kevent(2)` documents that the fd is removed from any kqueues referencing it if it is closed. While that may result in behavior the caller doesn't expect, it shouldn't be unsafe. There should be no way for an fd being inserted into a kqueue then closed to impact a new fd that is opened with the same value, which is generally the concern with IO safety.

I haven't tested this yet other than `cargo check` from a Linux system, and this would be a breaking API change. But if it can be safe, it should be changed in the next semver breaking version of Rustix.