### PR TITLE
Fix calling `proc_self_status()` more than once.

### DIFF
--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -21,8 +21,8 @@
 use crate::fd::{AsFd, BorrowedFd, OwnedFd};
 use crate::ffi::CStr;
 use crate::fs::{
-    fstat, fstatfs, major, openat, renameat, FileType, FsWord, Mode, OFlags, RawDir, Stat, CWD,
-    PROC_SUPER_MAGIC,
+    fstat, fstatfs, major, openat, renameat, seek, FileType, FsWord, Mode, OFlags, RawDir,
+    SeekFrom, Stat, CWD, PROC_SUPER_MAGIC,
 };
 use crate::io;
 use crate::path::DecInt;
@@ -487,6 +487,9 @@ fn open_and_check_file(
 
     let mut found_file = false;
     let mut found_dot = false;
+
+    // Position the directory iteration at the start.
+    seek(dir, SeekFrom::Start(0))?;
 
     let mut buf = [MaybeUninit::uninit(); 2048];
     let mut iter = RawDir::new(dir, &mut buf);

--- a/tests/procfs/basic.rs
+++ b/tests/procfs/basic.rs
@@ -6,3 +6,11 @@ fn test_proc_self() {
     let fd = rustix::procfs::proc_self_fd().unwrap();
     assert_ne!(fd.as_raw_fd(), 0);
 }
+
+#[test]
+fn test_status_twice() {
+    let fd = rustix::procfs::proc_self_status().unwrap();
+    drop(fd);
+    let fd = rustix::procfs::proc_self_status().unwrap();
+    drop(fd);
+}


### PR DESCRIPTION
Fix `proc_self_status()` to reset the directory cursor before iterating through the directory entries when searching for bind mounts. This fixes a failure when called more than once, due to the cursor being left at the end.

Fixes #994.