### PR TITLE
Add `Dir::new` function, constructing a `Dir` from an owned fd.

### DIFF
--- a/src/backend/linux_raw/fs/dir.rs
+++ b/src/backend/linux_raw/fs/dir.rs
@@ -32,8 +32,26 @@ pub struct Dir {
 }
 
 impl Dir {
-    /// Construct a `Dir` that reads entries from the given directory
-    /// file descriptor.
+    /// Take ownership of `fd` and construct a `Dir` that reads entries from
+    /// the given directory file descriptor.
+    #[inline]
+    pub fn new<Fd: Into<OwnedFd>>(fd: Fd) -> io::Result<Self> {
+        Self::_new(fd.into())
+    }
+
+    #[inline]
+    fn _new(fd: OwnedFd) -> io::Result<Self> {
+        Ok(Self {
+            fd,
+            any_errors: false,
+            rewind: false,
+            buf: Vec::new(),
+            pos: 0,
+        })
+    }
+
+    /// Borrow `fd` and construct a `Dir` that reads entries from the given
+    /// directory file descriptor.
     #[inline]
     pub fn read_from<Fd: AsFd>(fd: Fd) -> io::Result<Self> {
         Self::_read_from(fd.as_fd())


### PR DESCRIPTION
Add `Dir::new` function, which takes ownership of an `OwnedFd`. This incurs undefined behavior from the libc `readdir` function if there are any copies of the file descriptor live somewhere, so this function is `unsafe`.