### PR TITLE
IPV6_PKTINFO SendAncillaryMessage

### DIFF
--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1750,6 +1750,19 @@ pub struct UCred {
     pub gid: crate::ugid::Gid,
 }
 
+/// The IPV6_PKTINFO option enables the application to provide the following pieces of information:
+/// [`the source IP address for an outgoing packet`] and
+/// [`the outgoing interface for a packet`].
+#[cfg(linux_kernel)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[repr(C)]
+pub struct Ipv6PktInfo {
+    /// Source address
+    pub ipi6_addr: crate::net::Ipv6Addr,
+    /// Interface index
+    pub if_index: u32,
+}
+
 #[test]
 fn test_sizes() {
     use crate::backend::c;
@@ -1779,6 +1792,8 @@ fn test_sizes() {
 
     #[cfg(linux_kernel)]
     assert_eq_size!(UCred, libc::ucred);
+    #[cfg(linux_kernel)]
+    assert_eq_size!(Ipv6PktInfo, libc::in6_pktinfo);
 
     #[cfg(target_os = "linux")]
     assert_eq_size!(super::xdp::XdpUmemReg, c::xdp_umem_reg);


### PR DESCRIPTION
Add sendmsg ancillary IPV6_PKTINFO option which allows user to specify outgoing source IP address and interface index. This complements the sendmsg_v6 where the destination IP address can also be set.