### PR TITLE
Add mount2 syscall

### DIFF
--- a/src/mount/mount_unmount.rs
+++ b/src/mount/mount_unmount.rs
@@ -1,5 +1,7 @@
 //! Linux `mount`.
 
+use std::ffi::CStr;
+
 use crate::backend::mount::types::{
     InternalMountFlags, MountFlags, MountFlagsArg, MountPropagationFlags, UnmountFlags,
 };
@@ -33,6 +35,31 @@ pub fn mount<Source: path::Arg, Target: path::Arg, Fs: path::Arg, Data: path::Ar
                 })
             })
         })
+    })
+}
+
+/// `mount2(source, target, filesystemtype, mountflags, data)`
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/mount.2.html
+#[inline]
+pub fn mount2<Source: path::Arg, Target: path::Arg, Fs: path::Arg, Data: path::Arg>(
+    source: Option<&CStr>,
+    target: Target,
+    file_system_type: Option<&CStr>,
+    flags: MountFlags,
+    data: Option<&CStr>,
+) -> io::Result<()> {
+    target.into_with_c_str(|target| {
+        backend::mount::syscalls::mount(
+            source,
+            target,
+            file_system_type,
+            MountFlagsArg(flags.bits()),
+            data,
+        )
     })
 }
 

--- a/src/mount/mount_unmount.rs
+++ b/src/mount/mount_unmount.rs
@@ -1,6 +1,6 @@
 //! Linux `mount`.
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 use crate::backend::mount::types::{
     InternalMountFlags, MountFlags, MountFlagsArg, MountPropagationFlags, UnmountFlags,

--- a/src/mount/mount_unmount.rs
+++ b/src/mount/mount_unmount.rs
@@ -45,7 +45,7 @@ pub fn mount<Source: path::Arg, Target: path::Arg, Fs: path::Arg, Data: path::Ar
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/mount.2.html
 #[inline]
-pub fn mount2<Source: path::Arg, Target: path::Arg, Fs: path::Arg, Data: path::Arg>(
+pub fn mount2<Target: path::Arg>(
     source: Option<&CStr>,
     target: Target,
     file_system_type: Option<&CStr>,

--- a/src/path/arg.rs
+++ b/src/path/arg.rs
@@ -89,6 +89,19 @@ pub trait Arg {
         F: FnOnce(&CStr) -> io::Result<T>;
 }
 
+/// Runs a closure on `arg` where `A` is mapped to a `&CStr`
+pub fn option_into_with_c_str<T, F, A: Arg>(arg: Option<A>, f: F) -> io::Result<T>
+where
+    A: Sized,
+    F: FnOnce(Option<&CStr>) -> io::Result<T>,
+{
+    if let Some(arg) = arg {
+        arg.into_with_c_str(|p| f(Some(p)))
+    } else {
+        f(None)
+    }
+}
+
 impl Arg for &str {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -4,7 +4,7 @@ mod arg;
 #[cfg(feature = "itoa")]
 mod dec_int;
 
-pub use arg::Arg;
+pub use arg::{option_into_with_c_str, Arg};
 #[cfg(feature = "itoa")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "itoa")))]
 pub use dec_int::DecInt;


### PR DESCRIPTION
Adds a mount2 syscall.

This is actually the same as the current mount syscall. The main difference being the function parameters which are arguably wrong in the original implementation since it did not account for certain values being null.

This pr is incomplete since the parameters have been changed from `Arg ` to `&CStr`. This is not inline with other apis and should be fixed but I could not figure out how to convert the types properly. I temporarily used a different type because I needed to use the function. Help fixing the parameters would be appreciated.