### PR TITLE
Fix the return type of `fsmount`.

### DIFF
--- a/src/backend/libc/mount/syscalls.rs
+++ b/src/backend/libc/mount/syscalls.rs
@@ -50,7 +50,7 @@ pub(crate) fn fsmount(
     fs_fd: BorrowedFd<'_>,
     flags: super::types::FsMountFlags,
     attr_flags: super::types::MountAttrFlags,
-) -> io::Result<()> {
+) -> io::Result<OwnedFd> {
     syscall! {
         fn fsmount(
             fs_fd: c::c_int,
@@ -58,7 +58,7 @@ pub(crate) fn fsmount(
             attr_flags: c::c_uint
         ) via SYS_fsmount -> c::c_int
     }
-    unsafe { ret(fsmount(borrowed_fd(fs_fd), flags.bits(), attr_flags.bits())) }
+    unsafe { ret_owned_fd(fsmount(borrowed_fd(fs_fd), flags.bits(), attr_flags.bits())) }
 }
 
 #[cfg(linux_kernel)]

--- a/src/backend/linux_raw/mount/syscalls.rs
+++ b/src/backend/linux_raw/mount/syscalls.rs
@@ -51,8 +51,8 @@ pub(crate) fn fsmount(
     fs_fd: BorrowedFd<'_>,
     flags: super::types::FsMountFlags,
     attr_flags: super::types::MountAttrFlags,
-) -> io::Result<()> {
-    unsafe { ret(syscall_readonly!(__NR_fsmount, fs_fd, flags, attr_flags)) }
+) -> io::Result<OwnedFd> {
+    unsafe { ret_owned_fd(syscall_readonly!(__NR_fsmount, fs_fd, flags, attr_flags)) }
 }
 
 #[cfg(feature = "mount")]

--- a/src/mount/fsopen.rs
+++ b/src/mount/fsopen.rs
@@ -28,7 +28,7 @@ pub fn fsmount(
     fs_fd: BorrowedFd<'_>,
     flags: FsMountFlags,
     attr_flags: MountAttrFlags,
-) -> io::Result<()> {
+) -> io::Result<OwnedFd> {
     backend::mount::syscalls::fsmount(fs_fd, flags, attr_flags)
 }
 


### PR DESCRIPTION
The documentation for `fsmount` says that it returns an owned file descriptor.

Fixes #959.