### PR TITLE
Fix publish to Artifactory crates registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ itoa = { version = "1.0.1", default-features = false, optional = true }
 
 # Special dependencies used in rustc-dep-of-std mode.
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core"}
+rustc-std-workspace-alloc = { version = "1.0.0", optional = true} # not aliased here but in lib.rs casuse of name collision with the alloc feature
 compiler_builtins = { version = '0.1.49', optional = true }
 
 # The procfs feature needs once_cell.
@@ -238,6 +239,7 @@ alloc = []
 # for regular use.
 rustc-dep-of-std = [
     "core",
+    "rustc-std-workspace-alloc",
     "compiler_builtins",
     "linux-raw-sys/rustc-dep-of-std",
     "bitflags/rustc-dep-of-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ bitflags = { version = "2.4.0", default-features = false }
 itoa = { version = "1.0.1", default-features = false, optional = true }
 
 # Special dependencies used in rustc-dep-of-std mode.
-rustc-std-workspace-core = { version = "1.0.0", optional = true }
-rustc-std-workspace-alloc = { version = "1.0.0", optional = true }
+core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core"}
 compiler_builtins = { version = '0.1.49', optional = true }
 
 # The procfs feature needs once_cell.
@@ -238,9 +237,8 @@ alloc = []
 # This is used in the port of std to rustix. This is experimental and not meant
 # for regular use.
 rustc-dep-of-std = [
-    "dep:rustc-std-workspace-core",
-    "dep:rustc-std-workspace-alloc",
-    "dep:compiler_builtins",
+    "core",
+    "compiler_builtins",
     "linux-raw-sys/rustc-dep-of-std",
     "bitflags/rustc-dep-of-std",
     "compiler_builtins?/rustc-dep-of-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ bitflags = { version = "2.4.0", default-features = false }
 itoa = { version = "1.0.1", default-features = false, optional = true }
 
 # Special dependencies used in rustc-dep-of-std mode.
-core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
-alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
+rustc-std-workspace-core = { version = "1.0.0", optional = true }
+rustc-std-workspace-alloc = { version = "1.0.0", optional = true }
 compiler_builtins = { version = '0.1.49', optional = true }
 
 # The procfs feature needs once_cell.
@@ -238,8 +238,8 @@ alloc = []
 # This is used in the port of std to rustix. This is experimental and not meant
 # for regular use.
 rustc-dep-of-std = [
-    "dep:core",
-    "dep:alloc",
+    "dep:rustc-std-workspace-core",
+    "dep:rustc-std-workspace-alloc",
     "dep:compiler_builtins",
     "linux-raw-sys/rustc-dep-of-std",
     "bitflags/rustc-dep-of-std",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,9 @@
     allow(unused_imports)
 )]
 
+#[cfg(all(feature = "rustc-dep-of-std", feature = "alloc"))]
+extern crate rustc_std_workspace_alloc as alloc;
+
 #[cfg(all(feature = "alloc", not(feature = "rustc-dep-of-std")))]
 extern crate alloc;
 


### PR DESCRIPTION
The core and alloc aliases causes problems in Artifactory crates registry and prevents `rustix` from being discovered (and as a result downloaded) by cargo. 
This has been introduced in version 0.38.10 when the dep: syntax for Cargo.toml was first introduced.

My guess is that the usage of the core and alloc keywords caused issues while uploading and indexing the crate.

### Some background:

I have been crating a crates.io mirror registry using Artifactory (version 7.77.9) as the registry and after uploading `rustix` 0.38.34 cargo couldn't find it on the registry (not during the end of the publish process and not afterwards).

At first I couldn't understand why but after 2 days of debugging this I have noticed that version 0.38.9  is discoverable while 0.38.10 is not.
I started to check the diff between the 2 versions which lead me to those crates and after renaming the aliases it solved it and made it discoverable (and downloadable) by cargo.

I know it is a fairly niche problem that could be worked around in various ways but I believe it could be solved rather trivially by simply removing those aliases (or even renaming them to something else).

And of-course thank you for all your hard work supporting the Rust ecosystem with those wonderful crates!