### PR TITLE
Update ci to proper freebsd 14 release

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@
 task:
   name: stable x86_64-unknown-freebsd-14
   freebsd_instance:
-    image: freebsd-14-0-current-amd64-v20230803
+    image_family: freebsd-14-0
   setup_script:
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh --default-toolchain stable -y --profile=minimal


### PR DESCRIPTION
FreeBSD 14 has been properly released for a while now and cirrus has support for it. 
This pr updates the ci to the stable version