### PR TITLE
Unify inotify public interface across backends and accept `impl AsFd`

### DIFF
--- a/src/backend/linux_raw/fs/inotify.rs
+++ b/src/backend/linux_raw/fs/inotify.rs
@@ -1,9 +1,6 @@
 //! inotify support for working with inotifies
 
 use crate::backend::c;
-use crate::backend::fs::syscalls;
-use crate::fd::{BorrowedFd, OwnedFd};
-use crate::io;
 use bitflags::bitflags;
 
 bitflags! {
@@ -78,41 +75,4 @@ bitflags! {
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
         const _ = !0;
     }
-}
-
-/// `inotify_init1(flags)`—Creates a new inotify object.
-///
-/// Use the [`CreateFlags::CLOEXEC`] flag to prevent the resulting file
-/// descriptor from being implicitly passed across `exec` boundaries.
-#[doc(alias = "inotify_init1")]
-#[inline]
-pub fn inotify_init(flags: CreateFlags) -> io::Result<OwnedFd> {
-    syscalls::inotify_init1(flags)
-}
-
-/// `inotify_add_watch(self, path, flags)`—Adds a watch to inotify.
-///
-/// This registers or updates a watch for the filesystem path `path` and
-/// returns a watch descriptor corresponding to this watch.
-///
-/// Note: Due to the existence of hardlinks, providing two different paths to
-/// this method may result in it returning the same watch descriptor. An
-/// application should keep track of this externally to avoid logic errors.
-#[inline]
-pub fn inotify_add_watch<P: crate::path::Arg>(
-    inot: BorrowedFd<'_>,
-    path: P,
-    flags: WatchFlags,
-) -> io::Result<i32> {
-    path.into_with_c_str(|path| syscalls::inotify_add_watch(inot, path, flags))
-}
-
-/// `inotify_rm_watch(self, wd)`—Removes a watch from this inotify.
-///
-/// The watch descriptor provided should have previously been returned by
-/// [`inotify_add_watch`] and not previously have been removed.
-#[doc(alias = "inotify_rm_watch")]
-#[inline]
-pub fn inotify_remove_watch(inot: BorrowedFd<'_>, wd: i32) -> io::Result<()> {
-    syscalls::inotify_rm_watch(inot, wd)
 }

--- a/src/fs/inotify.rs
+++ b/src/fs/inotify.rs
@@ -1,0 +1,43 @@
+//! inotify support for working with inotifies
+
+pub use crate::backend::fs::inotify::{CreateFlags, WatchFlags};
+use crate::backend::fs::syscalls;
+use crate::fd::{BorrowedFd, OwnedFd};
+use crate::io;
+
+/// `inotify_init1(flags)`—Creates a new inotify object.
+///
+/// Use the [`CreateFlags::CLOEXEC`] flag to prevent the resulting file
+/// descriptor from being implicitly passed across `exec` boundaries.
+#[doc(alias = "inotify_init1")]
+#[inline]
+pub fn inotify_init(flags: CreateFlags) -> io::Result<OwnedFd> {
+    syscalls::inotify_init1(flags)
+}
+
+/// `inotify_add_watch(self, path, flags)`—Adds a watch to inotify.
+///
+/// This registers or updates a watch for the filesystem path `path` and
+/// returns a watch descriptor corresponding to this watch.
+///
+/// Note: Due to the existence of hardlinks, providing two different paths to
+/// this method may result in it returning the same watch descriptor. An
+/// application should keep track of this externally to avoid logic errors.
+#[inline]
+pub fn inotify_add_watch<P: crate::path::Arg>(
+    inot: BorrowedFd<'_>,
+    path: P,
+    flags: WatchFlags,
+) -> io::Result<i32> {
+    path.into_with_c_str(|path| syscalls::inotify_add_watch(inot, path, flags))
+}
+
+/// `inotify_rm_watch(self, wd)`—Removes a watch from this inotify.
+///
+/// The watch descriptor provided should have previously been returned by
+/// [`inotify_add_watch`] and not previously have been removed.
+#[doc(alias = "inotify_rm_watch")]
+#[inline]
+pub fn inotify_remove_watch(inot: BorrowedFd<'_>, wd: i32) -> io::Result<()> {
+    syscalls::inotify_rm_watch(inot, wd)
+}

--- a/src/fs/inotify.rs
+++ b/src/fs/inotify.rs
@@ -2,7 +2,7 @@
 
 pub use crate::backend::fs::inotify::{CreateFlags, WatchFlags};
 use crate::backend::fs::syscalls;
-use crate::fd::{BorrowedFd, OwnedFd};
+use crate::fd::{AsFd, OwnedFd};
 use crate::io;
 
 /// `inotify_init1(flags)`—Creates a new inotify object.
@@ -25,11 +25,11 @@ pub fn inotify_init(flags: CreateFlags) -> io::Result<OwnedFd> {
 /// application should keep track of this externally to avoid logic errors.
 #[inline]
 pub fn inotify_add_watch<P: crate::path::Arg>(
-    inot: BorrowedFd<'_>,
+    inot: impl AsFd,
     path: P,
     flags: WatchFlags,
 ) -> io::Result<i32> {
-    path.into_with_c_str(|path| syscalls::inotify_add_watch(inot, path, flags))
+    path.into_with_c_str(|path| syscalls::inotify_add_watch(inot.as_fd(), path, flags))
 }
 
 /// `inotify_rm_watch(self, wd)`—Removes a watch from this inotify.
@@ -38,6 +38,6 @@ pub fn inotify_add_watch<P: crate::path::Arg>(
 /// [`inotify_add_watch`] and not previously have been removed.
 #[doc(alias = "inotify_rm_watch")]
 #[inline]
-pub fn inotify_remove_watch(inot: BorrowedFd<'_>, wd: i32) -> io::Result<()> {
-    syscalls::inotify_rm_watch(inot, wd)
+pub fn inotify_remove_watch(inot: impl AsFd, wd: i32) -> io::Result<()> {
+    syscalls::inotify_rm_watch(inot.as_fd(), wd)
 }

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -33,6 +33,8 @@ mod getpath;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have get[gpu]id.
 mod id;
 #[cfg(linux_kernel)]
+pub mod inotify;
+#[cfg(linux_kernel)]
 mod ioctl;
 #[cfg(not(any(
     target_os = "espidf",
@@ -66,8 +68,6 @@ mod sync;
 #[cfg(any(apple, linux_kernel, target_os = "hurd"))]
 mod xattr;
 
-#[cfg(linux_kernel)]
-pub use crate::backend::fs::inotify;
 pub use abs::*;
 #[cfg(not(target_os = "redox"))]
 pub use at::*;


### PR DESCRIPTION
It currently only accepts a `BorrowedFd` which is annoying. Pretty sure this is a backwards compatible change.