### PR TITLE
Support `init_module` etc. in the libc backend.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -437,7 +437,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched
@@ -573,7 +573,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched
@@ -665,7 +665,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -15,7 +15,7 @@
 
 use super::c;
 use super::fd::{AsRawFd, BorrowedFd, FromRawFd, RawFd};
-#[cfg(any(feature = "event", feature = "runtime"))]
+#[cfg(any(feature = "event", feature = "runtime", feature = "system"))]
 use super::io::errno::try_decode_error;
 #[cfg(target_pointer_width = "64")]
 use super::io::errno::try_decode_u64;
@@ -874,7 +874,7 @@ pub(super) unsafe fn ret(raw: RetReg<R0>) -> io::Result<()> {
 ///
 /// The caller must ensure that this is the return value of a syscall which
 /// doesn't return on success.
-#[cfg(any(feature = "event", feature = "runtime"))]
+#[cfg(any(feature = "event", feature = "runtime", feature = "system"))]
 #[inline]
 pub(super) unsafe fn ret_error(raw: RetReg<R0>) -> io::Errno {
     try_decode_error(raw)

--- a/src/backend/linux_raw/io/errno.rs
+++ b/src/backend/linux_raw/io/errno.rs
@@ -236,7 +236,7 @@ pub(in crate::backend) unsafe fn try_decode_void<Num: RetNumber>(
 /// # Safety
 ///
 /// This must only be used with syscalls which do not return on success.
-#[cfg(any(feature = "event", feature = "runtime"))]
+#[cfg(any(feature = "event", feature = "runtime", feature = "system"))]
 #[inline]
 pub(in crate::backend) unsafe fn try_decode_error<Num: RetNumber>(raw: RetReg<Num>) -> io::Errno {
     debug_assert!(raw.is_in_range(-4095..0));

--- a/src/backend/linux_raw/net/mod.rs
+++ b/src/backend/linux_raw/net/mod.rs
@@ -1,6 +1,5 @@
 pub(crate) mod addr;
 pub(crate) mod msghdr;
-#[cfg(linux_kernel)]
 pub(crate) mod netdevice;
 pub(crate) mod read_sockaddr;
 pub(crate) mod send_recv;

--- a/src/system.rs
+++ b/src/system.rs
@@ -7,7 +7,7 @@
 #![allow(unsafe_code)]
 
 use crate::backend;
-#[cfg(any(linux_raw, target_os = "linux"))]
+#[cfg(linux_kernel)]
 use crate::backend::c;
 use crate::ffi::CStr;
 #[cfg(not(any(target_os = "espidf", target_os = "emscripten", target_os = "vita")))]
@@ -17,9 +17,9 @@ use core::fmt;
 #[cfg(linux_kernel)]
 pub use backend::system::types::Sysinfo;
 
-#[cfg(linux_raw)]
+#[cfg(linux_kernel)]
 use crate::fd::AsFd;
-#[cfg(linux_raw)]
+#[cfg(linux_kernel)]
 use c::c_int;
 
 /// `uname()`—Returns high-level information about the runtime OS and
@@ -231,8 +231,8 @@ pub fn reboot(cmd: RebootCommand) -> io::Result<()> {
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/init_module.2.html
 #[inline]
-#[cfg(linux_raw)]
-pub fn init_module(image: &[u8], param_values: &CStr) -> io::Errno {
+#[cfg(linux_kernel)]
+pub fn init_module(image: &[u8], param_values: &CStr) -> io::Result<()> {
     backend::system::syscalls::init_module(image, param_values)
 }
 
@@ -243,9 +243,8 @@ pub fn init_module(image: &[u8], param_values: &CStr) -> io::Errno {
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/finit_module.2.html
 #[inline]
-#[cfg(linux_raw)]
-#[cfg(feature = "fs")]
-pub fn finit_module<Fd: AsFd>(fd: Fd, param_values: &CStr, flags: c_int) -> io::Errno {
+#[cfg(linux_kernel)]
+pub fn finit_module<Fd: AsFd>(fd: Fd, param_values: &CStr, flags: c_int) -> io::Result<()> {
     backend::system::syscalls::finit_module(fd.as_fd(), param_values, flags)
 }
 
@@ -256,7 +255,7 @@ pub fn finit_module<Fd: AsFd>(fd: Fd, param_values: &CStr, flags: c_int) -> io::
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/delete_module.2.html
 #[inline]
-#[cfg(linux_raw)]
-pub fn delete_module(name: &CStr, flags: c_int) -> io::Errno {
+#[cfg(linux_kernel)]
+pub fn delete_module(name: &CStr, flags: c_int) -> io::Result<()> {
     backend::system::syscalls::delete_module(name, flags)
 }


### PR DESCRIPTION
And, fix the return types of `init_module` and friends to be `io::Result<()>`, as they can succeed and return.