### PR TITLE
Fix typos in docs

### DIFF
--- a/src/backend/linux_raw/event/poll_fd.rs
+++ b/src/backend/linux_raw/event/poll_fd.rs
@@ -4,7 +4,7 @@ use bitflags::bitflags;
 bitflags! {
     /// `POLL*` flags for use with [`poll`].
     ///
-    /// [`poll`]: crate::io::poll
+    /// [`poll`]: crate::event::poll
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct PollFlags: u16 {

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -69,7 +69,7 @@ impl AddressFamily {
     /// # References
     ///  - [Linux]
     ///
-    /// [Linux]: https://man7.org/linux/man-pages/man7/ip.7.html>
+    /// [Linux]: https://man7.org/linux/man-pages/man7/ip.7.html
     pub const INET: Self = Self(c::AF_INET as _);
     /// `AF_INET6`
     ///


### PR DESCRIPTION
The `>` at the end of the link lets the link 404.