### PR TITLE
Fix `procfs`'s `open_and_check_file` to work in the presence of threads.

### DIFF
--- a/tests/procfs/basic.rs
+++ b/tests/procfs/basic.rs
@@ -14,3 +14,20 @@ fn test_status_twice() {
     let fd = rustix::procfs::proc_self_status().unwrap();
     drop(fd);
 }
+
+#[test]
+fn parallel_self_proc_status() {
+    const THREADS: usize = 3;
+
+    fn self_proc_status() {
+        rustix::procfs::proc_self_status().expect("error getting proc/self/status pid");
+    }
+
+    let mut handles = Vec::with_capacity(THREADS);
+    for _ in 0..THREADS {
+        handles.push(std::thread::spawn(self_proc_status));
+    }
+    for handle in handles.drain(..) {
+        handle.join().expect("thread crashed");
+    }
+}


### PR DESCRIPTION
Have `open_and_check_file` create a new file descriptor before scanning for directory entries, so that it doesn't share a directory position with other threads.

Fixes #1050.