### PR TITLE
Add documentation links to `uninit` functions.

### DIFF
--- a/src/io/read_write.rs
+++ b/src/io/read_write.rs
@@ -16,6 +16,9 @@ pub use backend::io::types::ReadWriteFlags;
 
 /// `read(fd, buf)`—Reads from a stream.
 ///
+/// This takes a `&mut [u8]` which Rust requires to contain initialized memory.
+/// To use an uninitialized buffer, use [`read_uninit`].
+///
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
@@ -87,6 +90,9 @@ pub fn write<Fd: AsFd>(fd: Fd, buf: &[u8]) -> io::Result<usize> {
 }
 
 /// `pread(fd, buf, offset)`—Reads from a file at a given position.
+///
+/// This takes a `&mut [u8]` which Rust requires to contain initialized memory.
+/// To use an uninitialized buffer, use [`pread_uninit`].
 ///
 /// # References
 ///  - [POSIX]

--- a/src/net/send_recv/mod.rs
+++ b/src/net/send_recv/mod.rs
@@ -34,6 +34,9 @@ pub use msg::*;
 
 /// `recv(fd, buf, flags)`—Reads data from a socket.
 ///
+/// This takes a `&mut [u8]` which Rust requires to contain initialized memory.
+/// To use an uninitialized buffer, use [`recv_uninit`].
+///
 /// # References
 ///  - [Beej's Guide to Network Programming]
 ///  - [POSIX]
@@ -114,6 +117,9 @@ pub fn send<Fd: AsFd>(fd: Fd, buf: &[u8], flags: SendFlags) -> io::Result<usize>
 
 /// `recvfrom(fd, buf, flags, addr, len)`—Reads data from a socket and
 /// returns the sender address.
+///
+/// This takes a `&mut [u8]` which Rust requires to contain initialized memory.
+/// To use an uninitialized buffer, use [`recvfrom_uninit`].
 ///
 /// # References
 ///  - [Beej's Guide to Network Programming]

--- a/src/rand/getrandom.rs
+++ b/src/rand/getrandom.rs
@@ -11,6 +11,9 @@ pub use backend::rand::types::GetRandomFlags;
 /// This is a very low-level API which may be difficult to use correctly. Most
 /// users should prefer to use [`getrandom`] or [`rand`] APIs instead.
 ///
+/// This takes a `&mut [u8]` which Rust requires to contain initialized memory.
+/// To use an uninitialized buffer, use [`getrandom_uninit`].
+///
 /// [`getrandom`]: https://crates.io/crates/getrandom
 /// [`rand`]: https://crates.io/crates/rand
 ///


### PR DESCRIPTION
In non-`uninit` functions, add documentation links to their corresponding `uninit` functions.