### PR TITLE
Fix mising MREMAP_FIXED for mremap_fixed for linux_raw

### DIFF
--- a/src/backend/linux_raw/mm/syscalls.rs
+++ b/src/backend/linux_raw/mm/syscalls.rs
@@ -17,6 +17,7 @@ use crate::backend::conv::{c_uint, no_fd, pass_usize, ret, ret_owned_fd, ret_voi
 use crate::fd::{BorrowedFd, OwnedFd};
 use crate::io;
 use linux_raw_sys::general::MAP_ANONYMOUS;
+use linux_raw_sys::general::MREMAP_FIXED;
 
 #[inline]
 pub(crate) fn madvise(addr: *mut c::c_void, len: usize, advice: Advice) -> io::Result<()> {
@@ -170,7 +171,7 @@ pub(crate) unsafe fn mremap_fixed(
         old_address,
         pass_usize(old_size),
         pass_usize(new_size),
-        flags,
+        c_uint(flags.bits() | MREMAP_FIXED),
         new_address
     ))
 }


### PR DESCRIPTION
According to https://man7.org/linux/man-pages/man2/mremap.2.html, mremap_fixed missed flag of MREMAP_FIXED. This flag should be applied automatically like libc-backend.