### PR TITLE
Enable linux_raw support for android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ once_cell = { version = "1.5.2", optional = true }
 # addition to the libc backend. The linux_raw backend is used by default. The
 # libc backend can be selected via adding `--cfg=rustix_use_libc` to
 # `RUSTFLAGS` or enabling the `use-libc` cargo feature.
-[target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
+[target.'cfg(all(not(rustix_use_libc), not(miri), any(target_os = "linux", target_os = "android"), target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
 linux-raw-sys = { version = "0.4.14", default-features = false, features = ["general", "errno", "ioctl", "no_std", "elf"] }
 libc_errno = { package = "errno", version = "0.3.8", default-features = false, optional = true }
 libc = { version = "0.2.153", default-features = false, optional = true }
@@ -44,7 +44,7 @@ libc = { version = "0.2.153", default-features = false, optional = true }
 #
 # On all other Unix-family platforms, and under Miri, we always use the libc
 # backend, so enable its dependencies unconditionally.
-[target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
+[target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(any(target_os = "linux", target_os = "android"), target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.8", default-features = false }
 libc = { version = "0.2.153", default-features = false }
 

--- a/build.rs
+++ b/build.rs
@@ -84,13 +84,9 @@ fn main() {
 
     // If the libc backend is requested, or if we're not on a platform for
     // which we have linux_raw support, use the libc backend.
-    //
-    // For now Android uses the libc backend; in theory it could use the
-    // linux_raw backend, but to do that we'll need to figure out how to
-    // install the toolchain for it.
     let libc = feature_use_libc
         || cfg_use_libc
-        || os != "linux"
+        || (os != "linux" && os != "android")
         || !inline_asm_name_present
         || is_unsupported_abi
         || miri

--- a/src/backend/linux_raw/mod.rs
+++ b/src/backend/linux_raw/mod.rs
@@ -69,7 +69,7 @@ pub(crate) mod pty;
 pub(crate) mod rand;
 #[cfg(feature = "runtime")]
 pub(crate) mod runtime;
-#[cfg(feature = "shm")]
+#[cfg(all(not(target_os = "android"), feature = "shm"))]
 pub(crate) mod shm;
 #[cfg(feature = "system")]
 pub(crate) mod system;

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -463,7 +463,7 @@ impl AddressFamily {
     #[cfg(freebsdlike)]
     pub const ATM: Self = Self(c::AF_ATM as _);
     /// `AF_CAIF`
-    #[cfg(any(target_os = "android", target_os = "emscripten", target_os = "fuchsia"))]
+    #[cfg(any(target_os = "emscripten", target_os = "fuchsia"))]
     pub const CAIF: Self = Self(c::AF_CAIF as _);
     /// `AF_CCITT`
     #[cfg(any(bsd, solarish, target_os = "aix", target_os = "nto"))]
@@ -589,7 +589,7 @@ impl AddressFamily {
     #[cfg(target_os = "aix")]
     pub const RIF: Self = Self(c::AF_RIF as _);
     /// `AF_ROUTE`
-    #[cfg(any(bsd, solarish, target_os = "android", target_os = "emscripten", target_os = "fuchsia", target_os = "haiku", target_os = "nto"))]
+    #[cfg(any(bsd, solarish, target_os = "emscripten", target_os = "fuchsia", target_os = "haiku", target_os = "nto"))]
     pub const ROUTE: Self = Self(c::AF_ROUTE as _);
     /// `AF_SCLUSTER`
     #[cfg(target_os = "freebsd")]

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -13,9 +13,9 @@ mod ioctl;
 mod kill;
 #[cfg(linux_kernel)]
 mod membarrier;
-#[cfg(target_os = "linux")]
+#[cfg(linux_kernel)]
 mod pidfd;
-#[cfg(target_os = "linux")]
+#[cfg(linux_kernel)]
 mod pidfd_getfd;
 #[cfg(linux_kernel)]
 mod prctl;
@@ -53,9 +53,9 @@ pub use ioctl::*;
 pub use kill::*;
 #[cfg(linux_kernel)]
 pub use membarrier::*;
-#[cfg(target_os = "linux")]
+#[cfg(linux_kernel)]
 pub use pidfd::*;
-#[cfg(target_os = "linux")]
+#[cfg(linux_kernel)]
 pub use pidfd_getfd::*;
 #[cfg(linux_kernel)]
 pub use prctl::*;

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -2,7 +2,7 @@ use crate::process::Pid;
 use crate::{backend, io};
 use bitflags::bitflags;
 
-#[cfg(target_os = "linux")]
+#[cfg(linux_kernel)]
 use crate::fd::BorrowedFd;
 
 #[cfg(linux_raw)]
@@ -266,13 +266,13 @@ pub enum WaitId<'a> {
     Pgid(Option<Pid>),
 
     /// Wait for a specific process file descriptor.
-    #[cfg(target_os = "linux")]
+    #[cfg(linux_kernel)]
     #[doc(alias = "P_PIDFD")]
     PidFd(BorrowedFd<'a>),
 
     /// Eat the lifetime for non-Linux platforms.
     #[doc(hidden)]
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(linux_kernel))]
     __EatLifetime(core::marker::PhantomData<&'a ()>),
 }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -169,7 +169,7 @@ pub fn sethostname(name: &[u8]) -> io::Result<()> {
 }
 
 /// Reboot command for use with [`reboot`].
-#[cfg(target_os = "linux")]
+#[cfg(linux_kernel)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(i32)]
 #[non_exhaustive]
@@ -219,7 +219,7 @@ pub enum RebootCommand {
 /// - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/reboot.2.html
-#[cfg(target_os = "linux")]
+#[cfg(linux_kernel)]
 pub fn reboot(cmd: RebootCommand) -> io::Result<()> {
     backend::system::syscalls::reboot(cmd)
 }


### PR DESCRIPTION
I have no idea why we need use libc backend, but definitely, we should not prevent users from using linux_raw backend.

CI test fails because some constants are missing from libc, and the fix is rust-lang/libc#3779.