### PR TITLE
setns: Add a doc alias

### DIFF
--- a/src/thread/setns.rs
+++ b/src/thread/setns.rs
@@ -101,6 +101,7 @@ bitflags! {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/setns.2.html
+#[doc(alias = "setns")]
 pub fn move_into_link_name_space(
     fd: BorrowedFd<'_>,
     allowed_type: Option<LinkNameSpaceType>,
@@ -118,6 +119,7 @@ pub fn move_into_link_name_space(
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/setns.2.html
+#[doc(alias = "setns")]
 pub fn move_into_thread_name_spaces(
     fd: BorrowedFd<'_>,
     allowed_types: ThreadNameSpaceType,


### PR DESCRIPTION
At first I thought this wasn't bound in rustix until I went to search the source code to look at adding it.