### PR TITLE
Use manual inits in tests to avoid dev-dependeing on the ctor crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,9 +84,6 @@ static_assertions = "1.1.0"
 [target.'cfg(all(criterion, not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]
 criterion = "0.4"
 
-[target.'cfg(windows)'.dev-dependencies]
-ctor = "0.2.0"
-
 # Add Criterion configuration, as described here:
 # <https://bheisler.github.io/criterion.rs/book/getting_started.html#step-1---add-dependency-to-cargotoml>
 [[bench]]

--- a/tests/net/connect_bind_send.rs
+++ b/tests/net/connect_bind_send.rs
@@ -9,6 +9,8 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 /// Test `connect_any`.
 #[test]
 fn net_v4_connect_any() {
+    crate::init();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::STREAM, None).unwrap();
@@ -40,6 +42,8 @@ fn net_v4_connect_any() {
 #[cfg(not(any(apple, windows, target_os = "haiku")))]
 #[test]
 fn net_v4_connect_any_accept_with() {
+    crate::init();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::STREAM, None).unwrap();
@@ -70,6 +74,8 @@ fn net_v4_connect_any_accept_with() {
 /// Similar, but with V6.
 #[test]
 fn net_v6_connect_any() {
+    crate::init();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET6, SocketType::STREAM, None).unwrap();
@@ -101,6 +107,8 @@ fn net_v6_connect_any() {
 #[cfg(not(any(apple, windows, target_os = "haiku")))]
 #[test]
 fn net_v6_connect_any_accept_with() {
+    crate::init();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET6, SocketType::STREAM, None).unwrap();
@@ -131,6 +139,8 @@ fn net_v6_connect_any_accept_with() {
 /// Test `connect` with a `SocketAddr`.
 #[test]
 fn net_v4_connect() {
+    crate::init();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::STREAM, None).unwrap();
@@ -164,6 +174,8 @@ fn net_v4_connect() {
 /// Similar, but use V6.
 #[test]
 fn net_v6_connect() {
+    crate::init();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET6, SocketType::STREAM, None).unwrap();
@@ -197,6 +209,8 @@ fn net_v6_connect() {
 /// Test `connect_unspec`.
 #[test]
 fn net_v4_connect_unspec() {
+    crate::init();
+
     const SOME_PORT: u16 = 47;
     let localhost_addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, SOME_PORT);
 
@@ -241,6 +255,8 @@ fn net_v4_connect_unspec() {
 /// Test `connect_unspec`.
 #[test]
 fn net_v6_connect_unspec() {
+    crate::init();
+
     const SOME_PORT: u16 = 47;
     let localhost_addr = SocketAddrV6::new(Ipv6Addr::LOCALHOST, SOME_PORT, 0, 0);
 
@@ -285,6 +301,8 @@ fn net_v6_connect_unspec() {
 /// Test `bind_any`.
 #[test]
 fn net_v4_bind_any() {
+    crate::init();
+
     let localhost = Ipv4Addr::LOCALHOST;
     let addr = SocketAddrV4::new(localhost, 0).into();
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::STREAM, None).unwrap();
@@ -314,6 +332,8 @@ fn net_v4_bind_any() {
 /// Similar, but use V6.
 #[test]
 fn net_v6_bind_any() {
+    crate::init();
+
     let localhost = Ipv6Addr::LOCALHOST;
     let addr = SocketAddrAny::V6(SocketAddrV6::new(localhost, 0, 0, 0));
     let listener = rustix::net::socket(AddressFamily::INET6, SocketType::STREAM, None).unwrap();
@@ -343,6 +363,8 @@ fn net_v6_bind_any() {
 /// Test `sendto`.
 #[test]
 fn net_v4_sendto() {
+    crate::init();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::STREAM, None).unwrap();
@@ -378,6 +400,8 @@ fn net_v4_sendto() {
 /// Similar, but with V6.
 #[test]
 fn net_v6_sendto() {
+    crate::init();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET6, SocketType::STREAM, None).unwrap();
@@ -413,6 +437,8 @@ fn net_v6_sendto() {
 /// Test `sendto_any`.
 #[test]
 fn net_v4_sendto_any() {
+    crate::init();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::STREAM, None).unwrap();
@@ -445,6 +471,8 @@ fn net_v4_sendto_any() {
 /// Similar, but with V6.
 #[test]
 fn net_v6_sendto_any() {
+    crate::init();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET6, SocketType::STREAM, None).unwrap();
@@ -477,6 +505,8 @@ fn net_v6_sendto_any() {
 /// Test `acceptfrom`.
 #[test]
 fn net_v4_acceptfrom() {
+    crate::init();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::STREAM, None).unwrap();
@@ -531,6 +561,8 @@ fn net_v4_acceptfrom() {
 /// Similar, but with V6.
 #[test]
 fn net_v6_acceptfrom() {
+    crate::init();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET6, SocketType::STREAM, None).unwrap();
@@ -585,6 +617,8 @@ fn net_v6_acceptfrom() {
 /// Test `shutdown`.
 #[test]
 fn net_shutdown() {
+    crate::init();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::STREAM, None).unwrap();

--- a/tests/net/dgram.rs
+++ b/tests/net/dgram.rs
@@ -9,6 +9,8 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 /// Test `connect_any`.
 #[test]
 fn net_dgram_v4_connect_any() {
+    crate::init();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::DGRAM, None).unwrap();
@@ -38,6 +40,8 @@ fn net_dgram_v4_connect_any() {
 #[cfg(not(any(apple, windows, target_os = "haiku")))]
 #[test]
 fn net_dgram_v4_connect_any_accept_with() {
+    crate::init();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::DGRAM, None).unwrap();
@@ -66,6 +70,8 @@ fn net_dgram_v4_connect_any_accept_with() {
 /// Similar, but with V6.
 #[test]
 fn net_dgram_v6_connect_any() {
+    crate::init();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET6, SocketType::DGRAM, None).unwrap();
@@ -95,6 +101,8 @@ fn net_dgram_v6_connect_any() {
 #[cfg(not(any(apple, windows, target_os = "haiku")))]
 #[test]
 fn net_dgram_v6_connect_any_accept_with() {
+    crate::init();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET6, SocketType::DGRAM, None).unwrap();
@@ -123,6 +131,8 @@ fn net_dgram_v6_connect_any_accept_with() {
 /// Test `connect` with a `SocketAddr`.
 #[test]
 fn net_dgram_v4_connect() {
+    crate::init();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::DGRAM, None).unwrap();
@@ -154,6 +164,8 @@ fn net_dgram_v4_connect() {
 /// Similar, but use V6.
 #[test]
 fn net_dgram_v6_connect() {
+    crate::init();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET6, SocketType::DGRAM, None).unwrap();
@@ -185,6 +197,8 @@ fn net_dgram_v6_connect() {
 /// Test `connect_unspec`.
 #[test]
 fn net_dgram_v4_connect_unspec() {
+    crate::init();
+
     const SOME_PORT: u16 = 47;
     let localhost_addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, SOME_PORT);
 
@@ -229,6 +243,8 @@ fn net_dgram_v4_connect_unspec() {
 /// Test `connect_unspec`.
 #[test]
 fn net_dgram_v6_connect_unspec() {
+    crate::init();
+
     const SOME_PORT: u16 = 47;
     let localhost_addr = SocketAddrV6::new(Ipv6Addr::LOCALHOST, SOME_PORT, 0, 0);
 
@@ -273,6 +289,8 @@ fn net_dgram_v6_connect_unspec() {
 /// Test `bind_any`.
 #[test]
 fn net_dgram_v4_bind_any() {
+    crate::init();
+
     let localhost = Ipv4Addr::LOCALHOST;
     let addr = SocketAddrV4::new(localhost, 0).into();
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::DGRAM, None).unwrap();
@@ -300,6 +318,8 @@ fn net_dgram_v4_bind_any() {
 /// Similar, but use V6.
 #[test]
 fn net_dgram_v6_bind_any() {
+    crate::init();
+
     let localhost = Ipv6Addr::LOCALHOST;
     let addr = SocketAddrAny::V6(SocketAddrV6::new(localhost, 0, 0, 0));
     let listener = rustix::net::socket(AddressFamily::INET6, SocketType::DGRAM, None).unwrap();
@@ -328,6 +348,8 @@ fn net_dgram_v6_bind_any() {
 #[cfg(not(any(bsd, target_os = "illumos")))]
 #[test]
 fn net_dgram_v4_connect_sendto() {
+    crate::init();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::DGRAM, None).unwrap();
@@ -373,6 +395,8 @@ fn net_dgram_v4_connect_sendto() {
 /// Test `sendto` without calling `connect`.
 #[test]
 fn net_dgram_v4_sendto() {
+    crate::init();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::DGRAM, None).unwrap();
@@ -418,6 +442,8 @@ fn net_dgram_v4_sendto() {
 #[cfg(not(any(bsd, target_os = "illumos")))]
 #[test]
 fn net_dgram_v6_connect_sendto() {
+    crate::init();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET6, SocketType::DGRAM, None).unwrap();
@@ -463,6 +489,8 @@ fn net_dgram_v6_connect_sendto() {
 /// Similar, but with V6.
 #[test]
 fn net_dgram_v6_sendto() {
+    crate::init();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET6, SocketType::DGRAM, None).unwrap();
@@ -508,6 +536,8 @@ fn net_dgram_v6_sendto() {
 #[cfg(not(any(bsd, target_os = "illumos")))]
 #[test]
 fn net_dgram_v4_connect_sendto_any() {
+    crate::init();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::DGRAM, None).unwrap();
@@ -550,6 +580,8 @@ fn net_dgram_v4_connect_sendto_any() {
 /// Test `sendto_any` without calling connect.
 #[test]
 fn net_dgram_v4_sendto_any() {
+    crate::init();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::DGRAM, None).unwrap();
@@ -592,6 +624,8 @@ fn net_dgram_v4_sendto_any() {
 #[cfg(not(any(bsd, target_os = "illumos")))]
 #[test]
 fn net_dgram_v6_connect_sendto_any() {
+    crate::init();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET6, SocketType::DGRAM, None).unwrap();
@@ -634,6 +668,8 @@ fn net_dgram_v6_connect_sendto_any() {
 /// Similar, but with V6.
 #[test]
 fn net_dgram_v6_sendto_any() {
+    crate::init();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET6, SocketType::DGRAM, None).unwrap();
@@ -675,6 +711,8 @@ fn net_dgram_v6_sendto_any() {
 /// Test `acceptfrom`.
 #[test]
 fn net_dgram_v4_acceptfrom() {
+    crate::init();
+
     let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET, SocketType::DGRAM, None).unwrap();
@@ -702,6 +740,8 @@ fn net_dgram_v4_acceptfrom() {
 /// Similar, but with V6.
 #[test]
 fn net_dgram_v6_acceptfrom() {
+    crate::init();
+
     let localhost = IpAddr::V6(Ipv6Addr::LOCALHOST);
     let addr = SocketAddr::new(localhost, 0);
     let listener = rustix::net::socket(AddressFamily::INET6, SocketType::DGRAM, None).unwrap();

--- a/tests/net/poll.rs
+++ b/tests/net/poll.rs
@@ -95,6 +95,8 @@ fn client(ready: Arc<(Mutex<u16>, Condvar)>) {
 
 #[test]
 fn test_poll() {
+    crate::init();
+
     let ready = Arc::new((Mutex::new(0_u16), Condvar::new()));
     let ready_clone = Arc::clone(&ready);
 

--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -292,6 +292,8 @@ fn test_sockopts_tcp(s: &OwnedFd) {
 
 #[test]
 fn test_sockopts_ipv4() {
+    crate::init();
+
     let s = rustix::net::socket(AddressFamily::INET, SocketType::STREAM, None).unwrap();
 
     test_sockopts_socket(&s);
@@ -379,6 +381,8 @@ fn test_sockopts_ipv4() {
 
 #[test]
 fn test_sockopts_ipv6() {
+    crate::init();
+
     let s = rustix::net::socket(AddressFamily::INET6, SocketType::STREAM, None).unwrap();
 
     test_sockopts_socket(&s);

--- a/tests/net/unix.rs
+++ b/tests/net/unix.rs
@@ -93,6 +93,8 @@ fn client(ready: Arc<(Mutex<bool>, Condvar)>, path: &Path, runs: &[(&[&str], i32
 
 #[test]
 fn test_unix() {
+    crate::init();
+
     let ready = Arc::new((Mutex::new(false), Condvar::new()));
     let ready_clone = Arc::clone(&ready);
 
@@ -360,6 +362,8 @@ fn do_test_unix_msg_unconnected(addr: SocketAddrUnix) {
 #[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "wasi")))]
 #[test]
 fn test_unix_msg() {
+    crate::init();
+
     let tmpdir = tempfile::tempdir().unwrap();
     let path = tmpdir.path().join("scp_4804");
 
@@ -373,6 +377,8 @@ fn test_unix_msg() {
 #[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "wasi")))]
 #[test]
 fn test_unix_msg_unconnected() {
+    crate::init();
+
     let tmpdir = tempfile::tempdir().unwrap();
     let path = tmpdir.path().join("scp_4804");
 
@@ -385,6 +391,8 @@ fn test_unix_msg_unconnected() {
 #[cfg(linux_kernel)]
 #[test]
 fn test_abstract_unix_msg() {
+    crate::init();
+
     use std::os::unix::ffi::OsStrExt;
 
     let tmpdir = tempfile::tempdir().unwrap();
@@ -398,6 +406,8 @@ fn test_abstract_unix_msg() {
 #[cfg(linux_kernel)]
 #[test]
 fn test_abstract_unix_msg_unconnected() {
+    crate::init();
+
     use std::os::unix::ffi::OsStrExt;
 
     let tmpdir = tempfile::tempdir().unwrap();
@@ -410,6 +420,8 @@ fn test_abstract_unix_msg_unconnected() {
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[test]
 fn test_unix_msg_with_scm_rights() {
+    crate::init();
+
     use rustix::fd::AsFd;
     use rustix::io::{IoSlice, IoSliceMut};
     use rustix::net::{
@@ -583,6 +595,8 @@ fn test_unix_msg_with_scm_rights() {
 #[cfg(all(feature = "process", linux_kernel))]
 #[test]
 fn test_unix_peercred_explicit() {
+    crate::init();
+
     use rustix::io::{IoSlice, IoSliceMut};
     use rustix::net::{
         recvmsg, sendmsg, sockopt, RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags,
@@ -637,6 +651,8 @@ fn test_unix_peercred_explicit() {
 #[cfg(all(feature = "process", linux_kernel))]
 #[test]
 fn test_unix_peercred_implicit() {
+    crate::init();
+
     use rustix::io::{IoSlice, IoSliceMut};
     use rustix::net::{
         recvmsg, sendmsg, sockopt, RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags,
@@ -692,6 +708,8 @@ fn test_unix_peercred_implicit() {
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[test]
 fn test_unix_msg_with_combo() {
+    crate::init();
+
     use rustix::fd::AsFd;
     use rustix::io::{IoSlice, IoSliceMut};
     use rustix::net::{

--- a/tests/net/unix_alloc.rs
+++ b/tests/net/unix_alloc.rs
@@ -91,6 +91,8 @@ fn client(ready: Arc<(Mutex<bool>, Condvar)>, path: &Path, runs: &[(&[&str], i32
 
 #[test]
 fn test_unix() {
+    crate::init();
+
     let ready = Arc::new((Mutex::new(false), Condvar::new()));
     let ready_clone = Arc::clone(&ready);
 
@@ -358,6 +360,8 @@ fn do_test_unix_msg_unconnected(addr: SocketAddrUnix) {
 #[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "wasi")))]
 #[test]
 fn test_unix_msg() {
+    crate::init();
+
     let tmpdir = tempfile::tempdir().unwrap();
     let path = tmpdir.path().join("scp_4804");
 
@@ -371,6 +375,8 @@ fn test_unix_msg() {
 #[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "wasi")))]
 #[test]
 fn test_unix_msg_unconnected() {
+    crate::init();
+
     let tmpdir = tempfile::tempdir().unwrap();
     let path = tmpdir.path().join("scp_4804");
 
@@ -383,6 +389,8 @@ fn test_unix_msg_unconnected() {
 #[cfg(linux_kernel)]
 #[test]
 fn test_abstract_unix_msg() {
+    crate::init();
+
     use std::os::unix::ffi::OsStrExt;
 
     let tmpdir = tempfile::tempdir().unwrap();
@@ -396,6 +404,8 @@ fn test_abstract_unix_msg() {
 #[cfg(linux_kernel)]
 #[test]
 fn test_abstract_unix_msg_unconnected() {
+    crate::init();
+
     use std::os::unix::ffi::OsStrExt;
 
     let tmpdir = tempfile::tempdir().unwrap();
@@ -408,6 +418,8 @@ fn test_abstract_unix_msg_unconnected() {
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[test]
 fn test_unix_msg_with_scm_rights() {
+    crate::init();
+
     use rustix::fd::AsFd;
     use rustix::io::{IoSlice, IoSliceMut};
     use rustix::net::{
@@ -581,6 +593,8 @@ fn test_unix_msg_with_scm_rights() {
 #[cfg(all(feature = "process", linux_kernel))]
 #[test]
 fn test_unix_peercred() {
+    crate::init();
+
     use rustix::io::{IoSlice, IoSliceMut};
     use rustix::net::{
         recvmsg, sendmsg, sockopt, RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags,
@@ -639,6 +653,8 @@ fn test_unix_peercred() {
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[test]
 fn test_unix_msg_with_combo() {
+    crate::init();
+
     use rustix::fd::AsFd;
     use rustix::io::{IoSlice, IoSliceMut};
     use rustix::net::{

--- a/tests/net/v4.rs
+++ b/tests/net/v4.rs
@@ -65,6 +65,8 @@ fn client(ready: Arc<(Mutex<u16>, Condvar)>) {
 
 #[test]
 fn test_v4() {
+    crate::init();
+
     let ready = Arc::new((Mutex::new(0_u16), Condvar::new()));
     let ready_clone = Arc::clone(&ready);
 
@@ -87,6 +89,8 @@ fn test_v4() {
 #[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "wasi")))]
 #[test]
 fn test_v4_msg() {
+    crate::init();
+
     use rustix::io::{IoSlice, IoSliceMut};
     use rustix::net::{recvmsg, sendmsg};
 

--- a/tests/net/v6.rs
+++ b/tests/net/v6.rs
@@ -65,6 +65,8 @@ fn client(ready: Arc<(Mutex<u16>, Condvar)>) {
 
 #[test]
 fn test_v6() {
+    crate::init();
+
     let ready = Arc::new((Mutex::new(0_u16), Condvar::new()));
     let ready_clone = Arc::clone(&ready);
 
@@ -87,6 +89,8 @@ fn test_v6() {
 #[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "wasi")))]
 #[test]
 fn test_v6_msg() {
+    crate::init();
+
     use rustix::io::{IoSlice, IoSliceMut};
     use rustix::net::{recvmsg, sendmsg};
 


### PR DESCRIPTION
The `ctor` crate recently started to cause link errors:

 = note: symbols.o : error LNK2001: unresolved external symbol _ZN3net34windows_shutdown___rust_dtor___mod13__dtor_export17h23ee8b3200f4e26dE
          symbols.o : error LNK2001: unresolved external symbol _ZN3net34windows_startup___rust_ctor___ctor17hd7d3fdaa3ef2ca94E
          D:\a\rustix\rustix\target\release\deps\net-f008608c7b4f9589.exe : fatal error LNK1120: 2 unresolved externals

so add manual inits to the net tests so that we don't need to depend on the ctor crate.