### PR TITLE
In Rust 1.63 builds, pin the half crate to v2.2.1.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,16 +26,3 @@ task:
   test_script:
     - . $HOME/.cargo/env
     - cargo test --workspace --features=all-apis
-
-task:
-  name: stable x86_64-unknown-freebsd-12
-  freebsd_instance:
-    image_family: freebsd-12-4
-  setup_script:
-    - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh --default-toolchain stable -y --profile=minimal
-    - . $HOME/.cargo/env
-    - rustup default stable
-  test_script:
-    - . $HOME/.cargo/env
-    - cargo test --workspace --features=all-apis

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,7 @@ jobs:
       run: |
         cargo update --package=dashmap --precise 5.4.0
         cargo update --package=regex --precise=1.9.0
+        cargo update --package=half --precise=2.2.1
 
     - run: >
         rustup target add
@@ -492,6 +493,7 @@ jobs:
       run: |
         cargo update --package=dashmap --precise 5.4.0
         cargo update --package=regex --precise=1.9.0
+        cargo update --package=half --precise=2.2.1
 
     - run: |
         cargo test --verbose --features=all-apis --release --workspace -- --nocapture


### PR DESCRIPTION
half 2.3.1 appears to depend on newer Rust vesions, so in the Rust 1.63 build use half 2.2.1.