### PR TITLE
Fix compilation with Rust 1.63.

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -8,5 +8,5 @@ inputs:
     default: 'stable'
 
 runs:
-  using: node16
+  using: node20
   main: 'main.js'

--- a/src/system.rs
+++ b/src/system.rs
@@ -7,7 +7,7 @@
 #![allow(unsafe_code)]
 
 use crate::backend;
-#[cfg(target_os = "linux")]
+#[cfg(any(linux_raw, target_os = "linux"))]
 use crate::backend::c;
 use crate::ffi::CStr;
 #[cfg(not(any(target_os = "espidf", target_os = "emscripten", target_os = "vita")))]
@@ -20,7 +20,7 @@ pub use backend::system::types::Sysinfo;
 #[cfg(linux_raw)]
 use crate::fd::AsFd;
 #[cfg(linux_raw)]
-use core::ffi::c_int;
+use c::c_int;
 
 /// `uname()`—Returns high-level information about the runtime OS and
 /// hardware.


### PR DESCRIPTION
Rust 1.63 doesn't have `core::ffi::c_int`, so use the `c_int` from libc or linux-raw-sys.