### PR TITLE
Remove incorrect mount API and allow null data arg

### DIFF
--- a/src/mount/mount_unmount.rs
+++ b/src/mount/mount_unmount.rs
@@ -14,12 +14,12 @@ use crate::{backend, io};
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/mount.2.html
 #[inline]
-pub fn mount<Source: path::Arg, Target: path::Arg, Fs: path::Arg, Data: path::Arg>(
+pub fn mount<'a, Source: path::Arg, Target: path::Arg, Fs: path::Arg>(
     source: Source,
     target: Target,
     file_system_type: Fs,
     flags: MountFlags,
-    data: impl Into<Option<Data>>,
+    data: impl Into<Option<&'a CStr>>,
 ) -> io::Result<()> {
     source.into_with_c_str(|source| {
         target.into_with_c_str(|target| {
@@ -33,41 +33,6 @@ pub fn mount<Source: path::Arg, Target: path::Arg, Fs: path::Arg, Data: path::Ar
                         data,
                     )
                 })
-            })
-        })
-    })
-}
-
-/// `mount2(source, target, filesystemtype, mountflags, data)`
-///
-/// This is same as the [`mount`], except it adds support for the source,
-/// target, and data being omitted, and the data is passed as a `CStr` rather
-/// than a `path::Arg`.
-///
-/// # References
-///  - [Linux]
-///
-/// [Linux]: https://man7.org/linux/man-pages/man2/mount.2.html
-#[inline]
-#[deprecated(note = "This API was added in error, use the expressive mount APIs instead.")]
-#[doc(hidden)]
-pub fn mount2<Source: path::Arg, Target: path::Arg, Fs: path::Arg>(
-    source: Option<Source>,
-    target: Target,
-    file_system_type: Option<Fs>,
-    flags: MountFlags,
-    data: Option<&CStr>,
-) -> io::Result<()> {
-    option_into_with_c_str(source, |source| {
-        target.into_with_c_str(|target| {
-            option_into_with_c_str(file_system_type, |file_system_type| {
-                backend::mount::syscalls::mount(
-                    source,
-                    target,
-                    file_system_type,
-                    MountFlagsArg(flags.bits()),
-                    data,
-                )
             })
         })
     })

--- a/src/mount/mount_unmount.rs
+++ b/src/mount/mount_unmount.rs
@@ -19,18 +19,18 @@ pub fn mount<Source: path::Arg, Target: path::Arg, Fs: path::Arg, Data: path::Ar
     target: Target,
     file_system_type: Fs,
     flags: MountFlags,
-    data: Data,
+    data: impl Into<Option<Data>>,
 ) -> io::Result<()> {
     source.into_with_c_str(|source| {
         target.into_with_c_str(|target| {
             file_system_type.into_with_c_str(|file_system_type| {
-                data.into_with_c_str(|data| {
+                option_into_with_c_str(data.into(), |data| {
                     backend::mount::syscalls::mount(
                         Some(source),
                         target,
                         Some(file_system_type),
                         MountFlagsArg(flags.bits()),
-                        Some(data),
+                        data,
                     )
                 })
             })
@@ -49,6 +49,8 @@ pub fn mount<Source: path::Arg, Target: path::Arg, Fs: path::Arg, Data: path::Ar
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/mount.2.html
 #[inline]
+#[deprecated(note = "This API was added in error, use the expressive mount APIs instead.")]
+#[doc(hidden)]
 pub fn mount2<Source: path::Arg, Target: path::Arg, Fs: path::Arg>(
     source: Option<Source>,
     target: Target,


### PR DESCRIPTION
Added in error in https://github.com/bytecodealliance/rustix/pull/1024 due to a misunderstanding of how the API works. I've made a tweak to the existing API to allow passing in null options (should be backwards compatible!) as some poorly designed FS might require this, but in practice you could have just passed in the empty string.