### PR TITLE
Support the timerfd API on FreeBSD.

### DIFF
--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -519,24 +519,44 @@ pub(crate) use __fsid_t as fsid_t;
 #[cfg(target_os = "android")]
 pub(crate) const MAP_DROPPABLE: c_int = bitcast!(linux_raw_sys::general::MAP_DROPPABLE);
 
-// FreeBSD added `timer_*` in FreeBSD 14.
-#[cfg(all(feature = "time", target_os = "freebsd"))]
+// FreeBSD added `timerfd_*` in FreeBSD 14. NetBSD added then in NetBSD 10.
+#[cfg(all(feature = "time", any(target_os = "freebsd", target_os = "netbsd")))]
 syscall!(pub(crate) fn timerfd_create(
     clockid: c_int,
     flags: c_int
 ) via SYS_timerfd_create -> c_int);
-#[cfg(all(feature = "time", target_os = "freebsd"))]
+#[cfg(all(feature = "time", any(target_os = "freebsd", target_os = "netbsd")))]
 syscall!(pub(crate) fn timerfd_gettime(
     fd: c_int,
     curr_value: *mut itimerspec
 ) via SYS_timerfd_gettime -> c_int);
-#[cfg(all(feature = "time", target_os = "freebsd"))]
+#[cfg(all(feature = "time", any(target_os = "freebsd", target_os = "netbsd")))]
 syscall!(pub(crate) fn timerfd_settime(
     fd: c_int,
     flags: c_int,
     new_value: *const itimerspec,
     old_value: *mut itimerspec
 ) via SYS_timerfd_settime -> c_int);
+
+#[cfg(all(feature = "time", target_os = "illumos"))]
+extern "C" {
+    pub(crate) fn timerfd_create(clockid: c_int, flags: c_int) -> c_int;
+    pub(crate) fn timerfd_gettime(fd: c_int, curr_value: *mut itimerspec) -> c_int;
+    pub(crate) fn timerfd_settime(
+        fd: c_int,
+        flags: c_int,
+        new_value: *const itimerspec,
+        old_value: *mut itimerspec,
+    ) -> c_int;
+}
+#[cfg(all(feature = "time", any(target_os = "illumos", target_os = "netbsd")))]
+pub(crate) const TFD_CLOEXEC: i32 = 0o2000000;
+#[cfg(all(feature = "time", any(target_os = "illumos", target_os = "netbsd")))]
+pub(crate) const TFD_NONBLOCK: i32 = 0o4000;
+#[cfg(all(feature = "time", any(target_os = "illumos", target_os = "netbsd")))]
+pub(crate) const TFD_TIMER_ABSTIME: i32 = 1 << 0;
+#[cfg(all(feature = "time", any(target_os = "illumos", target_os = "netbsd")))]
+pub(crate) const TFD_TIMER_CANCEL_ON_SET: i32 = 1 << 1;
 
 #[cfg(test)]
 mod tests {

--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -519,6 +519,25 @@ pub(crate) use __fsid_t as fsid_t;
 #[cfg(target_os = "android")]
 pub(crate) const MAP_DROPPABLE: c_int = bitcast!(linux_raw_sys::general::MAP_DROPPABLE);
 
+// FreeBSD added `timer_*` in FreeBSD 14.
+#[cfg(all(feature = "time", target_os = "freebsd"))]
+syscall!(pub(crate) fn timerfd_create(
+    clockid: c_int,
+    flags: c_int
+) via SYS_timerfd_create -> c_int);
+#[cfg(all(feature = "time", target_os = "freebsd"))]
+syscall!(pub(crate) fn timerfd_gettime(
+    fd: c_int,
+    curr_value: *mut itimerspec
+) via SYS_timerfd_gettime -> c_int);
+#[cfg(all(feature = "time", target_os = "freebsd"))]
+syscall!(pub(crate) fn timerfd_settime(
+    fd: c_int,
+    flags: c_int,
+    new_value: *const itimerspec,
+    old_value: *mut itimerspec
+) via SYS_timerfd_settime -> c_int);
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -549,14 +549,29 @@ extern "C" {
         old_value: *mut itimerspec,
     ) -> c_int;
 }
-#[cfg(all(feature = "time", any(target_os = "illumos", target_os = "netbsd")))]
+
+// illumos and NetBSD timerfd support.
+// Submitted upstream in <https://github.com/rust-lang/libc/pull/4333>.
+
+// <https://code.illumos.org/plugins/gitiles/illumos-gate/+/refs/heads/master/usr/src/uts/common/sys/timerfd.h#34>
+#[cfg(all(feature = "time", target_os = "illumos"))]
 pub(crate) const TFD_CLOEXEC: i32 = 0o2000000;
-#[cfg(all(feature = "time", any(target_os = "illumos", target_os = "netbsd")))]
+#[cfg(all(feature = "time", target_os = "illumos"))]
 pub(crate) const TFD_NONBLOCK: i32 = 0o4000;
-#[cfg(all(feature = "time", any(target_os = "illumos", target_os = "netbsd")))]
+#[cfg(all(feature = "time", target_os = "illumos"))]
 pub(crate) const TFD_TIMER_ABSTIME: i32 = 1 << 0;
-#[cfg(all(feature = "time", any(target_os = "illumos", target_os = "netbsd")))]
+#[cfg(all(feature = "time", target_os = "illumos"))]
 pub(crate) const TFD_TIMER_CANCEL_ON_SET: i32 = 1 << 1;
+
+// <https://nxr.netbsd.org/xref/src/sys/sys/timerfd.h#44>
+#[cfg(all(feature = "time", target_os = "netbsd"))]
+pub(crate) const TFD_CLOEXEC: i32 = O_CLOEXEC;
+#[cfg(all(feature = "time", target_os = "netbsd"))]
+pub(crate) const TFD_NONBLOCK: i32 = O_NONBLOCK;
+#[cfg(all(feature = "time", target_os = "netbsd"))]
+pub(crate) const TFD_TIMER_ABSTIME: i32 = O_WRONLY;
+#[cfg(all(feature = "time", target_os = "netbsd"))]
+pub(crate) const TFD_TIMER_CANCEL_ON_SET: i32 = O_RDWR;
 
 #[cfg(test)]
 mod tests {

--- a/src/backend/libc/time/syscalls.rs
+++ b/src/backend/libc/time/syscalls.rs
@@ -2,7 +2,7 @@
 
 use crate::backend::c;
 use crate::backend::conv::ret;
-#[cfg(any(linux_kernel, target_os = "fuchsia"))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
 #[cfg(any(all(target_env = "gnu", fix_y2038), not(fix_y2038)))]
 use crate::backend::time::types::LibcItimerspec;
 #[cfg(not(target_os = "wasi"))]
@@ -21,7 +21,7 @@ use crate::timespec::as_libc_timespec_ptr;
 use crate::timespec::LibcTimespec;
 use crate::timespec::Timespec;
 use core::mem::MaybeUninit;
-#[cfg(any(linux_kernel, target_os = "fuchsia"))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
 use {
     crate::backend::conv::{borrowed_fd, ret_owned_fd},
     crate::fd::{BorrowedFd, OwnedFd},
@@ -34,10 +34,10 @@ weak!(fn __clock_gettime64(c::clockid_t, *mut LibcTimespec) -> c::c_int);
 weak!(fn __clock_settime64(c::clockid_t, *const LibcTimespec) -> c::c_int);
 #[cfg(all(target_env = "gnu", fix_y2038))]
 weak!(fn __clock_getres64(c::clockid_t, *mut LibcTimespec) -> c::c_int);
-#[cfg(any(linux_kernel, target_os = "fuchsia"))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
 #[cfg(all(target_env = "gnu", fix_y2038))]
 weak!(fn __timerfd_gettime64(c::c_int, *mut LibcItimerspec) -> c::c_int);
-#[cfg(any(linux_kernel, target_os = "fuchsia"))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
 #[cfg(all(target_env = "gnu", fix_y2038))]
 weak!(fn __timerfd_settime64(c::c_int, c::c_int, *const LibcItimerspec, *mut LibcItimerspec) -> c::c_int);
 
@@ -172,7 +172,7 @@ pub(crate) fn clock_gettime_dynamic(id: DynamicClockId<'_>) -> io::Result<Timesp
             return Err(io::Errno::INVAL);
         }
 
-        #[cfg(linux_kernel)]
+        #[cfg(any(linux_kernel, target_os = "fuchsia"))]
         DynamicClockId::RealtimeAlarm => c::CLOCK_REALTIME_ALARM,
 
         #[cfg(linux_kernel)]
@@ -298,12 +298,12 @@ fn clock_settime_old(id: ClockId, timespec: Timespec) -> io::Result<()> {
     unsafe { ret(c::clock_settime(id as c::clockid_t, &old_timespec)) }
 }
 
-#[cfg(any(linux_kernel, target_os = "fuchsia"))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
 pub(crate) fn timerfd_create(id: TimerfdClockId, flags: TimerfdFlags) -> io::Result<OwnedFd> {
     unsafe { ret_owned_fd(c::timerfd_create(id as c::clockid_t, bitflags_bits!(flags))) }
 }
 
-#[cfg(any(linux_kernel, target_os = "fuchsia"))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
 pub(crate) fn timerfd_settime(
     fd: BorrowedFd<'_>,
     flags: TimerfdTimerFlags,
@@ -345,7 +345,7 @@ pub(crate) fn timerfd_settime(
     }
 }
 
-#[cfg(any(linux_kernel, target_os = "fuchsia"))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
 #[cfg(fix_y2038)]
 fn timerfd_settime_old(
     fd: BorrowedFd<'_>,
@@ -412,7 +412,7 @@ fn timerfd_settime_old(
     })
 }
 
-#[cfg(any(linux_kernel, target_os = "fuchsia"))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
 pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
     // Old 32-bit version: libc has `timerfd_gettime` but it is not y2038 safe
     // by default. But there may be a `__timerfd_gettime64` we can use.
@@ -443,7 +443,7 @@ pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
     }
 }
 
-#[cfg(any(linux_kernel, target_os = "fuchsia"))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
 #[cfg(fix_y2038)]
 fn timerfd_gettime_old(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
     let mut old_result = MaybeUninit::<c::itimerspec>::uninit();

--- a/src/backend/libc/time/syscalls.rs
+++ b/src/backend/libc/time/syscalls.rs
@@ -2,7 +2,13 @@
 
 use crate::backend::c;
 use crate::backend::conv::ret;
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 #[cfg(any(all(target_env = "gnu", fix_y2038), not(fix_y2038)))]
 use crate::backend::time::types::LibcItimerspec;
 #[cfg(not(target_os = "wasi"))]
@@ -21,7 +27,13 @@ use crate::timespec::as_libc_timespec_ptr;
 use crate::timespec::LibcTimespec;
 use crate::timespec::Timespec;
 use core::mem::MaybeUninit;
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 use {
     crate::backend::conv::{borrowed_fd, ret_owned_fd},
     crate::fd::{BorrowedFd, OwnedFd},
@@ -298,12 +310,24 @@ fn clock_settime_old(id: ClockId, timespec: Timespec) -> io::Result<()> {
     unsafe { ret(c::clock_settime(id as c::clockid_t, &old_timespec)) }
 }
 
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 pub(crate) fn timerfd_create(id: TimerfdClockId, flags: TimerfdFlags) -> io::Result<OwnedFd> {
     unsafe { ret_owned_fd(c::timerfd_create(id as c::clockid_t, bitflags_bits!(flags))) }
 }
 
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 pub(crate) fn timerfd_settime(
     fd: BorrowedFd<'_>,
     flags: TimerfdTimerFlags,
@@ -345,7 +369,13 @@ pub(crate) fn timerfd_settime(
     }
 }
 
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 #[cfg(fix_y2038)]
 fn timerfd_settime_old(
     fd: BorrowedFd<'_>,
@@ -412,7 +442,13 @@ fn timerfd_settime_old(
     })
 }
 
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
     // Old 32-bit version: libc has `timerfd_gettime` but it is not y2038 safe
     // by default. But there may be a `__timerfd_gettime64` we can use.
@@ -443,7 +479,13 @@ pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
     }
 }
 
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 #[cfg(fix_y2038)]
 fn timerfd_gettime_old(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
     let mut old_result = MaybeUninit::<c::itimerspec>::uninit();

--- a/src/backend/libc/time/types.rs
+++ b/src/backend/libc/time/types.rs
@@ -1,21 +1,57 @@
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 use crate::backend::c;
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 use crate::time::Itimerspec;
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 #[cfg(fix_y2038)]
 use crate::timespec::LibcTimespec;
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 use bitflags::bitflags;
 
 /// On most platforms, `LibcItimerspec` is just `Itimerspec`.
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 #[cfg(not(fix_y2038))]
 pub(crate) type LibcItimerspec = Itimerspec;
 
 /// On 32-bit glibc platforms, `LibcTimespec` differs from `Timespec`, so we
 /// define our own struct, with bidirectional `From` impls.
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 #[cfg(fix_y2038)]
 #[repr(C)]
 #[derive(Debug, Clone)]
@@ -24,7 +60,13 @@ pub(crate) struct LibcItimerspec {
     pub it_value: LibcTimespec,
 }
 
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 #[cfg(fix_y2038)]
 impl From<LibcItimerspec> for Itimerspec {
     #[inline]
@@ -36,7 +78,13 @@ impl From<LibcItimerspec> for Itimerspec {
     }
 }
 
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 #[cfg(fix_y2038)]
 impl From<Itimerspec> for LibcItimerspec {
     #[inline]
@@ -48,7 +96,13 @@ impl From<Itimerspec> for LibcItimerspec {
     }
 }
 
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 #[cfg(not(fix_y2038))]
 pub(crate) fn as_libc_itimerspec_ptr(itimerspec: &Itimerspec) -> *const c::itimerspec {
     #[cfg(test)]
@@ -58,7 +112,13 @@ pub(crate) fn as_libc_itimerspec_ptr(itimerspec: &Itimerspec) -> *const c::itime
     crate::utils::as_ptr(itimerspec).cast::<c::itimerspec>()
 }
 
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 #[cfg(not(fix_y2038))]
 pub(crate) fn as_libc_itimerspec_mut_ptr(
     itimerspec: &mut core::mem::MaybeUninit<Itimerspec>,
@@ -70,7 +130,13 @@ pub(crate) fn as_libc_itimerspec_mut_ptr(
     itimerspec.as_mut_ptr().cast::<c::itimerspec>()
 }
 
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 bitflags! {
     /// `TFD_*` flags for use with [`timerfd_create`].
     ///
@@ -91,7 +157,13 @@ bitflags! {
     }
 }
 
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 bitflags! {
     /// `TFD_TIMER_*` flags for use with [`timerfd_settime`].
     ///
@@ -104,7 +176,7 @@ bitflags! {
         const ABSTIME = bitcast!(c::TFD_TIMER_ABSTIME);
 
         /// `TFD_TIMER_CANCEL_ON_SET`
-        #[cfg(any(linux_kernel, target_os = "freebsd"))]
+        #[cfg(not(target_os = "fuchsia"))]
         #[doc(alias = "TFD_TIMER_CANCEL_ON_SET")]
         const CANCEL_ON_SET = bitcast!(c::TFD_TIMER_CANCEL_ON_SET);
 
@@ -116,7 +188,13 @@ bitflags! {
 /// `CLOCK_*` constants for use with [`timerfd_create`].
 ///
 /// [`timerfd_create`]: crate::time::timerfd_create
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[repr(u32)]
 #[non_exhaustive]
@@ -146,6 +224,7 @@ pub enum TimerfdClockId {
     /// This clock is similar to `Monotonic`, but does advance while the system
     /// is suspended.
     #[doc(alias = "CLOCK_BOOTTIME")]
+    #[cfg(any(linux_kernel, target_os = "fuchsia", target_os = "openbsd"))]
     Boottime = bitcast!(c::CLOCK_BOOTTIME),
 
     /// `CLOCK_REALTIME_ALARM`—Like `Realtime`, but wakes a suspended system.
@@ -162,7 +241,7 @@ pub enum TimerfdClockId {
     /// This clock is like `Boottime`, but can wake up a suspended system.
     ///
     /// Use of this clock requires the `CAP_WAKE_ALARM` Linux capability.
-    #[cfg(any(linux_kernel, target_os = "fuchsia"))]
+    #[cfg(any(linux_kernel, target_os = "cygwin", target_os = "fuchsia"))]
     #[doc(alias = "CLOCK_BOOTTIME_ALARM")]
     BoottimeAlarm = bitcast!(c::CLOCK_BOOTTIME_ALARM),
 }
@@ -172,7 +251,13 @@ mod tests {
     #[allow(unused_imports)]
     use super::*;
 
-    #[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+    #[cfg(any(
+        linux_kernel,
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "illumos",
+        target_os = "netbsd"
+    ))]
     #[test]
     fn test_types() {
         assert_eq_size!(TimerfdFlags, c::c_int);

--- a/src/clockid.rs
+++ b/src/clockid.rs
@@ -145,7 +145,7 @@ pub enum DynamicClockId<'a> {
     Dynamic(BorrowedFd<'a>),
 
     /// `CLOCK_REALTIME_ALARM`
-    #[cfg(linux_kernel)]
+    #[cfg(any(linux_kernel, target_os = "fuchsia"))]
     #[doc(alias = "CLOCK_REALTIME_ALARM")]
     RealtimeAlarm,
 

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -1,11 +1,11 @@
 //! Time-related operations.
 
 mod clock;
-#[cfg(any(linux_kernel, target_os = "fuchsia"))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
 mod timerfd;
 
 // TODO: Convert WASI'S clock APIs to use handles rather than ambient clock
 // identifiers, update `wasi-libc`, and then add support in `rustix`.
 pub use clock::*;
-#[cfg(any(linux_kernel, target_os = "fuchsia"))]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
 pub use timerfd::*;

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -1,11 +1,23 @@
 //! Time-related operations.
 
 mod clock;
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 mod timerfd;
 
 // TODO: Convert WASI'S clock APIs to use handles rather than ambient clock
 // identifiers, update `wasi-libc`, and then add support in `rustix`.
 pub use clock::*;
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 pub use timerfd::*;

--- a/src/time/timerfd.rs
+++ b/src/time/timerfd.rs
@@ -21,8 +21,14 @@ pub struct Itimerspec {
 ///
 /// # References
 ///  - [Linux]
+///  - [FreeBSD]
+///  - [illumos]
+///  - [NetBSD]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/timerfd_create.2.html
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=timerfd_create&sektion=2
+/// [illumos]: https://illumos.org/man/3C/timerfd_create
+/// [NetBSD]: https://man.netbsd.org/timerfd_create.2
 #[inline]
 pub fn timerfd_create(clockid: TimerfdClockId, flags: TimerfdFlags) -> io::Result<OwnedFd> {
     backend::time::syscalls::timerfd_create(clockid, flags)
@@ -32,8 +38,14 @@ pub fn timerfd_create(clockid: TimerfdClockId, flags: TimerfdFlags) -> io::Resul
 ///
 /// # References
 ///  - [Linux]
+///  - [FreeBSD]
+///  - [illumos]
+///  - [NetBSD]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/timerfd_settime.2.html
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=timerfd_settime&sektion=2
+/// [illumos]: https://illumos.org/man/3C/timerfd_settime
+/// [NetBSD]: https://man.netbsd.org/timerfd_settime.2
 #[inline]
 pub fn timerfd_settime<Fd: AsFd>(
     fd: Fd,
@@ -47,8 +59,14 @@ pub fn timerfd_settime<Fd: AsFd>(
 ///
 /// # References
 ///  - [Linux]
+///  - [FreeBSD]
+///  - [illumos]
+///  - [NetBSD]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/timerfd_gettime.2.html
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=timerfd_gettime&sektion=2
+/// [illumos]: https://illumos.org/man/3C/timerfd_gettime
+/// [NetBSD]: https://man.netbsd.org/timerfd_gettime.2
 #[inline]
 pub fn timerfd_gettime<Fd: AsFd>(fd: Fd) -> io::Result<Itimerspec> {
     backend::time::syscalls::timerfd_gettime(fd.as_fd())

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -146,8 +146,8 @@ unsafe fn fetch(name: &str) -> *mut c_void {
 
 #[cfg(not(linux_kernel))]
 macro_rules! syscall {
-    (fn $name:ident($($arg_name:ident: $t:ty),*) via $_sys_name:ident -> $ret:ty) => (
-        unsafe fn $name($($arg_name: $t),*) -> $ret {
+    ($vis:vis fn $name:ident($($arg_name:ident: $t:ty),*) via $_sys_name:ident -> $ret:ty) => (
+        $vis unsafe fn $name($($arg_name: $t),*) -> $ret {
             weak! { fn $name($($t),*) -> $ret }
 
             if let Some(fun) = $name.get() {
@@ -162,8 +162,8 @@ macro_rules! syscall {
 
 #[cfg(linux_kernel)]
 macro_rules! syscall {
-    (fn $name:ident($($arg_name:ident: $t:ty),*) via $sys_name:ident -> $ret:ty) => (
-        unsafe fn $name($($arg_name:$t),*) -> $ret {
+    ($vis:vis fn $name:ident($($arg_name:ident: $t:ty),*) via $sys_name:ident -> $ret:ty) => (
+        $vis unsafe fn $name($($arg_name:$t),*) -> $ret {
             // This looks like a hack, but `concat_idents` only accepts idents
             // (not paths).
             use libc::*;

--- a/tests/time/main.rs
+++ b/tests/time/main.rs
@@ -14,7 +14,7 @@ mod monotonic;
     all(apple, not(target_os = "macos"))
 )))]
 mod settime;
-#[cfg(linux_kernel)]
+#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
 mod timerfd;
 mod timespec;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]

--- a/tests/time/main.rs
+++ b/tests/time/main.rs
@@ -14,7 +14,13 @@ mod monotonic;
     all(apple, not(target_os = "macos"))
 )))]
 mod settime;
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
+    target_os = "netbsd"
+))]
 mod timerfd;
 mod timespec;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]

--- a/tests/time/timerfd.rs
+++ b/tests/time/timerfd.rs
@@ -5,7 +5,11 @@ use rustix::time::{
 
 #[test]
 fn test_timerfd() {
-    let fd = timerfd_create(TimerfdClockId::Monotonic, TimerfdFlags::CLOEXEC).unwrap();
+    let fd = match timerfd_create(TimerfdClockId::Monotonic, TimerfdFlags::CLOEXEC) {
+        Ok(fd) => fd,
+        Err(rustix::io::Errno::NOSYS) => return,
+        Err(err) => Err(err).unwrap(),
+    };
 
     let set = Itimerspec {
         it_interval: Timespec {
@@ -39,7 +43,11 @@ fn test_timerfd() {
 /// times are monotonic because that would race with the timer repeating.
 #[test]
 fn test_timerfd_with_interval() {
-    let fd = timerfd_create(TimerfdClockId::Monotonic, TimerfdFlags::CLOEXEC).unwrap();
+    let fd = match timerfd_create(TimerfdClockId::Monotonic, TimerfdFlags::CLOEXEC) {
+        Ok(fd) => fd,
+        Err(rustix::io::Errno::NOSYS) => return,
+        Err(err) => Err(err).unwrap(),
+    };
 
     // An `Itimerspec` with an initial value and an interval.
     //

--- a/tests/time/timerfd.rs
+++ b/tests/time/timerfd.rs
@@ -41,10 +41,14 @@ fn test_timerfd() {
 fn test_timerfd_with_interval() {
     let fd = timerfd_create(TimerfdClockId::Monotonic, TimerfdFlags::CLOEXEC).unwrap();
 
+    // An `Itimerspec` with an initial value and an interval.
+    //
+    // For the interval, use a value of more than 200000 nanoseconds, as
+    // illumos appears not to support values smaller than that.
     let set = Itimerspec {
         it_interval: Timespec {
             tv_sec: 0,
-            tv_nsec: 6,
+            tv_nsec: 200001,
         },
         it_value: Timespec {
             tv_sec: 1,


### PR DESCRIPTION
FreeBSD has recently added support for Linux's timerfd API. Enable rustix's timerfd API on FreeBSD as well.