### PR TITLE
On 32-bit x86, add more strategies for the syscall mechanism.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,7 +217,8 @@ jobs:
     #- run: cargo check -Z build-std --target=riscv32imc-esp-espidf --features=all-apis
     - run: cargo check -Z build-std --target=aarch64-unknown-nto-qnx710 --features=all-apis
     - run: cargo check -Z build-std --target=x86_64-pc-nto-qnx710 --features=all-apis
-    - run: cargo check -Z build-std --target=armv7-sony-vita-newlibeabihf --features=all-apis
+    # Temporarily disable armv7-sony-vita-newlibeabihf due to std using SOMAXCONN.
+    #- run: cargo check -Z build-std --target=armv7-sony-vita-newlibeabihf --features=all-apis
     # `std` doesn't appear to build on AIX yet, so test in `no_std` mode.
     - run: cargo check -Zbuild-std=core,alloc --target=powerpc64-ibm-aix --features=all-apis --no-default-features
     # Disable MIPS entirely for now as it fails with errors like

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -213,7 +213,8 @@ jobs:
     # Omit --all-targets on haiku because not all the tests build yet.
     - run: cargo check -Z build-std --target x86_64-unknown-haiku --features=all-apis
     - run: cargo check -Z build-std --target x86_64-uwp-windows-msvc --all-targets --features=all-apis
-    - run: cargo check -Z build-std --target=riscv32imc-esp-espidf --features=all-apis
+    # Temporarily disable riscv32imc-esp-espidf due to std using SOMAXCONN.
+    #- run: cargo check -Z build-std --target=riscv32imc-esp-espidf --features=all-apis
     - run: cargo check -Z build-std --target=aarch64-unknown-nto-qnx710 --features=all-apis
     - run: cargo check -Z build-std --target=x86_64-pc-nto-qnx710 --features=all-apis
     - run: cargo check -Z build-std --target=armv7-sony-vita-newlibeabihf --features=all-apis


### PR DESCRIPTION
By default, rustix uses `libc` to read aux records, to get the sysinfo information needed to locate the vsyscall function. If that's disabled, add more fallback paths:

Add a way to use `PR_GET_AUXV` even when "alloc" is not available, by using a statically-sized buffer and being prepared to proceed to the next fallback if the buffer isn't big enough.

And, if `PR_GET_AUXV` and /proc/self/auxv both fail, fall back to using `int 0x80`.