### PR TITLE
Remove linux-raw-sys and libc from public API

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -9,9 +9,9 @@ use crate::backend::c;
 use crate::backend::conv::ret_usize;
 use crate::backend::conv::{borrowed_fd, c_str, ret, ret_c_int, ret_off_t, ret_owned_fd};
 use crate::fd::{BorrowedFd, OwnedFd};
-use crate::ffi::CStr;
 #[cfg(apple)]
 use crate::ffi::CString;
+use crate::ffi::{self, CStr};
 #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
 use crate::fs::Access;
 #[cfg(not(any(
@@ -90,7 +90,7 @@ use {
 };
 
 #[cfg(all(target_env = "gnu", fix_y2038))]
-weak!(fn __utimensat64(c::c_int, *const c::c_char, *const LibcTimespec, c::c_int) -> c::c_int);
+weak!(fn __utimensat64(c::c_int, *const ffi::c_char, *const LibcTimespec, c::c_int) -> c::c_int);
 #[cfg(all(target_env = "gnu", fix_y2038))]
 weak!(fn __futimens64(c::c_int, *const LibcTimespec) -> c::c_int);
 
@@ -123,7 +123,7 @@ fn open_via_syscall(path: &CStr, oflags: OFlags, mode: Mode) -> io::Result<Owned
     unsafe {
         syscall! {
             fn open(
-                pathname: *const c::c_char,
+                pathname: *const ffi::c_char,
                 oflags: c::c_int,
                 mode: c::mode_t
             ) via SYS_open -> c::c_int
@@ -178,7 +178,7 @@ fn openat_via_syscall(
     syscall! {
         fn openat(
             base_dirfd: c::c_int,
-            pathname: *const c::c_char,
+            pathname: *const ffi::c_char,
             oflags: c::c_int,
             mode: c::mode_t
         ) via SYS_openat -> c::c_int
@@ -268,9 +268,11 @@ pub(crate) fn statvfs(filename: &CStr) -> io::Result<StatVfs> {
 #[inline]
 pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     unsafe {
-        ret_usize(
-            c::readlink(c_str(path), buf.as_mut_ptr().cast::<c::c_char>(), buf.len()) as isize,
-        )
+        ret_usize(c::readlink(
+            c_str(path),
+            buf.as_mut_ptr().cast::<ffi::c_char>(),
+            buf.len(),
+        ) as isize)
     }
 }
 
@@ -285,7 +287,7 @@ pub(crate) fn readlinkat(
         ret_usize(c::readlinkat(
             borrowed_fd(dirfd),
             c_str(path),
-            buf.as_mut_ptr().cast::<c::c_char>(),
+            buf.as_mut_ptr().cast::<ffi::c_char>(),
             buf.len(),
         ) as isize)
     }
@@ -345,9 +347,9 @@ pub(crate) fn linkat(
         weak! {
             fn linkat(
                 c::c_int,
-                *const c::c_char,
+                *const ffi::c_char,
                 c::c_int,
-                *const c::c_char,
+                *const ffi::c_char,
                 c::c_int
             ) -> c::c_int
         }
@@ -402,7 +404,7 @@ pub(crate) fn unlinkat(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io
         weak! {
             fn unlinkat(
                 c::c_int,
-                *const c::c_char,
+                *const ffi::c_char,
                 c::c_int
             ) -> c::c_int
         }
@@ -455,9 +457,9 @@ pub(crate) fn renameat(
         weak! {
             fn renameat(
                 c::c_int,
-                *const c::c_char,
+                *const ffi::c_char,
                 c::c_int,
-                *const c::c_char
+                *const ffi::c_char
             ) -> c::c_int
         }
         // If we have `renameat`, use it.
@@ -499,9 +501,9 @@ pub(crate) fn renameat2(
     weak_or_syscall! {
         fn renameat2(
             olddirfd: c::c_int,
-            oldpath: *const c::c_char,
+            oldpath: *const ffi::c_char,
             newdirfd: c::c_int,
-            newpath: *const c::c_char,
+            newpath: *const ffi::c_char,
             flags: c::c_uint
         ) via SYS_renameat2 -> c::c_int
     }
@@ -538,9 +540,9 @@ pub(crate) fn renameat2(
         syscall! {
             fn renameat2(
                 olddirfd: c::c_int,
-                oldpath: *const c::c_char,
+                oldpath: *const ffi::c_char,
                 newdirfd: c::c_int,
-                newpath: *const c::c_char,
+                newpath: *const ffi::c_char,
                 flags: c::c_uint
             ) via SYS_renameat2 -> c::c_int
         }
@@ -741,7 +743,7 @@ pub(crate) fn accessat(
         weak! {
             fn faccessat(
                 c::c_int,
-                *const c::c_char,
+                *const ffi::c_char,
                 c::c_int,
                 c::c_int
             ) -> c::c_int
@@ -848,14 +850,14 @@ pub(crate) fn utimensat(
         weak! {
             fn utimensat(
                 c::c_int,
-                *const c::c_char,
+                *const ffi::c_char,
                 *const c::timespec,
                 c::c_int
             ) -> c::c_int
         }
         extern "C" {
             fn setattrlist(
-                path: *const c::c_char,
+                path: *const ffi::c_char,
                 attr_list: *const Attrlist,
                 attr_buf: *const c::c_void,
                 attr_buf_size: c::size_t,
@@ -1040,7 +1042,7 @@ pub(crate) fn chmodat(
     syscall! {
         fn fchmodat(
             base_dirfd: c::c_int,
-            pathname: *const c::c_char,
+            pathname: *const ffi::c_char,
             mode: c::mode_t
         ) via SYS_fchmodat -> c::c_int
     }
@@ -1070,7 +1072,7 @@ pub(crate) fn fclonefileat(
         fn fclonefileat(
             srcfd: BorrowedFd<'_>,
             dst_dirfd: BorrowedFd<'_>,
-            dst: *const c::c_char,
+            dst: *const ffi::c_char,
             flags: c::c_int
         ) via SYS_fclonefileat -> c::c_int
     }
@@ -1703,7 +1705,7 @@ pub(crate) fn memfd_create(name: &CStr, flags: MemfdFlags) -> io::Result<OwnedFd
     #[cfg(target_os = "freebsd")]
     weakcall! {
         fn memfd_create(
-            name: *const c::c_char,
+            name: *const ffi::c_char,
             flags: c::c_uint
         ) -> c::c_int
     }
@@ -1711,7 +1713,7 @@ pub(crate) fn memfd_create(name: &CStr, flags: MemfdFlags) -> io::Result<OwnedFd
     #[cfg(linux_kernel)]
     weak_or_syscall! {
         fn memfd_create(
-            name: *const c::c_char,
+            name: *const ffi::c_char,
             flags: c::c_uint
         ) via SYS_memfd_create -> c::c_int
     }
@@ -1732,7 +1734,7 @@ pub(crate) fn openat2(
     syscall! {
         fn openat2(
             base_dirfd: c::c_int,
-            pathname: *const c::c_char,
+            pathname: *const ffi::c_char,
             how: *mut open_how,
             size: usize
         ) via SYS_OPENAT2 -> c::c_int
@@ -1922,12 +1924,12 @@ fn stat64_to_stat(s64: c::stat64) -> io::Result<Stat> {
 #[cfg(linux_kernel)]
 #[allow(non_upper_case_globals)]
 mod sys {
-    use super::{c, BorrowedFd, Statx};
+    use super::{c, ffi, BorrowedFd, Statx};
 
     weak_or_syscall! {
         pub(super) fn statx(
             dirfd_: BorrowedFd<'_>,
-            path: *const c::c_char,
+            path: *const ffi::c_char,
             flags: c::c_int,
             mask: c::c_uint,
             buf: *mut Statx
@@ -2405,7 +2407,7 @@ pub(crate) fn fsetxattr(
 }
 
 #[cfg(any(apple, linux_kernel))]
-pub(crate) fn listxattr(path: &CStr, list: &mut [c::c_char]) -> io::Result<usize> {
+pub(crate) fn listxattr(path: &CStr, list: &mut [ffi::c_char]) -> io::Result<usize> {
     #[cfg(not(apple))]
     unsafe {
         ret_usize(c::listxattr(path.as_ptr(), list.as_mut_ptr(), list.len()))
@@ -2423,7 +2425,7 @@ pub(crate) fn listxattr(path: &CStr, list: &mut [c::c_char]) -> io::Result<usize
 }
 
 #[cfg(any(apple, linux_kernel))]
-pub(crate) fn llistxattr(path: &CStr, list: &mut [c::c_char]) -> io::Result<usize> {
+pub(crate) fn llistxattr(path: &CStr, list: &mut [ffi::c_char]) -> io::Result<usize> {
     #[cfg(not(apple))]
     unsafe {
         ret_usize(c::llistxattr(path.as_ptr(), list.as_mut_ptr(), list.len()))
@@ -2441,7 +2443,7 @@ pub(crate) fn llistxattr(path: &CStr, list: &mut [c::c_char]) -> io::Result<usiz
 }
 
 #[cfg(any(apple, linux_kernel))]
-pub(crate) fn flistxattr(fd: BorrowedFd<'_>, list: &mut [c::c_char]) -> io::Result<usize> {
+pub(crate) fn flistxattr(fd: BorrowedFd<'_>, list: &mut [ffi::c_char]) -> io::Result<usize> {
     let fd = borrowed_fd(fd);
 
     #[cfg(not(apple))]

--- a/src/backend/libc/mount/types.rs
+++ b/src/backend/libc/mount/types.rs
@@ -1,4 +1,5 @@
 use crate::backend::c;
+use crate::ffi;
 use bitflags::bitflags;
 
 #[cfg(linux_kernel)]
@@ -8,7 +9,7 @@ bitflags! {
     /// [`mount`]: crate::mount::mount
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct MountFlags: c::c_ulong {
+    pub struct MountFlags: ffi::c_ulong {
         /// `MS_BIND`
         const BIND = c::MS_BIND;
 
@@ -90,7 +91,7 @@ bitflags! {
     /// [`fsopen`]: crate::mount::fsopen
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct FsOpenFlags: c::c_uint {
+    pub struct FsOpenFlags: ffi::c_uint {
         /// `FSOPEN_CLOEXEC`
         const FSOPEN_CLOEXEC = 0x0000_0001;
 
@@ -107,7 +108,7 @@ bitflags! {
     /// [`fsmount`]: crate::mount::fsmount
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct FsMountFlags: c::c_uint {
+    pub struct FsMountFlags: ffi::c_uint {
         /// `FSMOUNT_CLOEXEC`
         const FSMOUNT_CLOEXEC = 0x0000_0001;
 
@@ -155,7 +156,7 @@ bitflags! {
     /// [`fsmount`]: crate::mount::fsmount
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct MountAttrFlags: c::c_uint {
+    pub struct MountAttrFlags: ffi::c_uint {
         /// `MOUNT_ATTR_RDONLY`
         const MOUNT_ATTR_RDONLY = 0x0000_0001;
 
@@ -205,7 +206,7 @@ bitflags! {
     /// [`move_mount`]: crate::mount::move_mount
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct MoveMountFlags: c::c_uint {
+    pub struct MoveMountFlags: ffi::c_uint {
         /// `MOVE_MOUNT_F_EMPTY_PATH`
         const MOVE_MOUNT_F_SYMLINKS = 0x0000_0001;
 
@@ -247,7 +248,7 @@ bitflags! {
     /// [`open_tree`]: crate::mount::open_tree
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct OpenTreeFlags: c::c_uint {
+    pub struct OpenTreeFlags: ffi::c_uint {
         /// `OPENTREE_CLONE`
         const OPEN_TREE_CLONE = 1;
 
@@ -279,7 +280,7 @@ bitflags! {
     /// [`fspick`]: crate::mount::fspick
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct FsPickFlags: c::c_uint {
+    pub struct FsPickFlags: ffi::c_uint {
         /// `FSPICK_CLOEXEC`
         const FSPICK_CLOEXEC = 0x0000_0001;
 
@@ -304,7 +305,7 @@ bitflags! {
     /// [`mount_change`]: crate::mount::mount_change
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct MountPropagationFlags: c::c_ulong {
+    pub struct MountPropagationFlags: ffi::c_ulong {
         /// `MS_SILENT`
         const SILENT = c::MS_SILENT;
         /// `MS_SHARED`

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -82,7 +82,12 @@ pub(crate) fn clock_nanosleep_relative(id: ClockId, request: &Timespec) -> Nanos
         let flags = 0;
         let mut remain = MaybeUninit::<Timespec>::uninit();
 
-        match c::clock_nanosleep(id as c::clockid_t, flags, request, remain.as_mut_ptr()) {
+        match c::clock_nanosleep(
+            id as c::clockid_t,
+            flags,
+            request as *const Timespec as *const libc::timespec,
+            remain.as_mut_ptr().cast(),
+        ) {
             0 => NanosleepRelativeResult::Ok,
             err if err == io::Errno::INTR.0 => {
                 NanosleepRelativeResult::Interrupted(remain.assume_init())
@@ -179,7 +184,14 @@ pub(crate) fn clock_nanosleep_absolute(id: ClockId, request: &Timespec) -> io::R
     {
         let flags = c::TIMER_ABSTIME;
 
-        match unsafe { c::clock_nanosleep(id as c::clockid_t, flags as _, request, null_mut()) } {
+        match unsafe {
+            c::clock_nanosleep(
+                id as c::clockid_t,
+                flags as _,
+                request as *const Timespec as *const libc::timespec,
+                null_mut(),
+            )
+        } {
             0 => Ok(()),
             err => Err(io::Errno(err)),
         }
@@ -237,7 +249,10 @@ pub(crate) fn nanosleep(request: &Timespec) -> NanosleepRelativeResult {
     unsafe {
         let mut remain = MaybeUninit::<Timespec>::uninit();
 
-        match ret(c::nanosleep(request, remain.as_mut_ptr())) {
+        match ret(c::nanosleep(
+            request as *const Timespec as *const libc::timespec,
+            remain.as_mut_ptr().cast(),
+        )) {
             Ok(()) => NanosleepRelativeResult::Ok,
             Err(io::Errno::INTR) => NanosleepRelativeResult::Interrupted(remain.assume_init()),
             Err(err) => NanosleepRelativeResult::Err(err),

--- a/src/backend/libc/time/types.rs
+++ b/src/backend/libc/time/types.rs
@@ -1,6 +1,8 @@
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 use crate::backend::c;
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
+use crate::time::Itimerspec;
+#[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(fix_y2038)]
 use crate::timespec::LibcTimespec;
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
@@ -8,31 +10,6 @@ use crate::timespec::LibcTimespec;
 use crate::timespec::Timespec;
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 use bitflags::bitflags;
-
-/// `struct itimerspec` for use with [`timerfd_gettime`] and
-/// [`timerfd_settime`].
-///
-/// [`timerfd_gettime`]: crate::time::timerfd_gettime
-/// [`timerfd_settime`]: crate::time::timerfd_settime
-#[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[cfg(not(fix_y2038))]
-pub type Itimerspec = c::itimerspec;
-
-/// `struct itimerspec` for use with [`timerfd_gettime`] and
-/// [`timerfd_settime`].
-///
-/// [`timerfd_gettime`]: crate::time::timerfd_gettime
-/// [`timerfd_settime`]: crate::time::timerfd_settime
-#[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[cfg(fix_y2038)]
-#[repr(C)]
-#[derive(Debug, Clone)]
-pub struct Itimerspec {
-    /// The interval of an interval timer.
-    pub it_interval: Timespec,
-    /// Time remaining in the current interval.
-    pub it_value: Timespec,
-}
 
 /// On most platforms, `LibcItimerspec` is just `Itimerspec`.
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -25,7 +25,7 @@ use crate::backend::conv::{loff_t, loff_t_from_u64, ret_u64};
 ))]
 use crate::fd::AsFd;
 use crate::fd::{BorrowedFd, OwnedFd};
-use crate::ffi::CStr;
+use crate::ffi::{self, CStr};
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use crate::fs::CWD;
 use crate::fs::{
@@ -1623,19 +1623,19 @@ pub(crate) fn fsetxattr(
 }
 
 #[inline]
-pub(crate) fn listxattr(path: &CStr, list: &mut [c::c_char]) -> io::Result<usize> {
+pub(crate) fn listxattr(path: &CStr, list: &mut [ffi::c_char]) -> io::Result<usize> {
     let (list_addr_mut, list_len) = slice_mut(list);
     unsafe { ret_usize(syscall!(__NR_listxattr, path, list_addr_mut, list_len)) }
 }
 
 #[inline]
-pub(crate) fn llistxattr(path: &CStr, list: &mut [c::c_char]) -> io::Result<usize> {
+pub(crate) fn llistxattr(path: &CStr, list: &mut [ffi::c_char]) -> io::Result<usize> {
     let (list_addr_mut, list_len) = slice_mut(list);
     unsafe { ret_usize(syscall!(__NR_llistxattr, path, list_addr_mut, list_len)) }
 }
 
 #[inline]
-pub(crate) fn flistxattr(fd: BorrowedFd<'_>, list: &mut [c::c_char]) -> io::Result<usize> {
+pub(crate) fn flistxattr(fd: BorrowedFd<'_>, list: &mut [ffi::c_char]) -> io::Result<usize> {
     let (list_addr_mut, list_len) = slice_mut(list);
     unsafe { ret_usize(syscall!(__NR_flistxattr, fd, list_addr_mut, list_len)) }
 }

--- a/src/backend/linux_raw/mm/syscalls.rs
+++ b/src/backend/linux_raw/mm/syscalls.rs
@@ -15,11 +15,12 @@ use crate::backend::c;
 use crate::backend::conv::loff_t_from_u64;
 use crate::backend::conv::{c_uint, no_fd, pass_usize, ret, ret_owned_fd, ret_void_star};
 use crate::fd::{BorrowedFd, OwnedFd};
+use crate::ffi::c_void;
 use crate::io;
 use linux_raw_sys::general::MAP_ANONYMOUS;
 
 #[inline]
-pub(crate) fn madvise(addr: *mut c::c_void, len: usize, advice: Advice) -> io::Result<()> {
+pub(crate) fn madvise(addr: *mut c_void, len: usize, advice: Advice) -> io::Result<()> {
     unsafe {
         ret(syscall!(
             __NR_madvise,
@@ -31,7 +32,7 @@ pub(crate) fn madvise(addr: *mut c::c_void, len: usize, advice: Advice) -> io::R
 }
 
 #[inline]
-pub(crate) unsafe fn msync(addr: *mut c::c_void, len: usize, flags: MsyncFlags) -> io::Result<()> {
+pub(crate) unsafe fn msync(addr: *mut c_void, len: usize, flags: MsyncFlags) -> io::Result<()> {
     ret(syscall!(__NR_msync, addr, pass_usize(len), flags))
 }
 
@@ -41,13 +42,13 @@ pub(crate) unsafe fn msync(addr: *mut c::c_void, len: usize, flags: MsyncFlags) 
 /// with memory pointed to by raw pointers is unsafe.
 #[inline]
 pub(crate) unsafe fn mmap(
-    addr: *mut c::c_void,
+    addr: *mut c_void,
     length: usize,
     prot: ProtFlags,
     flags: MapFlags,
     fd: BorrowedFd<'_>,
     offset: u64,
-) -> io::Result<*mut c::c_void> {
+) -> io::Result<*mut c_void> {
     #[cfg(target_pointer_width = "32")]
     {
         ret_void_star(syscall!(
@@ -83,11 +84,11 @@ pub(crate) unsafe fn mmap(
 /// with memory pointed to by raw pointers is unsafe.
 #[inline]
 pub(crate) unsafe fn mmap_anonymous(
-    addr: *mut c::c_void,
+    addr: *mut c_void,
     length: usize,
     prot: ProtFlags,
     flags: MapFlags,
-) -> io::Result<*mut c::c_void> {
+) -> io::Result<*mut c_void> {
     #[cfg(target_pointer_width = "32")]
     {
         ret_void_star(syscall!(
@@ -116,7 +117,7 @@ pub(crate) unsafe fn mmap_anonymous(
 
 #[inline]
 pub(crate) unsafe fn mprotect(
-    ptr: *mut c::c_void,
+    ptr: *mut c_void,
     len: usize,
     flags: MprotectFlags,
 ) -> io::Result<()> {
@@ -128,7 +129,7 @@ pub(crate) unsafe fn mprotect(
 /// `munmap` is primarily unsafe due to the `addr` parameter, as anything
 /// working with memory pointed to by raw pointers is unsafe.
 #[inline]
-pub(crate) unsafe fn munmap(addr: *mut c::c_void, length: usize) -> io::Result<()> {
+pub(crate) unsafe fn munmap(addr: *mut c_void, length: usize) -> io::Result<()> {
     ret(syscall!(__NR_munmap, addr, pass_usize(length)))
 }
 
@@ -138,11 +139,11 @@ pub(crate) unsafe fn munmap(addr: *mut c::c_void, length: usize) -> io::Result<(
 /// anything working with memory pointed to by raw pointers is unsafe.
 #[inline]
 pub(crate) unsafe fn mremap(
-    old_address: *mut c::c_void,
+    old_address: *mut c_void,
     old_size: usize,
     new_size: usize,
     flags: MremapFlags,
-) -> io::Result<*mut c::c_void> {
+) -> io::Result<*mut c_void> {
     ret_void_star(syscall!(
         __NR_mremap,
         old_address,
@@ -159,12 +160,12 @@ pub(crate) unsafe fn mremap(
 /// pointers is unsafe.
 #[inline]
 pub(crate) unsafe fn mremap_fixed(
-    old_address: *mut c::c_void,
+    old_address: *mut c_void,
     old_size: usize,
     new_size: usize,
     flags: MremapFlags,
-    new_address: *mut c::c_void,
-) -> io::Result<*mut c::c_void> {
+    new_address: *mut c_void,
+) -> io::Result<*mut c_void> {
     ret_void_star(syscall!(
         __NR_mremap,
         old_address,
@@ -180,7 +181,7 @@ pub(crate) unsafe fn mremap_fixed(
 /// `mlock` operates on raw pointers and may round out to the nearest page
 /// boundaries.
 #[inline]
-pub(crate) unsafe fn mlock(addr: *mut c::c_void, length: usize) -> io::Result<()> {
+pub(crate) unsafe fn mlock(addr: *mut c_void, length: usize) -> io::Result<()> {
     ret(syscall!(__NR_mlock, addr, pass_usize(length)))
 }
 
@@ -190,7 +191,7 @@ pub(crate) unsafe fn mlock(addr: *mut c::c_void, length: usize) -> io::Result<()
 /// boundaries.
 #[inline]
 pub(crate) unsafe fn mlock_with(
-    addr: *mut c::c_void,
+    addr: *mut c_void,
     length: usize,
     flags: MlockFlags,
 ) -> io::Result<()> {
@@ -202,7 +203,7 @@ pub(crate) unsafe fn mlock_with(
 /// `munlock` operates on raw pointers and may round out to the nearest page
 /// boundaries.
 #[inline]
-pub(crate) unsafe fn munlock(addr: *mut c::c_void, length: usize) -> io::Result<()> {
+pub(crate) unsafe fn munlock(addr: *mut c_void, length: usize) -> io::Result<()> {
     ret(syscall!(__NR_munlock, addr, pass_usize(length)))
 }
 

--- a/src/backend/linux_raw/mount/types.rs
+++ b/src/backend/linux_raw/mount/types.rs
@@ -1,4 +1,4 @@
-use crate::backend::c;
+use crate::ffi;
 use bitflags::bitflags;
 
 bitflags! {
@@ -7,7 +7,7 @@ bitflags! {
     /// [`mount`]: crate::mount::mount
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct MountFlags: c::c_uint {
+    pub struct MountFlags: ffi::c_uint {
         /// `MS_BIND`
         const BIND = linux_raw_sys::general::MS_BIND;
 
@@ -68,7 +68,7 @@ bitflags! {
     /// [`unmount`]: crate::mount::unmount
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct UnmountFlags: c::c_uint {
+    pub struct UnmountFlags: ffi::c_uint {
         /// `MNT_FORCE`
         const FORCE = linux_raw_sys::general::MNT_FORCE;
         /// `MNT_DETACH`
@@ -90,7 +90,7 @@ bitflags! {
     /// [`fsopen`]: crate::mount::fsopen
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct FsOpenFlags: c::c_uint {
+    pub struct FsOpenFlags: ffi::c_uint {
         /// `FSOPEN_CLOEXEC`
         const FSOPEN_CLOEXEC = linux_raw_sys::general::FSOPEN_CLOEXEC;
 
@@ -106,7 +106,7 @@ bitflags! {
     /// [`fsmount`]: crate::mount::fsmount
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct FsMountFlags: c::c_uint {
+    pub struct FsMountFlags: ffi::c_uint {
         /// `FSMOUNT_CLOEXEC`
         const FSMOUNT_CLOEXEC = linux_raw_sys::general::FSMOUNT_CLOEXEC;
 
@@ -152,7 +152,7 @@ bitflags! {
     /// [`fsmount`]: crate::mount::fsmount
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct MountAttrFlags: c::c_uint {
+    pub struct MountAttrFlags: ffi::c_uint {
         /// `MOUNT_ATTR_RDONLY`
         const MOUNT_ATTR_RDONLY = linux_raw_sys::general::MOUNT_ATTR_RDONLY;
 
@@ -201,7 +201,7 @@ bitflags! {
     /// [`move_mount`]: crate::mount::move_mount
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct MoveMountFlags: c::c_uint {
+    pub struct MoveMountFlags: ffi::c_uint {
         /// `MOVE_MOUNT_F_EMPTY_PATH`
         const MOVE_MOUNT_F_SYMLINKS = linux_raw_sys::general::MOVE_MOUNT_F_SYMLINKS;
 
@@ -242,7 +242,7 @@ bitflags! {
     /// [`open_tree`]: crate::mount::open_tree
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct OpenTreeFlags: c::c_uint {
+    pub struct OpenTreeFlags: ffi::c_uint {
         /// `OPENTREE_CLONE`
         const OPEN_TREE_CLONE = linux_raw_sys::general::OPEN_TREE_CLONE;
 
@@ -273,7 +273,7 @@ bitflags! {
     /// [`fspick`]: crate::mount::fspick
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct FsPickFlags: c::c_uint {
+    pub struct FsPickFlags: ffi::c_uint {
         /// `FSPICK_CLOEXEC`
         const FSPICK_CLOEXEC = linux_raw_sys::general::FSPICK_CLOEXEC;
 
@@ -297,7 +297,7 @@ bitflags! {
     /// [`mount_change`]: crate::mount::mount_change
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct MountPropagationFlags: c::c_uint {
+    pub struct MountPropagationFlags: ffi::c_uint {
         /// `MS_SILENT`
         const SILENT = linux_raw_sys::general::MS_SILENT;
         /// `MS_SHARED`
@@ -319,7 +319,7 @@ bitflags! {
 bitflags! {
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub(crate) struct InternalMountFlags: c::c_uint {
+    pub(crate) struct InternalMountFlags: ffi::c_uint {
         const REMOUNT = linux_raw_sys::general::MS_REMOUNT;
         const MOVE = linux_raw_sys::general::MS_MOVE;
 
@@ -329,4 +329,4 @@ bitflags! {
 }
 
 #[repr(transparent)]
-pub(crate) struct MountFlagsArg(pub(crate) c::c_uint);
+pub(crate) struct MountFlagsArg(pub(crate) ffi::c_uint);

--- a/src/backend/linux_raw/time/types.rs
+++ b/src/backend/linux_raw/time/types.rs
@@ -1,13 +1,6 @@
 use crate::backend::c;
 use bitflags::bitflags;
 
-/// `struct itimerspec` for use with [`timerfd_gettime`] and
-/// [`timerfd_settime`].
-///
-/// [`timerfd_gettime`]: crate::time::timerfd_gettime
-/// [`timerfd_settime`]: crate::time::timerfd_settime
-pub type Itimerspec = linux_raw_sys::general::__kernel_itimerspec;
-
 bitflags! {
     /// `TFD_*` flags for use with [`timerfd_create`].
     ///

--- a/src/backend/linux_raw/vdso_wrappers.rs
+++ b/src/backend/linux_raw/vdso_wrappers.rs
@@ -26,9 +26,6 @@ use core::mem::transmute;
 use core::ptr::null_mut;
 use core::sync::atomic::AtomicPtr;
 use core::sync::atomic::Ordering::Relaxed;
-#[cfg(target_pointer_width = "32")]
-#[cfg(feature = "time")]
-use linux_raw_sys::general::timespec as __kernel_old_timespec;
 #[cfg(any(
     all(
         feature = "process",
@@ -48,17 +45,17 @@ use {
     crate::clockid::{ClockId, DynamicClockId},
     crate::io,
     crate::timespec::Timespec,
-    linux_raw_sys::general::{__kernel_clockid_t, __kernel_timespec},
+    linux_raw_sys::general::__kernel_clockid_t,
 };
 
 #[cfg(feature = "time")]
 #[inline]
-pub(crate) fn clock_gettime(which_clock: ClockId) -> __kernel_timespec {
+pub(crate) fn clock_gettime(which_clock: ClockId) -> Timespec {
     // SAFETY: `CLOCK_GETTIME` contains either null or the address of a
     // function with an ABI like libc `clock_gettime`, and calling it has the
     // side effect of writing to the result buffer, and no others.
     unsafe {
-        let mut result = MaybeUninit::<__kernel_timespec>::uninit();
+        let mut result = MaybeUninit::<Timespec>::uninit();
         let callee = match transmute(CLOCK_GETTIME.load(Relaxed)) {
             Some(callee) => callee,
             None => init_clock_gettime(),

--- a/src/event/port.rs
+++ b/src/event/port.rs
@@ -3,6 +3,7 @@
 use crate::backend::c;
 use crate::backend::event::syscalls;
 use crate::fd::{AsFd, AsRawFd, OwnedFd};
+use crate::ffi;
 use crate::io;
 
 use super::PollFlags;
@@ -25,7 +26,7 @@ impl Event {
     }
 
     /// Get the userdata associated with this event.
-    pub fn userdata(&self) -> *mut c::c_void {
+    pub fn userdata(&self) -> *mut ffi::c_void {
         self.0.portev_user
     }
 }
@@ -61,7 +62,7 @@ pub unsafe fn port_associate_fd(
     port: impl AsFd,
     object: impl AsRawFd,
     events: PollFlags,
-    userdata: *mut c::c_void,
+    userdata: *mut ffi::c_void,
 ) -> io::Result<()> {
     syscalls::port_associate(
         port.as_fd(),
@@ -146,6 +147,6 @@ pub fn port_getn(
 ///
 /// [OpenSolaris]: https://www.unix.com/man-page/opensolaris/3C/port_send/
 /// [illumos]: https://illumos.org/man/3C/port_send
-pub fn port_send(port: impl AsFd, events: i32, userdata: *mut c::c_void) -> io::Result<()> {
+pub fn port_send(port: impl AsFd, events: i32, userdata: *mut ffi::c_void) -> io::Result<()> {
     syscalls::port_send(port.as_fd(), events, userdata.cast())
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "std")]
 pub use {
     std::ffi::{CStr, CString, FromBytesWithNulError, NulError},
-    std::os::raw::c_char,
+    std::os::raw::{c_char, c_int, c_long, c_uint, c_ulong, c_ushort, c_void},
 };
 
 // If we don't have std, we can depend on core and alloc having these features
@@ -12,4 +12,6 @@ pub use {
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 pub use alloc::ffi::{CString, NulError};
 #[cfg(not(feature = "std"))]
-pub use core::ffi::{c_char, CStr, FromBytesWithNulError};
+pub use core::ffi::{
+    c_char, c_int, c_long, c_uint, c_ulong, c_ushort, c_void, CStr, FromBytesWithNulError,
+};

--- a/src/fs/xattr.rs
+++ b/src/fs/xattr.rs
@@ -1,4 +1,4 @@
-use crate::{backend, io, path};
+use crate::{backend, ffi, io, path};
 use backend::c;
 use backend::fd::AsFd;
 use bitflags::bitflags;
@@ -8,7 +8,7 @@ bitflags! {
     /// functions.
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct XattrFlags: c::c_uint {
+    pub struct XattrFlags: ffi::c_uint {
         /// `XATTR_CREATE`
         const CREATE = c::XATTR_CREATE as c::c_uint;
 
@@ -137,7 +137,7 @@ pub fn fsetxattr<Fd: AsFd, Name: path::Arg>(
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/listxattr.2.html
 #[inline]
-pub fn listxattr<P: path::Arg>(path: P, list: &mut [c::c_char]) -> io::Result<usize> {
+pub fn listxattr<P: path::Arg>(path: P, list: &mut [ffi::c_char]) -> io::Result<usize> {
     path.into_with_c_str(|path| backend::fs::syscalls::listxattr(path, list))
 }
 
@@ -149,7 +149,7 @@ pub fn listxattr<P: path::Arg>(path: P, list: &mut [c::c_char]) -> io::Result<us
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/llistxattr.2.html
 #[inline]
-pub fn llistxattr<P: path::Arg>(path: P, list: &mut [c::c_char]) -> io::Result<usize> {
+pub fn llistxattr<P: path::Arg>(path: P, list: &mut [ffi::c_char]) -> io::Result<usize> {
     path.into_with_c_str(|path| backend::fs::syscalls::llistxattr(path, list))
 }
 
@@ -161,7 +161,7 @@ pub fn llistxattr<P: path::Arg>(path: P, list: &mut [c::c_char]) -> io::Result<u
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/flistxattr.2.html
 #[inline]
-pub fn flistxattr<Fd: AsFd>(fd: Fd, list: &mut [c::c_char]) -> io::Result<usize> {
+pub fn flistxattr<Fd: AsFd>(fd: Fd, list: &mut [ffi::c_char]) -> io::Result<usize> {
     backend::fs::syscalls::flistxattr(fd.as_fd(), list)
 }
 

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -35,6 +35,7 @@ use linux_raw_sys::net;
 pub use crate::event::epoll::{
     Event as EpollEvent, EventData as EpollEventData, EventFlags as EpollEventFlags,
 };
+pub use crate::ffi::c_char;
 pub use crate::fs::{Advice, AtFlags, Mode, OFlags, RenameFlags, ResolveFlags, Statx, StatxFlags};
 pub use crate::io::ReadWriteFlags;
 pub use crate::net::{RecvFlags, SendFlags, SocketFlags};
@@ -42,37 +43,6 @@ pub use crate::timespec::Timespec;
 pub use linux_raw_sys::general::sigset_t;
 
 pub use net::{__kernel_sockaddr_storage as sockaddr_storage, msghdr, sockaddr, socklen_t};
-
-// Declare the `c_char` type for use with entries that take pointers
-// to C strings. Define it as unsigned or signed according to the platform
-// so that we match what Rust's `CStr` uses.
-//
-// When we can update to linux-raw-sys 0.5, we can remove this, as its
-// `c_char` type will declare this.
-/// The C `char` type.
-#[cfg(any(
-    target_arch = "aarch64",
-    target_arch = "arm",
-    target_arch = "msp430",
-    target_arch = "powerpc",
-    target_arch = "powerpc64",
-    target_arch = "riscv32",
-    target_arch = "riscv64",
-    target_arch = "s390x",
-))]
-#[allow(non_camel_case_types)]
-pub type c_char = u8;
-/// The C `char` type.
-#[cfg(any(
-    target_arch = "mips",
-    target_arch = "mips64",
-    target_arch = "sparc64",
-    target_arch = "x86",
-    target_arch = "x86_64",
-    target_arch = "xtensa",
-))]
-#[allow(non_camel_case_types)]
-pub type c_char = i8;
 
 mod sys {
     pub(super) use linux_raw_sys::io_uring::*;

--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -14,8 +14,8 @@
 
 #![allow(unsafe_code)]
 
-use crate::backend::c;
 use crate::fd::{AsFd, BorrowedFd};
+use crate::ffi as c;
 use crate::io::Result;
 
 #[cfg(any(linux_kernel, bsd))]

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -47,7 +47,7 @@ impl SocketType {
 }
 
 /// A type for holding raw integer address families.
-pub type RawAddressFamily = c::sa_family_t;
+pub type RawAddressFamily = crate::ffi::c_ushort;
 
 /// `AF_*` constants for use with [`socket`], [`socket_with`], and
 /// [`socketpair`].

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -2,11 +2,10 @@
 
 #![allow(unsafe_code)]
 
-use crate::backend::c;
 use core::num::NonZeroI32;
 
 /// A process identifier as a raw integer.
-pub type RawPid = c::pid_t;
+pub type RawPid = i32;
 
 /// `pid_t`—A non-zero Unix process ID.
 ///

--- a/src/prctl.rs
+++ b/src/prctl.rs
@@ -2,8 +2,8 @@
 
 #![allow(unsafe_code)]
 
-use crate::backend::c::{c_int, c_void};
 use crate::backend::prctl::syscalls;
+use crate::ffi::{c_int, c_void};
 use crate::io;
 use crate::utils::as_mut_ptr;
 use bitflags::bitflags;

--- a/src/process/prctl.rs
+++ b/src/process/prctl.rs
@@ -10,10 +10,9 @@ use core::ptr::{null, null_mut, NonNull};
 
 use bitflags::bitflags;
 
-use crate::backend::c::{c_int, c_uint, c_void};
 use crate::backend::prctl::syscalls;
 use crate::fd::{AsRawFd, BorrowedFd};
-use crate::ffi::CStr;
+use crate::ffi::{c_int, c_uint, c_void, CStr};
 use crate::io;
 use crate::prctl::*;
 use crate::process::{Pid, RawPid};

--- a/src/process/procctl.rs
+++ b/src/process/procctl.rs
@@ -12,9 +12,9 @@ use core::ptr;
 
 use bitflags::bitflags;
 
-use crate::backend::c::{c_int, c_uint, c_void};
 use crate::backend::process::syscalls;
 use crate::backend::process::types::RawId;
+use crate::ffi::{c_int, c_uint, c_void};
 use crate::io;
 use crate::process::{Pid, RawPid};
 use crate::signal::Signal;

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -35,7 +35,7 @@ pub struct Termios {
         target_os = "haiku",
         target_os = "redox"
     ))]
-    pub line_discipline: c::cc_t,
+    pub line_discipline: u8,
 
     /// How are various special control codes handled?
     #[doc(alias = "c_cc")]
@@ -1099,7 +1099,7 @@ pub mod speed {
 pub struct SpecialCodes(pub(crate) [c::cc_t; c::NCCS as usize]);
 
 impl core::ops::Index<SpecialCodeIndex> for SpecialCodes {
-    type Output = c::cc_t;
+    type Output = u8;
 
     fn index(&self, index: SpecialCodeIndex) -> &Self::Output {
         &self.0[index.0]

--- a/src/thread/prctl.rs
+++ b/src/thread/prctl.rs
@@ -17,11 +17,10 @@ use core::sync::atomic::AtomicU8;
 
 use bitflags::bitflags;
 
-use crate::backend::c::{c_int, c_uint, c_void};
 use crate::backend::prctl::syscalls;
-use crate::ffi::CStr;
 #[cfg(feature = "alloc")]
 use crate::ffi::CString;
+use crate::ffi::{c_int, c_uint, c_void, CStr};
 use crate::io;
 use crate::pid::Pid;
 use crate::prctl::{

--- a/src/time/timerfd.rs
+++ b/src/time/timerfd.rs
@@ -1,7 +1,21 @@
 use crate::fd::{AsFd, OwnedFd};
+use crate::timespec::Timespec;
 use crate::{backend, io};
 
-pub use backend::time::types::{Itimerspec, TimerfdClockId, TimerfdFlags, TimerfdTimerFlags};
+pub use backend::time::types::{TimerfdClockId, TimerfdFlags, TimerfdTimerFlags};
+
+/// `struct itimerspec` for use with [`timerfd_gettime`] and
+/// [`timerfd_settime`].
+///
+/// [`timerfd_gettime`]: crate::time::timerfd_gettime
+/// [`timerfd_settime`]: crate::time::timerfd_settime
+#[derive(Debug, Clone)]
+pub struct Itimerspec {
+    /// Interval between times.
+    pub it_interval: Timespec,
+    /// Value of the time.
+    pub it_value: Timespec,
+}
 
 /// `timerfd_create(clockid, flags)`—Create a timer.
 ///

--- a/src/timespec.rs
+++ b/src/timespec.rs
@@ -1,6 +1,7 @@
 //! `Timespec` and related types, which are used by multiple public API
 //! modules.
 
+#[allow(unused)]
 use crate::ffi;
 
 /// `struct timespec`
@@ -15,12 +16,12 @@ pub struct Timespec {
 }
 
 /// A type for the `tv_sec` field of [`Timespec`].
-#[cfg(not(fix_y2038))]
+#[cfg(target_pointer_width = "64")]
 #[allow(deprecated)]
 pub type Secs = ffi::c_long;
 
 /// A type for the `tv_sec` field of [`Timespec`].
-#[cfg(fix_y2038)]
+#[cfg(not(target_pointer_width = "64"))]
 pub type Secs = i64;
 
 /// A type for the `tv_sec` field of [`Timespec`].
@@ -106,4 +107,10 @@ fn test_sizes() {
 #[allow(deprecated)]
 fn test_fix_y2038() {
     assert_eq_size!(libc::time_t, u32);
+}
+
+#[test]
+fn timespec_layouts() {
+    use crate::backend::c;
+    check_renamed_type!(Timespec, timespec);
 }

--- a/src/timespec.rs
+++ b/src/timespec.rs
@@ -1,15 +1,9 @@
 //! `Timespec` and related types, which are used by multiple public API
 //! modules.
 
-#[cfg(not(fix_y2038))]
-use crate::backend::c;
+use crate::ffi;
 
 /// `struct timespec`
-#[cfg(not(fix_y2038))]
-pub type Timespec = c::timespec;
-
-/// `struct timespec`
-#[cfg(fix_y2038)]
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct Timespec {
@@ -23,7 +17,7 @@ pub struct Timespec {
 /// A type for the `tv_sec` field of [`Timespec`].
 #[cfg(not(fix_y2038))]
 #[allow(deprecated)]
-pub type Secs = c::time_t;
+pub type Secs = ffi::c_long;
 
 /// A type for the `tv_sec` field of [`Timespec`].
 #[cfg(fix_y2038)]
@@ -43,7 +37,7 @@ pub type Nsecs = i64;
     libc,
     not(all(target_arch = "x86_64", target_pointer_width = "32"))
 ))]
-pub type Nsecs = c::c_long;
+pub type Nsecs = ffi::c_long;
 
 /// On 32-bit glibc platforms, `timespec` has anonymous padding fields, which
 /// Rust doesn't support yet (see `unnamed_fields`), so we define our own

--- a/src/ugid.rs
+++ b/src/ugid.rs
@@ -2,14 +2,14 @@
 
 #![allow(unsafe_code)]
 
-use crate::backend::c;
+use crate::ffi;
 
 /// A group identifier as a raw integer.
 #[cfg(not(target_os = "wasi"))]
-pub type RawGid = c::gid_t;
+pub type RawGid = ffi::c_uint;
 /// A user identifier as a raw integer.
 #[cfg(not(target_os = "wasi"))]
-pub type RawUid = c::uid_t;
+pub type RawUid = ffi::c_uint;
 
 /// `uid_t`—A Unix user ID.
 #[repr(transparent)]


### PR DESCRIPTION
This prevents libc and linux-raw-sys from affecting the semver status of this crate.