### PR TITLE
Fix a warning on right nightly.

### DIFF
--- a/src/weak.rs
+++ b/src/weak.rs
@@ -167,6 +167,7 @@ macro_rules! syscall {
             // (not paths).
             use libc::*;
 
+            #[allow(dead_code)]
             trait AsSyscallArg {
                 type SyscallArgType;
                 fn into_syscall_arg(self) -> Self::SyscallArgType;


### PR DESCRIPTION
In CI we enable `-D warnings`, so this is needed to unbreak the build.