### PR TITLE
Add a `DROPPABLE` flag to `MapFlags`.

### DIFF
--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -101,6 +101,10 @@ pub(crate) const O_LARGEFILE: c_int = linux_raw_sys::general::O_LARGEFILE as _;
 #[cfg(target_os = "illumos")]
 pub(crate) const O_LARGEFILE: c_int = 0x2000;
 
+// TODO: This is new in Linux 6.11; remove when linux-raw-sys is updated.
+#[cfg(linux_kernel)]
+pub(crate) const MAP_DROPPABLE: u32 = 0x8;
+
 // On PowerPC, the regular `termios` has the `termios2` fields and there is no
 // `termios2`. linux-raw-sys has aliases `termios2` to `termios` to cover this
 // difference, but we still need to manually import it since `libc` doesn't

--- a/src/backend/libc/mm/types.rs
+++ b/src/backend/libc/mm/types.rs
@@ -240,6 +240,9 @@ bitflags! {
         /// `MAP_UNINITIALIZED`
         #[cfg(any())]
         const UNINITIALIZED = bitcast!(c::MAP_UNINITIALIZED);
+        /// `MAP_DROPPABLE`
+        #[cfg(linux_kernel)]
+        const DROPPABLE = bitcast!(c::MAP_DROPPABLE);
 
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
         const _ = !0;

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -317,3 +317,6 @@ mod reboot_symbols {
 }
 #[cfg(feature = "system")]
 pub(crate) use reboot_symbols::*;
+
+// TODO: This is new in Linux 6.11; remove when linux-raw-sys is updated.
+pub(crate) const MAP_DROPPABLE: u32 = 0x8;

--- a/src/backend/linux_raw/mm/types.rs
+++ b/src/backend/linux_raw/mm/types.rs
@@ -105,6 +105,8 @@ bitflags! {
         /// `MAP_UNINITIALIZED`
         #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6", target_arch = "mips64", target_arch = "mips64r6")))]
         const UNINITIALIZED = linux_raw_sys::general::MAP_UNINITIALIZED;
+        /// `MAP_DROPPABLE`
+        const DROPPABLE = c::MAP_DROPPABLE;
 
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
         const _ = !0;


### PR DESCRIPTION
Fixes #1096.