### PR TITLE
Make the libc "extra_traits" feature optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ once_cell = { version = "1.5.2", optional = true }
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
 linux-raw-sys = { version = "0.4.12", default-features = false, features = ["general", "errno", "ioctl", "no_std", "elf"] }
 libc_errno = { package = "errno", version = "0.3.8", default-features = false, optional = true }
-libc = { version = "0.2.153", default-features = false, features = ["extra_traits"], optional = true }
+libc = { version = "0.2.153", default-features = false, optional = true }
 
 # Dependencies for platforms where only libc is supported:
 #
@@ -46,7 +46,7 @@ libc = { version = "0.2.153", default-features = false, features = ["extra_trait
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.8", default-features = false }
-libc = { version = "0.2.153", default-features = false, features = ["extra_traits"] }
+libc = { version = "0.2.153", default-features = false }
 
 # Additional dependencies for Linux with the libc backend:
 #
@@ -119,14 +119,18 @@ targets = [
 # It turns out to be bizarrely awkward to obtain the aux values reliably and
 # efficiently on Linux from anywhere other than libc. We can do it, but most
 # users are better served by just using libc for this.
-default = ["std", "use-libc-auxv"]
+default = ["std", "use-libc-auxv", "libc-extra-traits"]
+
+# Enable `extra_traits` in libc types, to provide `Debug`, `Hash`, and other
+# trait impls for libc types.
+libc-extra-traits = ["libc?/extra_traits"]
 
 # This enables use of std. Disabling this enables `#![no_std]`, and requires
 # Rust 1.64 or newer.
 std = ["bitflags/std", "alloc", "libc?/std", "libc_errno?/std"]
 
 # Enable this to request the libc backend.
-use-libc = ["libc_errno", "libc"]
+use-libc = ["libc_errno", "libc", "libc-extra-traits"]
 
 # Enable `rustix::event::*`.
 event = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,18 +119,18 @@ targets = [
 # It turns out to be bizarrely awkward to obtain the aux values reliably and
 # efficiently on Linux from anywhere other than libc. We can do it, but most
 # users are better served by just using libc for this.
-default = ["std", "use-libc-auxv", "libc-extra-traits"]
+default = ["std", "use-libc-auxv"]
+
+# This enables use of std. Disabling this enables `#![no_std]`, and requires
+# Rust 1.64 or newer.
+std = ["bitflags/std", "alloc", "libc?/std", "libc_errno?/std", "libc-extra-traits"]
+
+# Enable this to request the libc backend.
+use-libc = ["libc_errno", "libc", "libc-extra-traits"]
 
 # Enable `extra_traits` in libc types, to provide `Debug`, `Hash`, and other
 # trait impls for libc types.
 libc-extra-traits = ["libc?/extra_traits"]
-
-# This enables use of std. Disabling this enables `#![no_std]`, and requires
-# Rust 1.64 or newer.
-std = ["bitflags/std", "alloc", "libc?/std", "libc_errno?/std"]
-
-# Enable this to request the libc backend.
-use-libc = ["libc_errno", "libc", "libc-extra-traits"]
 
 # Enable `rustix::event::*`.
 event = []

--- a/src/backend/libc/event/poll_fd.rs
+++ b/src/backend/libc/event/poll_fd.rs
@@ -1,13 +1,11 @@
 use crate::backend::c;
 use crate::backend::conv::borrowed_fd;
 use crate::backend::fd::{AsFd, AsRawFd, BorrowedFd, LibcFd};
-use bitflags::bitflags;
-use core::marker::PhantomData;
 #[cfg(windows)]
-use {
-    crate::backend::fd::{AsSocket, RawFd},
-    core::fmt,
-};
+use crate::backend::fd::{AsSocket, RawFd};
+use bitflags::bitflags;
+use core::fmt;
+use core::marker::PhantomData;
 
 bitflags! {
     /// `POLL*` flags for use with [`poll`].
@@ -58,17 +56,15 @@ bitflags! {
 /// [`poll`]: crate::event::poll
 #[doc(alias = "pollfd")]
 #[derive(Clone)]
-#[cfg_attr(not(windows), derive(Debug))]
 #[repr(transparent)]
 pub struct PollFd<'fd> {
     pollfd: c::pollfd,
     _phantom: PhantomData<BorrowedFd<'fd>>,
 }
 
-#[cfg(windows)]
 impl<'fd> fmt::Debug for PollFd<'fd> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("pollfd")
+        fmt.debug_struct("PollFd")
             .field("fd", &self.pollfd.fd)
             .field("events", &self.pollfd.events)
             .field("revents", &self.pollfd.revents)

--- a/src/backend/libc/process/cpu_set.rs
+++ b/src/backend/libc/process/cpu_set.rs
@@ -48,3 +48,8 @@ pub(crate) fn CPU_ISSET(cpu: usize, cpuset: &RawCpuSet) -> bool {
 pub(crate) fn CPU_COUNT(cpuset: &RawCpuSet) -> u32 {
     unsafe { c::CPU_COUNT(cpuset).try_into().unwrap() }
 }
+
+#[inline]
+pub(crate) fn CPU_EQUAL(this: &RawCpuSet, that: &RawCpuSet) -> bool {
+    unsafe { c::CPU_EQUAL(this, that) }
+}

--- a/src/backend/libc/process/cpu_set.rs
+++ b/src/backend/libc/process/cpu_set.rs
@@ -51,5 +51,18 @@ pub(crate) fn CPU_COUNT(cpuset: &RawCpuSet) -> u32 {
 
 #[inline]
 pub(crate) fn CPU_EQUAL(this: &RawCpuSet, that: &RawCpuSet) -> bool {
-    unsafe { c::CPU_EQUAL(this, that) }
+    #[cfg(any(linux_like, target_os = "fuchsia", target_os = "hurd"))]
+    unsafe {
+        c::CPU_EQUAL(this, that)
+    }
+
+    #[cfg(not(any(linux_like, target_os = "fuchsia", target_os = "hurd")))]
+    unsafe {
+        for i in 0..c::CPU_SETSIZE as usize {
+            if c::CPU_ISSET(i, this) != c::CPU_ISSET(i, that) {
+                return false;
+            }
+        }
+        true
+    }
 }

--- a/src/backend/linux_raw/param/auxv.rs
+++ b/src/backend/linux_raw/param/auxv.rs
@@ -22,7 +22,8 @@ use core::sync::atomic::Ordering::Relaxed;
 use core::sync::atomic::{AtomicPtr, AtomicUsize};
 use linux_raw_sys::elf::*;
 use linux_raw_sys::general::{
-    AT_CLKTCK, AT_EXECFN, AT_HWCAP, AT_HWCAP2, AT_MINSIGSTKSZ, AT_NULL, AT_PAGESZ, AT_SYSINFO_EHDR,
+    AT_BASE, AT_CLKTCK, AT_EXECFN, AT_HWCAP, AT_HWCAP2, AT_MINSIGSTKSZ, AT_NULL, AT_PAGESZ,
+    AT_SYSINFO_EHDR,
 };
 #[cfg(feature = "runtime")]
 use linux_raw_sys::general::{

--- a/src/backend/linux_raw/process/cpu_set.rs
+++ b/src/backend/linux_raw/process/cpu_set.rs
@@ -44,3 +44,8 @@ pub(crate) fn CPU_COUNT_S(size_in_bytes: usize, cpuset: &RawCpuSet) -> u32 {
 pub(crate) fn CPU_COUNT(cpuset: &RawCpuSet) -> u32 {
     CPU_COUNT_S(core::mem::size_of::<RawCpuSet>(), cpuset)
 }
+
+#[inline]
+pub(crate) fn CPU_EQUAL(this: &RawCpuSet, that: &RawCpuSet) -> bool {
+    this.bits == that.bits
+}

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -40,6 +40,7 @@ use backend::fs::types::Stat;
 use backend::fs::types::StatFs;
 #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 use backend::fs::types::StatVfs;
+use core::fmt;
 
 /// Timestamps used by [`utimensat`] and [`futimens`].
 ///
@@ -48,13 +49,24 @@ use backend::fs::types::StatVfs;
 // This is `repr(C)` and specifically laid out to match the representation used
 // by `utimensat` and `futimens`, which expect 2-element arrays of timestamps.
 #[repr(C)]
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Timestamps {
     /// The timestamp of the last access to a filesystem object.
     pub last_access: Timespec,
 
     /// The timestamp of the last modification of a filesystem object.
     pub last_modification: Timespec,
+}
+
+impl fmt::Debug for Timestamps {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("Timestamps")
+            .field("last_access.tv_sec", &self.last_access.tv_sec)
+            .field("last_access.tv_nsec", &self.last_access.tv_nsec)
+            .field("last_modification.tv_sec", &self.last_modification.tv_sec)
+            .field("last_modification.tv_nsec", &self.last_modification.tv_nsec)
+            .finish()
+    }
 }
 
 /// The filesystem magic number for procfs.

--- a/src/thread/clock.rs
+++ b/src/thread/clock.rs
@@ -1,4 +1,5 @@
 use crate::{backend, io};
+use core::fmt;
 
 pub use crate::timespec::Timespec;
 
@@ -88,7 +89,7 @@ pub fn nanosleep(request: &Timespec) -> NanosleepRelativeResult {
 }
 
 /// A return type for `nanosleep` and `clock_nanosleep_relative`.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 #[must_use]
 pub enum NanosleepRelativeResult {
     /// The sleep completed normally.
@@ -97,4 +98,18 @@ pub enum NanosleepRelativeResult {
     Interrupted(Timespec),
     /// An invalid time value was provided.
     Err(io::Errno),
+}
+
+impl fmt::Debug for NanosleepRelativeResult {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NanosleepRelativeResult::Ok => fmt.write_str("Ok"),
+            NanosleepRelativeResult::Interrupted(remaining) => write!(
+                fmt,
+                "Interrupted(Timespec {{ tv_sec: {:?}, tv_nsec: {:?} }})",
+                remaining.tv_sec, remaining.tv_nsec
+            ),
+            NanosleepRelativeResult::Err(err) => write!(fmt, "Err({:?})", err),
+        }
+    }
 }


### PR DESCRIPTION
Make "libc/extra_traits" optional and enabled by default, so that it can be disabled by --no-default-features. This fixes rustc-dep-of-std builds, because extra_traits depends on std.