### PR TITLE
Add `io_uring_register` flags

### DIFF
--- a/src/backend/libc/io_uring/syscalls.rs
+++ b/src/backend/libc/io_uring/syscalls.rs
@@ -4,7 +4,7 @@ use crate::backend::c;
 use crate::backend::conv::{borrowed_fd, ret_owned_fd, ret_u32};
 use crate::fd::{BorrowedFd, OwnedFd};
 use crate::io;
-use crate::io_uring::{io_uring_params, IoringEnterFlags, IoringRegisterOp};
+use crate::io_uring::{io_uring_params, IoringEnterFlags, IoringRegisterFlags, IoringRegisterOp};
 
 #[inline]
 pub(crate) fn io_uring_setup(entries: u32, params: &mut io_uring_params) -> io::Result<OwnedFd> {
@@ -21,6 +21,7 @@ pub(crate) fn io_uring_setup(entries: u32, params: &mut io_uring_params) -> io::
 pub(crate) unsafe fn io_uring_register(
     fd: BorrowedFd<'_>,
     opcode: IoringRegisterOp,
+    flags: IoringRegisterFlags,
     arg: *const c::c_void,
     nr_args: u32,
 ) -> io::Result<u32> {
@@ -34,7 +35,7 @@ pub(crate) unsafe fn io_uring_register(
     }
     ret_u32(io_uring_register(
         borrowed_fd(fd) as _,
-        opcode as u32,
+        opcode as u32 | flags.bits(),
         arg,
         nr_args,
     ))

--- a/src/backend/linux_raw/io_uring/syscalls.rs
+++ b/src/backend/linux_raw/io_uring/syscalls.rs
@@ -8,7 +8,7 @@
 use crate::backend::conv::{by_mut, c_uint, pass_usize, ret_c_uint, ret_owned_fd};
 use crate::fd::{BorrowedFd, OwnedFd};
 use crate::io;
-use crate::io_uring::{io_uring_params, IoringEnterFlags, IoringRegisterOp};
+use crate::io_uring::{io_uring_params, IoringEnterFlags, IoringRegisterFlags, IoringRegisterOp};
 use core::ffi::c_void;
 
 #[inline]
@@ -26,13 +26,14 @@ pub(crate) fn io_uring_setup(entries: u32, params: &mut io_uring_params) -> io::
 pub(crate) unsafe fn io_uring_register(
     fd: BorrowedFd<'_>,
     opcode: IoringRegisterOp,
+    flags: IoringRegisterFlags,
     arg: *const c_void,
     nr_args: u32,
 ) -> io::Result<u32> {
     ret_c_uint(syscall_readonly!(
         __NR_io_uring_register,
         fd,
-        c_uint(opcode as u32),
+        c_uint(opcode as u32 | flags.bits()),
         arg,
         c_uint(nr_args)
     ))

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -109,10 +109,11 @@ pub fn io_uring_setup(entries: u32, params: &mut io_uring_params) -> io::Result<
 pub unsafe fn io_uring_register<Fd: AsFd>(
     fd: Fd,
     opcode: IoringRegisterOp,
+    flags: IoringRegisterFlags,
     arg: *const c_void,
     nr_args: u32,
 ) -> io::Result<u32> {
-    backend::io_uring::syscalls::io_uring_register(fd.as_fd(), opcode, arg, nr_args)
+    backend::io_uring::syscalls::io_uring_register(fd.as_fd(), opcode, flags, arg, nr_args)
 }
 
 /// `io_uring_enter(fd, to_submit, min_complete, flags, arg, size)`—Initiate
@@ -258,6 +259,19 @@ pub enum IoringRegisterOp {
 
     /// `IORING_REGISTER_FILE_ALLOC_RANGE`
     RegisterFileAllocRange = sys::IORING_REGISTER_FILE_ALLOC_RANGE as _,
+}
+
+bitflags::bitflags! {
+    /// `IORING_REGISTER*` flags for use with [`io_uring_register`].
+    #[repr(transparent)]
+    #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
+    pub struct IoringRegisterFlags: u32 {
+        /// `IORING_REGISTER_USE_REGISTERED_RING`
+        const USE_REGISTERED_RING = sys::IORING_REGISTER_USE_REGISTERED_RING as _;
+
+        /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
+        const _ = !0;
+    }
 }
 
 /// `IORING_OP_*` constants for use with [`io_uring_sqe`].


### PR DESCRIPTION
Adds `IoringRegisterFlags` to `rustix::io_uring::io_uring_register`.

```
int io_uring_register(unsigned int fd, unsigned int opcode, void *arg, unsigned int nr_args);
```

`fd` is the file descriptor returned by a call to `io_uring_setup`. If opcode has the flag **IORING_REGISTER_USE_REGISTERED_RING** ored into it, `fd` is instead the index of a registered ring fd.


Resources: [liburing](https://github.com/axboe/liburing/blob/liburing-2.5/src/register.c#L17), [kernel](https://github.com/torvalds/linux/blob/v6.7/io_uring/io_uring.c#L4621)