### PR TITLE
Fix `dup2_stdout` et al to handle fd aliasing.

### DIFF
--- a/tests/stdio/dup2_stdio.rs
+++ b/tests/stdio/dup2_stdio.rs
@@ -1,0 +1,20 @@
+use rustix::io::fcntl_getfd;
+use rustix::stdio::{dup2_stdout, stdout};
+
+#[test]
+fn dup2_stdin_stdin() {
+    let _ = dup2_stdout(stdout());
+    fcntl_getfd(stdout()).unwrap();
+}
+
+#[test]
+fn dup2_stdout_stdout() {
+    let _ = dup2_stdout(stdout());
+    fcntl_getfd(stdout()).unwrap();
+}
+
+#[test]
+fn dup2_stderr_stderr() {
+    let _ = dup2_stdout(stdout());
+    fcntl_getfd(stdout()).unwrap();
+}

--- a/tests/stdio/main.rs
+++ b/tests/stdio/main.rs
@@ -4,3 +4,7 @@
 #[cfg(not(windows))]
 #[cfg(not(target_os = "wasi"))]
 mod dup2_to_replace_stdio;
+#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(not(windows))]
+#[cfg(not(target_os = "wasi"))]
+mod dup2_stdio;

--- a/tests/stdio/main.rs
+++ b/tests/stdio/main.rs
@@ -1,10 +1,12 @@
 //! Tests for [`rustix::stdio`].
 
-#[cfg(not(feature = "rustc-dep-of-std"))]
-#[cfg(not(windows))]
-#[cfg(not(target_os = "wasi"))]
-mod dup2_to_replace_stdio;
+#![cfg(feature = "stdio")]
+
 #[cfg(not(feature = "rustc-dep-of-std"))]
 #[cfg(not(windows))]
 #[cfg(not(target_os = "wasi"))]
 mod dup2_stdio;
+#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(not(windows))]
+#[cfg(not(target_os = "wasi"))]
+mod dup2_to_replace_stdio;


### PR DESCRIPTION
Fix `dup2_stdout` et al to work in the case where the file descriptor they are passed is the same as the file descriptor they implicitly operate on, including on targets that don't have a `dup2` syscall and implement it using `dup3`, such as aarch64.

Fixes #1067.