### PR TITLE
Fix compilation on various `cfg` configurations

### DIFF
--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -86,18 +86,18 @@ pub(crate) const XCASE: tcflag_t = linux_raw_sys::general::XCASE as _;
 #[cfg(target_os = "aix")]
 pub(crate) const MSG_DONTWAIT: c_int = libc::MSG_NONBLOCK;
 
-// TODO: Remove once https://github.com/rust-lang/libc/pull/3377 is merged and released.
+// TODO: Remove once <https://github.com/rust-lang/libc/pull/3377> is merged and released.
 #[cfg(target_os = "netbsd")]
 #[cfg(feature = "net")]
 pub(crate) const SO_NOSIGPIPE: c_int = 0x0800;
 
-// It is defined as 0 in libc under 64-bit platforms, but is automatically set by kernel.
-// https://github.com/torvalds/linux/blob/v6.7/fs/open.c#L1458-L1459
+// It is defined as 0 in libc under 64-bit platforms, but is automatically set
+// by kernel. <https://github.com/torvalds/linux/blob/v6.7/fs/open.c#L1458-L1459>
 #[cfg(linux_kernel)]
 pub(crate) const O_LARGEFILE: c_int = linux_raw_sys::general::O_LARGEFILE as _;
 
 // Gated under `_LARGEFILE_SOURCE` but automatically set by the kernel.
-// https://github.com/illumos/illumos-gate/blob/fb2cb638e5604b214d8ea8d4f01ad2e77b437c17/usr/src/ucbhead/sys/fcntl.h#L64
+// <https://github.com/illumos/illumos-gate/blob/fb2cb638e5604b214d8ea8d4f01ad2e77b437c17/usr/src/ucbhead/sys/fcntl.h#L64>
 #[cfg(target_os = "illumos")]
 pub(crate) const O_LARGEFILE: c_int = 0x2000;
 

--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -8,7 +8,7 @@ use crate::event::PollFd;
 #[cfg(any(linux_kernel, bsd, solarish, target_os = "espidf"))]
 use crate::fd::OwnedFd;
 use crate::io;
-#[cfg(any(bsd, solarish))]
+#[cfg(any(all(feature = "alloc", bsd), solarish))]
 use {crate::backend::conv::borrowed_fd, crate::fd::BorrowedFd, core::mem::MaybeUninit};
 #[cfg(solarish)]
 use {

--- a/src/backend/libc/io/windows_syscalls.rs
+++ b/src/backend/libc/io/windows_syscalls.rs
@@ -1,6 +1,8 @@
 //! Windows system calls in the `io` module.
 
 use crate::backend::c;
+#[cfg(feature = "try_close")]
+use crate::backend::conv::ret;
 use crate::backend::conv::{borrowed_fd, ret_c_int};
 use crate::backend::fd::LibcFd;
 use crate::fd::{BorrowedFd, RawFd};
@@ -9,6 +11,11 @@ use crate::ioctl::{IoctlOutput, RawOpcode};
 
 pub(crate) unsafe fn close(raw_fd: RawFd) {
     let _ = c::close(raw_fd as LibcFd);
+}
+
+#[cfg(feature = "try_close")]
+pub(crate) unsafe fn try_close(raw_fd: RawFd) -> io::Result<()> {
+    ret(c::close(raw_fd as LibcFd))
 }
 
 #[inline]

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -5,7 +5,7 @@ use super::types::RawCpuSet;
 use crate::backend::c;
 #[cfg(not(any(target_os = "wasi", target_os = "fuchsia")))]
 use crate::backend::conv::borrowed_fd;
-#[cfg(feature = "fs")]
+#[cfg(any(target_os = "linux", feature = "fs"))]
 use crate::backend::conv::c_str;
 #[cfg(all(feature = "alloc", feature = "fs", not(target_os = "wasi")))]
 use crate::backend::conv::ret_discarded_char_ptr;
@@ -28,7 +28,7 @@ use crate::backend::conv::{ret, ret_c_int};
 use crate::fd::BorrowedFd;
 #[cfg(target_os = "linux")]
 use crate::fd::{AsRawFd, OwnedFd, RawFd};
-#[cfg(feature = "fs")]
+#[cfg(any(target_os = "linux", feature = "fs"))]
 use crate::ffi::CStr;
 #[cfg(feature = "fs")]
 use crate::fs::Mode;

--- a/src/backend/linux_raw/event/epoll.rs
+++ b/src/backend/linux_raw/event/epoll.rs
@@ -172,10 +172,11 @@ pub fn create(flags: CreateFlags) -> io::Result<OwnedFd> {
 /// This registers interest in any of the events set in `events` occurring on
 /// the file descriptor associated with `data`.
 ///
-/// Note that `close`ing a file descriptor does not necessarily unregister interest
-/// which can lead to spurious events being returned from [`wait`]. If a file descriptor
-/// is an `Arc<dyn SystemResource>`, then `epoll` can be thought to maintain a
-/// `Weak<dyn SystemResource>` to the file descriptor. Check the [faq] for details.
+/// Note that `close`ing a file descriptor does not necessarily unregister
+/// interest which can lead to spurious events being returned from [`wait`]. If
+/// a file descriptor is an `Arc<dyn SystemResource>`, then `epoll` can be
+/// thought to maintain a `Weak<dyn SystemResource>` to the file descriptor.
+/// Check the [faq] for details.
 ///
 /// # References
 ///

--- a/src/backend/linux_raw/event/syscalls.rs
+++ b/src/backend/linux_raw/event/syscalls.rs
@@ -6,10 +6,15 @@
 #![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
 use crate::backend::c;
+#[cfg(any(
+    feature = "alloc",
+    not(any(target_arch = "aarch64", target_arch = "riscv64"))
+))]
+use crate::backend::conv::c_int;
 #[cfg(feature = "alloc")]
 use crate::backend::conv::pass_usize;
 use crate::backend::conv::{
-    by_ref, c_int, c_uint, raw_fd, ret, ret_error, ret_owned_fd, ret_usize, slice_mut, zero,
+    by_ref, c_uint, raw_fd, ret, ret_error, ret_owned_fd, ret_usize, slice_mut, zero,
 };
 use crate::event::{epoll, EventfdFlags, PollFd};
 use crate::fd::{BorrowedFd, OwnedFd};

--- a/src/backend/linux_raw/mm/syscalls.rs
+++ b/src/backend/linux_raw/mm/syscalls.rs
@@ -16,8 +16,7 @@ use crate::backend::conv::loff_t_from_u64;
 use crate::backend::conv::{c_uint, no_fd, pass_usize, ret, ret_owned_fd, ret_void_star};
 use crate::fd::{BorrowedFd, OwnedFd};
 use crate::io;
-use linux_raw_sys::general::MAP_ANONYMOUS;
-use linux_raw_sys::general::MREMAP_FIXED;
+use linux_raw_sys::general::{MAP_ANONYMOUS, MREMAP_FIXED};
 
 #[inline]
 pub(crate) fn madvise(addr: *mut c::c_void, len: usize, advice: Advice) -> io::Result<()> {

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -150,7 +150,7 @@ pub use std::os::wasi::fs::{DirEntryExt, FileExt, FileTypeExt, MetadataExt, Open
 /// the Unix epoch. Until the next semver bump, these unsigned fields are
 /// deprecated, and this trait provides accessors which return their values
 /// as signed integers.
-#[cfg(all(unix))]
+#[cfg(unix)]
 pub trait StatExt {
     /// Return the value of the `st_atime` field, casted to the correct type.
     fn atime(&self) -> i64;

--- a/src/net/netdevice.rs
+++ b/src/net/netdevice.rs
@@ -2,14 +2,13 @@
 //!
 //! The methods in this module take a socket's file descriptor to communicate
 //! with the kernel in their ioctl call:
-//! - glibc uses an `AF_UNIX`, `AF_INET`, or `AF_INET6` socket.
-//! The address family itself does not matter and glibc tries the next address
-//! family if socket creation with one fails.
+//! - glibc uses an `AF_UNIX`, `AF_INET`, or `AF_INET6` socket. The address
+//!   family itself does not matter and glibc tries the next address family if
+//!   socket creation with one fails.
 //! - Android (bionic) uses an `AF_INET` socket.
 //! - Both create the socket with `SOCK_DGRAM|SOCK_CLOEXEC` type/flag.
 //! - The [man-pages] specify, that the ioctl calls "can be used on any
-//!   socket's file descriptor regardless of the
-//! family or type".
+//!   socket's file descriptor regardless of the family or type".
 //!
 //! # References
 //! - [Linux]

--- a/src/process/procctl.rs
+++ b/src/process/procctl.rs
@@ -284,6 +284,7 @@ pub fn get_reaper_status(process: ProcSelector) -> io::Result<ReaperStatus> {
     })
 }
 
+#[cfg(feature = "alloc")]
 const PROC_REAP_GETPIDS: c_int = 5;
 
 bitflags! {

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -112,8 +112,8 @@ fn test_file() {
     // Test `fcntl_getfl`.
     let fl = rustix::fs::fcntl_getfl(&file).unwrap();
 
-    // Clear O_LARGEFILE, which may be set by rustix on 32-bit Linux or automatically by some
-    // kernel on 64-bit (Linux and illumos).
+    // Clear `O_LARGEFILE`, which may be set by rustix on 32-bit Linux or
+    // automatically by some kernel on 64-bit (Linux and illumos).
     #[cfg(any(linux_kernel, target_os = "illumos"))]
     let fl = fl - rustix::fs::OFlags::LARGEFILE;
 

--- a/tests/io_uring/register.rs
+++ b/tests/io_uring/register.rs
@@ -1,11 +1,9 @@
 use libc::c_void;
-use rustix::{
-    fd::{AsFd, AsRawFd, BorrowedFd},
-    io::Result,
-    io_uring::{
-        io_uring_params, io_uring_register_with, io_uring_rsrc_update, io_uring_setup,
-        IoringFeatureFlags, IoringRegisterFlags, IoringRegisterOp,
-    },
+use rustix::fd::{AsFd, AsRawFd, BorrowedFd};
+use rustix::io::Result;
+use rustix::io_uring::{
+    io_uring_params, io_uring_register_with, io_uring_rsrc_update, io_uring_setup,
+    IoringFeatureFlags, IoringRegisterFlags, IoringRegisterOp,
 };
 
 fn do_register<FD>(
@@ -71,8 +69,8 @@ where
     Ok(())
 }
 
-/// Set bounded and unbounded async kernel worker counts to 0, to test registering with registered
-/// ring fd.
+/// Set bounded and unbounded async kernel worker counts to 0, to test
+/// registering with registered ring fd.
 fn register_iowq_max_workers<FD>(fd: FD) -> Result<()>
 where
     FD: AsFd,


### PR DESCRIPTION
Fix some clippy lints, and fix compilation on various targets with various feature flags enabled.