### PR TITLE
Add ELF aux vector AT_MINSIGSTKSZ

### DIFF
--- a/src/backend/libc/param/auxv.rs
+++ b/src/backend/libc/param/auxv.rs
@@ -45,6 +45,21 @@ pub(crate) fn linux_hwcap() -> (usize, usize) {
     target_os = "linux",
 ))]
 #[inline]
+pub(crate) fn linux_minsigstksz() -> usize {
+    // FIXME: reuse const from libc when available?
+    const AT_MINSIGSTKSZ: c::c_ulong = 51;
+    if let Some(libc_getauxval) = getauxval.get() {
+        unsafe { libc_getauxval(AT_MINSIGSTKSZ) as usize }
+    } else {
+        0
+    }
+}
+
+#[cfg(any(
+    all(target_os = "android", target_pointer_width = "64"),
+    target_os = "linux",
+))]
+#[inline]
 pub(crate) fn linux_execfn() -> &'static CStr {
     if let Some(libc_getauxval) = getauxval.get() {
         unsafe { CStr::from_ptr(libc_getauxval(c::AT_EXECFN).cast()) }

--- a/src/backend/linux_raw/param/init.rs
+++ b/src/backend/linux_raw/param/init.rs
@@ -15,7 +15,7 @@ use core::sync::atomic::AtomicBool;
 use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 use linux_raw_sys::elf::*;
 use linux_raw_sys::general::{
-    AT_CLKTCK, AT_EXECFN, AT_HWCAP, AT_HWCAP2, AT_NULL, AT_PAGESZ, AT_SYSINFO_EHDR,
+    AT_CLKTCK, AT_EXECFN, AT_HWCAP, AT_HWCAP2, AT_MINSIGSTKSZ, AT_NULL, AT_PAGESZ, AT_SYSINFO_EHDR,
 };
 #[cfg(feature = "runtime")]
 use linux_raw_sys::general::{AT_ENTRY, AT_PHDR, AT_PHENT, AT_PHNUM, AT_RANDOM, AT_SECURE};
@@ -41,6 +41,12 @@ pub(crate) fn linux_hwcap() -> (usize, usize) {
             HWCAP2.load(Ordering::Relaxed),
         )
     }
+}
+
+#[cfg(feature = "param")]
+#[inline]
+pub(crate) fn linux_minsigstksz() -> usize {
+    unsafe { MINSIGSTKSZ.load(Ordering::Relaxed) }
 }
 
 #[cfg(feature = "param")]
@@ -94,6 +100,7 @@ static mut PAGE_SIZE: AtomicUsize = AtomicUsize::new(0);
 static mut CLOCK_TICKS_PER_SECOND: AtomicUsize = AtomicUsize::new(0);
 static mut HWCAP: AtomicUsize = AtomicUsize::new(0);
 static mut HWCAP2: AtomicUsize = AtomicUsize::new(0);
+static mut MINSIGSTKSZ: AtomicUsize = AtomicUsize::new(0);
 static mut SYSINFO_EHDR: AtomicPtr<Elf_Ehdr> = AtomicPtr::new(null_mut());
 // Initialize `EXECFN` to a valid `CStr` pointer so that we don't need to check
 // for null on every `execfn` call.
@@ -147,6 +154,7 @@ unsafe fn init_from_auxp(mut auxp: *const Elf_auxv_t) {
             AT_CLKTCK => CLOCK_TICKS_PER_SECOND.store(a_val as usize, Ordering::Relaxed),
             AT_HWCAP => HWCAP.store(a_val as usize, Ordering::Relaxed),
             AT_HWCAP2 => HWCAP2.store(a_val as usize, Ordering::Relaxed),
+            AT_MINSIGSTKSZ => MINSIGSTKSZ.store(a_val as usize, Ordering::Relaxed),
             AT_EXECFN => EXECFN.store(a_val.cast::<c::c_char>(), Ordering::Relaxed),
             AT_SYSINFO_EHDR => SYSINFO_EHDR.store(a_val.cast::<Elf_Ehdr>(), Ordering::Relaxed),
 

--- a/src/backend/linux_raw/param/libc_auxv.rs
+++ b/src/backend/linux_raw/param/libc_auxv.rs
@@ -110,6 +110,25 @@ pub(crate) fn linux_hwcap() -> (usize, usize) {
 
 #[cfg(feature = "param")]
 #[inline]
+pub(crate) fn linux_minsigstksz() -> usize {
+    // FIXME: reuse const from libc when available?
+    const AT_MINSIGSTKSZ: c::c_ulong = 51;
+
+    #[cfg(not(feature = "runtime"))]
+    if let Some(libc_getauxval) = getauxval.get() {
+        unsafe { libc_getauxval(AT_MINSIGSTKSZ) as usize }
+    } else {
+        0
+    }
+
+    #[cfg(feature = "runtime")]
+    unsafe {
+        getauxval(AT_MINSIGSTKSZ) as usize
+    }
+}
+
+#[cfg(feature = "param")]
+#[inline]
 pub(crate) fn linux_execfn() -> &'static CStr {
     #[cfg(not(feature = "runtime"))]
     unsafe {

--- a/src/param/auxv.rs
+++ b/src/param/auxv.rs
@@ -65,6 +65,27 @@ pub fn linux_hwcap() -> (usize, usize) {
     backend::param::auxv::linux_hwcap()
 }
 
+/// `getauxval(AT_MINSIGSTKSZ)`—Returns the Linux "minsigstksz" data.
+///
+/// Return the Linux `AT_MINSIGSTKSZ` value passed to the current process.
+/// Returns 0 if it is not available.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man3/getauxval.3.html
+#[cfg(any(
+    linux_raw,
+    any(
+        all(target_os = "android", target_pointer_width = "64"),
+        target_os = "linux",
+    )
+))]
+#[inline]
+pub fn linux_minsigstksz() -> usize {
+    backend::param::auxv::linux_minsigstksz()
+}
+
 /// `getauxval(AT_EXECFN)`—Returns the Linux "execfn" string.
 ///
 /// Return the string that Linux has recorded as the filesystem path to the

--- a/tests/param/auxv.rs
+++ b/tests/param/auxv.rs
@@ -1,9 +1,9 @@
+use rustix::param::{clock_ticks_per_second, page_size};
 #[cfg(any(
     all(target_os = "android", target_pointer_width = "64"),
     target_os = "linux",
 ))]
-use rustix::param::linux_hwcap;
-use rustix::param::{clock_ticks_per_second, page_size};
+use rustix::param::{linux_hwcap, linux_minsigstksz};
 
 #[test]
 fn test_page_size() {
@@ -37,5 +37,23 @@ fn test_linux_hwcap() {
         assert_eq!(_hwcap, unsafe { libc_getauxval(libc::AT_HWCAP) } as usize);
 
         assert_eq!(hwcap2, unsafe { libc_getauxval(libc::AT_HWCAP2) } as usize);
+    }
+}
+
+#[cfg(any(
+    all(target_os = "android", target_pointer_width = "64"),
+    target_os = "linux",
+))]
+#[test]
+fn test_linux_minsigstksz() {
+    weak!(fn getauxval(libc::c_ulong) -> libc::c_ulong);
+
+    if let Some(libc_getauxval) = getauxval.get() {
+        // FIXME: reuse const from libc when available?
+        const AT_MINSIGSTKSZ: libc::c_ulong = 51;
+        assert_eq!(
+            linux_minsigstksz(),
+            unsafe { libc_getauxval(AT_MINSIGSTKSZ) } as usize
+        );
     }
 }


### PR DESCRIPTION
https://github.com/rust-lang/rust/commit/9da004ea1997ac0eedbb882fa52960417725bd48 uses `AT_MINSIGSTKSZ` which is not supported by `rustix`. `AT_MINSIGSTKSZ` was introduced since glibc 2.35 on all architectures.