### PR TITLE
Disable `-D warnings` in CI for now.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -210,7 +210,9 @@ jobs:
     - run: cargo check -Z build-std --target mips64-openwrt-linux-musl --all-targets --features=all-apis
     - run: cargo check -Z build-std --target x86_64-unknown-dragonfly --all-targets --features=all-apis
     - run: cargo check -Z build-std --target sparc-unknown-linux-gnu --all-targets --features=all-apis
-    - run: cargo check -Z build-std --target armv7-unknown-freebsd --all-targets --features=all-apis
+    # Temporarily disable this because the target appears to have changed and needs
+    # fixes and we transitively dev-depend on what can be an older version of rustix.
+    #- run: cargo check -Z build-std --target armv7-unknown-freebsd --all-targets --features=all-apis
     # Omit --all-targets on gnu_ilp32 because dev-dependency tempfile depends on an older rustix
     - run: cargo check -Z build-std --target aarch64-unknown-linux-gnu_ilp32 --features=all-apis
     # Omit --all-targets on haiku because not all the tests build yet.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,10 @@ jobs:
             os: ubuntu-latest
             rust: 1.63
 
-    env:
-      # -D warnings is commented out in our install-rust action; re-add it here.
-      RUSTFLAGS: -D warnings -D elided-lifetimes-in-paths --cfg criterion
+    # TODO: Reenable this once we can remove the redundant `Vec` imports.
+    #env:
+    #  # -D warnings is commented out in our install-rust action; re-add it here.
+    #  RUSTFLAGS: -D warnings -D elided-lifetimes-in-paths --cfg criterion
     steps:
     - uses: actions/checkout@v4
       with:
@@ -134,9 +135,10 @@ jobs:
             os: ubuntu-latest
             rust: nightly
 
-    env:
-      # -D warnings is commented out in our install-rust action; re-add it here.
-      RUSTFLAGS: -D warnings -D elided-lifetimes-in-paths
+    # TODO: Reenable this once we can remove the redundant `Vec` imports.
+    #env:
+    #  # -D warnings is commented out in our install-rust action; re-add it here.
+    #  RUSTFLAGS: -D warnings -D elided-lifetimes-in-paths
     steps:
     - uses: actions/checkout@v4
       with:
@@ -557,7 +559,8 @@ jobs:
             qemu_target: arm-linux-user
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.
-      RUSTFLAGS: -D warnings -D elided-lifetimes-in-paths
+      # TODO: Reenable this once we can remove the redundant `Vec` imports.
+      #RUSTFLAGS: -D warnings -D elided-lifetimes-in-paths
       QEMU_BUILD_VERSION: 8.1.2
     steps:
     - uses: actions/checkout@v4
@@ -647,7 +650,9 @@ jobs:
             qemu_target: ppc64le-linux-user
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.
-      RUSTFLAGS: --cfg rustix_use_experimental_asm -D warnings -D elided-lifetimes-in-paths
+      # TODO: Reenable this once we can remove the redundant `Vec` imports.
+      #RUSTFLAGS: --cfg rustix_use_experimental_asm -D warnings -D elided-lifetimes-in-paths
+      RUSTFLAGS: --cfg rustix_use_experimental_asm
       RUSTDOCFLAGS: --cfg rustix_use_experimental_asm
       CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_experimental_asm
       QEMU_BUILD_VERSION: 8.1.2

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -140,7 +140,12 @@ fn open_via_syscall(path: &CStr, oflags: OFlags, mode: Mode) -> io::Result<Owned
 pub(crate) fn open(path: &CStr, oflags: OFlags, mode: Mode) -> io::Result<OwnedFd> {
     // Work around <https://sourceware.org/bugzilla/show_bug.cgi?id=17523>.
     // glibc versions before 2.25 don't handle `O_TMPFILE` correctly.
-    #[cfg(all(unix, target_env = "gnu", not(target_os = "hurd")))]
+    #[cfg(all(
+        unix,
+        target_env = "gnu",
+        not(target_os = "hurd"),
+        not(target_os = "freebsd")
+    ))]
     if oflags.contains(OFlags::TMPFILE) && crate::backend::if_glibc_is_less_than_2_25() {
         return open_via_syscall(path, oflags, mode);
     }
@@ -203,7 +208,12 @@ pub(crate) fn openat(
 ) -> io::Result<OwnedFd> {
     // Work around <https://sourceware.org/bugzilla/show_bug.cgi?id=17523>.
     // glibc versions before 2.25 don't handle `O_TMPFILE` correctly.
-    #[cfg(all(unix, target_env = "gnu", not(target_os = "hurd")))]
+    #[cfg(all(
+        unix,
+        target_env = "gnu",
+        not(target_os = "hurd"),
+        not(target_os = "freebsd")
+    ))]
     if oflags.contains(OFlags::TMPFILE) && crate::backend::if_glibc_is_less_than_2_25() {
         return openat_via_syscall(dirfd, path, oflags, mode);
     }

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -101,7 +101,10 @@ pub(crate) fn clock_nanosleep_relative(id: ClockId, request: &Timespec) -> Nanos
         target_os = "vita"
     ))
 ))]
-fn clock_nanosleep_relative_old(id: ClockId, request: &Timespec) -> NanosleepRelativeResult {
+fn clock_nanosleep_relative_old(
+    id: crate::clockid::ClockId,
+    request: &Timespec,
+) -> NanosleepRelativeResult {
     let tv_sec = match request.tv_sec.try_into() {
         Ok(tv_sec) => tv_sec,
         Err(_) => return NanosleepRelativeResult::Err(io::Errno::OVERFLOW),
@@ -195,14 +198,21 @@ pub(crate) fn clock_nanosleep_absolute(id: ClockId, request: &Timespec) -> io::R
         target_os = "vita"
     ))
 ))]
-fn clock_nanosleep_absolute_old(id: ClockId, request: &Timespec) -> io::Result<()> {
+fn clock_nanosleep_absolute_old(id: crate::clockid::ClockId, request: &Timespec) -> io::Result<()> {
     let flags = c::TIMER_ABSTIME;
 
     let old_request = c::timespec {
         tv_sec: request.tv_sec.try_into().map_err(|_| io::Errno::OVERFLOW)?,
         tv_nsec: request.tv_nsec.try_into().map_err(|_| io::Errno::INVAL)?,
     };
-    match unsafe { c::clock_nanosleep(id as c::clockid_t, flags, &old_request, null_mut()) } {
+    match unsafe {
+        c::clock_nanosleep(
+            id as c::clockid_t,
+            flags,
+            &old_request,
+            core::ptr::null_mut(),
+        )
+    } {
         0 => Ok(()),
         err => Err(io::Errno(err)),
     }


### PR DESCRIPTION
Rust nightly doesn't want us to import `Vec` ourselves, but Rust stable still needs us to. So for now, leave the imports in place and don't fail on warnings.