### PR TITLE
Replace `Ioctl::OPCODE` with an `Ioctl::opcode()` method

### DIFF
--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -85,7 +85,7 @@ use bsd as platform;
 #[inline]
 pub unsafe fn ioctl<F: AsFd, I: Ioctl>(fd: F, mut ioctl: I) -> Result<I::Output> {
     let fd = fd.as_fd();
-    let request = I::OPCODE.raw();
+    let request = ioctl.opcode().raw();
     let arg = ioctl.as_ptr();
 
     // SAFETY: The variant of `Ioctl` asserts that this is a valid IOCTL call
@@ -154,7 +154,8 @@ pub unsafe trait Ioctl {
     ///
     /// There are different types of opcode depending on the operation. See
     /// documentation for the [`Opcode`] struct for more information.
-    const OPCODE: Opcode;
+    //const OPCODE: Opcode;
+    fn opcode(&self) -> Opcode;
 
     /// Does the `ioctl` mutate any data in the userspace?
     ///

--- a/src/ioctl/patterns.rs
+++ b/src/ioctl/patterns.rs
@@ -39,7 +39,9 @@ unsafe impl<Opcode: CompileTimeOpcode> Ioctl for NoArg<Opcode> {
     type Output = ();
 
     const IS_MUTATING: bool = false;
-    const OPCODE: self::Opcode = Opcode::OPCODE;
+    fn opcode(&self) -> self::Opcode {
+        Opcode::OPCODE
+    }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
         core::ptr::null_mut()
@@ -89,7 +91,9 @@ unsafe impl<Opcode: CompileTimeOpcode, Output> Ioctl for Getter<Opcode, Output> 
     type Output = Output;
 
     const IS_MUTATING: bool = true;
-    const OPCODE: self::Opcode = Opcode::OPCODE;
+    fn opcode(&self) -> self::Opcode {
+        Opcode::OPCODE
+    }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
         self.output.as_mut_ptr().cast()
@@ -142,7 +146,9 @@ unsafe impl<Opcode: CompileTimeOpcode, Input> Ioctl for Setter<Opcode, Input> {
     type Output = ();
 
     const IS_MUTATING: bool = false;
-    const OPCODE: self::Opcode = Opcode::OPCODE;
+    fn opcode(&self) -> self::Opcode {
+        Opcode::OPCODE
+    }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
         addr_of_mut!(self.input).cast::<c::c_void>()
@@ -186,7 +192,9 @@ unsafe impl<'a, Opcode: CompileTimeOpcode, T> Ioctl for Updater<'a, Opcode, T> {
     type Output = ();
 
     const IS_MUTATING: bool = true;
-    const OPCODE: self::Opcode = Opcode::OPCODE;
+    fn opcode(&self) -> self::Opcode {
+        Opcode::OPCODE
+    }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
         (self.value as *mut T).cast()


### PR DESCRIPTION
This is a breaking API change.

This is needed for something like `SPI_IOC_MESSAGE(N)`, which takes an array of `N` `spi_ioc_transfer` structs. Which nix this ioctl would use `ioctl_write_buf!`. I'm not sure what other ioctls use this.

It probably should also have a helper type implementing `Ioctl` for this use case. Though it would help to know that it works for more than one ioctl...