### PR TITLE
Modernize epoll API

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -5,17 +5,17 @@
 use core::mem::MaybeUninit;
 use core::slice;
 
-/// Split an uninitialized byte slice into initialized and uninitialized parts.
+/// Split an uninitialized slice into initialized and uninitialized parts.
 ///
 /// # Safety
 ///
-/// At least `init` bytes must be initialized.
+/// At least `init` items must be initialized.
 #[inline]
-pub(super) unsafe fn split_init(
-    buf: &mut [MaybeUninit<u8>],
+pub(super) unsafe fn split_init<T>(
+    buf: &mut [MaybeUninit<T>],
     init: usize,
-) -> (&mut [u8], &mut [MaybeUninit<u8>]) {
+) -> (&mut [T], &mut [MaybeUninit<T>]) {
     let (init, uninit) = buf.split_at_mut(init);
-    let init = slice::from_raw_parts_mut(init.as_mut_ptr().cast::<u8>(), init.len());
+    let init = slice::from_raw_parts_mut(init.as_mut_ptr().cast::<T>(), init.len());
     (init, uninit)
 }

--- a/tests/event/epoll.rs
+++ b/tests/event/epoll.rs
@@ -41,10 +41,10 @@ fn server(ready: Arc<(Mutex<u16>, Condvar)>) {
     let mut next_data = epoll::EventData::new_u64(2);
     let mut targets = HashMap::new();
 
-    let mut event_list = epoll::EventVec::with_capacity(4);
+    let mut event_list = Vec::with_capacity(4);
     loop {
         epoll::wait(&epoll, &mut event_list, -1).unwrap();
-        for event in &event_list {
+        for event in event_list.drain(..) {
             let target = event.data;
             if target.u64() == 1 {
                 let conn_sock = accept(&listen_sock).unwrap();


### PR DESCRIPTION
This PR:
- Unifies the epoll backends
- Implements the ideas in #1100, meaning the user can now pass in a Vec and uninits with the same API
- Enables using `epoll::wait` in non-alloc crates

cc @notgull for extra review

@sunfishcode this buffer trait idea seems pretty cool, maybe we should use this pattern in other areas that take uninits?

All of this should be fully backwards compatible.