### PR TITLE
Futex Rework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ libc = { version = "0.2.156", default-features = false, optional = true }
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.8", default-features = false }
-libc = { version = "0.2.158", default-features = false }
+libc = { version = "0.2.156", default-features = false }
 
 # Additional dependencies for Linux with the libc backend:
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ libc = { version = "0.2.156", default-features = false, optional = true }
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.8", default-features = false }
-libc = { version = "0.2.156", default-features = false }
+libc = { version = "0.2.158", default-features = false }
 
 # Additional dependencies for Linux with the libc backend:
 #

--- a/src/backend/libc/thread/futex.rs
+++ b/src/backend/libc/thread/futex.rs
@@ -51,7 +51,7 @@ pub enum FutexOperation {
 }
 
 /// `FUTEX_WAITERS`
-pub const FUTEX_WAITERS: u32 = libc::FUTEX_WAITERS;
+pub const FUTEX_WAITERS: u32 = 0x80000000;
 
 /// `FUTEX_OWNER_DIED`
-pub const FUTEX_OWNER_DIED: u32 = libc::FUTEX_OWNER_DIED;
+pub const FUTEX_OWNER_DIED: u32 = 0x40000000;

--- a/src/backend/libc/thread/futex.rs
+++ b/src/backend/libc/thread/futex.rs
@@ -40,4 +40,18 @@ pub enum FutexOperation {
     TrylockPi = bitcast!(c::FUTEX_TRYLOCK_PI),
     /// `FUTEX_WAIT_BITSET`
     WaitBitset = bitcast!(c::FUTEX_WAIT_BITSET),
+    /// `FUTEX_WAKE_BITSET`
+    WakeBitset = bitcast!(c::FUTEX_WAKE_BITSET),
+    /// `FUTEX_WAIT_REQUEUE_PI`
+    WaitRequeuePi = bitcast!(c::FUTEX_WAIT_REQUEUE_PI),
+    /// `FUTEX_CMP_REQUEUE_PI`
+    CmpRequeuePi = bitcast!(c::FUTEX_CMP_REQUEUE_PI),
+    /// `FUTEX_LOCK_PI2`
+    LockPi2 = bitcast!(c::FUTEX_LOCK_PI2),
 }
+
+/// `FUTEX_WAITERS`
+pub const FUTEX_WAITERS: u32 = 0x80000000;
+
+/// `FUTEX_OWNER_DIED`
+pub const FUTEX_OWNER_DIED: u32 = 0x40000000;

--- a/src/backend/libc/thread/futex.rs
+++ b/src/backend/libc/thread/futex.rs
@@ -51,7 +51,7 @@ pub enum FutexOperation {
 }
 
 /// `FUTEX_WAITERS`
-pub const FUTEX_WAITERS: u32 = 0x80000000;
+pub const FUTEX_WAITERS: u32 = libc::FUTEX_WAITERS;
 
 /// `FUTEX_OWNER_DIED`
-pub const FUTEX_OWNER_DIED: u32 = 0x40000000;
+pub const FUTEX_OWNER_DIED: u32 = libc::FUTEX_OWNER_DIED;

--- a/src/backend/libc/thread/futex.rs
+++ b/src/backend/libc/thread/futex.rs
@@ -3,7 +3,7 @@ use crate::backend::c;
 bitflags::bitflags! {
     /// `FUTEX_*` flags for use with [`futex`].
     ///
-    /// [`futex`]: crate::thread::futex
+    /// [`futex`]: mod@crate::thread::futex
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct FutexFlags: u32 {
@@ -16,7 +16,7 @@ bitflags::bitflags! {
 
 /// `FUTEX_*` operations for use with [`futex`].
 ///
-/// [`futex`]: crate::thread::futex
+/// [`futex`]: mod@crate::thread::futex
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u32)]
 pub enum FutexOperation {

--- a/src/backend/libc/thread/futex.rs
+++ b/src/backend/libc/thread/futex.rs
@@ -51,7 +51,7 @@ pub enum FutexOperation {
 }
 
 /// `FUTEX_WAITERS`
-pub const FUTEX_WAITERS: u32 = 0x80000000;
+pub const FUTEX_WAITERS: u32 = linux_raw_sys::general::FUTEX_WAITERS;
 
 /// `FUTEX_OWNER_DIED`
-pub const FUTEX_OWNER_DIED: u32 = 0x40000000;
+pub const FUTEX_OWNER_DIED: u32 = linux_raw_sys::general::FUTEX_OWNER_DIED;

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -597,7 +597,10 @@ unsafe fn futex_old_timespec(
     } else {
         Some(linux_raw_sys::general::__kernel_old_timespec {
             tv_sec: (*timeout).tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
-            tv_nsec: (*timeout).tv_nsec.try_into().map_err(|_| io::Errno::INVAL)?,
+            tv_nsec: (*timeout)
+                .tv_nsec
+                .try_into()
+                .map_err(|_| io::Errno::INVAL)?,
         })
     };
     ret_usize(futex(

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -430,7 +430,7 @@ pub(crate) unsafe fn futex_val2(
     // the least significant four bytes of the timeout pointer are used as `val2`.
     // ["the kernel casts the timeout value first to unsigned long, then to uint32_t"](https://man7.org/linux/man-pages/man2/futex.2.html),
     // so we perform that exact conversion in reverse to create the pointer.
-    let utime = val2 as usize as *const Timespec;
+    let timeout = val2 as usize as *const Timespec;
 
     #[cfg(all(
         target_pointer_width = "32",
@@ -456,7 +456,7 @@ pub(crate) unsafe fn futex_val2(
             uaddr,
             op as i32 | flags.bits() as i32,
             val,
-            utime,
+            timeout,
             uaddr2,
             val3,
         ))
@@ -483,7 +483,7 @@ pub(crate) unsafe fn futex_val2(
             uaddr,
             op as i32 | flags.bits() as i32,
             val,
-            utime.cast(),
+            timeout.cast(),
             uaddr2,
             val3,
         ) as isize)
@@ -491,12 +491,12 @@ pub(crate) unsafe fn futex_val2(
 }
 
 #[cfg(linux_kernel)]
-pub(crate) unsafe fn futex_timespec(
+pub(crate) unsafe fn futex_timeout(
     uaddr: *const AtomicU32,
     op: FutexOperation,
     flags: FutexFlags,
     val: u32,
-    utime: *const Timespec,
+    timeout: *const Timespec,
     uaddr2: *const AtomicU32,
     val3: u32,
 ) -> io::Result<usize> {
@@ -524,7 +524,7 @@ pub(crate) unsafe fn futex_timespec(
             uaddr,
             op as i32 | flags.bits() as i32,
             val,
-            utime,
+            timeout,
             uaddr2,
             val3,
         ))
@@ -532,7 +532,7 @@ pub(crate) unsafe fn futex_timespec(
             // See the comments in `rustix_clock_gettime_via_syscall` about
             // emulation.
             if err == io::Errno::NOSYS {
-                futex_old_timespec(uaddr, op, flags, val, utime, uaddr2, val3)
+                futex_old_timespec(uaddr, op, flags, val, timeout, uaddr2, val3)
             } else {
                 Err(err)
             }
@@ -560,7 +560,7 @@ pub(crate) unsafe fn futex_timespec(
             uaddr,
             op as i32 | flags.bits() as i32,
             val,
-            utime.cast(),
+            timeout.cast(),
             uaddr2,
             val3,
         ) as isize)
@@ -577,7 +577,7 @@ unsafe fn futex_old_timespec(
     op: FutexOperation,
     flags: FutexFlags,
     val: u32,
-    utime: *const Timespec,
+    timeout: *const Timespec,
     uaddr2: *const AtomicU32,
     val3: u32,
 ) -> io::Result<usize> {
@@ -592,21 +592,21 @@ unsafe fn futex_old_timespec(
         ) via SYS_futex -> c::c_long
     }
 
-    let old_utime = if utime.is_null() {
+    let old_timeout = if timeout.is_null() {
         None
     } else {
         Some(linux_raw_sys::general::__kernel_old_timespec {
-            tv_sec: (*utime).tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
-            tv_nsec: (*utime).tv_nsec.try_into().map_err(|_| io::Errno::INVAL)?,
+            tv_sec: (*timeout).tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
+            tv_nsec: (*timeout).tv_nsec.try_into().map_err(|_| io::Errno::INVAL)?,
         })
     };
     ret_usize(futex(
         uaddr,
         op as i32 | flags.bits() as i32,
         val,
-        old_utime
+        old_timeout
             .as_ref()
-            .map(|r| r as *const linux_raw_sys::general::__kernel_old_timespec)
+            .map(|timeout| timeout as *const linux_raw_sys::general::__kernel_old_timespec)
             .unwrap_or(core::ptr::null()),
         uaddr2,
         val3,

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -417,9 +417,81 @@ pub(crate) fn setresgid_thread(
     unsafe { ret(setresgid(rgid.as_raw(), egid.as_raw(), sgid.as_raw())) }
 }
 
-// TODO: This could be de-multiplexed.
 #[cfg(linux_kernel)]
-pub(crate) unsafe fn futex(
+pub(crate) unsafe fn futex_val2(
+    uaddr: *const AtomicU32,
+    op: FutexOperation,
+    flags: FutexFlags,
+    val: u32,
+    val2: u32,
+    uaddr2: *const AtomicU32,
+    val3: u32,
+) -> io::Result<usize> {
+    // the least significant four bytes of the timeout pointer are used as `val2`.
+    // ["the kernel casts the timeout value first to unsigned long, then to uint32_t"](https://man7.org/linux/man-pages/man2/futex.2.html),
+    // so we perform that exact conversion in reverse to create the pointer.
+    let utime = val2 as usize as *const Timespec;
+
+    #[cfg(all(
+        target_pointer_width = "32",
+        not(any(target_arch = "aarch64", target_arch = "x86_64"))
+    ))]
+    {
+        // TODO: Upstream this to the libc crate.
+        #[allow(non_upper_case_globals)]
+        const SYS_futex_time64: i32 = linux_raw_sys::general::__NR_futex_time64 as i32;
+
+        syscall! {
+            fn futex_time64(
+                uaddr: *const AtomicU32,
+                futex_op: c::c_int,
+                val: u32,
+                timeout: *const Timespec,
+                uaddr2: *const AtomicU32,
+                val3: u32
+            ) via SYS_futex_time64 -> c::ssize_t
+        }
+
+        ret_usize(futex_time64(
+            uaddr,
+            op as i32 | flags.bits() as i32,
+            val,
+            utime,
+            uaddr2,
+            val3,
+        ))
+    }
+
+    #[cfg(any(
+        target_pointer_width = "64",
+        target_arch = "aarch64",
+        target_arch = "x86_64"
+    ))]
+    {
+        syscall! {
+            fn futex(
+                uaddr: *const AtomicU32,
+                futex_op: c::c_int,
+                val: u32,
+                timeout: *const linux_raw_sys::general::__kernel_timespec,
+                uaddr2: *const AtomicU32,
+                val3: u32
+            ) via SYS_futex -> c::c_long
+        }
+
+        ret_usize(futex(
+            uaddr,
+            op as i32 | flags.bits() as i32,
+            val,
+            utime.cast(),
+            uaddr2,
+            val3,
+        ) as isize)
+    }
+}
+
+#[cfg(linux_kernel)]
+pub(crate) unsafe fn futex_timespec(
     uaddr: *const AtomicU32,
     op: FutexOperation,
     flags: FutexFlags,
@@ -460,7 +532,7 @@ pub(crate) unsafe fn futex(
             // See the comments in `rustix_clock_gettime_via_syscall` about
             // emulation.
             if err == io::Errno::NOSYS {
-                futex_old(uaddr, op, flags, val, utime, uaddr2, val3)
+                futex_old_timespec(uaddr, op, flags, val, utime, uaddr2, val3)
             } else {
                 Err(err)
             }
@@ -500,7 +572,7 @@ pub(crate) unsafe fn futex(
     target_pointer_width = "32",
     not(any(target_arch = "aarch64", target_arch = "x86_64"))
 ))]
-unsafe fn futex_old(
+unsafe fn futex_old_timespec(
     uaddr: *const AtomicU32,
     op: FutexOperation,
     flags: FutexFlags,
@@ -520,15 +592,22 @@ unsafe fn futex_old(
         ) via SYS_futex -> c::c_long
     }
 
-    let old_utime = linux_raw_sys::general::__kernel_old_timespec {
-        tv_sec: (*utime).tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
-        tv_nsec: (*utime).tv_nsec.try_into().map_err(|_| io::Errno::INVAL)?,
+    let old_utime = if utime.is_null() {
+        None
+    } else {
+        Some(linux_raw_sys::general::__kernel_old_timespec {
+            tv_sec: (*utime).tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
+            tv_nsec: (*utime).tv_nsec.try_into().map_err(|_| io::Errno::INVAL)?,
+        })
     };
     ret_usize(futex(
         uaddr,
         op as i32 | flags.bits() as i32,
         val,
-        &old_utime,
+        old_utime
+            .as_ref()
+            .map(|r| r as *const linux_raw_sys::general::__kernel_old_timespec)
+            .unwrap_or(core::ptr::null()),
         uaddr2,
         val3,
     ) as isize)

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -790,11 +790,19 @@ impl<'a, Num: ArgNumber> From<(crate::net::SocketType, crate::net::SocketFlags)>
 }
 
 #[cfg(feature = "thread")]
-impl<'a, Num: ArgNumber> From<(crate::thread::FutexOperation, crate::thread::FutexFlags)>
-    for ArgReg<'a, Num>
+impl<'a, Num: ArgNumber>
+    From<(
+        crate::backend::thread::futex::FutexOperation,
+        crate::thread::FutexFlags,
+    )> for ArgReg<'a, Num>
 {
     #[inline]
-    fn from(pair: (crate::thread::FutexOperation, crate::thread::FutexFlags)) -> Self {
+    fn from(
+        pair: (
+            crate::backend::thread::futex::FutexOperation,
+            crate::thread::FutexFlags,
+        ),
+    ) -> Self {
         c_uint(pair.0 as u32 | pair.1.bits())
     }
 }

--- a/src/backend/linux_raw/thread/futex.rs
+++ b/src/backend/linux_raw/thread/futex.rs
@@ -42,4 +42,18 @@ pub enum FutexOperation {
     TrylockPi = linux_raw_sys::general::FUTEX_TRYLOCK_PI,
     /// `FUTEX_WAIT_BITSET`
     WaitBitset = linux_raw_sys::general::FUTEX_WAIT_BITSET,
+    /// `FUTEX_WAKE_BITSET`
+    WakeBitset = linux_raw_sys::general::FUTEX_WAKE_BITSET,
+    /// `FUTEX_WAIT_REQUEUE_PI`
+    WaitRequeuePi = linux_raw_sys::general::FUTEX_WAIT_REQUEUE_PI,
+    /// `FUTEX_CMP_REQUEUE_PI`
+    CmpRequeuePi = linux_raw_sys::general::FUTEX_CMP_REQUEUE_PI,
+    /// `FUTEX_LOCK_PI2`
+    LockPi2 = linux_raw_sys::general::FUTEX_LOCK_PI2,
 }
+
+/// `FUTEX_WAITERS`
+pub const FUTEX_WAITERS: u32 = linux_raw_sys::general::FUTEX_WAITERS;
+
+/// `FUTEX_OWNER_DIED`
+pub const FUTEX_OWNER_DIED: u32 = linux_raw_sys::general::FUTEX_OWNER_DIED;

--- a/src/backend/linux_raw/thread/futex.rs
+++ b/src/backend/linux_raw/thread/futex.rs
@@ -1,7 +1,7 @@
 bitflags::bitflags! {
     /// `FUTEX_*` flags for use with [`futex`].
     ///
-    /// [`futex`]: crate::thread::futex
+    /// [`futex`]: mod@crate::thread::futex
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct FutexFlags: u32 {
@@ -18,7 +18,7 @@ bitflags::bitflags! {
 
 /// `FUTEX_*` operations for use with [`futex`].
 ///
-/// [`futex`]: crate::thread::futex
+/// [`futex`]: mod@crate::thread::futex
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u32)]
 pub enum FutexOperation {

--- a/src/backend/linux_raw/thread/syscalls.rs
+++ b/src/backend/linux_raw/thread/syscalls.rs
@@ -302,7 +302,10 @@ unsafe fn futex_old_timespec(
     } else {
         Some(__kernel_old_timespec {
             tv_sec: (*timeout).tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
-            tv_nsec: (*timeout).tv_nsec.try_into().map_err(|_| io::Errno::INVAL)?,
+            tv_nsec: (*timeout)
+                .tv_nsec
+                .try_into()
+                .map_err(|_| io::Errno::INVAL)?,
         })
     };
     ret_usize(syscall!(

--- a/src/backend/linux_raw/thread/syscalls.rs
+++ b/src/backend/linux_raw/thread/syscalls.rs
@@ -205,9 +205,47 @@ pub(crate) fn gettid() -> Pid {
     }
 }
 
-// TODO: This could be de-multiplexed.
 #[inline]
-pub(crate) unsafe fn futex(
+pub(crate) unsafe fn futex_val2(
+    uaddr: *const AtomicU32,
+    op: FutexOperation,
+    flags: FutexFlags,
+    val: u32,
+    val2: u32,
+    uaddr2: *const AtomicU32,
+    val3: u32,
+) -> io::Result<usize> {
+    // the least significant four bytes of the timeout pointer are used as `val2`.
+    // ["the kernel casts the timeout value first to unsigned long, then to uint32_t"](https://man7.org/linux/man-pages/man2/futex.2.html),
+    // so we perform that exact conversion in reverse to create the pointer.
+    let utime = val2 as usize as *const Timespec;
+
+    #[cfg(target_pointer_width = "32")]
+    {
+        ret_usize(syscall!(
+            __NR_futex_time64,
+            uaddr,
+            (op, flags),
+            c_uint(val),
+            utime,
+            uaddr2,
+            c_uint(val3)
+        ))
+    }
+    #[cfg(target_pointer_width = "64")]
+    ret_usize(syscall!(
+        __NR_futex,
+        uaddr,
+        (op, flags),
+        c_uint(val),
+        utime,
+        uaddr2,
+        c_uint(val3)
+    ))
+}
+
+#[inline]
+pub(crate) unsafe fn futex_timespec(
     uaddr: *const AtomicU32,
     op: FutexOperation,
     flags: FutexFlags,
@@ -231,7 +269,7 @@ pub(crate) unsafe fn futex(
             // See the comments in `rustix_clock_gettime_via_syscall` about
             // emulation.
             if err == io::Errno::NOSYS {
-                futex_old(uaddr, op, flags, val, utime, uaddr2, val3)
+                futex_old_timespec(uaddr, op, flags, val, utime, uaddr2, val3)
             } else {
                 Err(err)
             }
@@ -250,7 +288,7 @@ pub(crate) unsafe fn futex(
 }
 
 #[cfg(target_pointer_width = "32")]
-unsafe fn futex_old(
+unsafe fn futex_old_timespec(
     uaddr: *const AtomicU32,
     op: FutexOperation,
     flags: FutexFlags,
@@ -259,16 +297,23 @@ unsafe fn futex_old(
     uaddr2: *const AtomicU32,
     val3: u32,
 ) -> io::Result<usize> {
-    let old_utime = __kernel_old_timespec {
-        tv_sec: (*utime).tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
-        tv_nsec: (*utime).tv_nsec.try_into().map_err(|_| io::Errno::INVAL)?,
+    let old_utime = if utime.is_null() {
+        None
+    } else {
+        Some(__kernel_old_timespec {
+            tv_sec: (*utime).tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
+            tv_nsec: (*utime).tv_nsec.try_into().map_err(|_| io::Errno::INVAL)?,
+        })
     };
     ret_usize(syscall!(
         __NR_futex,
         uaddr,
         (op, flags),
         c_uint(val),
-        by_ref(&old_utime),
+        old_utime
+            .as_ref()
+            .map(|r| r as *const __kernel_old_timespec)
+            .unwrap_or(core::ptr::null()),
         uaddr2,
         c_uint(val3)
     ))

--- a/src/thread/futex.rs
+++ b/src/thread/futex.rs
@@ -10,17 +10,72 @@ use core::num::NonZeroU32;
 use core::ptr;
 use core::sync::atomic::AtomicU32;
 
+use crate::backend::thread::syscalls::{futex_timespec, futex_val2};
 use crate::fd::{FromRawFd, OwnedFd};
 use crate::thread::Timespec;
 use crate::{backend, io};
 
 pub use backend::thread::futex::FutexFlags;
-use backend::thread::futex::FutexOperation;
+pub use backend::thread::futex::FutexOperation;
 
 /// `FUTEX_WAITERS`
 pub const FUTEX_WAITERS: u32 = backend::thread::futex::FUTEX_WAITERS;
 /// `FUTEX_OWNER_DIED`
 pub const FUTEX_OWNER_DIED: u32 = backend::thread::futex::FUTEX_OWNER_DIED;
+
+/// DEPRECATED: There are now individual functions available to perform futex operations with improved type safety. See the [futex module](`self`).
+///
+/// `futex(uaddr, op, val, utime, uaddr2, val3)`
+///
+/// # References
+///  - [Linux `futex` system call]
+///  - [Linux `futex` feature]
+///
+/// # Safety
+///
+/// This is a very low-level feature for implementing synchronization
+/// primitives. See the references links above.
+///
+/// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
+/// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
+#[deprecated(
+    since = "0.38.35",
+    note = "There are now individual functions available to perform futex operations with improved type safety. See the futex module."
+)]
+#[inline]
+pub unsafe fn futex(
+    uaddr: *mut u32,
+    op: FutexOperation,
+    flags: FutexFlags,
+    val: u32,
+    utime: *const Timespec,
+    uaddr2: *mut u32,
+    val3: u32,
+) -> io::Result<usize> {
+    use FutexOperation::*;
+
+    match op {
+        Wait | LockPi | WaitBitset | WaitRequeuePi | LockPi2 => futex_timespec(
+            uaddr as *const AtomicU32,
+            op,
+            flags,
+            val,
+            utime,
+            uaddr2 as *const AtomicU32,
+            val3,
+        ),
+        Wake | Fd | Requeue | CmpRequeue | WakeOp | UnlockPi | TrylockPi | WakeBitset
+        | CmpRequeuePi => futex_val2(
+            uaddr as *const AtomicU32,
+            op,
+            flags,
+            val,
+            utime as usize as u32,
+            uaddr2 as *const AtomicU32,
+            val3,
+        ),
+    }
+}
 
 /// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_WAIT, val, timeout, NULL, 0)`
 ///
@@ -36,13 +91,13 @@ pub const FUTEX_OWNER_DIED: u32 = backend::thread::futex::FUTEX_OWNER_DIED;
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn futex_wait(
+pub unsafe fn wait(
     uaddr: &AtomicU32,
     flags: FutexFlags,
     val: u32,
     timeout: Option<Timespec>,
 ) -> io::Result<()> {
-    backend::thread::syscalls::futex(
+    backend::thread::syscalls::futex_timespec(
         uaddr,
         FutexOperation::Wait,
         flags,
@@ -70,13 +125,13 @@ pub unsafe fn futex_wait(
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn futex_wake(uaddr: &AtomicU32, flags: FutexFlags, val: u32) -> io::Result<usize> {
-    backend::thread::syscalls::futex(
+pub unsafe fn wake(uaddr: &AtomicU32, flags: FutexFlags, val: u32) -> io::Result<usize> {
+    backend::thread::syscalls::futex_val2(
         uaddr,
         FutexOperation::Wake,
         flags,
         val,
-        ptr::null(),
+        0,
         ptr::null(),
         0,
     )
@@ -96,17 +151,9 @@ pub unsafe fn futex_wake(uaddr: &AtomicU32, flags: FutexFlags, val: u32) -> io::
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn futex_fd(uaddr: &AtomicU32, flags: FutexFlags, val: u32) -> io::Result<OwnedFd> {
-    backend::thread::syscalls::futex(
-        uaddr,
-        FutexOperation::Fd,
-        flags,
-        val,
-        ptr::null(),
-        ptr::null(),
-        0,
-    )
-    .map(|fd| OwnedFd::from_raw_fd(fd.try_into().expect("return value should be a valid fd")))
+pub unsafe fn fd(uaddr: &AtomicU32, flags: FutexFlags, val: u32) -> io::Result<OwnedFd> {
+    backend::thread::syscalls::futex_val2(uaddr, FutexOperation::Fd, flags, val, 0, ptr::null(), 0)
+        .map(|fd| OwnedFd::from_raw_fd(fd.try_into().expect("return value should be a valid fd")))
 }
 
 /// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_REQUEUE, val, val2, uaddr2, 0)`
@@ -123,23 +170,19 @@ pub unsafe fn futex_fd(uaddr: &AtomicU32, flags: FutexFlags, val: u32) -> io::Re
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn futex_requeue(
+pub unsafe fn requeue(
     uaddr: &AtomicU32,
     flags: FutexFlags,
     val: u32,
     val2: u32,
     uaddr2: &AtomicU32,
 ) -> io::Result<usize> {
-    // the least significant four bytes of the timeout pointer are used as `val2`.
-    // ["the kernel casts the timeout value first to unsigned long, then to uint32_t"](https://man7.org/linux/man-pages/man2/futex.2.html),
-    // so we perform that exact conversion in reverse to create the pointer.
-    let timeout = val2 as usize as *const Timespec;
-    backend::thread::syscalls::futex(
+    backend::thread::syscalls::futex_val2(
         uaddr,
         FutexOperation::Requeue,
         flags,
         val,
-        timeout,
+        val2,
         uaddr2,
         0,
     )
@@ -159,7 +202,7 @@ pub unsafe fn futex_requeue(
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn futex_cmp_requeue(
+pub unsafe fn cmp_requeue(
     uaddr: &AtomicU32,
     flags: FutexFlags,
     val: u32,
@@ -167,27 +210,21 @@ pub unsafe fn futex_cmp_requeue(
     uaddr2: &AtomicU32,
     val3: u32,
 ) -> io::Result<usize> {
-    // the least significant four bytes of the timeout pointer are used as `val2`.
-    // ["the kernel casts the timeout value first to unsigned long, then to uint32_t"](https://man7.org/linux/man-pages/man2/futex.2.html),
-    // so we perform that exact conversion in reverse to create the pointer.
-    let timeout = val2 as usize as *const Timespec;
-    backend::thread::syscalls::futex(
+    backend::thread::syscalls::futex_val2(
         uaddr,
         FutexOperation::CmpRequeue,
         flags,
         val,
-        timeout,
+        val2,
         uaddr2,
         val3,
     )
 }
 
-/// `FUTEX_OP_*` operations for use with [`futex_wake_op`].
-///
-/// [`futex`]: crate::thread::futex
+/// `FUTEX_OP_*` operations for use with [`wake_op`].
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u32)]
-pub enum FutexOp {
+pub enum WakeOp {
     /// `FUTEX_OP_SET`: `uaddr2 = oparg;`
     Set = 0,
     /// `FUTEX_OP_ADD`: `uaddr2 += oparg;`
@@ -210,12 +247,10 @@ pub enum FutexOp {
     XOrShift = 4 | 8,
 }
 
-/// `FUTEX_OP_CMP_*` operations for use with [`futex_wake_op`].
-///
-/// [`futex`]: crate::thread::futex
+/// `FUTEX_OP_CMP_*` operations for use with [`wake_op`].
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u32)]
-pub enum FutexOpCmp {
+pub enum WakeOpCmp {
     /// `FUTEX_OP_CMP_EQ`: `if oldval == cmparg { wake(); }`
     Eq = 0,
     /// `FUTEX_OP_CMP_EQ`: `if oldval != cmparg { wake(); }`
@@ -244,14 +279,14 @@ pub enum FutexOpCmp {
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn futex_wake_op(
+pub unsafe fn wake_op(
     uaddr: &AtomicU32,
     flags: FutexFlags,
     val: u32,
     val2: u32,
     uaddr2: &AtomicU32,
-    op: FutexOp,
-    cmp: FutexOpCmp,
+    op: WakeOp,
+    cmp: WakeOpCmp,
     oparg: u16,
     cmparg: u16,
 ) -> io::Result<usize> {
@@ -259,20 +294,15 @@ pub unsafe fn futex_wake_op(
         return Err(io::Errno::INVAL);
     }
 
-    // the least significant four bytes of the timeout pointer are used as `val2`.
-    // ["the kernel casts the timeout value first to unsigned long, then to uint32_t"](https://man7.org/linux/man-pages/man2/futex.2.html),
-    // so we perform that exact conversion in reverse to create the pointer.
-    let timeout = val2 as usize as *const Timespec;
-
     let val3 =
         ((op as u32) << 28) | ((cmp as u32) << 24) | ((oparg as u32) << 12) | (cmparg as u32);
 
-    backend::thread::syscalls::futex(
+    backend::thread::syscalls::futex_val2(
         uaddr,
         FutexOperation::WakeOp,
         flags,
         val,
-        timeout,
+        val2,
         uaddr2,
         val3,
     )
@@ -292,12 +322,12 @@ pub unsafe fn futex_wake_op(
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn futex_lock_pi(
+pub unsafe fn lock_pi(
     uaddr: &AtomicU32,
     flags: FutexFlags,
     timeout: Option<Timespec>,
 ) -> io::Result<()> {
-    backend::thread::syscalls::futex(
+    backend::thread::syscalls::futex_timespec(
         uaddr,
         FutexOperation::LockPi,
         flags,
@@ -325,13 +355,13 @@ pub unsafe fn futex_lock_pi(
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn futex_unlock_pi(uaddr: &AtomicU32, flags: FutexFlags) -> io::Result<()> {
-    backend::thread::syscalls::futex(
+pub unsafe fn unlock_pi(uaddr: &AtomicU32, flags: FutexFlags) -> io::Result<()> {
+    backend::thread::syscalls::futex_val2(
         uaddr,
         FutexOperation::UnlockPi,
         flags,
         0,
-        ptr::null(),
+        0,
         ptr::null(),
         0,
     )?;
@@ -352,13 +382,13 @@ pub unsafe fn futex_unlock_pi(uaddr: &AtomicU32, flags: FutexFlags) -> io::Resul
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn futex_trylock_pi(uaddr: &AtomicU32, flags: FutexFlags) -> io::Result<()> {
-    backend::thread::syscalls::futex(
+pub unsafe fn trylock_pi(uaddr: &AtomicU32, flags: FutexFlags) -> io::Result<()> {
+    backend::thread::syscalls::futex_val2(
         uaddr,
         FutexOperation::TrylockPi,
         flags,
         0,
-        ptr::null(),
+        0,
         ptr::null(),
         0,
     )?;
@@ -379,14 +409,14 @@ pub unsafe fn futex_trylock_pi(uaddr: &AtomicU32, flags: FutexFlags) -> io::Resu
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn futex_wait_bitset(
+pub unsafe fn wait_bitset(
     uaddr: &AtomicU32,
     flags: FutexFlags,
     val: u32,
     timeout: Option<Timespec>,
     val3: NonZeroU32,
 ) -> io::Result<()> {
-    backend::thread::syscalls::futex(
+    backend::thread::syscalls::futex_timespec(
         uaddr,
         FutexOperation::WaitBitset,
         flags,
@@ -414,18 +444,18 @@ pub unsafe fn futex_wait_bitset(
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn futex_wake_bitset(
+pub unsafe fn wake_bitset(
     uaddr: &AtomicU32,
     flags: FutexFlags,
     val: u32,
     val3: NonZeroU32,
 ) -> io::Result<usize> {
-    backend::thread::syscalls::futex(
+    backend::thread::syscalls::futex_val2(
         uaddr,
         FutexOperation::WakeBitset,
         flags,
         val,
-        ptr::null(),
+        0,
         ptr::null(),
         val3.get(),
     )
@@ -445,14 +475,14 @@ pub unsafe fn futex_wake_bitset(
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn futex_wait_requeue_pi(
+pub unsafe fn wait_requeue_pi(
     uaddr: &AtomicU32,
     flags: FutexFlags,
     val: u32,
     timeout: Option<Timespec>,
     uaddr2: &AtomicU32,
 ) -> io::Result<()> {
-    backend::thread::syscalls::futex(
+    backend::thread::syscalls::futex_timespec(
         uaddr,
         FutexOperation::WaitRequeuePi,
         flags,
@@ -480,23 +510,19 @@ pub unsafe fn futex_wait_requeue_pi(
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn futex_cmp_requeue_pi(
+pub unsafe fn cmp_requeue_pi(
     uaddr: &AtomicU32,
     flags: FutexFlags,
     val2: u32,
     uaddr2: &AtomicU32,
     val3: u32,
 ) -> io::Result<usize> {
-    // the least significant four bytes of the timeout pointer are used as `val2`.
-    // ["the kernel casts the timeout value first to unsigned long, then to uint32_t"](https://man7.org/linux/man-pages/man2/futex.2.html),
-    // so we perform that exact conversion in reverse to create the pointer.
-    let timeout = val2 as usize as *const Timespec;
-    backend::thread::syscalls::futex(
+    backend::thread::syscalls::futex_val2(
         uaddr,
         FutexOperation::CmpRequeuePi,
         flags,
         1,
-        timeout,
+        val2,
         uaddr2,
         val3,
     )
@@ -516,12 +542,8 @@ pub unsafe fn futex_cmp_requeue_pi(
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn futex_lock_pi2(
-    uaddr: &AtomicU32,
-    flags: FutexFlags,
-    timeout: &Timespec,
-) -> io::Result<()> {
-    backend::thread::syscalls::futex(
+pub unsafe fn lock_pi2(uaddr: &AtomicU32, flags: FutexFlags, timeout: &Timespec) -> io::Result<()> {
+    backend::thread::syscalls::futex_timespec(
         uaddr,
         FutexOperation::LockPi2,
         flags,

--- a/src/thread/futex.rs
+++ b/src/thread/futex.rs
@@ -10,7 +10,7 @@ use core::num::NonZeroU32;
 use core::ptr;
 use core::sync::atomic::AtomicU32;
 
-use crate::backend::thread::syscalls::{futex_timespec, futex_val2};
+use crate::backend::thread::syscalls::{futex_timeout, futex_val2};
 use crate::fd::{FromRawFd, OwnedFd};
 use crate::thread::Timespec;
 use crate::{backend, io};
@@ -55,7 +55,7 @@ pub unsafe fn futex(
     use FutexOperation::*;
 
     match op {
-        Wait | LockPi | WaitBitset | WaitRequeuePi | LockPi2 => futex_timespec(
+        Wait | LockPi | WaitBitset | WaitRequeuePi | LockPi2 => futex_timeout(
             uaddr as *const AtomicU32,
             op,
             flags,
@@ -97,7 +97,7 @@ pub unsafe fn wait(
     val: u32,
     timeout: Option<Timespec>,
 ) -> io::Result<()> {
-    backend::thread::syscalls::futex_timespec(
+    backend::thread::syscalls::futex_timeout(
         uaddr,
         FutexOperation::Wait,
         flags,
@@ -328,7 +328,7 @@ pub unsafe fn lock_pi(
     flags: FutexFlags,
     timeout: Option<Timespec>,
 ) -> io::Result<()> {
-    backend::thread::syscalls::futex_timespec(
+    backend::thread::syscalls::futex_timeout(
         uaddr,
         FutexOperation::LockPi,
         flags,
@@ -418,7 +418,7 @@ pub unsafe fn wait_bitset(
     timeout: Option<Timespec>,
     val3: NonZeroU32,
 ) -> io::Result<()> {
-    backend::thread::syscalls::futex_timespec(
+    backend::thread::syscalls::futex_timeout(
         uaddr,
         FutexOperation::WaitBitset,
         flags,
@@ -485,7 +485,7 @@ pub unsafe fn wait_requeue_pi(
     timeout: Option<Timespec>,
     uaddr2: &AtomicU32,
 ) -> io::Result<()> {
-    backend::thread::syscalls::futex_timespec(
+    backend::thread::syscalls::futex_timeout(
         uaddr,
         FutexOperation::WaitRequeuePi,
         flags,
@@ -547,7 +547,7 @@ pub unsafe fn cmp_requeue_pi(
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
 pub unsafe fn lock_pi2(uaddr: &AtomicU32, flags: FutexFlags, timeout: &Timespec) -> io::Result<()> {
-    backend::thread::syscalls::futex_timespec(
+    backend::thread::syscalls::futex_timeout(
         uaddr,
         FutexOperation::LockPi2,
         flags,

--- a/src/thread/futex.rs
+++ b/src/thread/futex.rs
@@ -384,7 +384,7 @@ pub unsafe fn unlock_pi(uaddr: &AtomicU32, flags: FutexFlags) -> io::Result<()> 
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn trylock_pi(uaddr: &AtomicU32, flags: FutexFlags) -> io::Result<()> {
+pub unsafe fn trylock_pi(uaddr: &AtomicU32, flags: FutexFlags) -> io::Result<bool> {
     backend::thread::syscalls::futex_val2(
         uaddr,
         FutexOperation::TrylockPi,
@@ -393,8 +393,8 @@ pub unsafe fn trylock_pi(uaddr: &AtomicU32, flags: FutexFlags) -> io::Result<()>
         0,
         ptr::null(),
         0,
-    )?;
-    Ok(())
+    )
+    .map(|ret| ret == 0)
 }
 
 /// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_WAIT_BITSET, val, timeout/val2, NULL, val3)`

--- a/src/thread/futex.rs
+++ b/src/thread/futex.rs
@@ -546,13 +546,20 @@ pub unsafe fn cmp_requeue_pi(
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn lock_pi2(uaddr: &AtomicU32, flags: FutexFlags, timeout: &Timespec) -> io::Result<()> {
+pub unsafe fn lock_pi2(
+    uaddr: &AtomicU32,
+    flags: FutexFlags,
+    timeout: Option<Timespec>,
+) -> io::Result<()> {
     backend::thread::syscalls::futex_timeout(
         uaddr,
         FutexOperation::LockPi2,
         flags,
         0,
-        timeout,
+        timeout
+            .as_ref()
+            .map(|timeout| timeout as *const Timespec)
+            .unwrap_or(ptr::null()),
         ptr::null(),
         0,
     )?;

--- a/src/thread/futex.rs
+++ b/src/thread/futex.rs
@@ -6,17 +6,23 @@
 //! primitives.
 #![allow(unsafe_code)]
 
+use core::num::NonZeroU32;
+use core::ptr;
+use core::sync::atomic::AtomicU32;
+
+use crate::fd::{FromRawFd, OwnedFd};
 use crate::thread::Timespec;
 use crate::{backend, io};
 
-pub use backend::thread::futex::{FutexFlags, FutexOperation};
+pub use backend::thread::futex::FutexFlags;
+use backend::thread::futex::FutexOperation;
 
 /// `FUTEX_WAITERS`
 pub const FUTEX_WAITERS: u32 = backend::thread::futex::FUTEX_WAITERS;
 /// `FUTEX_OWNER_DIED`
 pub const FUTEX_OWNER_DIED: u32 = backend::thread::futex::FUTEX_OWNER_DIED;
 
-/// `futex(uaddr, op, val, utime, uaddr2, val3)`
+/// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_WAIT, val, timeout, NULL, 0)`
 ///
 /// # References
 ///  - [Linux `futex` system call]
@@ -30,14 +36,499 @@ pub const FUTEX_OWNER_DIED: u32 = backend::thread::futex::FUTEX_OWNER_DIED;
 /// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 /// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
 #[inline]
-pub unsafe fn futex(
-    uaddr: *mut u32,
-    op: FutexOperation,
+pub unsafe fn futex_wait(
+    uaddr: &AtomicU32,
     flags: FutexFlags,
     val: u32,
-    utime: *const Timespec,
-    uaddr2: *mut u32,
+    timeout: Option<Timespec>,
+) -> io::Result<()> {
+    backend::thread::syscalls::futex(
+        uaddr,
+        FutexOperation::Wait,
+        flags,
+        val,
+        timeout
+            .map(|timeout| &timeout as *const Timespec)
+            .unwrap_or(ptr::null()),
+        ptr::null(),
+        0,
+    )?;
+    Ok(())
+}
+
+/// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_WAKE, val, NULL, NULL, 0)`
+///
+/// # References
+///  - [Linux `futex` system call]
+///  - [Linux `futex` feature]
+///
+/// # Safety
+///
+/// This is a very low-level feature for implementing synchronization
+/// primitives. See the references links above.
+///
+/// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
+/// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
+#[inline]
+pub unsafe fn futex_wake(uaddr: &AtomicU32, flags: FutexFlags, val: u32) -> io::Result<usize> {
+    backend::thread::syscalls::futex(
+        uaddr,
+        FutexOperation::Wake,
+        flags,
+        val,
+        ptr::null(),
+        ptr::null(),
+        0,
+    )
+}
+
+/// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_FD, val, NULL, NULL, 0)`
+///
+/// # References
+///  - [Linux `futex` system call]
+///  - [Linux `futex` feature]
+///
+/// # Safety
+///
+/// This is a very low-level feature for implementing synchronization
+/// primitives. See the references links above.
+///
+/// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
+/// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
+#[inline]
+pub unsafe fn futex_fd(uaddr: &AtomicU32, flags: FutexFlags, val: u32) -> io::Result<OwnedFd> {
+    backend::thread::syscalls::futex(
+        uaddr,
+        FutexOperation::Fd,
+        flags,
+        val,
+        ptr::null(),
+        ptr::null(),
+        0,
+    )
+    .map(|fd| OwnedFd::from_raw_fd(fd.try_into().expect("return value should be a valid fd")))
+}
+
+/// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_REQUEUE, val, val2, uaddr2, 0)`
+///
+/// # References
+///  - [Linux `futex` system call]
+///  - [Linux `futex` feature]
+///
+/// # Safety
+///
+/// This is a very low-level feature for implementing synchronization
+/// primitives. See the references links above.
+///
+/// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
+/// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
+#[inline]
+pub unsafe fn futex_requeue(
+    uaddr: &AtomicU32,
+    flags: FutexFlags,
+    val: u32,
+    val2: u32,
+    uaddr2: &AtomicU32,
+) -> io::Result<usize> {
+    // the least significant four bytes of the timeout pointer are used as `val2`.
+    // ["the kernel casts the timeout value first to unsigned long, then to uint32_t"](https://man7.org/linux/man-pages/man2/futex.2.html),
+    // so we perform that exact conversion in reverse to create the pointer.
+    let timeout = val2 as usize as *const Timespec;
+    backend::thread::syscalls::futex(
+        uaddr,
+        FutexOperation::Requeue,
+        flags,
+        val,
+        timeout,
+        uaddr2,
+        0,
+    )
+}
+
+/// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_CMP_REQUEUE, val, val2, uaddr2, val3)`
+///
+/// # References
+///  - [Linux `futex` system call]
+///  - [Linux `futex` feature]
+///
+/// # Safety
+///
+/// This is a very low-level feature for implementing synchronization
+/// primitives. See the references links above.
+///
+/// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
+/// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
+#[inline]
+pub unsafe fn futex_cmp_requeue(
+    uaddr: &AtomicU32,
+    flags: FutexFlags,
+    val: u32,
+    val2: u32,
+    uaddr2: &AtomicU32,
     val3: u32,
 ) -> io::Result<usize> {
-    backend::thread::syscalls::futex(uaddr, op, flags, val, utime, uaddr2, val3)
+    // the least significant four bytes of the timeout pointer are used as `val2`.
+    // ["the kernel casts the timeout value first to unsigned long, then to uint32_t"](https://man7.org/linux/man-pages/man2/futex.2.html),
+    // so we perform that exact conversion in reverse to create the pointer.
+    let timeout = val2 as usize as *const Timespec;
+    backend::thread::syscalls::futex(
+        uaddr,
+        FutexOperation::CmpRequeue,
+        flags,
+        val,
+        timeout,
+        uaddr2,
+        val3,
+    )
+}
+
+/// `FUTEX_OP_*` operations for use with [`futex_wake_op`].
+///
+/// [`futex`]: crate::thread::futex
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(u32)]
+pub enum FutexOp {
+    /// `FUTEX_OP_SET`: `uaddr2 = oparg;`
+    Set = 0,
+    /// `FUTEX_OP_ADD`: `uaddr2 += oparg;`
+    Add = 1,
+    /// `FUTEX_OP_OR`: `uaddr2 |= oparg;`
+    Or = 2,
+    /// `FUTEX_OP_ANDN`: `uaddr2 &= ~oparg;`
+    AndN = 3,
+    /// `FUTEX_OP_XOR`: `uaddr2 ^= oparg;`
+    XOr = 4,
+    /// `FUTEX_OP_SET | FUTEX_OP_ARG_SHIFT`: `uaddr2 = (oparg << 1);`
+    SetShift = 0 | 8,
+    /// `FUTEX_OP_ADD | FUTEX_OP_ARG_SHIFT`: `uaddr2 += (oparg << 1);`
+    AddShift = 1 | 8,
+    /// `FUTEX_OP_OR | FUTEX_OP_ARG_SHIFT`: `uaddr2 |= (oparg << 1);`
+    OrShift = 2 | 8,
+    /// `FUTEX_OP_ANDN | FUTEX_OP_ARG_SHIFT`: `uaddr2 &= !(oparg << 1);`
+    AndNShift = 3 | 8,
+    /// `FUTEX_OP_XOR | FUTEX_OP_ARG_SHIFT`: `uaddr2 ^= (oparg << 1);`
+    XOrShift = 4 | 8,
+}
+
+/// `FUTEX_OP_CMP_*` operations for use with [`futex_wake_op`].
+///
+/// [`futex`]: crate::thread::futex
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(u32)]
+pub enum FutexOpCmp {
+    /// `FUTEX_OP_CMP_EQ`: `if oldval == cmparg { wake(); }`
+    Eq = 0,
+    /// `FUTEX_OP_CMP_EQ`: `if oldval != cmparg { wake(); }`
+    Ne = 1,
+    /// `FUTEX_OP_CMP_EQ`: `if oldval < cmparg { wake(); }`
+    Lt = 2,
+    /// `FUTEX_OP_CMP_EQ`: `if oldval <= cmparg { wake(); }`
+    Le = 3,
+    /// `FUTEX_OP_CMP_EQ`: `if oldval > cmparg { wake(); }`
+    Gt = 4,
+    /// `FUTEX_OP_CMP_EQ`: `if oldval >= cmparg { wake(); }`
+    Ge = 5,
+}
+
+/// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_WAKE_OP, val, val2, uaddr2, val3)`
+///
+/// # References
+///  - [Linux `futex` system call]
+///  - [Linux `futex` feature]
+///
+/// # Safety
+///
+/// This is a very low-level feature for implementing synchronization
+/// primitives. See the references links above.
+///
+/// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
+/// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
+#[inline]
+pub unsafe fn futex_wake_op(
+    uaddr: &AtomicU32,
+    flags: FutexFlags,
+    val: u32,
+    val2: u32,
+    uaddr2: &AtomicU32,
+    op: FutexOp,
+    cmp: FutexOpCmp,
+    oparg: u16,
+    cmparg: u16,
+) -> io::Result<usize> {
+    if oparg >= 1 << 12 || cmparg >= 1 << 12 {
+        return Err(io::Errno::INVAL);
+    }
+
+    // the least significant four bytes of the timeout pointer are used as `val2`.
+    // ["the kernel casts the timeout value first to unsigned long, then to uint32_t"](https://man7.org/linux/man-pages/man2/futex.2.html),
+    // so we perform that exact conversion in reverse to create the pointer.
+    let timeout = val2 as usize as *const Timespec;
+
+    let val3 =
+        ((op as u32) << 28) | ((cmp as u32) << 24) | ((oparg as u32) << 12) | (cmparg as u32);
+
+    backend::thread::syscalls::futex(
+        uaddr,
+        FutexOperation::WakeOp,
+        flags,
+        val,
+        timeout,
+        uaddr2,
+        val3,
+    )
+}
+
+/// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_LOCK_PI, 0, timeout, NULL, 0)`
+///
+/// # References
+///  - [Linux `futex` system call]
+///  - [Linux `futex` feature]
+///
+/// # Safety
+///
+/// This is a very low-level feature for implementing synchronization
+/// primitives. See the references links above.
+///
+/// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
+/// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
+#[inline]
+pub unsafe fn futex_lock_pi(
+    uaddr: &AtomicU32,
+    flags: FutexFlags,
+    timeout: Option<Timespec>,
+) -> io::Result<()> {
+    backend::thread::syscalls::futex(
+        uaddr,
+        FutexOperation::LockPi,
+        flags,
+        0,
+        timeout
+            .map(|timeout| &timeout as *const Timespec)
+            .unwrap_or(ptr::null()),
+        ptr::null(),
+        0,
+    )?;
+    Ok(())
+}
+
+/// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_UNLOCK_PI, 0, NULL, NULL, 0)`
+///
+/// # References
+///  - [Linux `futex` system call]
+///  - [Linux `futex` feature]
+///
+/// # Safety
+///
+/// This is a very low-level feature for implementing synchronization
+/// primitives. See the references links above.
+///
+/// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
+/// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
+#[inline]
+pub unsafe fn futex_unlock_pi(uaddr: &AtomicU32, flags: FutexFlags) -> io::Result<()> {
+    backend::thread::syscalls::futex(
+        uaddr,
+        FutexOperation::UnlockPi,
+        flags,
+        0,
+        ptr::null(),
+        ptr::null(),
+        0,
+    )?;
+    Ok(())
+}
+
+/// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_TRYLOCK_PI, 0, NULL, NULL, 0)`
+///
+/// # References
+///  - [Linux `futex` system call]
+///  - [Linux `futex` feature]
+///
+/// # Safety
+///
+/// This is a very low-level feature for implementing synchronization
+/// primitives. See the references links above.
+///
+/// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
+/// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
+#[inline]
+pub unsafe fn futex_trylock_pi(uaddr: &AtomicU32, flags: FutexFlags) -> io::Result<()> {
+    backend::thread::syscalls::futex(
+        uaddr,
+        FutexOperation::TrylockPi,
+        flags,
+        0,
+        ptr::null(),
+        ptr::null(),
+        0,
+    )?;
+    Ok(())
+}
+
+/// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_WAIT_BITSET, val, timeout/val2, NULL, val3)`
+///
+/// # References
+///  - [Linux `futex` system call]
+///  - [Linux `futex` feature]
+///
+/// # Safety
+///
+/// This is a very low-level feature for implementing synchronization
+/// primitives. See the references links above.
+///
+/// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
+/// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
+#[inline]
+pub unsafe fn futex_wait_bitset(
+    uaddr: &AtomicU32,
+    flags: FutexFlags,
+    val: u32,
+    timeout: Option<Timespec>,
+    val3: NonZeroU32,
+) -> io::Result<()> {
+    backend::thread::syscalls::futex(
+        uaddr,
+        FutexOperation::WaitBitset,
+        flags,
+        val,
+        timeout
+            .map(|timeout| &timeout as *const Timespec)
+            .unwrap_or(ptr::null()),
+        ptr::null(),
+        val3.get(),
+    )?;
+    Ok(())
+}
+
+/// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_WAKE_BITSET, val, NULL, NULL, val3)`
+///
+/// # References
+///  - [Linux `futex` system call]
+///  - [Linux `futex` feature]
+///
+/// # Safety
+///
+/// This is a very low-level feature for implementing synchronization
+/// primitives. See the references links above.
+///
+/// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
+/// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
+#[inline]
+pub unsafe fn futex_wake_bitset(
+    uaddr: &AtomicU32,
+    flags: FutexFlags,
+    val: u32,
+    val3: NonZeroU32,
+) -> io::Result<usize> {
+    backend::thread::syscalls::futex(
+        uaddr,
+        FutexOperation::WakeBitset,
+        flags,
+        val,
+        ptr::null(),
+        ptr::null(),
+        val3.get(),
+    )
+}
+
+/// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_WAIT_REQUEUE_PI, val, timeout, uaddr2, 0)`
+///
+/// # References
+///  - [Linux `futex` system call]
+///  - [Linux `futex` feature]
+///
+/// # Safety
+///
+/// This is a very low-level feature for implementing synchronization
+/// primitives. See the references links above.
+///
+/// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
+/// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
+#[inline]
+pub unsafe fn futex_wait_requeue_pi(
+    uaddr: &AtomicU32,
+    flags: FutexFlags,
+    val: u32,
+    timeout: Option<Timespec>,
+    uaddr2: &AtomicU32,
+) -> io::Result<()> {
+    backend::thread::syscalls::futex(
+        uaddr,
+        FutexOperation::WaitRequeuePi,
+        flags,
+        val,
+        timeout
+            .map(|timeout| &timeout as *const Timespec)
+            .unwrap_or(ptr::null()),
+        uaddr2,
+        0,
+    )?;
+    Ok(())
+}
+
+/// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_CMP_REQUEUE_PI, 1, val2, uaddr2, val3)`
+///
+/// # References
+///  - [Linux `futex` system call]
+///  - [Linux `futex` feature]
+///
+/// # Safety
+///
+/// This is a very low-level feature for implementing synchronization
+/// primitives. See the references links above.
+///
+/// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
+/// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
+#[inline]
+pub unsafe fn futex_cmp_requeue_pi(
+    uaddr: &AtomicU32,
+    flags: FutexFlags,
+    val2: u32,
+    uaddr2: &AtomicU32,
+    val3: u32,
+) -> io::Result<usize> {
+    // the least significant four bytes of the timeout pointer are used as `val2`.
+    // ["the kernel casts the timeout value first to unsigned long, then to uint32_t"](https://man7.org/linux/man-pages/man2/futex.2.html),
+    // so we perform that exact conversion in reverse to create the pointer.
+    let timeout = val2 as usize as *const Timespec;
+    backend::thread::syscalls::futex(
+        uaddr,
+        FutexOperation::CmpRequeuePi,
+        flags,
+        1,
+        timeout,
+        uaddr2,
+        val3,
+    )
+}
+
+/// Equivalent to `syscall(SYS_futex, uaddr, FUTEX_LOCK_PI2, 0, timeout, NULL, 0)`
+///
+/// # References
+///  - [Linux `futex` system call]
+///  - [Linux `futex` feature]
+///
+/// # Safety
+///
+/// This is a very low-level feature for implementing synchronization
+/// primitives. See the references links above.
+///
+/// [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
+/// [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
+#[inline]
+pub unsafe fn futex_lock_pi2(
+    uaddr: &AtomicU32,
+    flags: FutexFlags,
+    timeout: &Timespec,
+) -> io::Result<()> {
+    backend::thread::syscalls::futex(
+        uaddr,
+        FutexOperation::LockPi2,
+        flags,
+        0,
+        timeout,
+        ptr::null(),
+        0,
+    )?;
+    Ok(())
 }

--- a/src/thread/futex.rs
+++ b/src/thread/futex.rs
@@ -103,7 +103,8 @@ pub unsafe fn wait(
         flags,
         val,
         timeout
-            .map(|timeout| &timeout as *const Timespec)
+            .as_ref()
+            .map(|timeout| timeout as *const Timespec)
             .unwrap_or(ptr::null()),
         ptr::null(),
         0,
@@ -333,7 +334,8 @@ pub unsafe fn lock_pi(
         flags,
         0,
         timeout
-            .map(|timeout| &timeout as *const Timespec)
+            .as_ref()
+            .map(|timeout| timeout as *const Timespec)
             .unwrap_or(ptr::null()),
         ptr::null(),
         0,
@@ -422,7 +424,8 @@ pub unsafe fn wait_bitset(
         flags,
         val,
         timeout
-            .map(|timeout| &timeout as *const Timespec)
+            .as_ref()
+            .map(|timeout| timeout as *const Timespec)
             .unwrap_or(ptr::null()),
         ptr::null(),
         val3.get(),
@@ -488,7 +491,8 @@ pub unsafe fn wait_requeue_pi(
         flags,
         val,
         timeout
-            .map(|timeout| &timeout as *const Timespec)
+            .as_ref()
+            .map(|timeout| timeout as *const Timespec)
             .unwrap_or(ptr::null()),
         uaddr2,
         0,

--- a/src/thread/futex.rs
+++ b/src/thread/futex.rs
@@ -11,6 +11,11 @@ use crate::{backend, io};
 
 pub use backend::thread::futex::{FutexFlags, FutexOperation};
 
+/// `FUTEX_WAITERS`
+pub const FUTEX_WAITERS: u32 = backend::thread::futex::FUTEX_WAITERS;
+/// `FUTEX_OWNER_DIED`
+pub const FUTEX_OWNER_DIED: u32 = backend::thread::futex::FUTEX_OWNER_DIED;
+
 /// `futex(uaddr, op, val, utime, uaddr2, val3)`
 ///
 /// # References

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -16,7 +16,7 @@ mod setns;
 #[cfg(not(target_os = "redox"))]
 pub use clock::*;
 #[cfg(linux_kernel)]
-pub use futex::{futex, FutexFlags, FutexOperation};
+pub use futex::{futex, FutexFlags, FutexOperation, FUTEX_OWNER_DIED, FUTEX_WAITERS};
 #[cfg(linux_kernel)]
 pub use id::{
     gettid, set_thread_gid, set_thread_groups, set_thread_res_gid, set_thread_res_uid,

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -16,7 +16,12 @@ mod setns;
 #[cfg(not(target_os = "redox"))]
 pub use clock::*;
 #[cfg(linux_kernel)]
-pub use futex::{futex, FutexFlags, FutexOperation, FUTEX_OWNER_DIED, FUTEX_WAITERS};
+pub use futex::{
+    futex_cmp_requeue, futex_cmp_requeue_pi, futex_fd, futex_lock_pi, futex_lock_pi2,
+    futex_requeue, futex_trylock_pi, futex_unlock_pi, futex_wait, futex_wait_bitset,
+    futex_wait_requeue_pi, futex_wake, futex_wake_bitset, futex_wake_op, FutexFlags,
+    FUTEX_OWNER_DIED, FUTEX_WAITERS,
+};
 #[cfg(linux_kernel)]
 pub use id::{
     gettid, set_thread_gid, set_thread_groups, set_thread_res_gid, set_thread_res_uid,

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -3,7 +3,7 @@
 #[cfg(not(target_os = "redox"))]
 mod clock;
 #[cfg(linux_kernel)]
-mod futex;
+pub mod futex;
 #[cfg(linux_kernel)]
 mod id;
 #[cfg(linux_kernel)]
@@ -16,12 +16,8 @@ mod setns;
 #[cfg(not(target_os = "redox"))]
 pub use clock::*;
 #[cfg(linux_kernel)]
-pub use futex::{
-    futex_cmp_requeue, futex_cmp_requeue_pi, futex_fd, futex_lock_pi, futex_lock_pi2,
-    futex_requeue, futex_trylock_pi, futex_unlock_pi, futex_wait, futex_wait_bitset,
-    futex_wait_requeue_pi, futex_wake, futex_wake_bitset, futex_wake_op, FutexFlags,
-    FUTEX_OWNER_DIED, FUTEX_WAITERS,
-};
+#[allow(deprecated)]
+pub use futex::{futex, FutexFlags, FutexOperation, FUTEX_OWNER_DIED, FUTEX_WAITERS};
 #[cfg(linux_kernel)]
 pub use id::{
     gettid, set_thread_gid, set_thread_groups, set_thread_res_gid, set_thread_res_uid,

--- a/tests/thread/futex.rs
+++ b/tests/thread/futex.rs
@@ -1,0 +1,91 @@
+use core::sync::atomic::{AtomicU32, Ordering};
+use rustix::{
+    io::Errno,
+    thread::{futex, FutexFlags},
+};
+
+#[test]
+fn test_lock_unlock_pi() {
+    let lock = AtomicU32::new(0);
+    unsafe {
+        futex::lock_pi(&lock, FutexFlags::empty(), None).unwrap();
+    }
+    assert_ne!(lock.load(Ordering::SeqCst), 0);
+
+    let err = unsafe { futex::lock_pi(&lock, FutexFlags::empty(), None).unwrap_err() };
+    assert_eq!(err, Errno::DEADLK);
+
+    unsafe {
+        futex::unlock_pi(&lock, FutexFlags::empty()).unwrap();
+    }
+    assert_eq!(lock.load(Ordering::SeqCst), 0);
+
+    let err = unsafe { futex::unlock_pi(&lock, FutexFlags::empty()).unwrap_err() };
+    assert_eq!(err, Errno::PERM);
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn test_wait_wake() {
+    let lock = std::sync::Arc::new(AtomicU32::new(0));
+
+    match unsafe { futex::wait(&lock, FutexFlags::empty(), 1, None) } {
+			Ok(()) => panic!("Nobody should be waking us!"),
+			Err(Errno::AGAIN) => assert_eq!(lock.load(Ordering::SeqCst), 0, "the lock should still be 0"),
+			Err(err) => panic!("{err}"),
+	}
+
+    let other = std::thread::spawn({
+        let lock = lock.clone();
+        move || {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+						lock.store(1, Ordering::SeqCst);
+            unsafe {
+                futex::wake(&lock, FutexFlags::empty(), 1);
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(50));
+						match unsafe { futex::wait(&lock, FutexFlags::empty(), 1, None) } {
+								Ok(()) => (),
+								Err(Errno::AGAIN) => assert_eq!(lock.load(Ordering::SeqCst), 2, "the lock should now be 2"),
+								Err(err) => panic!("{err}"),
+						}
+        }
+    });
+
+    match unsafe { futex::wait(&lock, FutexFlags::empty(), 0, None) } {
+        Ok(()) => (),
+        Err(Errno::AGAIN) => assert_eq!(lock.load(Ordering::SeqCst), 1, "the lock should now be 1"),
+        Err(err) => panic!("{err}"),
+    }
+
+		lock.store(2, Ordering::SeqCst);
+		unsafe {
+				futex::wake(&lock, FutexFlags::empty(), 1);
+		}
+
+		other.join().unwrap();
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn test_timeout() {
+    use rustix::fs::Timespec;
+
+    let lock = AtomicU32::new(0);
+		
+    let err = unsafe {
+			futex::wait(&lock, FutexFlags::empty(), 0, Some(Timespec{tv_sec: 1, tv_nsec: 13})).unwrap_err()
+		};
+		assert_eq!(err, Errno::TIMEDOUT);
+		
+    let err = unsafe {
+			futex::wait(&lock, FutexFlags::empty(), 0, Some(Timespec{tv_sec: 0, tv_nsec: 1_000_000_000})).unwrap_err()
+		};
+		assert_eq!(err, Errno::INVAL);
+		
+    let err = unsafe {
+			futex::wait(&lock, FutexFlags::empty(), 0, Some(Timespec{tv_sec: -1, tv_nsec: 0})).unwrap_err()
+		};
+		assert_eq!(err, Errno::INVAL);
+}

--- a/tests/thread/futex.rs
+++ b/tests/thread/futex.rs
@@ -7,20 +7,16 @@ use rustix::{
 #[test]
 fn test_lock_unlock_pi() {
     let lock = AtomicU32::new(0);
-    unsafe {
-        futex::lock_pi(&lock, FutexFlags::empty(), None).unwrap();
-    }
+    futex::lock_pi(&lock, FutexFlags::empty(), None).unwrap();
     assert_ne!(lock.load(Ordering::SeqCst), 0);
 
     let err = unsafe { futex::lock_pi(&lock, FutexFlags::empty(), None).unwrap_err() };
     assert_eq!(err, Errno::DEADLK);
 
-    unsafe {
-        futex::unlock_pi(&lock, FutexFlags::empty()).unwrap();
-    }
+    futex::unlock_pi(&lock, FutexFlags::empty()).unwrap();
     assert_eq!(lock.load(Ordering::SeqCst), 0);
 
-    let err = unsafe { futex::unlock_pi(&lock, FutexFlags::empty()).unwrap_err() };
+    let err = futex::unlock_pi(&lock, FutexFlags::empty()).unwrap_err();
     assert_eq!(err, Errno::PERM);
 }
 
@@ -29,7 +25,7 @@ fn test_lock_unlock_pi() {
 fn test_wait_wake() {
     let lock = std::sync::Arc::new(AtomicU32::new(0));
 
-    match unsafe { futex::wait(&lock, FutexFlags::empty(), 1, None) } {
+    match futex::wait(&lock, FutexFlags::empty(), 1, None) {
         Ok(()) => panic!("Nobody should be waking us!"),
         Err(Errno::AGAIN) => {
             assert_eq!(lock.load(Ordering::SeqCst), 0, "the lock should still be 0")
@@ -42,12 +38,10 @@ fn test_wait_wake() {
         move || {
             std::thread::sleep(std::time::Duration::from_millis(1));
             lock.store(1, Ordering::SeqCst);
-            unsafe {
-                futex::wake(&lock, FutexFlags::empty(), 1);
-            }
+            futex::wake(&lock, FutexFlags::empty(), 1);
 
             std::thread::sleep(std::time::Duration::from_millis(50));
-            match unsafe { futex::wait(&lock, FutexFlags::empty(), 1, None) } {
+            match futex::wait(&lock, FutexFlags::empty(), 1, None) {
                 Ok(()) => (),
                 Err(Errno::AGAIN) => {
                     assert_eq!(lock.load(Ordering::SeqCst), 2, "the lock should now be 2")
@@ -57,16 +51,14 @@ fn test_wait_wake() {
         }
     });
 
-    match unsafe { futex::wait(&lock, FutexFlags::empty(), 0, None) } {
+    match futex::wait(&lock, FutexFlags::empty(), 0, None) {
         Ok(()) => (),
         Err(Errno::AGAIN) => assert_eq!(lock.load(Ordering::SeqCst), 1, "the lock should now be 1"),
         Err(err) => panic!("{err}"),
     }
 
     lock.store(2, Ordering::SeqCst);
-    unsafe {
-        futex::wake(&lock, FutexFlags::empty(), 1);
-    }
+    futex::wake(&lock, FutexFlags::empty(), 1);
 
     other.join().unwrap();
 }
@@ -78,45 +70,39 @@ fn test_timeout() {
 
     let lock = AtomicU32::new(0);
 
-    let err = unsafe {
-        futex::wait(
-            &lock,
-            FutexFlags::empty(),
-            0,
-            Some(Timespec {
-                tv_sec: 1,
-                tv_nsec: 13,
-            }),
-        )
-        .unwrap_err()
-    };
+    let err = futex::wait(
+        &lock,
+        FutexFlags::empty(),
+        0,
+        Some(Timespec {
+            tv_sec: 1,
+            tv_nsec: 13,
+        }),
+    )
+    .unwrap_err();
     assert_eq!(err, Errno::TIMEDOUT);
 
-    let err = unsafe {
-        futex::wait(
-            &lock,
-            FutexFlags::empty(),
-            0,
-            Some(Timespec {
-                tv_sec: 0,
-                tv_nsec: 1_000_000_000,
-            }),
-        )
-        .unwrap_err()
-    };
+    let err = futex::wait(
+        &lock,
+        FutexFlags::empty(),
+        0,
+        Some(Timespec {
+            tv_sec: 0,
+            tv_nsec: 1_000_000_000,
+        }),
+    )
+    .unwrap_err();
     assert_eq!(err, Errno::INVAL);
 
-    let err = unsafe {
-        futex::wait(
-            &lock,
-            FutexFlags::empty(),
-            0,
-            Some(Timespec {
-                tv_sec: -1,
-                tv_nsec: 0,
-            }),
-        )
-        .unwrap_err()
-    };
+    let err = futex::wait(
+        &lock,
+        FutexFlags::empty(),
+        0,
+        Some(Timespec {
+            tv_sec: -1,
+            tv_nsec: 0,
+        }),
+    )
+    .unwrap_err();
     assert_eq!(err, Errno::INVAL);
 }

--- a/tests/thread/main.rs
+++ b/tests/thread/main.rs
@@ -6,6 +6,8 @@
 #[cfg(not(target_os = "redox"))]
 mod clocks;
 #[cfg(linux_kernel)]
+mod futex;
+#[cfg(linux_kernel)]
 mod id;
 #[cfg(linux_kernel)]
 mod libcap;


### PR DESCRIPTION
This PR splits `futex` into a zoo of `futex_*` functions with different and correctly typed arguments.

There are still a few open issues and questions:
1. The `futex` syscall treats one of its arguments as _either_ a _nullable_ `*const Timespec` _or_ a `u32`, depending on the context. The `futex_time64` fallback to `futex_old` uses `NOSYS` as its deciding factor, which can also be generated in other ways. This may lead to `futex_old` dereferencing an invalid pointer (because it is null, or not a pointer in the first place). As we now have different entrypoints that know whether the value should be a nullable pointer or a `u32`, I would suggest splitting up the backend `futex` functions into two variants (each) with different signatures. This would prevent a fallback to `futex_old` happening when the argument is not a pointer. Adding the null check is then trivial.
2. There are two flags that may sometimes change the function behavior. The first flag, `FUTEX_PRIVATE_FLAG` basically just says whether the lock(s) are guaranteed to be process-private (for some kernel optimizations). It is available for every single function. The second flag `FUTEX_CLOCK_REALTIME` changes how the timeout is interpreted in a few functions. Removing those flags by way of introducing more functions is viable, but I am unsure if it really makes sense to add that many more functions. Since their meaning is very different, I would suggest splitting them into two enums (`FutexPrivacy::Shared` and `FutexPrivacy::ProcessPrivate`, and `FutexClock::Realtime` and `FutexClock::Monotone`) and making them two arguments. It might even make sense to take them as compile time parameters. What do you think?
3. There are (already) a lot of functions. Instead of having them be global functions, there could be a `struct Futex<'a>(&'a AtomicU32);` (and similarly `FutexPI`), which then could show only the functions applicable to that scenario. E.g., `Futex(&word).cmp_requeue(...)` and `FutexPI(&word).cmp_requeue(...)` would call `futex_cmp_requeue` and `futex_cmp_requeue_pi` respectively without polluting each other's namespace. While this would make the API a bit nicer, I fear it would suggest that it does more than just the syscalls. What do you prefer?
4. While I have not done so right now, it should be possible to retain the old `futex` API, so as to be semver compatible - ideally with a `#[deprecated]`. Would this be important to you? If so, should `FutexOperations` be retained in a way that does not add any new variants?

This PR implements #214 and one point from #753 (`futex`'s first argument should be `Atomic`) and builds on the changes from #1097.

