### PR TITLE
Add pivot_root syscall.

### DIFF
--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -725,6 +725,17 @@ pub(crate) fn pidfd_getfd(
     }
 }
 
+#[cfg(target_os = "linux")]
+pub(crate) fn pivot_root(new_root: &CStr, put_old: &CStr) -> io::Result<()> {
+    syscall! {
+        fn pivot_root(
+            new_root: *const c::c_char,
+            put_old: *const c::c_char
+        ) via SYS_pivot_root -> c::c_int
+    }
+    unsafe { ret(pivot_root(c_str(new_root), c_str(put_old))) }
+}
+
 #[cfg(all(feature = "alloc", not(target_os = "wasi")))]
 pub(crate) fn getgroups(buf: &mut [Gid]) -> io::Result<usize> {
     let len = buf.len().try_into().map_err(|_| io::Errno::NOMEM)?;

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -601,6 +601,12 @@ pub(crate) fn pidfd_send_signal(fd: BorrowedFd<'_>, sig: Signal) -> io::Result<(
     }
 }
 
+#[cfg(feature = "fs")]
+#[inline]
+pub(crate) fn pivot_root(new_root: &CStr, put_old: &CStr) -> io::Result<()> {
+    unsafe { ret(syscall_readonly!(__NR_pivot_root, new_root, put_old)) }
+}
+
 #[cfg(feature = "alloc")]
 #[inline]
 pub(crate) fn getgroups(buf: &mut [Gid]) -> io::Result<usize> {

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -17,6 +17,8 @@ mod membarrier;
 mod pidfd;
 #[cfg(target_os = "linux")]
 mod pidfd_getfd;
+#[cfg(target_os = "linux")]
+mod pivot_root;
 #[cfg(linux_kernel)]
 mod prctl;
 #[cfg(not(any(target_os = "fuchsia", target_os = "vita", target_os = "wasi")))]
@@ -57,6 +59,8 @@ pub use membarrier::*;
 pub use pidfd::*;
 #[cfg(target_os = "linux")]
 pub use pidfd_getfd::*;
+#[cfg(target_os = "linux")]
+pub use pivot_root::*;
 #[cfg(linux_kernel)]
 pub use prctl::*;
 #[cfg(not(any(target_os = "fuchsia", target_os = "vita", target_os = "wasi")))]

--- a/src/process/pivot_root.rs
+++ b/src/process/pivot_root.rs
@@ -1,0 +1,18 @@
+#[cfg(feature = "fs")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
+use crate::{backend, io, path};
+
+/// `pivot_root(new_root, put_old)`—Change the root mount.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/pivot_root.2.html
+#[cfg(feature = "fs")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
+#[inline]
+pub fn pivot_root<P: path::Arg, Q: path::Arg>(new_root: P, put_old: Q) -> io::Result<()> {
+    new_root.into_with_c_str(|new_root| {
+        put_old.into_with_c_str(|put_old| backend::process::syscalls::pivot_root(new_root, put_old))
+    })
+}


### PR DESCRIPTION
This pull-request adds the [`pivot_root`](https://man7.org/linux/man-pages/man2/pivot_root.2.html) syscall.

The implementation is behind the `fs` feature, like `chroot`.

It is only enabled on Linux. The manpages for FreeBSD, OpenBSD, and NetBSD show no results. And, according to <https://github.com/nginx/unit/issues/737>, macOS implements the syscall, but it is undocumented, and its signature is very different.

## Test Program

I tested the syscall with the following program:

```rust
// Cargo.toml
//
//   [dependencies]
//   rustix = { version = "0.38.34", path = "../rustix", features = ["fs", "mount", "process", "thread"] }

use std::{fs, io::ErrorKind};

use rustix::{
    fs::{mount, unmount, MountFlags, UnmountFlags},
    process::{chdir, pivot_root},
    thread::{unshare, UnshareFlags},
};

fn main() {
    unshare(UnshareFlags::NEWNS | UnshareFlags::NEWUSER).expect("unshare");

    fs::write("/proc/self/uid_map", "0 1000 1").expect("write uid_map");
    fs::write("/proc/self/setgroups", "deny").expect("write setgroups");
    fs::write("/proc/self/gid_map", "0 1000 1").expect("write gid_map");

    // tmpfs on /tmp
    mount(c"none", c"/tmp", c"tmpfs", MountFlags::empty(), c"").expect("mount tmpfs");

    fs::write("/tmp/file0", "").expect("write file0");
    fs::write("/tmp/file1", "").expect("write file1");

    // pivot_root to /tmp
    chdir(c"/tmp").expect("cd /tmp");
    pivot_root(c".", c".").expect("pivot_root");
    unmount(c".", UnmountFlags::DETACH).expect("unmount");

    // See the contents in root.
    chdir(c"/").expect("cd /");
    for entry in std::fs::read_dir("/").expect("read_dir /") {
        println!("{:?}", entry);
    }

    // Detect errors.
    assert_eq!(
        pivot_root(c"bad", c"path").unwrap_err().kind(),
        ErrorKind::NotFound,
    )
}
```

Output:

```console
$ ./target/debug/rustix-pivot_root
Ok(DirEntry("/file1"))
Ok(DirEntry("/file0"))
```

From `strace`:

```c
chdir("/tmp")                           = 0
pivot_root(".", ".")                    = 0
umount2(".", MNT_DETACH)                = 0
chdir("/")                              = 0
```
