### PR TITLE
rawdir: Use `ignore`, not `notrust`

### DIFF
--- a/src/fs/raw_dir.rs
+++ b/src/fs/raw_dir.rs
@@ -89,8 +89,8 @@ impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
     /// Heap allocated growing buffer for supporting directory entries with
     /// arbitrarily large file names:
     ///
-    /// ```notrust
-    /// # // The `notrust` above can be removed when we can depend on Rust 1.65.
+    /// ```ignore
+    /// # // The `ignore` above can be removed when we can depend on Rust 1.65.
     /// # use std::mem::MaybeUninit;
     /// # use rustix::fs::{CWD, Mode, OFlags, openat, RawDir};
     /// # use rustix::io::Errno;


### PR DESCRIPTION
- Fixes the problem that the prelude comments show up in the docs, including the confusing comment " # // The `notrust` above can be removed when we can depend on Rust 1.65." because the reader can't *see* the `notrust`
- I parsed `notrust` as "no-trust" and thought there was some security thing

The `ignore` attribute AFAICS is intended for these situations.