### PR TITLE
Fix `c_char` vs `u8` errors in the linux_raw backend.

### DIFF
--- a/src/backend/linux_raw/net/read_sockaddr.rs
+++ b/src/backend/linux_raw/net/read_sockaddr.rs
@@ -6,6 +6,7 @@ use crate::backend::c;
 use crate::io;
 use crate::net::{Ipv4Addr, Ipv6Addr, SocketAddrAny, SocketAddrUnix, SocketAddrV4, SocketAddrV6};
 use core::mem::size_of;
+use core::slice;
 
 // This must match the header of `sockaddr`.
 #[repr(C)]
@@ -93,17 +94,24 @@ pub(crate) unsafe fn read_sockaddr(
                 //
                 // [abstract namespace]: https://man7.org/linux/man-pages/man7/unix.7.html
                 if decode.sun_path[0] == 0 {
-                    return SocketAddrUnix::new_abstract_name(
-                        &decode.sun_path[1..len - offsetof_sun_path],
-                    )
-                    .map(SocketAddrAny::Unix);
+                    let bytes = &decode.sun_path[1..len - offsetof_sun_path];
+
+                    // SAFETY: Convert `&[c_char]` to `&[u8]`.
+                    let bytes =
+                        unsafe { slice::from_raw_parts(bytes.as_ptr().cast::<u8>(), bytes.len()) };
+
+                    return SocketAddrUnix::new_abstract_name(bytes).map(SocketAddrAny::Unix);
                 }
 
                 // Otherwise we expect a NUL-terminated filesystem path.
+                let bytes = &decode.sun_path[..len - 1 - offsetof_sun_path];
+
+                // SAFETY: Convert `&[c_char]` to `&[u8]`.
+                let bytes =
+                    unsafe { slice::from_raw_parts(bytes.as_ptr().cast::<u8>(), bytes.len()) };
+
                 assert_eq!(decode.sun_path[len - 1 - offsetof_sun_path], 0);
-                Ok(SocketAddrAny::Unix(SocketAddrUnix::new(
-                    &decode.sun_path[..len - 1 - offsetof_sun_path],
-                )?))
+                Ok(SocketAddrAny::Unix(SocketAddrUnix::new(bytes)?))
             }
         }
         _ => Err(io::Errno::NOTSUP),
@@ -165,19 +173,25 @@ pub(crate) unsafe fn read_sockaddr_os(storage: *const c::sockaddr, len: usize) -
                 //
                 // [abstract namespace]: https://man7.org/linux/man-pages/man7/unix.7.html
                 if decode.sun_path[0] == 0 {
-                    return SocketAddrAny::Unix(
-                        SocketAddrUnix::new_abstract_name(
-                            &decode.sun_path[1..len - offsetof_sun_path],
-                        )
-                        .unwrap(),
-                    );
+                    let bytes = &decode.sun_path[1..len - offsetof_sun_path];
+
+                    // SAFETY: Convert `&[c_char]` to `&[u8]`.
+                    let bytes =
+                        unsafe { slice::from_raw_parts(bytes.as_ptr().cast::<u8>(), bytes.len()) };
+
+                    return SocketAddrAny::Unix(SocketAddrUnix::new_abstract_name(bytes).unwrap());
                 }
 
                 // Otherwise we expect a NUL-terminated filesystem path.
                 assert_eq!(decode.sun_path[len - 1 - offsetof_sun_path], 0);
-                SocketAddrAny::Unix(
-                    SocketAddrUnix::new(&decode.sun_path[..len - 1 - offsetof_sun_path]).unwrap(),
-                )
+
+                let bytes = &decode.sun_path[..len - 1 - offsetof_sun_path];
+
+                // SAFETY: Convert `&[c_char]` to `&[u8]`.
+                let bytes =
+                    unsafe { slice::from_raw_parts(bytes.as_ptr().cast::<u8>(), bytes.len()) };
+
+                SocketAddrAny::Unix(SocketAddrUnix::new(bytes).unwrap())
             }
         }
         other => unimplemented!("{:?}", other),

--- a/src/backend/linux_raw/net/read_sockaddr.rs
+++ b/src/backend/linux_raw/net/read_sockaddr.rs
@@ -97,8 +97,7 @@ pub(crate) unsafe fn read_sockaddr(
                     let bytes = &decode.sun_path[1..len - offsetof_sun_path];
 
                     // SAFETY: Convert `&[c_char]` to `&[u8]`.
-                    let bytes =
-                        unsafe { slice::from_raw_parts(bytes.as_ptr().cast::<u8>(), bytes.len()) };
+                    let bytes = slice::from_raw_parts(bytes.as_ptr().cast::<u8>(), bytes.len());
 
                     return SocketAddrUnix::new_abstract_name(bytes).map(SocketAddrAny::Unix);
                 }
@@ -107,8 +106,7 @@ pub(crate) unsafe fn read_sockaddr(
                 let bytes = &decode.sun_path[..len - 1 - offsetof_sun_path];
 
                 // SAFETY: Convert `&[c_char]` to `&[u8]`.
-                let bytes =
-                    unsafe { slice::from_raw_parts(bytes.as_ptr().cast::<u8>(), bytes.len()) };
+                let bytes = slice::from_raw_parts(bytes.as_ptr().cast::<u8>(), bytes.len());
 
                 assert_eq!(decode.sun_path[len - 1 - offsetof_sun_path], 0);
                 Ok(SocketAddrAny::Unix(SocketAddrUnix::new(bytes)?))
@@ -176,8 +174,7 @@ pub(crate) unsafe fn read_sockaddr_os(storage: *const c::sockaddr, len: usize) -
                     let bytes = &decode.sun_path[1..len - offsetof_sun_path];
 
                     // SAFETY: Convert `&[c_char]` to `&[u8]`.
-                    let bytes =
-                        unsafe { slice::from_raw_parts(bytes.as_ptr().cast::<u8>(), bytes.len()) };
+                    let bytes = slice::from_raw_parts(bytes.as_ptr().cast::<u8>(), bytes.len());
 
                     return SocketAddrAny::Unix(SocketAddrUnix::new_abstract_name(bytes).unwrap());
                 }
@@ -188,8 +185,7 @@ pub(crate) unsafe fn read_sockaddr_os(storage: *const c::sockaddr, len: usize) -
                 let bytes = &decode.sun_path[..len - 1 - offsetof_sun_path];
 
                 // SAFETY: Convert `&[c_char]` to `&[u8]`.
-                let bytes =
-                    unsafe { slice::from_raw_parts(bytes.as_ptr().cast::<u8>(), bytes.len()) };
+                let bytes = slice::from_raw_parts(bytes.as_ptr().cast::<u8>(), bytes.len());
 
                 SocketAddrAny::Unix(SocketAddrUnix::new(bytes).unwrap())
             }


### PR DESCRIPTION
Fix the linux_raw backend to handle the case where linux-raw-sys defines `c_char` as `i8`.

linux-raw-sys used to always define `c_char` as `u8` because it usually isn't important to match the platform `char` type, but that makes it inconvenient to work with Rust's `CStr`/`CString` types which use `c_char`, so linux-raw-sys has started defining `c_char` as `i8` on platforms which define it that way.