### PR TITLE
Add pidfd_send_signal syscall

### DIFF
--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -684,6 +684,26 @@ pub(crate) fn pidfd_open(pid: Pid, flags: PidfdFlags) -> io::Result<OwnedFd> {
 }
 
 #[cfg(target_os = "linux")]
+pub(crate) fn pidfd_send_signal(pidfd: BorrowedFd<'_>, sig: Signal) -> io::Result<()> {
+    syscall! {
+        fn pidfd_send_signal(
+            pid: c::pid_t,
+            sig: c::c_int,
+            info: *const c::siginfo_t,
+            flags: c::c_int
+        ) via SYS_pidfd_send_signal -> c::c_int
+    }
+    unsafe {
+        ret(pidfd_send_signal(
+            borrowed_fd(pidfd),
+            sig as c::c_int,
+            core::ptr::null(),
+            0,
+        ))
+    }
+}
+
+#[cfg(target_os = "linux")]
 pub(crate) fn pidfd_getfd(
     pidfd: BorrowedFd<'_>,
     targetfd: RawFd,

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -588,6 +588,19 @@ pub(crate) fn pidfd_open(pid: Pid, flags: PidfdFlags) -> io::Result<OwnedFd> {
     unsafe { ret_owned_fd(syscall_readonly!(__NR_pidfd_open, pid, flags)) }
 }
 
+#[inline]
+pub(crate) fn pidfd_send_signal(fd: BorrowedFd<'_>, sig: Signal) -> io::Result<()> {
+    unsafe {
+        ret(syscall_readonly!(
+            __NR_pidfd_send_signal,
+            fd,
+            sig,
+            pass_usize(0),
+            pass_usize(0)
+        ))
+    }
+}
+
 #[cfg(feature = "alloc")]
 #[inline]
 pub(crate) fn getgroups(buf: &mut [Gid]) -> io::Result<usize> {

--- a/src/process/pidfd.rs
+++ b/src/process/pidfd.rs
@@ -1,6 +1,7 @@
 use crate::fd::OwnedFd;
-use crate::process::Pid;
+use crate::process::{Pid, Signal};
 use crate::{backend, io};
+use backend::fd::AsFd;
 
 bitflags::bitflags! {
     /// `PIDFD_*` flags for use with [`pidfd_open`].
@@ -27,4 +28,16 @@ bitflags::bitflags! {
 #[inline]
 pub fn pidfd_open(pid: Pid, flags: PidfdFlags) -> io::Result<OwnedFd> {
     backend::process::syscalls::pidfd_open(pid, flags)
+}
+
+/// `syscall(SYS_pidfd_send_signal, pidfd, sig, NULL, 0)`—Send a signal to a process
+/// specified by a file descriptor.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/pidfd_send_signal.2.html
+#[inline]
+pub fn pidfd_send_signal<Fd: AsFd>(pidfd: Fd, sig: Signal) -> io::Result<()> {
+    backend::process::syscalls::pidfd_send_signal(pidfd.as_fd(), sig)
 }


### PR DESCRIPTION
I didn't bother supporting a non-null siginfo_t because that will require a re-work of the WaitidStatus API. I think if somebody needs that support they can make the breaking changes necessary.