### PR TITLE
Fix `dup2_stdio` tests to test all three functions

### DIFF
--- a/tests/stdio/dup2_stdio.rs
+++ b/tests/stdio/dup2_stdio.rs
@@ -1,10 +1,10 @@
 use rustix::io::fcntl_getfd;
-use rustix::stdio::{dup2_stdout, stdout};
+use rustix::stdio::{dup2_stderr, dup2_stdin, dup2_stdout, stderr, stdin, stdout};
 
 #[test]
 fn dup2_stdin_stdin() {
-    let _ = dup2_stdout(stdout());
-    fcntl_getfd(stdout()).unwrap();
+    let _ = dup2_stdin(stdin());
+    fcntl_getfd(stdin()).unwrap();
 }
 
 #[test]
@@ -15,6 +15,6 @@ fn dup2_stdout_stdout() {
 
 #[test]
 fn dup2_stderr_stderr() {
-    let _ = dup2_stdout(stdout());
-    fcntl_getfd(stdout()).unwrap();
+    let _ = dup2_stderr(stderr());
+    fcntl_getfd(stderr()).unwrap();
 }


### PR DESCRIPTION
These tests were added in #1069, but despite the names suggesting that they test all of stdin, stdout and stderr, the tests were identical and only tested stdout.