### PR TITLE
Deprecate `rustix::net::SendFlags::EOT` and add `EOR`.

### DIFF
--- a/src/backend/libc/net/send_recv.rs
+++ b/src/backend/libc/net/send_recv.rs
@@ -27,9 +27,13 @@ bitflags! {
         /// `MSG_DONTWAIT`
         #[cfg(not(windows))]
         const DONTWAIT = bitcast!(c::MSG_DONTWAIT);
+        /// Deprecated alias for [`EOR`].
+        #[cfg(not(windows))]
+        #[deprecated(note = "`rustix::net::SendFlags::EOT` is renamed to `rustix::net::SendFlags::EOR`.")]
+        const EOT = bitcast!(c::MSG_EOR);
         /// `MSG_EOR`
         #[cfg(not(windows))]
-        const EOT = bitcast!(c::MSG_EOR);
+        const EOR = bitcast!(c::MSG_EOR);
         /// `MSG_MORE`
         #[cfg(not(any(
             bsd,

--- a/src/backend/linux_raw/net/send_recv.rs
+++ b/src/backend/linux_raw/net/send_recv.rs
@@ -16,8 +16,11 @@ bitflags! {
         const DONTROUTE = c::MSG_DONTROUTE;
         /// `MSG_DONTWAIT`
         const DONTWAIT = c::MSG_DONTWAIT;
-        /// `MSG_EOT`
+        /// Deprecated alias for [`EOR`].
+        #[deprecated(note = "`rustix::net::SendFlags::EOT` is renamed to `rustix::net::SendFlags::EOR`.")]
         const EOT = c::MSG_EOR;
+        /// `MSG_EOR`
+        const EOR = c::MSG_EOR;
         /// `MSG_MORE`
         const MORE = c::MSG_MORE;
         /// `MSG_NOSIGNAL`


### PR DESCRIPTION
In `rustix::net::SendFlags`, deprecate the mis-spelled `EOT` and add the correctly-spelled `EOT`.

Fixes #1053.