### PR TITLE
Don't silently ignore errors in the manual auxv code.

### DIFF
--- a/src/backend/linux_raw/fs/dir.rs
+++ b/src/backend/linux_raw/fs/dir.rs
@@ -157,6 +157,7 @@ impl Dir {
         }))
     }
 
+    #[must_use]
     fn read_more(&mut self) -> Option<io::Result<()>> {
         // The first few times we're called, we allocate a relatively small
         // buffer, because many directories are small. If we're called more,

--- a/src/backend/linux_raw/param/auxv.rs
+++ b/src/backend/linux_raw/param/auxv.rs
@@ -207,7 +207,7 @@ fn init_auxv() {
             Ok(buffer) => {
                 // SAFETY: We assume the kernel returns a valid auxv.
                 unsafe {
-                    init_from_aux_iter(AuxPointer(buffer.as_ptr().cast()));
+                    init_from_aux_iter(AuxPointer(buffer.as_ptr().cast())).unwrap();
                 }
                 return;
             }
@@ -235,6 +235,7 @@ fn init_auxv() {
 /// Process auxv entries from the open file `auxv`.
 #[cfg(feature = "alloc")]
 #[cold]
+#[must_use]
 fn init_from_auxv_file(auxv: OwnedFd) -> Option<()> {
     let mut buffer = Vec::<u8>::with_capacity(512);
     loop {
@@ -271,6 +272,7 @@ fn init_from_auxv_file(auxv: OwnedFd) -> Option<()> {
 /// The buffer contains `Elf_aux_t` elements, though it need not be aligned;
 /// function uses `read_unaligned` to read from it.
 #[cold]
+#[must_use]
 unsafe fn init_from_aux_iter(aux_iter: impl Iterator<Item = Elf_auxv_t>) -> Option<()> {
     let mut pagesz = 0;
     let mut clktck = 0;
@@ -375,6 +377,7 @@ unsafe fn init_from_aux_iter(aux_iter: impl Iterator<Item = Elf_auxv_t>) -> Opti
 /// which hopefully holds the value of the kernel-provided vDSO in memory. Do a
 /// series of checks to be as sure as we can that it's safe to use.
 #[cold]
+#[must_use]
 unsafe fn check_elf_base(base: *const Elf_Ehdr) -> Option<NonNull<Elf_Ehdr>> {
     // If we're reading a 64-bit auxv on a 32-bit platform, we'll see a zero
     // `a_val` because `AT_*` values are never greater than `u32::MAX`. Zero is


### PR DESCRIPTION
When we have `default-features = false` and we don't have either "use-explicitly-provided-auxv" or "use-libc-auxv", we fall back t using

src/backend/linux_raw/param/auxv.rs

Add `#[must_use]` to several functions.