### PR TITLE
Add uninit buffer ancillary APIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -267,5 +267,11 @@ argument optionallly containing a raw file descriptor.
 
 [`rustix::io_uring::io_uring_setup`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/fn.io_uring_setup.html
 
+The buffer for [`SendAncillaryBuffer`] and [`RecvAncillaryBuffer`] is now
+a `[MaybeUninit<u8>]` instead of a `[u8]`.
+
+[`SendAncillaryBuffer`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.SendAncillaryBuffer.html
+[`RecvAncillaryBuffer`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.RecvAncillaryBuffer.html
+
 All explicitly deprecated functions and types have been removed. Their
 deprecation messages will have identified alternatives.

--- a/src/net/send_recv/msg.rs
+++ b/src/net/send_recv/msg.rs
@@ -248,7 +248,8 @@ impl<'buf, 'slice, 'fd> SendAncillaryBuffer<'buf, 'slice, 'fd> {
     /// [`send`]: crate::net::send
     #[inline]
     pub fn new(buffer: &'buf mut [u8]) -> Self {
-        // SAFETY: T -> MaybeUninit<T> is always safe and we never uninitialize any bytes.
+        // SAFETY: T -> MaybeUninit<T> is always safe and we never uninitialize any
+        // bytes.
         Self::new_(unsafe { core::mem::transmute::<&mut [u8], &mut [MaybeUninit<u8>]>(buffer) })
     }
 
@@ -424,7 +425,8 @@ impl<'buf> RecvAncillaryBuffer<'buf> {
     /// [`recv`]: crate::net::recv
     #[inline]
     pub fn new(buffer: &'buf mut [u8]) -> Self {
-        // SAFETY: T -> MaybeUninit<T> is always safe and we never uninitialize any bytes.
+        // SAFETY: T -> MaybeUninit<T> is always safe and we never uninitialize any
+        // bytes.
         Self::new_(unsafe { core::mem::transmute::<&mut [u8], &mut [MaybeUninit<u8>]>(buffer) })
     }
 

--- a/src/net/send_recv/msg.rs
+++ b/src/net/send_recv/msg.rs
@@ -184,15 +184,9 @@ pub struct SendAncillaryBuffer<'buf, 'slice, 'fd> {
     _phantom: PhantomData<&'slice [BorrowedFd<'fd>]>,
 }
 
-impl<'buf> From<&'buf mut [u8]> for SendAncillaryBuffer<'buf, '_, '_> {
-    fn from(buffer: &'buf mut [u8]) -> Self {
-        Self::new(buffer)
-    }
-}
-
 impl<'buf> From<&'buf mut [MaybeUninit<u8>]> for SendAncillaryBuffer<'buf, '_, '_> {
     fn from(buffer: &'buf mut [MaybeUninit<u8>]) -> Self {
-        Self::new_(buffer)
+        Self::new(buffer)
     }
 }
 
@@ -217,9 +211,10 @@ impl<'buf, 'slice, 'fd> SendAncillaryBuffer<'buf, 'slice, 'fd> {
     ///
     /// Allocate a buffer for a single file descriptor:
     /// ```
+    /// # use core::mem::MaybeUninit;
     /// # use rustix::cmsg_space;
     /// # use rustix::net::SendAncillaryBuffer;
-    /// let mut space = [0; rustix::cmsg_space!(ScmRights(1))];
+    /// let mut space = [MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(1))];
     /// let mut cmsg_buffer = SendAncillaryBuffer::new(&mut space);
     /// ```
     ///
@@ -227,9 +222,10 @@ impl<'buf, 'slice, 'fd> SendAncillaryBuffer<'buf, 'slice, 'fd> {
     /// ```
     /// # #[cfg(linux_kernel)]
     /// # {
+    /// # use core::mem::MaybeUninit;
     /// # use rustix::cmsg_space;
     /// # use rustix::net::SendAncillaryBuffer;
-    /// let mut space = [0; rustix::cmsg_space!(ScmCredentials(1))];
+    /// let mut space = [MaybeUninit::uninit(); rustix::cmsg_space!(ScmCredentials(1))];
     /// let mut cmsg_buffer = SendAncillaryBuffer::new(&mut space);
     /// # }
     /// ```
@@ -238,22 +234,17 @@ impl<'buf, 'slice, 'fd> SendAncillaryBuffer<'buf, 'slice, 'fd> {
     /// ```
     /// # #[cfg(linux_kernel)]
     /// # {
+    /// # use core::mem::MaybeUninit;
     /// # use rustix::cmsg_space;
     /// # use rustix::net::SendAncillaryBuffer;
-    /// let mut space = [0; rustix::cmsg_space!(ScmRights(2), ScmCredentials(1))];
+    /// let mut space = [MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(2), ScmCredentials(1))];
     /// let mut cmsg_buffer = SendAncillaryBuffer::new(&mut space);
     /// # }
     /// ```
     ///
     /// [`send`]: crate::net::send
     #[inline]
-    pub fn new(buffer: &'buf mut [u8]) -> Self {
-        // SAFETY: T -> MaybeUninit<T> is always safe and we never uninitialize any
-        // bytes.
-        Self::new_(unsafe { core::mem::transmute::<&mut [u8], &mut [MaybeUninit<u8>]>(buffer) })
-    }
-
-    fn new_(buffer: &'buf mut [MaybeUninit<u8>]) -> Self {
+    pub fn new(buffer: &'buf mut [MaybeUninit<u8>]) -> Self {
         Self {
             buffer: align_for_cmsghdr(buffer),
             length: 0,
@@ -371,15 +362,9 @@ pub struct RecvAncillaryBuffer<'buf> {
     length: usize,
 }
 
-impl<'buf> From<&'buf mut [u8]> for RecvAncillaryBuffer<'buf> {
-    fn from(buffer: &'buf mut [u8]) -> Self {
-        Self::new(buffer)
-    }
-}
-
 impl<'buf> From<&'buf mut [MaybeUninit<u8>]> for RecvAncillaryBuffer<'buf> {
     fn from(buffer: &'buf mut [MaybeUninit<u8>]) -> Self {
-        Self::new_(buffer)
+        Self::new(buffer)
     }
 }
 
@@ -394,9 +379,10 @@ impl<'buf> RecvAncillaryBuffer<'buf> {
     ///
     /// Allocate a buffer for a single file descriptor:
     /// ```
+    /// # use core::mem::MaybeUninit;
     /// # use rustix::cmsg_space;
     /// # use rustix::net::RecvAncillaryBuffer;
-    /// let mut space = [0; rustix::cmsg_space!(ScmRights(1))];
+    /// let mut space = [MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(1))];
     /// let mut cmsg_buffer = RecvAncillaryBuffer::new(&mut space);
     /// ```
     ///
@@ -404,9 +390,10 @@ impl<'buf> RecvAncillaryBuffer<'buf> {
     /// ```
     /// # #[cfg(linux_kernel)]
     /// # {
+    /// # use core::mem::MaybeUninit;
     /// # use rustix::cmsg_space;
     /// # use rustix::net::RecvAncillaryBuffer;
-    /// let mut space = [0; rustix::cmsg_space!(ScmCredentials(1))];
+    /// let mut space = [MaybeUninit::uninit(); rustix::cmsg_space!(ScmCredentials(1))];
     /// let mut cmsg_buffer = RecvAncillaryBuffer::new(&mut space);
     /// # }
     /// ```
@@ -415,22 +402,17 @@ impl<'buf> RecvAncillaryBuffer<'buf> {
     /// ```
     /// # #[cfg(linux_kernel)]
     /// # {
+    /// # use core::mem::MaybeUninit;
     /// # use rustix::cmsg_space;
     /// # use rustix::net::RecvAncillaryBuffer;
-    /// let mut space = [0; rustix::cmsg_space!(ScmRights(2), ScmCredentials(1))];
+    /// let mut space = [MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(2), ScmCredentials(1))];
     /// let mut cmsg_buffer = RecvAncillaryBuffer::new(&mut space);
     /// # }
     /// ```
     ///
     /// [`recv`]: crate::net::recv
     #[inline]
-    pub fn new(buffer: &'buf mut [u8]) -> Self {
-        // SAFETY: T -> MaybeUninit<T> is always safe and we never uninitialize any
-        // bytes.
-        Self::new_(unsafe { core::mem::transmute::<&mut [u8], &mut [MaybeUninit<u8>]>(buffer) })
-    }
-
-    fn new_(buffer: &'buf mut [MaybeUninit<u8>]) -> Self {
+    pub fn new(buffer: &'buf mut [MaybeUninit<u8>]) -> Self {
         Self {
             buffer: align_for_cmsghdr(buffer),
             read: 0,

--- a/tests/net/unix.rs
+++ b/tests/net/unix.rs
@@ -456,7 +456,7 @@ fn test_unix_msg_with_scm_rights() {
                 let data_socket = accept(&connection_socket).unwrap();
                 let mut sum = 0;
                 loop {
-                    let mut cmsg_buffer = RecvAncillaryBuffer::from(cmsg_space.as_mut_slice());
+                    let mut cmsg_buffer = RecvAncillaryBuffer::new(cmsg_space.as_mut_slice());
                     let result = recvmsg(
                         &data_socket,
                         &mut [IoSliceMut::new(&mut buffer)],
@@ -562,7 +562,7 @@ fn test_unix_msg_with_scm_rights() {
         let we = [write_end.as_fd()];
         let msg = SendAncillaryMessage::ScmRights(&we);
         let mut space = [MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(1))];
-        let mut cmsg_buffer = SendAncillaryBuffer::from(space.as_mut_slice());
+        let mut cmsg_buffer = SendAncillaryBuffer::new(space.as_mut_slice());
         assert!(cmsg_buffer.push(msg));
 
         connect(&data_socket, &addr).unwrap();
@@ -622,7 +622,7 @@ fn test_unix_peercred_explicit() {
     let ucred = sockopt::socket_peercred(&send_sock).unwrap();
     let msg = SendAncillaryMessage::ScmCredentials(ucred);
     let mut space = [MaybeUninit::uninit(); rustix::cmsg_space!(ScmCredentials(1))];
-    let mut cmsg_buffer = SendAncillaryBuffer::from(space.as_mut_slice());
+    let mut cmsg_buffer = SendAncillaryBuffer::new(space.as_mut_slice());
     assert!(cmsg_buffer.push(msg));
 
     sendmsg(
@@ -634,7 +634,7 @@ fn test_unix_peercred_explicit() {
     .unwrap();
 
     let mut cmsg_space = [MaybeUninit::uninit(); rustix::cmsg_space!(ScmCredentials(1))];
-    let mut cmsg_buffer = RecvAncillaryBuffer::from(cmsg_space.as_mut_slice());
+    let mut cmsg_buffer = RecvAncillaryBuffer::new(cmsg_space.as_mut_slice());
 
     let mut buffer = [0; BUFFER_SIZE];
     let result = recvmsg(
@@ -694,7 +694,7 @@ fn test_unix_peercred_implicit() {
     .unwrap();
 
     let mut cmsg_space = [MaybeUninit::uninit(); rustix::cmsg_space!(ScmCredentials(1))];
-    let mut cmsg_buffer = RecvAncillaryBuffer::from(cmsg_space.as_mut_slice());
+    let mut cmsg_buffer = RecvAncillaryBuffer::new(cmsg_space.as_mut_slice());
 
     let mut buffer = [0; BUFFER_SIZE];
     let result = recvmsg(
@@ -755,7 +755,7 @@ fn test_unix_msg_with_combo() {
                 let data_socket = accept(&connection_socket).unwrap();
                 let mut sum = 0;
                 loop {
-                    let mut cmsg_buffer = RecvAncillaryBuffer::from(cmsg_space.as_mut_slice());
+                    let mut cmsg_buffer = RecvAncillaryBuffer::new(cmsg_space.as_mut_slice());
                     let result = recvmsg(
                         &data_socket,
                         &mut [IoSliceMut::new(&mut buffer)],
@@ -875,7 +875,7 @@ fn test_unix_msg_with_combo() {
         let data_socket = socket(AddressFamily::UNIX, SocketType::SEQPACKET, None).unwrap();
 
         let mut space = [MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(2), ScmRights(1))];
-        let mut cmsg_buffer = SendAncillaryBuffer::from(space.as_mut_slice());
+        let mut cmsg_buffer = SendAncillaryBuffer::new(space.as_mut_slice());
 
         // Format a CMSG.
         let we = [write_end.as_fd(), another_write_end.as_fd()];

--- a/tests/net/unix_alloc.rs
+++ b/tests/net/unix_alloc.rs
@@ -453,8 +453,7 @@ fn test_unix_msg_with_scm_rights() {
                 let data_socket = accept(&connection_socket).unwrap();
                 let mut sum = 0;
                 loop {
-                    let mut cmsg_buffer =
-                        RecvAncillaryBuffer::from(cmsg_space.spare_capacity_mut());
+                    let mut cmsg_buffer = RecvAncillaryBuffer::new(cmsg_space.spare_capacity_mut());
                     let result = recvmsg(
                         &data_socket,
                         &mut [IoSliceMut::new(&mut buffer)],
@@ -560,7 +559,7 @@ fn test_unix_msg_with_scm_rights() {
         let we = [write_end.as_fd()];
         let msg = SendAncillaryMessage::ScmRights(&we);
         let mut space = Vec::with_capacity(msg.size());
-        let mut cmsg_buffer = SendAncillaryBuffer::from(space.spare_capacity_mut());
+        let mut cmsg_buffer = SendAncillaryBuffer::new(space.spare_capacity_mut());
         assert!(cmsg_buffer.push(msg));
 
         connect(&data_socket, &addr).unwrap();
@@ -625,7 +624,7 @@ fn test_unix_peercred() {
 
     let msg = SendAncillaryMessage::ScmCredentials(ucred);
     let mut space = Vec::with_capacity(msg.size());
-    let mut cmsg_buffer = SendAncillaryBuffer::from(space.spare_capacity_mut());
+    let mut cmsg_buffer = SendAncillaryBuffer::new(space.spare_capacity_mut());
     assert!(cmsg_buffer.push(msg));
 
     sendmsg(
@@ -637,7 +636,7 @@ fn test_unix_peercred() {
     .unwrap();
 
     let mut cmsg_space = Vec::with_capacity(rustix::cmsg_space!(ScmCredentials(1)));
-    let mut cmsg_buffer = RecvAncillaryBuffer::from(cmsg_space.spare_capacity_mut());
+    let mut cmsg_buffer = RecvAncillaryBuffer::new(cmsg_space.spare_capacity_mut());
 
     let mut buffer = vec![0; BUFFER_SIZE];
     recvmsg(
@@ -696,8 +695,7 @@ fn test_unix_msg_with_combo() {
                 let data_socket = accept(&connection_socket).unwrap();
                 let mut sum = 0;
                 loop {
-                    let mut cmsg_buffer =
-                        RecvAncillaryBuffer::from(cmsg_space.spare_capacity_mut());
+                    let mut cmsg_buffer = RecvAncillaryBuffer::new(cmsg_space.spare_capacity_mut());
                     let result = recvmsg(
                         &data_socket,
                         &mut [IoSliceMut::new(&mut buffer)],
@@ -817,7 +815,7 @@ fn test_unix_msg_with_combo() {
         let data_socket = socket(AddressFamily::UNIX, SocketType::SEQPACKET, None).unwrap();
 
         let mut space = Vec::with_capacity(rustix::cmsg_space!(ScmRights(1), ScmRights(2)));
-        let mut cmsg_buffer = SendAncillaryBuffer::from(space.spare_capacity_mut());
+        let mut cmsg_buffer = SendAncillaryBuffer::new(space.spare_capacity_mut());
 
         // Format a CMSG.
         let we = [write_end.as_fd(), another_write_end.as_fd()];


### PR DESCRIPTION
Pretty sure I managed to maintain backcompat via a conversion trait.

Closes #1103