### PR TITLE
Fix soundness issues in `dup2_stdout` et al

### DIFF
--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -17,7 +17,7 @@ use backend::fd::{BorrowedFd, FromRawFd, RawFd};
 use {
     crate::io,
     backend::fd::{AsFd, AsRawFd},
-    core::mem::forget,
+    core::mem::ManuallyDrop,
 };
 
 /// `STDIN_FILENO`—Standard input, borrowed.
@@ -477,48 +477,42 @@ pub const fn raw_stderr() -> RawFd {
 
 /// Utility function to safely `dup2` over stdin (fd 0).
 #[cfg(not(any(windows, target_os = "wasi")))]
-#[allow(clippy::mem_forget)]
 #[inline]
 pub fn dup2_stdin<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     let fd = fd.as_fd();
     if fd.as_raw_fd() != c::STDIN_FILENO {
-        // SAFETY: We pass the returned `OwnedFd` to `forget` so that it isn't
-        // dropped.
-        let mut target = unsafe { take_stdin() };
+        // SAFETY: We wrap the returned `OwnedFd` to `ManuallyDrop` so that it
+        // isn't dropped.
+        let mut target = ManuallyDrop::new(unsafe { take_stdin() });
         backend::io::syscalls::dup2(fd, &mut target)?;
-        forget(target);
     }
     Ok(())
 }
 
 /// Utility function to safely `dup2` over stdout (fd 1).
 #[cfg(not(any(windows, target_os = "wasi")))]
-#[allow(clippy::mem_forget)]
 #[inline]
 pub fn dup2_stdout<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     let fd = fd.as_fd();
     if fd.as_raw_fd() != c::STDOUT_FILENO {
-        // SAFETY: We pass the returned `OwnedFd` to `forget` so that it isn't
-        // dropped.
-        let mut target = unsafe { take_stdout() };
+        // SAFETY: We wrap the returned `OwnedFd` to `ManuallyDrop` so that it
+        // isn't dropped.
+        let mut target = ManuallyDrop::new(unsafe { take_stdout() });
         backend::io::syscalls::dup2(fd, &mut target)?;
-        forget(target);
     }
     Ok(())
 }
 
 /// Utility function to safely `dup2` over stderr (fd 2).
 #[cfg(not(any(windows, target_os = "wasi")))]
-#[allow(clippy::mem_forget)]
 #[inline]
 pub fn dup2_stderr<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     let fd = fd.as_fd();
     if fd.as_raw_fd() != c::STDERR_FILENO {
-        // SAFETY: We pass the returned `OwnedFd` to `forget` so that it isn't
-        // dropped.
-        let mut target = unsafe { take_stderr() };
+        // SAFETY: We wrap the returned `OwnedFd` to `ManuallyDrop` so that it
+        // isn't dropped.
+        let mut target = ManuallyDrop::new(unsafe { take_stderr() });
         backend::io::syscalls::dup2(fd, &mut target)?;
-        forget(target);
     }
     Ok(())
 }

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -480,11 +480,12 @@ pub const fn raw_stderr() -> RawFd {
 #[allow(clippy::mem_forget)]
 #[inline]
 pub fn dup2_stdin<Fd: AsFd>(fd: Fd) -> io::Result<()> {
-    if fd.as_fd().as_raw_fd() != c::STDIN_FILENO {
+    let fd = fd.as_fd();
+    if fd.as_raw_fd() != c::STDIN_FILENO {
         // SAFETY: We pass the returned `OwnedFd` to `forget` so that it isn't
         // dropped.
         let mut target = unsafe { take_stdin() };
-        backend::io::syscalls::dup2(fd.as_fd(), &mut target)?;
+        backend::io::syscalls::dup2(fd, &mut target)?;
         forget(target);
     }
     Ok(())
@@ -495,11 +496,12 @@ pub fn dup2_stdin<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 #[allow(clippy::mem_forget)]
 #[inline]
 pub fn dup2_stdout<Fd: AsFd>(fd: Fd) -> io::Result<()> {
-    if fd.as_fd().as_raw_fd() != c::STDOUT_FILENO {
+    let fd = fd.as_fd();
+    if fd.as_raw_fd() != c::STDOUT_FILENO {
         // SAFETY: We pass the returned `OwnedFd` to `forget` so that it isn't
         // dropped.
         let mut target = unsafe { take_stdout() };
-        backend::io::syscalls::dup2(fd.as_fd(), &mut target)?;
+        backend::io::syscalls::dup2(fd, &mut target)?;
         forget(target);
     }
     Ok(())
@@ -510,11 +512,12 @@ pub fn dup2_stdout<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 #[allow(clippy::mem_forget)]
 #[inline]
 pub fn dup2_stderr<Fd: AsFd>(fd: Fd) -> io::Result<()> {
-    if fd.as_fd().as_raw_fd() != c::STDERR_FILENO {
+    let fd = fd.as_fd();
+    if fd.as_raw_fd() != c::STDERR_FILENO {
         // SAFETY: We pass the returned `OwnedFd` to `forget` so that it isn't
         // dropped.
         let mut target = unsafe { take_stderr() };
-        backend::io::syscalls::dup2(fd.as_fd(), &mut target)?;
+        backend::io::syscalls::dup2(fd, &mut target)?;
         forget(target);
     }
     Ok(())


### PR DESCRIPTION
The `dup2_std*` functions had a few soundness issues that allowed safe code to close the stdio file descriptors.

1. `AsFd::as_fd()` was called twice, possibly returning a different `BorrowedFd` each time. This would allow safe code to bypass the `fd.as_fd().as_raw_fd() != c::STDOUT_FILENO` check.
2. `AsFd::as_fd()` was called between `let mut target = unsafe { take_stdout() };` and `forget(target);`. If `as_fd()` panics, then `target` would be automatically dropped without the call to `forget`. This violates [exception safety](https://doc.rust-lang.org/nomicon/exception-safety.html).
3. If `backend::io::syscalls::dup2` returns an error, this was immediately returned from the function using the `?` operator, so `forget(target);` wasn't called resulting in `target` getting dropped closing the stdio file descriptor.

Fix these issues by only calling `AsFd::as_fd()` once and by using [`ManuallyDrop`](https://doc.rust-lang.org/stable/core/mem/struct.ManuallyDrop.html) instead of `forget`.