### PR TITLE
Add missing futex operations

### DIFF
--- a/src/backend/libc/thread/futex.rs
+++ b/src/backend/libc/thread/futex.rs
@@ -40,4 +40,18 @@ pub enum FutexOperation {
     TrylockPi = bitcast!(c::FUTEX_TRYLOCK_PI),
     /// `FUTEX_WAIT_BITSET`
     WaitBitset = bitcast!(c::FUTEX_WAIT_BITSET),
+    /// `FUTEX_WAKE_BITSET`
+    WakeBitset = bitcast!(c::FUTEX_WAKE_BITSET),
+    /// `FUTEX_WAIT_REQUEUE_PI`
+    WaitRequeuePi = bitcast!(c::FUTEX_WAIT_REQUEUE_PI),
+    /// `FUTEX_CMP_REQUEUE_PI`
+    CmpRequeuePi = bitcast!(c::FUTEX_CMP_REQUEUE_PI),
+    /// `FUTEX_LOCK_PI2`
+    LockPi2 = bitcast!(c::FUTEX_LOCK_PI2),
 }
+
+/// `FUTEX_WAITERS`
+pub const FUTEX_WAITERS: u32 = 0x80000000;
+
+/// `FUTEX_OWNER_DIED`
+pub const FUTEX_OWNER_DIED: u32 = 0x40000000;

--- a/src/backend/linux_raw/thread/futex.rs
+++ b/src/backend/linux_raw/thread/futex.rs
@@ -42,4 +42,18 @@ pub enum FutexOperation {
     TrylockPi = linux_raw_sys::general::FUTEX_TRYLOCK_PI,
     /// `FUTEX_WAIT_BITSET`
     WaitBitset = linux_raw_sys::general::FUTEX_WAIT_BITSET,
+    /// `FUTEX_WAKE_BITSET`
+    WakeBitset = linux_raw_sys::general::FUTEX_WAKE_BITSET,
+    /// `FUTEX_WAIT_REQUEUE_PI`
+    WaitRequeuePi = linux_raw_sys::general::FUTEX_WAIT_REQUEUE_PI,
+    /// `FUTEX_CMP_REQUEUE_PI`
+    CmpRequeuePi = linux_raw_sys::general::FUTEX_CMP_REQUEUE_PI,
+    /// `FUTEX_LOCK_PI2`
+    LockPi2 = linux_raw_sys::general::FUTEX_LOCK_PI2,
 }
+
+/// `FUTEX_WAITERS`
+pub const FUTEX_WAITERS: u32 = linux_raw_sys::general::FUTEX_WAITERS;
+
+/// `FUTEX_OWNER_DIED`
+pub const FUTEX_OWNER_DIED: u32 = linux_raw_sys::general::FUTEX_OWNER_DIED;

--- a/src/thread/futex.rs
+++ b/src/thread/futex.rs
@@ -11,6 +11,11 @@ use crate::{backend, io};
 
 pub use backend::thread::futex::{FutexFlags, FutexOperation};
 
+/// `FUTEX_WAITERS`
+pub const FUTEX_WAITERS: u32 = backend::thread::futex::FUTEX_WAITERS;
+/// `FUTEX_OWNER_DIED`
+pub const FUTEX_OWNER_DIED: u32 = backend::thread::futex::FUTEX_OWNER_DIED;
+
 /// `futex(uaddr, op, val, utime, uaddr2, val3)`
 ///
 /// # References

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -16,7 +16,7 @@ mod setns;
 #[cfg(not(target_os = "redox"))]
 pub use clock::*;
 #[cfg(linux_kernel)]
-pub use futex::{futex, FutexFlags, FutexOperation};
+pub use futex::{futex, FutexFlags, FutexOperation, FUTEX_OWNER_DIED, FUTEX_WAITERS};
 #[cfg(linux_kernel)]
 pub use id::{
     gettid, set_thread_gid, set_thread_groups, set_thread_res_gid, set_thread_res_uid,


### PR DESCRIPTION
This PR simply exposes already existing futex operations to the user. I recently ran into this issue when attempting to port a futex module to use rustix as its backend, where I ended up missing `FUTEX_CMP_REQUEUE_PI`. Note that other PI operations (such as `FUTEX_LOCK_PI`) are already exposed.

The additions are symmetric across the backends.