### PR TITLE
Add methods for reading into unitialized buffers

### DIFF
--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -27,7 +27,7 @@ use {
 };
 
 pub(crate) unsafe fn read(fd: BorrowedFd<'_>, buf: *mut u8, len: usize) -> io::Result<usize> {
-    unsafe { ret_usize(c::read(borrowed_fd(fd), buf.cast(), min(len, READ_LIMIT))) }
+    ret_usize(c::read(borrowed_fd(fd), buf.cast(), min(len, READ_LIMIT)))
 }
 
 pub(crate) fn write(fd: BorrowedFd<'_>, buf: &[u8]) -> io::Result<usize> {
@@ -55,7 +55,7 @@ pub(crate) unsafe fn pread(
     #[cfg(any(target_os = "espidf", target_os = "vita"))]
     let offset: i32 = offset.try_into().map_err(|_| io::Errno::OVERFLOW)?;
 
-    unsafe { ret_usize(c::pread(borrowed_fd(fd), buf.cast(), len, offset)) }
+    ret_usize(c::pread(borrowed_fd(fd), buf.cast(), len, offset))
 }
 
 pub(crate) fn pwrite(fd: BorrowedFd<'_>, buf: &[u8], offset: u64) -> io::Result<usize> {

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -26,14 +26,8 @@ use {
     crate::io::{IoSlice, IoSliceMut},
 };
 
-pub(crate) fn read(fd: BorrowedFd<'_>, buf: &mut [u8]) -> io::Result<usize> {
-    unsafe {
-        ret_usize(c::read(
-            borrowed_fd(fd),
-            buf.as_mut_ptr().cast(),
-            min(buf.len(), READ_LIMIT),
-        ))
-    }
+pub(crate) unsafe fn read(fd: BorrowedFd<'_>, buf: *mut u8, len: usize) -> io::Result<usize> {
+    unsafe { ret_usize(c::read(borrowed_fd(fd), buf.cast(), min(len, READ_LIMIT))) }
 }
 
 pub(crate) fn write(fd: BorrowedFd<'_>, buf: &[u8]) -> io::Result<usize> {
@@ -46,8 +40,13 @@ pub(crate) fn write(fd: BorrowedFd<'_>, buf: &[u8]) -> io::Result<usize> {
     }
 }
 
-pub(crate) fn pread(fd: BorrowedFd<'_>, buf: &mut [u8], offset: u64) -> io::Result<usize> {
-    let len = min(buf.len(), READ_LIMIT);
+pub(crate) unsafe fn pread(
+    fd: BorrowedFd<'_>,
+    buf: *mut u8,
+    len: usize,
+    offset: u64,
+) -> io::Result<usize> {
+    let len = min(len, READ_LIMIT);
 
     // Silently cast; we'll get `EINVAL` if the value is negative.
     let offset = offset as i64;
@@ -56,14 +55,7 @@ pub(crate) fn pread(fd: BorrowedFd<'_>, buf: &mut [u8], offset: u64) -> io::Resu
     #[cfg(any(target_os = "espidf", target_os = "vita"))]
     let offset: i32 = offset.try_into().map_err(|_| io::Errno::OVERFLOW)?;
 
-    unsafe {
-        ret_usize(c::pread(
-            borrowed_fd(fd),
-            buf.as_mut_ptr().cast(),
-            len,
-            offset,
-        ))
-    }
+    unsafe { ret_usize(c::pread(borrowed_fd(fd), buf.cast(), len, offset)) }
 }
 
 pub(crate) fn pwrite(fd: BorrowedFd<'_>, buf: &[u8], offset: u64) -> io::Result<usize> {

--- a/src/backend/libc/rand/syscalls.rs
+++ b/src/backend/libc/rand/syscalls.rs
@@ -4,11 +4,15 @@
 use {crate::backend::c, crate::backend::conv::ret_usize, crate::io, crate::rand::GetRandomFlags};
 
 #[cfg(linux_kernel)]
-pub(crate) fn getrandom(buf: &mut [u8], flags: GetRandomFlags) -> io::Result<usize> {
+pub(crate) unsafe fn getrandom(
+    buf: *mut u8,
+    cap: usize,
+    flags: GetRandomFlags,
+) -> io::Result<usize> {
     // `getrandom` wasn't supported in glibc until 2.25.
     weak_or_syscall! {
         fn getrandom(buf: *mut c::c_void, buflen: c::size_t, flags: c::c_uint) via SYS_getrandom -> c::ssize_t
     }
 
-    unsafe { ret_usize(getrandom(buf.as_mut_ptr().cast(), buf.len(), flags.bits())) }
+    unsafe { ret_usize(getrandom(buf.cast(), cap, flags.bits())) }
 }

--- a/src/backend/libc/rand/syscalls.rs
+++ b/src/backend/libc/rand/syscalls.rs
@@ -14,5 +14,5 @@ pub(crate) unsafe fn getrandom(
         fn getrandom(buf: *mut c::c_void, buflen: c::size_t, flags: c::c_uint) via SYS_getrandom -> c::ssize_t
     }
 
-    unsafe { ret_usize(getrandom(buf.cast(), cap, flags.bits())) }
+    ret_usize(getrandom(buf.cast(), cap, flags.bits()))
 }

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -269,15 +269,15 @@ pub(crate) fn is_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
         // Do a `recv` with `PEEK` and `DONTWAIT` for 1 byte. A 0 indicates
         // the read side is shut down; an `EWOULDBLOCK` indicates the read
         // side is still open.
-        //
-        // TODO: This code would benefit from having a better way to read into
-        // uninitialized memory.
-        let mut buf = [0];
-        match crate::backend::net::syscalls::recv(
-            fd,
-            &mut buf,
-            RecvFlags::PEEK | RecvFlags::DONTWAIT,
-        ) {
+        let mut buf = [core::mem::MaybeUninit::<u8>::uninit()];
+        match unsafe {
+            crate::backend::net::syscalls::recv(
+                fd,
+                buf.as_mut_ptr() as *mut u8,
+                1,
+                RecvFlags::PEEK | RecvFlags::DONTWAIT,
+            )
+        } {
             Ok(0) => read = false,
             Err(err) => {
                 #[allow(unreachable_patterns)] // `EAGAIN` may equal `EWOULDBLOCK`

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -45,7 +45,7 @@ pub(crate) unsafe fn pread(
         target_pointer_width = "32",
         any(target_arch = "arm", target_arch = "mips", target_arch = "mips32r6"),
     ))]
-    unsafe {
+    {
         ret_usize(syscall!(
             __NR_pread64,
             fd,
@@ -60,7 +60,7 @@ pub(crate) unsafe fn pread(
         target_pointer_width = "32",
         not(any(target_arch = "arm", target_arch = "mips", target_arch = "mips32r6")),
     ))]
-    unsafe {
+    {
         ret_usize(syscall!(
             __NR_pread64,
             fd,

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -30,7 +30,7 @@ use linux_raw_sys::general::{F_DUPFD_CLOEXEC, F_GETFD, F_SETFD};
 
 #[inline]
 pub(crate) unsafe fn read(fd: BorrowedFd<'_>, buf: *mut u8, len: usize) -> io::Result<usize> {
-    unsafe { ret_usize(syscall!(__NR_read, fd, buf, pass_usize(len))) }
+    ret_usize(syscall!(__NR_read, fd, buf, pass_usize(len)))
 }
 
 #[inline]
@@ -71,15 +71,13 @@ pub(crate) unsafe fn pread(
         ))
     }
     #[cfg(target_pointer_width = "64")]
-    unsafe {
-        ret_usize(syscall!(
-            __NR_pread64,
-            fd,
-            buf,
-            pass_usize(len),
-            loff_t_from_u64(pos)
-        ))
-    }
+    ret_usize(syscall!(
+        __NR_pread64,
+        fd,
+        buf,
+        pass_usize(len),
+        loff_t_from_u64(pos)
+    ))
 }
 
 #[inline]

--- a/src/backend/linux_raw/net/syscalls.rs
+++ b/src/backend/linux_raw/net/syscalls.rs
@@ -599,7 +599,7 @@ pub(crate) unsafe fn recv(
         target_arch = "x86",
         target_arch = "x86_64",
     )))]
-    unsafe {
+    {
         ret_usize(syscall!(__NR_recv, fd, buf, pass_usize(len), flags))
     }
     #[cfg(any(

--- a/src/backend/linux_raw/net/syscalls.rs
+++ b/src/backend/linux_raw/net/syscalls.rs
@@ -627,7 +627,7 @@ pub(crate) unsafe fn recv(
             x86_sys(SYS_RECV),
             slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
-                buf,
+                buf.into(),
                 pass_usize(len),
                 flags.into(),
             ])
@@ -667,7 +667,7 @@ pub(crate) unsafe fn recvfrom(
             x86_sys(SYS_RECVFROM),
             slice_just_addr::<ArgReg<'_, SocketArg>, _>(&[
                 fd.into(),
-                buf,
+                buf.into(),
                 pass_usize(len),
                 flags.into(),
                 (&mut storage).into(),

--- a/src/backend/linux_raw/net/syscalls.rs
+++ b/src/backend/linux_raw/net/syscalls.rs
@@ -621,7 +621,7 @@ pub(crate) unsafe fn recv(
         ))
     }
     #[cfg(target_arch = "x86")]
-    unsafe {
+    {
         ret_usize(syscall!(
             __NR_socketcall,
             x86_sys(SYS_RECV),

--- a/src/backend/linux_raw/rand/syscalls.rs
+++ b/src/backend/linux_raw/rand/syscalls.rs
@@ -15,5 +15,5 @@ pub(crate) unsafe fn getrandom(
     cap: usize,
     flags: GetRandomFlags,
 ) -> io::Result<usize> {
-    unsafe { ret_usize(syscall!(__NR_getrandom, buf, pass_usize(cap), flags)) }
+    ret_usize(syscall!(__NR_getrandom, buf, pass_usize(cap), flags))
 }

--- a/src/backend/linux_raw/rand/syscalls.rs
+++ b/src/backend/linux_raw/rand/syscalls.rs
@@ -5,12 +5,15 @@
 //! See the `rustix::backend` module documentation for details.
 #![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
-use crate::backend::conv::{ret_usize, slice_mut};
+use crate::backend::conv::{pass_usize, ret_usize};
 use crate::io;
 use crate::rand::GetRandomFlags;
 
 #[inline]
-pub(crate) fn getrandom(buf: &mut [u8], flags: GetRandomFlags) -> io::Result<usize> {
-    let (buf_addr_mut, buf_len) = slice_mut(buf);
-    unsafe { ret_usize(syscall!(__NR_getrandom, buf_addr_mut, buf_len, flags)) }
+pub(crate) unsafe fn getrandom(
+    buf: *mut u8,
+    cap: usize,
+    flags: GetRandomFlags,
+) -> io::Result<usize> {
+    unsafe { ret_usize(syscall!(__NR_getrandom, buf, pass_usize(cap), flags)) }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,0 +1,21 @@
+//! Utilities to help with buffering.
+
+#![allow(unsafe_code)]
+
+use core::mem::MaybeUninit;
+use core::slice;
+
+/// Split an uninitialized byte slice into initialized and uninitialized parts.
+///
+/// # Safety
+///
+/// At least `init` bytes must be initialized.
+#[inline]
+pub(super) unsafe fn split_init(
+    buf: &mut [MaybeUninit<u8>],
+    init: usize,
+) -> (&mut [u8], &mut [MaybeUninit<u8>]) {
+    let (init, uninit) = buf.split_at_mut(init);
+    let init = unsafe { slice::from_raw_parts_mut(init.as_mut_ptr() as *mut u8, init.len()) };
+    (init, uninit)
+}

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -16,6 +16,6 @@ pub(super) unsafe fn split_init(
     init: usize,
 ) -> (&mut [u8], &mut [MaybeUninit<u8>]) {
     let (init, uninit) = buf.split_at_mut(init);
-    let init = unsafe { slice::from_raw_parts_mut(init.as_mut_ptr() as *mut u8, init.len()) };
+    let init = slice::from_raw_parts_mut(init.as_mut_ptr() as *mut u8, init.len());
     (init, uninit)
 }

--- a/src/io/read_write.rs
+++ b/src/io/read_write.rs
@@ -46,27 +46,6 @@ pub fn read<Fd: AsFd>(fd: Fd, buf: &mut [u8]) -> io::Result<usize> {
 /// This is equivalent to [`read`], except that it can read into uninitialized
 /// memory. It returns the slice that was initialized by this function and the
 /// slice that remains uninitialized.
-///
-/// # References
-///  - [POSIX]
-///  - [Linux]
-///  - [Apple]
-///  - [FreeBSD]
-///  - [NetBSD]
-///  - [OpenBSD]
-///  - [DragonFly BSD]
-///  - [illumos]
-///  - [glibc]
-///
-/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html
-/// [Linux]: https://man7.org/linux/man-pages/man2/read.2.html
-/// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/read.2.html
-/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=read&sektion=2
-/// [NetBSD]: https://man.netbsd.org/read.2
-/// [OpenBSD]: https://man.openbsd.org/read.2
-/// [DragonFly BSD]: https://man.dragonflybsd.org/?command=read&section=2
-/// [illumos]: https://illumos.org/man/2/read
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/I_002fO-Primitives.html#index-reading-from-a-file-descriptor
 #[inline]
 pub fn read_uninit<Fd: AsFd>(
     fd: Fd,
@@ -137,25 +116,6 @@ pub fn pread<Fd: AsFd>(fd: Fd, buf: &mut [u8], offset: u64) -> io::Result<usize>
 /// This is equivalent to [`pread`], except that it can read into uninitialized
 /// memory. It returns the slice that was initialized by this function and the
 /// slice that remains uninitialized.
-///
-/// # References
-///  - [POSIX]
-///  - [Linux]
-///  - [Apple]
-///  - [FreeBSD]
-///  - [NetBSD]
-///  - [OpenBSD]
-///  - [DragonFly BSD]
-///  - [illumos]
-///
-/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/pread.html
-/// [Linux]: https://man7.org/linux/man-pages/man2/pread.2.html
-/// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/pread.2.html
-/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=pread&sektion=2
-/// [NetBSD]: https://man.netbsd.org/pread.2
-/// [OpenBSD]: https://man.openbsd.org/pread.2
-/// [DragonFly BSD]: https://man.dragonflybsd.org/?command=pread&section=2
-/// [illumos]: https://illumos.org/man/2/pread
 #[inline]
 pub fn pread_uninit<Fd: AsFd>(
     fd: Fd,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,7 @@ extern crate static_assertions;
 mod static_assertions;
 
 // Internal utilities.
+mod buffer;
 #[cfg(not(windows))]
 #[macro_use]
 pub(crate) mod cstr;

--- a/src/net/send_recv/mod.rs
+++ b/src/net/send_recv/mod.rs
@@ -66,31 +66,6 @@ pub fn recv<Fd: AsFd>(fd: Fd, buf: &mut [u8], flags: RecvFlags) -> io::Result<us
 /// This is equivalent to [`recv`], except that it can read into uninitialized
 /// memory. It returns the slice that was initialized by this function and the
 /// slice that remains uninitialized.
-///
-/// # References
-///  - [Beej's Guide to Network Programming]
-///  - [POSIX]
-///  - [Linux]
-///  - [Apple]
-///  - [Winsock2]
-///  - [FreeBSD]
-///  - [NetBSD]
-///  - [OpenBSD]
-///  - [DragonFly BSD]
-///  - [illumos]
-///  - [glibc]
-///
-/// [Beej's Guide to Network Programming]: https://beej.us/guide/bgnet/html/split/system-calls-or-bust.html#sendrecv
-/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/recv.html
-/// [Linux]: https://man7.org/linux/man-pages/man2/recv.2.html
-/// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/recv.2.html
-/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-recv
-/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2
-/// [NetBSD]: https://man.netbsd.org/recv.2
-/// [OpenBSD]: https://man.openbsd.org/recv.2
-/// [DragonFly BSD]: https://man.dragonflybsd.org/?command=recv&section=2
-/// [illumos]: https://illumos.org/man/3SOCKET/recv
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Receiving-Data.html
 #[inline]
 pub fn recv_uninit<Fd: AsFd>(
     fd: Fd,
@@ -177,31 +152,6 @@ pub fn recvfrom<Fd: AsFd>(
 /// This is equivalent to [`recvfrom`], except that it can read into uninitialized
 /// memory. It returns the slice that was initialized by this function and the
 /// slice that remains uninitialized.
-///
-/// # References
-///  - [Beej's Guide to Network Programming]
-///  - [POSIX]
-///  - [Linux]
-///  - [Apple]
-///  - [Winsock2]
-///  - [FreeBSD]
-///  - [NetBSD]
-///  - [OpenBSD]
-///  - [DragonFly BSD]
-///  - [illumos]
-///  - [glibc]
-///
-/// [Beej's Guide to Network Programming]: https://beej.us/guide/bgnet/html/split/system-calls-or-bust.html#sendtorecv
-/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html
-/// [Linux]: https://man7.org/linux/man-pages/man2/recvfrom.2.html
-/// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/recvfrom.2.html
-/// [Winsock2]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-recvfrom
-/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=recvfrom&sektion=2
-/// [NetBSD]: https://man.netbsd.org/recvfrom.2
-/// [OpenBSD]: https://man.openbsd.org/recvfrom.2
-/// [DragonFly BSD]: https://man.dragonflybsd.org/?command=recvfrom&section=2
-/// [illumos]: https://illumos.org/man/3SOCKET/recvfrom
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Receiving-Datagrams.html
 #[allow(clippy::type_complexity)]
 #[inline]
 pub fn recvfrom_uninit<Fd: AsFd>(

--- a/src/rand/getrandom.rs
+++ b/src/rand/getrandom.rs
@@ -25,20 +25,9 @@ pub fn getrandom(buf: &mut [u8], flags: GetRandomFlags) -> io::Result<usize> {
 
 /// `getrandom(buf, flags)`—Reads a sequence of random bytes.
 ///
-/// This is a very low-level API which may be difficult to use correctly. Most
-/// users should prefer to use [`getrandom`] or [`rand`] APIs instead.
-///
 /// This is identical to [`getrandom`], except that it can read into uninitialized
 /// memory. It returns the slice that was initialized by this function and the
 /// slice that remains uninitialized.
-///
-/// [`getrandom`]: https://crates.io/crates/getrandom
-/// [`rand`]: https://crates.io/crates/rand
-///
-/// # References
-///  - [Linux]
-///
-/// [Linux]: https://man7.org/linux/man-pages/man2/getrandom.2.html
 #[inline]
 pub fn getrandom_uninit(
     buf: &mut [MaybeUninit<u8>],

--- a/src/rand/getrandom.rs
+++ b/src/rand/getrandom.rs
@@ -1,4 +1,8 @@
+#![allow(unsafe_code)]
+
 use crate::{backend, io};
+use core::mem::MaybeUninit;
+use core::slice;
 
 pub use backend::rand::types::GetRandomFlags;
 
@@ -16,5 +20,36 @@ pub use backend::rand::types::GetRandomFlags;
 /// [Linux]: https://man7.org/linux/man-pages/man2/getrandom.2.html
 #[inline]
 pub fn getrandom(buf: &mut [u8], flags: GetRandomFlags) -> io::Result<usize> {
-    backend::rand::syscalls::getrandom(buf, flags)
+    unsafe { backend::rand::syscalls::getrandom(buf.as_mut_ptr(), buf.len(), flags) }
+}
+
+/// `getrandom(buf, flags)`—Reads a sequence of random bytes.
+///
+/// This is a very low-level API which may be difficult to use correctly. Most
+/// users should prefer to use [`getrandom`] or [`rand`] APIs instead.
+///
+/// This is identical to [`getn`]
+///
+/// [`getrandom`]: https://crates.io/crates/getrandom
+/// [`rand`]: https://crates.io/crates/rand
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/getrandom.2.html
+#[inline]
+pub fn getrandom_uninit(
+    buf: &mut [MaybeUninit<u8>],
+    flags: GetRandomFlags,
+) -> io::Result<(&mut [u8], &mut [MaybeUninit<u8>])> {
+    // Get number of initialized bytes.
+    let length = unsafe {
+        backend::rand::syscalls::getrandom(buf.as_mut_ptr() as *mut u8, buf.len(), flags)
+    };
+
+    // Split into the initialized and uninitialized portions.
+    let (init, uninit) = buf.split_at_mut(length?);
+    let init = unsafe { slice::from_raw_parts_mut(init.as_mut_ptr() as *mut u8, init.len()) };
+
+    Ok((init, uninit))
 }

--- a/src/rand/mod.rs
+++ b/src/rand/mod.rs
@@ -4,4 +4,4 @@
 mod getrandom;
 
 #[cfg(linux_kernel)]
-pub use getrandom::{getrandom, GetRandomFlags};
+pub use getrandom::{getrandom, getrandom_uninit, GetRandomFlags};

--- a/tests/rand/getrandom.rs
+++ b/tests/rand/getrandom.rs
@@ -1,7 +1,16 @@
-use rustix::rand::{getrandom, GetRandomFlags};
+use core::mem::MaybeUninit;
+use rustix::rand::{getrandom, getrandom_uninit, GetRandomFlags};
 
 #[test]
 fn test_getrandom() {
     let mut buf = [0_u8; 256];
     let _ = getrandom(&mut buf, GetRandomFlags::empty());
+}
+
+#[test]
+fn test_getrandom_uninit() {
+    let mut buf = unsafe { MaybeUninit::<[MaybeUninit<u8>; 256]>::uninit().assume_init() };
+    let (init, uninit) = getrandom_uninit(&mut buf, GetRandomFlags::empty()).unwrap();
+    let combined_len = init.len() + uninit.len();
+    assert_eq!(buf.len(), combined_len);
 }


### PR DESCRIPTION
An alternative to #908 that uses separate functions to enable reading into uninitialized bytes.

So far I've added uninitialized methods for `io` methods, `net` methods, and `rand`. There are other functions that take `&mut [u8]`, but those aren't as pressing for now.

cc #81

