### PR TITLE
Fix fallocate for apple platforms.

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -1662,7 +1662,7 @@ pub(crate) fn fallocate(
 
     let new_len = offset.checked_add(len).ok_or(io::Errno::FBIG)?;
     let mut store = c::fstore_t {
-        fst_flags: c::F_ALLOCATECONTIG,
+        fst_flags: c::F_ALLOCATECONTIG | c::F_ALLOCATEALL,
         fst_posmode: c::F_PEOFPOSMODE,
         fst_offset: 0,
         fst_length: new_len,


### PR DESCRIPTION
The `fallocate` implementation for apple platforms was not using the `F_ALLOCATEALL` flag during the first call to fcntl. This allows the call to allocate fewer bytes than the passed amount.

It's possible this shim still has different semantics from `posix_fallocate` or linux's `fallocate`, given newer versions of apple's libc also include this flag (the newest man page for `fcntl` seems to indicate that the filesystem is allowed to free unused blocks that were previously allocated during a close and that this flag may be passed as a hint to avoid that):

```
F_ALLOCATEPERSIST  Allocate space that is not freed when close(2) is called. (Note that the file system may ignore this request.)
```

That said, I haven't been able to trigger this scenario on a Macbook Pro M1 running Sonoma with APFS. My guess is this only applies to blocks allocated outside the file length, which the call to `ftruncate` here should prevent.