### PR TITLE
Add a `try_close` function.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,3 +248,7 @@ rustc-dep-of-std = [
 
 # Obsolete and deprecated.
 cc = []
+
+# Enable `rustix::io::try_close`. The rustix developers do not intend the
+# existence of this feature to imply that anyone should use it.
+try_close = []

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -201,6 +201,11 @@ pub(crate) unsafe fn close(raw_fd: RawFd) {
     let _ = c::close(raw_fd as c::c_int);
 }
 
+#[cfg(feature = "try_close")]
+pub(crate) unsafe fn try_close(raw_fd: RawFd) -> io::Result<()> {
+    ret(c::close(raw_fd as c::c_int))
+}
+
 #[inline]
 pub(crate) unsafe fn ioctl(
     fd: BorrowedFd<'_>,

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -241,6 +241,12 @@ pub(crate) unsafe fn close(fd: RawFd) {
     syscall_readonly!(__NR_close, raw_fd(fd)).decode_void();
 }
 
+#[cfg(feature = "try_close")]
+#[inline]
+pub(crate) unsafe fn try_close(fd: RawFd) -> io::Result<()> {
+    ret(syscall_readonly!(__NR_close, raw_fd(fd)))
+}
+
 #[inline]
 pub(crate) unsafe fn ioctl(
     fd: BorrowedFd<'_>,

--- a/src/io/close.rs
+++ b/src/io/close.rs
@@ -53,3 +53,13 @@ use backend::fd::RawFd;
 pub unsafe fn close(raw_fd: RawFd) {
     backend::io::syscalls::close(raw_fd)
 }
+
+/// `close(raw_fd)`—Closes a `RawFd` directly, and report any errors
+/// returned by the OS.
+///
+/// The rustix developers do not intend the existence of this feature to imply
+/// that anyone should use it.
+#[cfg(feature = "try_close")]
+pub unsafe fn try_close(raw_fd: RawFd) -> crate::io::Result<()> {
+    backend::io::syscalls::try_close(raw_fd)
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -18,7 +18,7 @@ mod is_read_write;
 #[cfg(not(windows))]
 mod read_write;
 
-pub use close::close;
+pub use close::*;
 #[cfg(not(windows))]
 pub use dup::*;
 pub use errno::{retry_on_intr, Errno, Result};

--- a/tests/io/close.rs
+++ b/tests/io/close.rs
@@ -18,3 +18,13 @@ fn test_close_socket() {
         rustix::io::close(raw);
     }
 }
+
+#[cfg(all(feature = "try_close", any(unix, target_os = "wasi")))]
+#[test]
+fn test_try_close() {
+    let file = std::fs::File::open("Cargo.toml").unwrap();
+    let raw = file.into_raw_fd();
+    unsafe {
+        rustix::io::try_close(raw).unwrap();
+    }
+}


### PR DESCRIPTION
The rustix developers do not intend the existence of this feature to imply that anyone should use it.