### PR TITLE
Add io_uring setup flags `NO_MMAP` and `REGISTERED_FD_ONLY`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ once_cell = { version = "1.5.2", optional = true }
 # libc backend can be selected via adding `--cfg=rustix_use_libc` to
 # `RUSTFLAGS` or enabling the `use-libc` cargo feature.
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
-linux-raw-sys = { version = "0.4.12", default-features = false, features = ["general", "errno", "ioctl", "no_std", "elf"] }
+linux-raw-sys = { version = "0.4.14", default-features = false, features = ["general", "errno", "ioctl", "no_std", "elf"] }
 libc_errno = { package = "errno", version = "0.3.8", default-features = false, optional = true }
 libc = { version = "0.2.153", default-features = false, optional = true }
 
@@ -53,7 +53,7 @@ libc = { version = "0.2.153", default-features = false }
 # Some syscalls do not have libc wrappers, such as in `io_uring`. For these,
 # the libc backend uses the linux-raw-sys ABI and `libc::syscall`.
 [target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
-linux-raw-sys = { version = "0.4.12", default-features = false, features = ["general", "ioctl", "no_std"] }
+linux-raw-sys = { version = "0.4.14", default-features = false, features = ["general", "ioctl", "no_std"] }
 
 # For the libc backend on Windows, use the Winsock API in windows-sys.
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -505,6 +505,12 @@ bitflags::bitflags! {
         /// `IORING_SETUP_DEFER_TASKRUN`
         const DEFER_TASKRUN = sys::IORING_SETUP_DEFER_TASKRUN;
 
+        /// `IORING_SETUP_NO_MMAP`
+        const NO_MMAP = sys::IORING_SETUP_NO_MMAP;
+
+        /// `IORING_SETUP_REGISTERED_FD_ONLY`
+        const REGISTERED_FD_ONLY = sys::IORING_SETUP_REGISTERED_FD_ONLY;
+
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
         const _ = !0;
     }


### PR DESCRIPTION
Adds the following setup flags:
 * `IORING_SETUP_NO_MMAP` - liburing 2.5, kernel 6.5
 * `IORING_SETUP_REGISTERED_FD_ONLY` - liburing 2.5, kernel 6.5

Upgrades linux-raw-sys to 0.6.4 to provide the constants with the linux-raw backend. This upgrade came with three renamed fields which were previously reserved by padding. The flags field in `io_uring_buf_reg` is currently unused by liburing, and doesn't have a good definition that can be ported to bitflags.

https://github.com/axboe/liburing/blob/master/src/include/liburing/io_uring.h#L188