### PR TITLE
Add a `rustix::runtime:::random()` function.

### DIFF
--- a/src/backend/linux_raw/param/libc_auxv.rs
+++ b/src/backend/linux_raw/param/libc_auxv.rs
@@ -33,6 +33,8 @@ const AT_PHNUM: c::c_ulong = 5;
 #[cfg(feature = "runtime")]
 const AT_ENTRY: c::c_ulong = 9;
 const AT_HWCAP: c::c_ulong = 16;
+#[cfg(feature = "runtime")]
+const AT_RANDOM: c::c_ulong = 25;
 const AT_HWCAP2: c::c_ulong = 26;
 const AT_SECURE: c::c_ulong = 23;
 const AT_EXECFN: c::c_ulong = 31;
@@ -68,6 +70,8 @@ fn test_abi() {
     const_assert_eq!(self::AT_PHNUM, ::libc::AT_PHNUM);
     #[cfg(feature = "runtime")]
     const_assert_eq!(self::AT_ENTRY, ::libc::AT_ENTRY);
+    #[cfg(feature = "runtime")]
+    const_assert_eq!(self::AT_RANDOM, ::libc::AT_RANDOM);
 }
 
 #[cfg(feature = "param")]
@@ -162,4 +166,10 @@ pub(in super::super) fn sysinfo_ehdr() -> *const Elf_Ehdr {
 #[inline]
 pub(crate) fn entry() -> usize {
     unsafe { getauxval(AT_ENTRY) as usize }
+}
+
+#[cfg(feature = "runtime")]
+#[inline]
+pub(crate) fn random() -> *const [u8; 16] {
+    unsafe { getauxval(AT_RANDOM) as *const [u8; 16] }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -229,6 +229,19 @@ pub fn entry() -> usize {
     backend::param::auxv::entry()
 }
 
+/// `getauxval(AT_RANDOM)`—Returns the address of 16 pseudorandom bytes.
+///
+/// These bytes are for use by libc. For anything else, use the `rand` crate.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man3/getauxval.3.html
+#[inline]
+pub fn random() -> *const [u8; 16] {
+    backend::param::auxv::random()
+}
+
 #[cfg(linux_raw)]
 pub use backend::runtime::tls::StartupTlsInfo;
 


### PR DESCRIPTION
This function returns the value of `AT_RANDOM`, for use by origin for initializing the stack-smashing protection canary.