### PR TITLE
Update linux-raw-sys to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ once_cell = { version = "1.5.2", optional = true }
 # libc backend can be selected via adding `--cfg=rustix_use_libc` to
 # `RUSTFLAGS` or enabling the `use-libc` cargo feature.
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_endian = "little", target_arch = "s390x"), any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "s390x"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
-linux-raw-sys = { version = "0.4.14", default-features = false, features = ["general", "errno", "ioctl", "no_std", "elf"] }
+linux-raw-sys = { version = "0.6", default-features = false, features = ["general", "errno", "ioctl", "no_std", "elf"] }
 libc_errno = { package = "errno", version = "0.3.10", default-features = false, optional = true }
 libc = { version = "0.2.161", default-features = false, optional = true }
 
@@ -53,7 +53,7 @@ libc = { version = "0.2.161", default-features = false }
 # Some syscalls do not have libc wrappers, such as in `io_uring`. For these,
 # the libc backend uses the linux-raw-sys ABI and `libc::syscall`.
 [target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_endian = "little", target_arch = "s390x"), any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "s390x"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
-linux-raw-sys = { version = "0.4.14", default-features = false, features = ["general", "ioctl", "no_std"] }
+linux-raw-sys = { version = "0.6", default-features = false, features = ["general", "ioctl", "no_std"] }
 
 # For the libc backend on Windows, use the Winsock API in windows-sys.
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -1211,7 +1211,9 @@ pub struct io_uring_sync_cancel_reg {
     pub fd: i32,
     pub flags: IoringAsyncCancelFlags,
     pub timeout: Timespec,
-    pub pad: [u64; 4],
+    pub opcode: u8,
+    pub pad: [u8; 7],
+    pub pad2: [u64; 3],
 }
 
 impl Default for io_uring_sync_cancel_reg {
@@ -1225,7 +1227,9 @@ impl Default for io_uring_sync_cancel_reg {
                 tv_sec: 0,
                 tv_nsec: 0,
             },
+            opcode: Default::default(),
             pad: Default::default(),
+            pad2: Default::default(),
         }
     }
 }
@@ -1291,7 +1295,7 @@ pub struct io_sqring_offsets {
     pub dropped: u32,
     pub array: u32,
     pub resv1: u32,
-    pub resv2: u64,
+    pub user_addr: u64,
 }
 
 #[allow(missing_docs)]
@@ -1306,7 +1310,7 @@ pub struct io_cqring_offsets {
     pub cqes: u32,
     pub flags: u32,
     pub resv1: u32,
-    pub resv2: u64,
+    pub user_addr: u64,
 }
 
 #[allow(missing_docs)]
@@ -1419,7 +1423,7 @@ pub struct io_uring_buf_reg {
     pub ring_addr: u64,
     pub ring_entries: u32,
     pub bgid: u16,
-    pub pad: u16,
+    pub flags: u16,
     pub resv: [u64; 3_usize],
 }
 
@@ -1605,7 +1609,7 @@ mod tests {
             dropped,
             array,
             resv1,
-            resv2
+            user_addr
         );
         check_struct!(
             io_cqring_offsets,
@@ -1617,7 +1621,7 @@ mod tests {
             cqes,
             flags,
             resv1,
-            resv2
+            user_addr
         );
         check_struct!(io_uring_recvmsg_out, namelen, controllen, payloadlen, flags);
         check_struct!(io_uring_probe, last_op, ops_len, resv, resv2, ops);
@@ -1629,9 +1633,18 @@ mod tests {
         check_struct!(io_uring_getevents_arg, sigmask, sigmask_sz, pad, ts);
         check_struct!(iovec, iov_base, iov_len);
         check_struct!(open_how, flags, mode, resolve);
-        check_struct!(io_uring_buf_reg, ring_addr, ring_entries, bgid, pad, resv);
+        check_struct!(io_uring_buf_reg, ring_addr, ring_entries, bgid, flags, resv);
         check_struct!(io_uring_buf, addr, len, bid, resv);
-        check_struct!(io_uring_sync_cancel_reg, addr, fd, flags, timeout, pad);
+        check_struct!(
+            io_uring_sync_cancel_reg,
+            addr,
+            fd,
+            flags,
+            timeout,
+            opcode,
+            pad,
+            pad2
+        );
 
         check_renamed_type!(tail_or_bufs_struct, io_uring_buf_ring__bindgen_ty_1);
         check_renamed_type!(

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1658,7 +1658,7 @@ pub mod xdp {
     /// XDP umem registration.
     ///
     /// `struct xdp_umem_reg`
-    // https://github.com/torvalds/linux/blob/v6.6/include/uapi/linux/if_xdp.h#L73-L79
+    // https://github.com/torvalds/linux/blob/v6.8/include/uapi/linux/if_xdp.h#L79-L86
     #[repr(C)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct XdpUmemReg {
@@ -1674,6 +1674,10 @@ pub mod xdp {
         ///
         /// Requires kernel version 5.4.
         pub flags: XdpUmemRegFlags,
+        /// AF_XDP TX metadata length
+        ///
+        /// Requires kernel version 6.8.
+        pub tx_metadata_len: u32,
     }
 
     /// XDP statistics.

--- a/tests/io_uring/register.rs
+++ b/tests/io_uring/register.rs
@@ -157,7 +157,7 @@ fn io_uring_buf_ring_can_be_registered() {
         ring_addr: br_ptr as u64,
         ring_entries: ENTRIES as u32,
         bgid: BGID,
-        pad: 0,
+        flags: 0,
         resv: [0u64; 3],
     };
 


### PR DESCRIPTION
This required changing fields of some structs under `io_uring` thus probably braking semantic versioning.