### PR TITLE
Patch low-hanging fruit semver removals for libc and linux-raw-sys

### DIFF
--- a/src/backend/libc/event/epoll.rs
+++ b/src/backend/libc/event/epoll.rs
@@ -74,6 +74,7 @@ use crate::backend::c;
 use crate::backend::conv::ret_u32;
 use crate::backend::conv::{ret, ret_owned_fd};
 use crate::fd::{AsFd, AsRawFd, OwnedFd};
+use crate::ffi;
 use crate::io;
 use crate::utils::as_mut_ptr;
 #[cfg(feature = "alloc")]
@@ -262,7 +263,7 @@ pub fn delete(epoll: impl AsFd, source: impl AsFd) -> io::Result<()> {
 /// success, this returns the number of written elements.
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-pub fn wait(epoll: impl AsFd, event_list: &mut EventVec, timeout: c::c_int) -> io::Result<()> {
+pub fn wait(epoll: impl AsFd, event_list: &mut EventVec, timeout: ffi::c_int) -> io::Result<()> {
     // SAFETY: We're calling `epoll_wait` via FFI and we know how it
     // behaves.
     unsafe {

--- a/src/backend/libc/event/poll_fd.rs
+++ b/src/backend/libc/event/poll_fd.rs
@@ -1,6 +1,7 @@
 use crate::backend::c;
 use crate::backend::conv::borrowed_fd;
 use crate::backend::fd::{AsFd, AsRawFd, BorrowedFd, LibcFd};
+use crate::ffi;
 use bitflags::bitflags;
 use core::marker::PhantomData;
 #[cfg(windows)]
@@ -15,7 +16,7 @@ bitflags! {
     /// [`poll`]: crate::event::poll
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct PollFlags: c::c_short {
+    pub struct PollFlags: ffi::c_short {
         /// `POLLIN`
         const IN = c::POLLIN;
         /// `POLLPRI`

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -1,4 +1,5 @@
 use crate::backend::c;
+use crate::ffi;
 use bitflags::bitflags;
 
 #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
@@ -8,7 +9,7 @@ bitflags! {
     /// [`accessat`]: fn.accessat.html
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct Access: c::c_int {
+    pub struct Access: ffi::c_int {
         /// `R_OK`
         const READ_OK = c::R_OK;
 
@@ -370,7 +371,7 @@ bitflags! {
     /// [`fcopyfile`]: crate::fs::fcopyfile
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct CopyfileFlags: c::c_uint {
+    pub struct CopyfileFlags: ffi::c_uint {
         /// `COPYFILE_ACL`
         const ACL = copyfile::ACL;
 
@@ -435,7 +436,7 @@ bitflags! {
     /// [`renameat_with`]: crate::fs::renameat_with
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct RenameFlags: c::c_uint {
+    pub struct RenameFlags: ffi::c_uint {
         /// `RENAME_EXCHANGE`
         const EXCHANGE = bitcast!(c::RENAME_EXCHANGE);
 
@@ -590,7 +591,7 @@ bitflags! {
     /// [`memfd_create`]: crate::fs::memfd_create
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct MemfdFlags: c::c_uint {
+    pub struct MemfdFlags: ffi::c_uint {
         /// `MFD_CLOEXEC`
         const CLOEXEC = c::MFD_CLOEXEC;
 
@@ -1110,7 +1111,7 @@ pub type RawMode = c::mode_t;
 
 /// `mode_t`
 #[cfg(all(target_os = "android", target_pointer_width = "32"))]
-pub type RawMode = c::c_uint;
+pub type RawMode = ffi::c_uint;
 
 /// `dev_t`
 #[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
@@ -1118,7 +1119,7 @@ pub type Dev = c::dev_t;
 
 /// `dev_t`
 #[cfg(all(target_os = "android", target_pointer_width = "32"))]
-pub type Dev = c::c_ulonglong;
+pub type Dev = ffi::c_ulonglong;
 
 /// `__fsword_t`
 #[cfg(all(

--- a/src/backend/libc/pipe/types.rs
+++ b/src/backend/libc/pipe/types.rs
@@ -1,7 +1,7 @@
 #[cfg(linux_kernel)]
 use core::marker::PhantomData;
 #[cfg(not(any(apple, target_os = "wasi")))]
-use {crate::backend::c, bitflags::bitflags};
+use {crate::backend::c, crate::ffi, bitflags::bitflags};
 
 #[cfg(not(any(apple, target_os = "wasi")))]
 bitflags! {
@@ -38,7 +38,7 @@ bitflags! {
     /// [`tee`].
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct SpliceFlags: c::c_uint {
+    pub struct SpliceFlags: ffi::c_uint {
         /// `SPLICE_F_MOVE`
         const MOVE = c::SPLICE_F_MOVE;
         /// `SPLICE_F_NONBLOCK`

--- a/src/backend/libc/termios/mod.rs
+++ b/src/backend/libc/termios/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod syscalls;
+pub(crate) mod types;

--- a/src/backend/libc/termios/types.rs
+++ b/src/backend/libc/termios/types.rs
@@ -1,0 +1,13 @@
+#[cfg(not(target_os = "redox"))]
+use crate::ffi;
+
+// We don't want to use tcflag_t directly so we don't expose libc
+// publicly. Redox uses u32, apple uses c_ulong, everything else
+// seems to use c_uint.
+
+#[cfg(apple)]
+pub type tcflag_t = ffi::c_ulong;
+#[cfg(target_os = "redox")]
+pub type tcflag_t = u32;
+#[cfg(not(any(apple, target_os = "redox")))]
+pub type tcflag_t = ffi::c_uint;

--- a/src/backend/linux_raw/event/epoll.rs
+++ b/src/backend/linux_raw/event/epoll.rs
@@ -71,9 +71,9 @@
 
 #![allow(unsafe_code)]
 
-use crate::backend::c;
 use crate::backend::event::syscalls;
 use crate::fd::{AsFd, AsRawFd, OwnedFd};
+use crate::ffi;
 use crate::io;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -86,7 +86,7 @@ bitflags! {
     /// `EPOLL_*` for use with [`new`].
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct CreateFlags: c::c_uint {
+    pub struct CreateFlags: ffi::c_uint {
         /// `EPOLL_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::EPOLL_CLOEXEC;
 
@@ -242,7 +242,7 @@ pub fn delete(epoll: impl AsFd, source: impl AsFd) -> io::Result<()> {
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[inline]
-pub fn wait(epoll: impl AsFd, event_list: &mut EventVec, timeout: c::c_int) -> io::Result<()> {
+pub fn wait(epoll: impl AsFd, event_list: &mut EventVec, timeout: ffi::c_int) -> io::Result<()> {
     // SAFETY: We're calling `epoll_wait` via FFI and we know how it
     // behaves.
     unsafe {
@@ -463,6 +463,8 @@ impl<'a> IntoIterator for &'a EventVec {
 
 #[test]
 fn test_epoll_layouts() {
+    use crate::backend::c;
+
     check_renamed_type!(Event, epoll_event);
     check_renamed_type!(Event, epoll_event);
     check_renamed_struct_renamed_field!(Event, epoll_event, flags, events);

--- a/src/backend/linux_raw/event/types.rs
+++ b/src/backend/linux_raw/event/types.rs
@@ -1,4 +1,4 @@
-use crate::backend::c;
+use crate::ffi;
 use bitflags::bitflags;
 
 bitflags! {
@@ -7,7 +7,7 @@ bitflags! {
     /// [`eventfd`]: crate::event::eventfd
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct EventfdFlags: c::c_uint {
+    pub struct EventfdFlags: ffi::c_uint {
         /// `EFD_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::EFD_CLOEXEC;
         /// `EFD_NONBLOCK`

--- a/src/backend/linux_raw/fs/inotify.rs
+++ b/src/backend/linux_raw/fs/inotify.rs
@@ -1,8 +1,8 @@
 //! inotify support for working with inotifies
 
-use crate::backend::c;
 use crate::backend::fs::syscalls;
 use crate::fd::{BorrowedFd, OwnedFd};
+use crate::ffi;
 use crate::io;
 use bitflags::bitflags;
 
@@ -12,7 +12,7 @@ bitflags! {
     /// [`inotify_init`]: crate::fs::inotify::inotify_init
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct CreateFlags: c::c_uint {
+    pub struct CreateFlags: ffi::c_uint {
         /// `IN_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::IN_CLOEXEC;
         /// `IN_NONBLOCK`
@@ -29,7 +29,7 @@ bitflags! {
     /// [`inotify_add_watch`]: crate::fs::inotify::inotify_add_watch
     #[repr(transparent)]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct WatchFlags: c::c_uint {
+    pub struct WatchFlags: ffi::c_uint {
         /// `IN_ACCESS`
         const ACCESS = linux_raw_sys::general::IN_ACCESS;
         /// `IN_ATTRIB`

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -1,4 +1,4 @@
-use crate::backend::c;
+use crate::ffi;
 use bitflags::bitflags;
 
 bitflags! {
@@ -7,7 +7,7 @@ bitflags! {
     /// [`accessat`]: fn.accessat.html
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct Access: c::c_uint {
+    pub struct Access: ffi::c_uint {
         /// `R_OK`
         const READ_OK = linux_raw_sys::general::R_OK;
 
@@ -33,7 +33,7 @@ bitflags! {
     /// [`statat`]: crate::fs::statat
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct AtFlags: c::c_uint {
+    pub struct AtFlags: ffi::c_uint {
         /// `AT_SYMLINK_NOFOLLOW`
         const SYMLINK_NOFOLLOW = linux_raw_sys::general::AT_SYMLINK_NOFOLLOW;
 
@@ -172,7 +172,7 @@ bitflags! {
     /// [`openat`]: crate::fs::openat
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct OFlags: c::c_uint {
+    pub struct OFlags: ffi::c_uint {
         /// `O_ACCMODE`
         const ACCMODE = linux_raw_sys::general::O_ACCMODE;
 
@@ -291,7 +291,7 @@ bitflags! {
     /// [`renameat_with`]: crate::fs::renameat_with
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct RenameFlags: c::c_uint {
+    pub struct RenameFlags: ffi::c_uint {
         /// `RENAME_EXCHANGE`
         const EXCHANGE = linux_raw_sys::general::RENAME_EXCHANGE;
 
@@ -418,7 +418,7 @@ bitflags! {
     /// [`memfd_create`]: crate::fs::memfd_create
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct MemfdFlags: c::c_uint {
+    pub struct MemfdFlags: ffi::c_uint {
         /// `MFD_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::MFD_CLOEXEC;
 
@@ -724,7 +724,7 @@ pub type RawMode = linux_raw_sys::general::__kernel_mode_t;
     target_arch = "arm",
 ))]
 // Don't use `__kernel_mode_t` since it's `u16` which differs from `st_size`.
-pub type RawMode = c::c_uint;
+pub type RawMode = ffi::c_uint;
 
 /// `dev_t`
 // Within the kernel the dev_t is 32-bit, but userspace uses a 64-bit field.

--- a/src/backend/linux_raw/io/types.rs
+++ b/src/backend/linux_raw/io/types.rs
@@ -1,4 +1,4 @@
-use crate::backend::c;
+use crate::ffi;
 use bitflags::bitflags;
 
 bitflags! {
@@ -8,7 +8,7 @@ bitflags! {
     /// [`fcntl_setfd`]: crate::io::fcntl_setfd
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct FdFlags: c::c_uint {
+    pub struct FdFlags: ffi::c_uint {
         /// `FD_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::FD_CLOEXEC;
 
@@ -24,7 +24,7 @@ bitflags! {
     /// [`pwritev2`]: crate::io::pwritev
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct ReadWriteFlags: c::c_uint {
+    pub struct ReadWriteFlags: ffi::c_uint {
         /// `RWF_DSYNC` (since Linux 4.7)
         const DSYNC = linux_raw_sys::general::RWF_DSYNC;
         /// `RWF_HIPRI` (since Linux 4.6)
@@ -47,7 +47,7 @@ bitflags! {
     /// [`dup2`]: crate::io::dup2
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct DupFlags: c::c_uint {
+    pub struct DupFlags: ffi::c_uint {
         /// `O_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::O_CLOEXEC;
 

--- a/src/backend/linux_raw/mm/types.rs
+++ b/src/backend/linux_raw/mm/types.rs
@@ -1,4 +1,4 @@
-use crate::backend::c;
+use crate::ffi;
 use bitflags::bitflags;
 
 bitflags! {
@@ -252,7 +252,7 @@ bitflags! {
     /// [`userfaultfd`]: crate::mm::userfaultfd
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct UserfaultfdFlags: c::c_uint {
+    pub struct UserfaultfdFlags: ffi::c_uint {
         /// `O_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::O_CLOEXEC;
         /// `O_NONBLOCK`

--- a/src/backend/linux_raw/pipe/types.rs
+++ b/src/backend/linux_raw/pipe/types.rs
@@ -1,4 +1,5 @@
 use crate::backend::c;
+use crate::ffi;
 use bitflags::bitflags;
 use core::marker::PhantomData;
 
@@ -8,7 +9,7 @@ bitflags! {
     /// [`pipe_with`]: crate::pipe::pipe_with
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct PipeFlags: c::c_uint {
+    pub struct PipeFlags: ffi::c_uint {
         /// `O_CLOEXEC`
         const CLOEXEC = linux_raw_sys::general::O_CLOEXEC;
         /// `O_DIRECT`
@@ -26,7 +27,7 @@ bitflags! {
     /// [`tee`].
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct SpliceFlags: c::c_uint {
+    pub struct SpliceFlags: ffi::c_uint {
         /// `SPLICE_F_MOVE`
         const MOVE = linux_raw_sys::general::SPLICE_F_MOVE;
         /// `SPLICE_F_NONBLOCK`
@@ -60,7 +61,7 @@ impl<'a> IoSliceRaw<'a> {
     pub fn from_slice(buf: &'a [u8]) -> Self {
         IoSliceRaw {
             _buf: c::iovec {
-                iov_base: (buf.as_ptr() as *mut u8).cast::<c::c_void>(),
+                iov_base: (buf.as_ptr() as *mut u8).cast::<ffi::c_void>(),
                 iov_len: buf.len() as _,
             },
             _lifetime: PhantomData,
@@ -71,7 +72,7 @@ impl<'a> IoSliceRaw<'a> {
     pub fn from_slice_mut(buf: &'a mut [u8]) -> Self {
         IoSliceRaw {
             _buf: c::iovec {
-                iov_base: buf.as_mut_ptr().cast::<c::c_void>(),
+                iov_base: buf.as_mut_ptr().cast::<ffi::c_void>(),
                 iov_len: buf.len() as _,
             },
             _lifetime: PhantomData,

--- a/src/backend/linux_raw/shm/types.rs
+++ b/src/backend/linux_raw/shm/types.rs
@@ -1,4 +1,4 @@
-use crate::backend::c;
+use crate::ffi;
 use bitflags::bitflags;
 
 bitflags! {
@@ -7,7 +7,7 @@ bitflags! {
     /// [`shm_open`]: crate:shm::shm_open
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct ShmOFlags: c::c_uint {
+    pub struct ShmOFlags: ffi::c_uint {
         /// `O_CREAT`
         #[doc(alias = "CREAT")]
         const CREATE = linux_raw_sys::general::O_CREAT;

--- a/src/backend/linux_raw/termios/mod.rs
+++ b/src/backend/linux_raw/termios/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod syscalls;
+pub(crate) mod types;

--- a/src/backend/linux_raw/termios/types.rs
+++ b/src/backend/linux_raw/termios/types.rs
@@ -1,0 +1,9 @@
+use crate::ffi;
+
+// We don't want to use tcflag_t directly so we don't expose linux_raw_sys
+// publicly. It appears to be c_ulong on SPARC and c_uint everywhere else.
+
+#[cfg(target_arch = "sparc")]
+pub type tcflag_t = ffi::c_ulong;
+#[cfg(not(target_arch = "sparc"))]
+pub type tcflag_t = ffi::c_uint;

--- a/src/backend/linux_raw/time/types.rs
+++ b/src/backend/linux_raw/time/types.rs
@@ -1,4 +1,4 @@
-use crate::backend::c;
+use crate::ffi;
 use bitflags::bitflags;
 
 bitflags! {
@@ -7,7 +7,7 @@ bitflags! {
     /// [`timerfd_create`]: crate::time::timerfd_create
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct TimerfdFlags: c::c_uint {
+    pub struct TimerfdFlags: ffi::c_uint {
         /// `TFD_NONBLOCK`
         #[doc(alias = "TFD_NONBLOCK")]
         const NONBLOCK = linux_raw_sys::general::TFD_NONBLOCK;
@@ -27,7 +27,7 @@ bitflags! {
     /// [`timerfd_settime`]: crate::time::timerfd_settime
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct TimerfdTimerFlags: c::c_uint {
+    pub struct TimerfdTimerFlags: ffi::c_uint {
         /// `TFD_TIMER_ABSTIME`
         #[doc(alias = "TFD_TIMER_ABSTIME")]
         const ABSTIME = linux_raw_sys::general::TFD_TIMER_ABSTIME;

--- a/src/backend/linux_raw/vdso_wrappers.rs
+++ b/src/backend/linux_raw/vdso_wrappers.rs
@@ -26,6 +26,9 @@ use core::mem::transmute;
 use core::ptr::null_mut;
 use core::sync::atomic::AtomicPtr;
 use core::sync::atomic::Ordering::Relaxed;
+#[cfg(target_pointer_width = "32")]
+#[cfg(feature = "time")]
+use linux_raw_sys::general::timespec as __kernel_old_timespec;
 #[cfg(any(
     all(
         feature = "process",
@@ -47,9 +50,6 @@ use {
     crate::timespec::Timespec,
     linux_raw_sys::general::__kernel_clockid_t,
 };
-#[cfg(target_pointer_width = "32")]
-#[cfg(feature = "time")]
-use linux_raw_sys::general::timespec as __kernel_old_timespec;
 
 #[cfg(feature = "time")]
 #[inline]

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "std")]
 pub use {
     std::ffi::{CStr, CString, FromBytesWithNulError, NulError},
-    std::os::raw::{c_char, c_int, c_long, c_uint, c_ulong, c_ushort, c_void},
+    std::os::raw::{c_char, c_int, c_long, c_short, c_uint, c_ulong, c_ushort, c_void},
 };
 
 // If we don't have std, we can depend on core and alloc having these features
@@ -13,5 +13,5 @@ pub use {
 pub use alloc::ffi::{CString, NulError};
 #[cfg(not(feature = "std"))]
 pub use core::ffi::{
-    c_char, c_int, c_long, c_uint, c_ulong, c_ushort, c_void, CStr, FromBytesWithNulError,
+    c_char, c_int, c_long, c_short, c_uint, c_ulong, c_ushort, c_void, CStr, FromBytesWithNulError,
 };

--- a/src/fs/ioctl.rs
+++ b/src/fs/ioctl.rs
@@ -4,9 +4,9 @@
 
 #[cfg(linux_kernel)]
 use {
+    crate::backend::c,
     crate::fd::AsFd,
-    crate::{backend, io, ioctl},
-    backend::c,
+    crate::{backend, ffi, io, ioctl},
 };
 
 use bitflags::bitflags;
@@ -96,7 +96,7 @@ unsafe impl ioctl::Ioctl for Ficlone<'_> {
 #[cfg(linux_kernel)]
 bitflags! {
     /// `FS_*` constants for use with [`ioctl_getflags`][crate::io::ioctl::ioctl_getflags].
-    pub struct IFlags: c::c_uint {
+    pub struct IFlags: ffi::c_uint {
         /// `FS_APPEND_FL`
         const APPEND = linux_raw_sys::general::FS_APPEND_FL;
         /// `FS_COMPR_FL`

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1,6 +1,7 @@
 //! Types and constants for `rustix::net`.
 
 use crate::backend::c;
+use crate::ffi;
 use bitflags::bitflags;
 
 /// A type for holding raw integer socket types.
@@ -1425,7 +1426,7 @@ bitflags! {
     /// [`acceptfrom_with`]: crate::net::acceptfrom_with
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct SocketFlags: c::c_uint {
+    pub struct SocketFlags: ffi::c_uint {
         /// `SOCK_NONBLOCK`
         #[cfg(not(any(
             apple,
@@ -1752,7 +1753,7 @@ pub struct UCred {
 #[test]
 fn test_sizes() {
     use crate::backend::c;
-    use c::c_int;
+    use crate::ffi::c_int;
     use core::mem::transmute;
 
     // Backend code needs to cast these to `c_int` so make sure that cast isn't

--- a/src/process/pidfd.rs
+++ b/src/process/pidfd.rs
@@ -1,6 +1,6 @@
 use crate::fd::OwnedFd;
 use crate::process::Pid;
-use crate::{backend, io};
+use crate::{backend, ffi, io};
 
 bitflags::bitflags! {
     /// `PIDFD_*` flags for use with [`pidfd_open`].
@@ -8,7 +8,7 @@ bitflags::bitflags! {
     /// [`pidfd_open`]: crate::process::pidfd_open
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct PidfdFlags: backend::c::c_uint {
+    pub struct PidfdFlags: ffi::c_uint {
         /// `PIDFD_NONBLOCK`.
         const NONBLOCK = backend::c::PIDFD_NONBLOCK;
 

--- a/src/process/pidfd_getfd.rs
+++ b/src/process/pidfd_getfd.rs
@@ -2,7 +2,7 @@
 
 #![allow(unsafe_code)]
 use crate::fd::OwnedFd;
-use crate::{backend, io};
+use crate::{backend, ffi, io};
 use backend::fd::{AsFd, RawFd};
 
 /// Raw file descriptor in another process.
@@ -17,7 +17,7 @@ bitflags::bitflags! {
     /// All flags are reserved for future use.
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct PidfdGetfdFlags: backend::c::c_uint {
+    pub struct PidfdGetfdFlags: ffi::c_uint {
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
         const _ = !0;
     }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,4 +1,5 @@
 use crate::backend::c;
+use crate::ffi;
 
 /// A signal number for use with [`kill_process`], [`kill_process_group`],
 /// and [`kill_current_process_group`].
@@ -147,7 +148,7 @@ pub enum Signal {
 
 impl Signal {
     /// Convert a raw signal number into a `Signal`, if possible.
-    pub fn from_raw(sig: c::c_int) -> Option<Self> {
+    pub fn from_raw(sig: ffi::c_int) -> Option<Self> {
         match sig {
             c::SIGHUP => Some(Self::Hup),
             c::SIGINT => Some(Self::Int),

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -1,4 +1,4 @@
-use crate::backend::c;
+use crate::backend::{c, termios::types};
 use crate::{backend, io};
 use bitflags::bitflags;
 
@@ -43,7 +43,7 @@ pub struct Termios {
     pub special_codes: SpecialCodes,
 
     #[cfg(target_os = "nto")]
-    pub(crate) __reserved: [c::c_uint; 3],
+    pub(crate) __reserved: [ffi::c_uint; 3],
 
     /// Line discipline.
     // On PowerPC, this field comes after `c_cc`.
@@ -235,7 +235,7 @@ bitflags! {
     /// Flags controlling terminal input.
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct InputModes: c::tcflag_t {
+    pub struct InputModes: types::tcflag_t {
         /// `IGNBRK`
         const IGNBRK = c::IGNBRK;
 
@@ -303,7 +303,7 @@ bitflags! {
     /// Flags controlling terminal output.
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct OutputModes: c::tcflag_t {
+    pub struct OutputModes: types::tcflag_t {
         /// `OPOST`
         const OPOST = c::OPOST;
 
@@ -522,7 +522,7 @@ bitflags! {
     /// related functions.
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct ControlModes: c::tcflag_t {
+    pub struct ControlModes: types::tcflag_t {
         /// `CSIZE`
         const CSIZE = c::CSIZE;
 
@@ -582,7 +582,7 @@ bitflags! {
     /// Flags controlling “local” terminal modes.
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct LocalModes: c::tcflag_t {
+    pub struct LocalModes: types::tcflag_t {
         /// `XCASE`
         #[cfg(any(linux_kernel, target_arch = "s390x", target_os = "haiku"))]
         const XCASE = c::XCASE;


### PR DESCRIPTION
libc and linux-raw-sys are exposed in the public API, which makes it problematic for us to change their versions. As linux-raw-sys has released a new breaking change and libc is planning on releasing one soon, this will cause a major issue for us if this is not patched in v1.0

This PR takes care of some of the low hanging fruit. Mostly bitflag types are taken care of by making sure they export types from the `crate::ffi` module instead of the `crate::c` module. I also add a `tcflag_t` type alias for the types in the `termios` module.

Remaining exposed types from linux-raw-sys:

```
    pub type rustix::fs::FsWord = linux_raw_sys::general::__fsword_t
    pub type rustix::fs::RawMode = linux_raw_sys::general::__kernel_mode_t
    pub type rustix::fs::Stat = linux_raw_sys::general::stat
    pub type rustix::fs::StatFs = linux_raw_sys::general::statfs64
    pub type rustix::fs::Statx = linux_raw_sys::general::statx
    pub type rustix::fs::StatxTimestamp = linux_raw_sys::general::statx_timestamp
    pub rustix::io_uring::io_uring_cqe::big_cqe: linux_raw_sys::io_uring::__IncompleteArrayField<u64>
    pub rustix::io_uring::io_uring_probe::ops: linux_raw_sys::io_uring::__IncompleteArrayField<rustix::io_uring::io_uring_probe_op>
    pub type rustix::io_uring::Statx = linux_raw_sys::general::statx
    pub type rustix::net::SocketAddrStorage = linux_raw_sys::net::sockaddr
    pub const fn rustix::process::WaitidStatus::as_raw(&self) -> &linux_raw_sys::general::siginfo_t
    pub type rustix::system::Sysinfo = linux_raw_sys::system::sysinfo
    pub type rustix::termios::Winsize = linux_raw_sys::general::winsize
```

Remaining exposed types for libc, at least on x86_64 Linux-GNU:

```
pub type rustix::fs::Dev = libc::unix::linux_like::linux::dev_t
pub type rustix::fs::FsWord = libc::unix::linux_like::linux::gnu::b64::__fsword_t
pub type rustix::fs::RawMode = libc::unix::linux_like::linux::mode_t
pub type rustix::fs::Stat = libc::unix::linux_like::linux::gnu::b64::x86_64::stat64
pub type rustix::fs::StatFs = libc::unix::linux_like::linux::gnu::b64::x86_64::statfs64
pub type rustix::fs::Statx = libc::unix::linux_like::linux::gnu::statx
pub type rustix::fs::StatxTimestamp = libc::unix::linux_like::linux::gnu::statx
pub type rustix::io_uring::Statx = libc::unix::linux_like::linux::gnu::statx
pub type rustix::net::SocketAddrStorage = libc::unix::linux_like::sockaddr_storage
pub const fn rustix::process::WaitidStatus::as_raw(&self) -> &libc::unix::linux_like::linux::gnu::b64::x86_64::siginfo_t
pub type rustix::system::Sysinfo = libc::unix::linux_like::linux::gnu::b64::sysinfo
pub type rustix::termios::Winsize = libc::unix::winsize
```
