### PR TITLE
Add `mount_setattr`

### DIFF
--- a/src/backend/libc/mount/syscalls.rs
+++ b/src/backend/libc/mount/syscalls.rs
@@ -270,3 +270,31 @@ pub(crate) fn fsconfig_reconfigure(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
         ))
     }
 }
+
+#[cfg(linux_kernel)]
+#[cfg(feature = "mount")]
+pub(crate) fn mount_setattr(
+    dir_fd: BorrowedFd<'_>,
+    path: &CStr,
+    flags: crate::fs::AtFlags,
+    mount_attr: &crate::mount::MountAttr<'_>,
+) -> io::Result<()> {
+    syscall! {
+        fn mount_setattr(
+            dir_fd: c::c_int,
+            fs_name: *const c::c_char,
+            flags: c::c_uint,
+            mount_attr: *const crate::mount::MountAttr<'_>,
+            size: usize
+        ) via SYS_mount_setattr -> c::c_int
+    }
+    unsafe {
+        ret(mount_setattr(
+            borrowed_fd(dir_fd),
+            c_str(path),
+            flags.bits(),
+            mount_attr as *const _,
+            core::mem::size_of::<crate::mount::MountAttr<'_>>(),
+        ))
+    }
+}

--- a/src/backend/libc/mount/types.rs
+++ b/src/backend/libc/mount/types.rs
@@ -1,4 +1,5 @@
 use crate::backend::c;
+use crate::fd::BorrowedFd;
 use bitflags::bitflags;
 
 #[cfg(linux_kernel)]
@@ -150,9 +151,10 @@ pub(crate) enum FsConfigCmd {
 #[cfg(feature = "mount")]
 #[cfg(linux_kernel)]
 bitflags! {
-    /// `MOUNT_ATTR_*` constants for use with [`fsmount`].
+    /// `MOUNT_ATTR_*` constants for use with [`fsmount`, `mount_setattr`].
     ///
     /// [`fsmount`]: crate::mount::fsmount
+    /// [`mount_setattr`]: crate::mount::mount_setattr
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MountAttrFlags: c::c_uint {
@@ -338,3 +340,13 @@ bitflags! {
 
 #[cfg(linux_kernel)]
 pub(crate) struct MountFlagsArg(pub(crate) c::c_ulong);
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]
+pub struct MountAttr<'a> {
+    pub attr_set: MountAttrFlags,
+    pub attr_clr: MountAttrFlags,
+    pub propagation: MountPropagationFlags,
+    pub userns_fd: BorrowedFd<'a>,
+}

--- a/src/backend/linux_raw/mount/syscalls.rs
+++ b/src/backend/linux_raw/mount/syscalls.rs
@@ -237,3 +237,23 @@ pub(crate) fn fsconfig_reconfigure(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
         ))
     }
 }
+
+#[cfg(feature = "mount")]
+#[inline]
+pub(crate) fn mount_setattr(
+    dir_fd: BorrowedFd<'_>,
+    path: &CStr,
+    flags: crate::fs::AtFlags,
+    mount_attr: &crate::mount::MountAttr<'_>,
+) -> io::Result<()> {
+    unsafe {
+        ret(syscall_readonly!(
+            __NR_mount_setattr,
+            dir_fd,
+            path,
+            flags,
+            mount_attr as *const crate::mount::MountAttr<'_>,
+            crate::backend::conv::size_of::<crate::mount::MountAttr<'_>, _>()
+        ))
+    }
+}

--- a/src/backend/linux_raw/mount/types.rs
+++ b/src/backend/linux_raw/mount/types.rs
@@ -1,4 +1,5 @@
 use crate::backend::c;
+use crate::fd::BorrowedFd;
 use bitflags::bitflags;
 
 bitflags! {
@@ -147,9 +148,10 @@ pub(crate) enum FsConfigCmd {
 
 #[cfg(feature = "mount")]
 bitflags! {
-    /// `MOUNT_ATTR_*` constants for use with [`fsmount`].
+    /// `MOUNT_ATTR_*` constants for use with [`fsmount`, `mount_setattr`].
     ///
     /// [`fsmount`]: crate::mount::fsmount
+    /// [`mount_setattr`]: crate::mount::mount_setattr
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MountAttrFlags: c::c_uint {
@@ -330,3 +332,13 @@ bitflags! {
 
 #[repr(transparent)]
 pub(crate) struct MountFlagsArg(pub(crate) c::c_uint);
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]
+pub struct MountAttr<'a> {
+    pub attr_set: MountAttrFlags,
+    pub attr_clr: MountAttrFlags,
+    pub propagation: MountPropagationFlags,
+    pub userns_fd: BorrowedFd<'a>,
+}

--- a/src/mount/misc.rs
+++ b/src/mount/misc.rs
@@ -1,0 +1,24 @@
+//! Miscellaneous mount APIs
+
+use crate::backend::mount::types::MountAttr;
+use crate::fd::BorrowedFd;
+use crate::fs::AtFlags;
+use crate::{backend, io, path};
+
+/// `mount_setattr(dir_fd, path, flags, mount_attr)`
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/mount_setattr.2.html
+#[inline]
+pub fn mount_setattr<Path: path::Arg>(
+    dir_fd: BorrowedFd<'_>,
+    path: Path,
+    flags: AtFlags,
+    mount_attr: &MountAttr<'_>,
+) -> io::Result<()> {
+    path.into_with_c_str(|path| {
+        backend::mount::syscalls::mount_setattr(dir_fd, path, flags, mount_attr)
+    })
+}

--- a/src/mount/mod.rs
+++ b/src/mount/mod.rs
@@ -10,10 +10,12 @@
 
 #[cfg(feature = "mount")]
 mod fsopen;
+mod misc;
 mod mount_unmount;
 mod types;
 
 #[cfg(feature = "mount")]
 pub use fsopen::*;
+pub use misc::*;
 pub use mount_unmount::*;
 pub use types::*;


### PR DESCRIPTION
Preliminary implementation of `mount_setattr`.

A few notes:
1. I leave the `size` non-exported. Should we export this?
2. I intentionally place `mount_setattr` in `misc.rs` because I am going to add [statmount](https://github.com/torvalds/linux/commit/46eae99ef73302f9fb3dddcd67c374b3dffe8fd6) and [listmount](https://github.com/torvalds/linux/commit/b4c2bea8ceaa50cd42a8f73667389d801a3ecf2d) syscall once 6.8 releases and `libc` adds the syscall number.
3. CI test requires rust-lang/libc#3558

Fix #975