### PR TITLE
chore: Update actions/checkout in GitHub Actions workflows to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -41,7 +41,7 @@ jobs:
       # -D warnings is commented out in our install-rust action; re-add it here.
       RUSTFLAGS: -D warnings -D elided-lifetimes-in-paths --cfg criterion
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -137,7 +137,7 @@ jobs:
       # -D warnings is commented out in our install-rust action; re-add it here.
       RUSTFLAGS: -D warnings -D elided-lifetimes-in-paths
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -166,7 +166,7 @@ jobs:
             rust: nightly
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -193,7 +193,7 @@ jobs:
             rust: nightly
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -423,7 +423,7 @@ jobs:
             rust: stable
             target: x86_64-unknown-linux-musl
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -558,7 +558,7 @@ jobs:
       RUSTFLAGS: -D warnings -D elided-lifetimes-in-paths
       QEMU_BUILD_VERSION: 8.1.2
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -650,7 +650,7 @@ jobs:
       CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_experimental_asm
       QEMU_BUILD_VERSION: 8.1.2
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -82,17 +82,17 @@ jobs:
             os: macos-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/rust-listenfd
         path: rust-listenfd
         ref: rustix-0.35.6-beta.2
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: davidedelpapa/thttp
         path: thttp
@@ -247,11 +247,11 @@ jobs:
             os: macos-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/async-io
         path: async-io
@@ -394,11 +394,11 @@ jobs:
             os: macos-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: bytecodealliance/cap-std
         path: cap-std
@@ -476,11 +476,11 @@ jobs:
             os: ubuntu-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/cargo
         path: cargo
@@ -570,11 +570,11 @@ jobs:
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/memfd-rs
         path: memfd-rs
@@ -712,11 +712,11 @@ jobs:
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/rust-timerfd
         path: rust-timerfd
@@ -854,11 +854,11 @@ jobs:
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/procfs
         path: procfs
@@ -996,11 +996,11 @@ jobs:
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/rust-atomicwrites
         path: rust-atomicwrites
@@ -1138,11 +1138,11 @@ jobs:
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/io-uring
         path: io-uring
@@ -1285,11 +1285,11 @@ jobs:
             os: macos-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/tempfile
         path: tempfile
@@ -1432,11 +1432,11 @@ jobs:
             os: macos-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/fd-lock
         path: fd-lock
@@ -1517,11 +1517,11 @@ jobs:
             os: macos-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/wasmtime
         path: wasmtime
@@ -1548,11 +1548,11 @@ jobs:
             os: ubuntu-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/nameless
         path: nameless
@@ -1643,11 +1643,11 @@ jobs:
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         #repository: coreos/cap-std-ext
         repository: sunfishcode/cap-std-ext
@@ -1728,11 +1728,11 @@ jobs:
             #rust: nightly
             rust: stable
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/dbus-rs
         path: dbus-rs
@@ -1759,11 +1759,11 @@ jobs:
             os: ubuntu-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/mustang
         path: mustang
@@ -1789,14 +1789,14 @@ jobs:
             os: ubuntu-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # Fetch everything to get rebase with rustc-dep-of-std.
         fetch-depth: 0
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/rust
         path: rust


### PR DESCRIPTION
This updates [actions/checkout](https://github.com/actions/checkout) in the GitHub Actions workflows to v4, it's current version.

Changelog:

> ## v4.1.0
> - Add support for partial checkout filters
>
> ## v4.0.0
> - Support fetching without the --progress option
> - Update to node20