### PR TITLE
Add support for epoll to RedoxOS

### DIFF
--- a/src/backend/libc/conv.rs
+++ b/src/backend/libc/conv.rs
@@ -70,7 +70,7 @@ pub(super) fn ret_c_int(raw: c::c_int) -> io::Result<c::c_int> {
     }
 }
 
-#[cfg(linux_kernel)]
+#[cfg(any(linux_kernel, all(target_os = "redox", feature = "event")))]
 #[inline]
 pub(super) fn ret_u32(raw: c::c_int) -> io::Result<u32> {
     if raw == -1 {

--- a/src/backend/libc/event/epoll.rs
+++ b/src/backend/libc/event/epoll.rs
@@ -197,6 +197,8 @@ pub fn add(
             as_mut_ptr(&mut Event {
                 flags: event_flags,
                 data,
+                #[cfg(target_os = "redox")]
+                _pad: 0,
             })
             .cast(),
         ))
@@ -228,6 +230,8 @@ pub fn modify(
             as_mut_ptr(&mut Event {
                 flags: event_flags,
                 data,
+                #[cfg(target_os = "redox")]
+                _pad: 0,
             })
             .cast(),
         ))
@@ -295,13 +299,16 @@ impl<'a> Iterator for Iter<'a> {
 /// A record of an event that occurred.
 #[repr(C)]
 #[cfg_attr(
-    any(
-        all(
-            target_arch = "x86",
-            not(target_env = "musl"),
-            not(target_os = "android"),
-        ),
-        target_arch = "x86_64",
+    all(
+        linux_kernel,
+        any(
+            all(
+                target_arch = "x86",
+                not(target_env = "musl"),
+                not(target_os = "android"),
+            ),
+            target_arch = "x86_64",
+        )
     ),
     repr(packed)
 )]
@@ -311,6 +318,9 @@ pub struct Event {
     pub flags: EventFlags,
     /// User data.
     pub data: EventData,
+
+    #[cfg(target_os = "redox")]
+    _pad: u64,
 }
 
 /// Data associated with an [`Event`]. This can either be a 64-bit integer

--- a/src/backend/libc/event/mod.rs
+++ b/src/backend/libc/event/mod.rs
@@ -5,5 +5,5 @@ pub(crate) mod types;
 #[cfg_attr(windows, path = "windows_syscalls.rs")]
 pub(crate) mod syscalls;
 
-#[cfg(linux_kernel)]
+#[cfg(any(linux_kernel, target_os = "redox"))]
 pub mod epoll;

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -15,7 +15,7 @@ mod poll;
 #[cfg(solarish)]
 pub mod port;
 
-#[cfg(linux_kernel)]
+#[cfg(any(linux_kernel, target_os = "redox"))]
 pub use crate::backend::event::epoll;
 #[cfg(any(
     linux_kernel,


### PR DESCRIPTION
For now it seems that epoll is the preferred way to access Redox's
underlying polling interface. There are event schemes but until Redox's
syscalls are better integrated with Rustix it's probably not worth it
yet.

cc https://github.com/smol-rs/polling/issues/176