### PR TITLE
Fix `Mode::from_raw_mode` to mask out the `S_IFMT` bits.

### DIFF
--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -162,7 +162,7 @@ impl Mode {
     /// `Mode`.
     #[inline]
     pub const fn from_raw_mode(st_mode: RawMode) -> Self {
-        Self::from_bits_truncate(st_mode & !c::S_IFMT)
+        Self::from_bits_truncate(st_mode & !c::S_IFMT as RawMode)
     }
 
     /// Construct an `st_mode` value from a `Mode`.

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -162,7 +162,7 @@ impl Mode {
     /// `Mode`.
     #[inline]
     pub const fn from_raw_mode(st_mode: RawMode) -> Self {
-        Self::from_bits_truncate(st_mode)
+        Self::from_bits_truncate(st_mode & !c::S_IFMT)
     }
 
     /// Construct an `st_mode` value from a `Mode`.

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -130,7 +130,7 @@ impl Mode {
     /// `Mode`.
     #[inline]
     pub const fn from_raw_mode(st_mode: RawMode) -> Self {
-        Self::from_bits_truncate(st_mode)
+        Self::from_bits_truncate(st_mode & !linux_raw_sys::general::S_IFMT)
     }
 
     /// Construct an `st_mode` value from a `Mode`.

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -188,13 +188,13 @@ fn test_setfl_append() {
 
 #[test]
 fn test_mode() {
-    use rustix::fs::Mode;
+    use rustix::fs::{Mode, RawMode};
 
-    let mode = Mode::from_raw_mode(libc::S_IFSOCK | libc::S_IRUSR);
+    let mode = Mode::from_raw_mode((libc::S_IFSOCK | libc::S_IRUSR) as RawMode);
     assert_eq!(mode, Mode::RUSR);
-    assert_eq!(mode.bits(), libc::S_IRUSR);
+    assert_eq!(mode.bits(), libc::S_IRUSR as RawMode);
 
-    let mode = Mode::from_raw_mode(libc::S_IFSOCK | libc::S_IRWXU);
+    let mode = Mode::from_raw_mode((libc::S_IFSOCK | libc::S_IRWXU) as RawMode);
     assert_eq!(mode, Mode::RWXU);
-    assert_eq!(mode.bits(), libc::S_IRWXU);
+    assert_eq!(mode.bits(), libc::S_IRWXU as RawMode);
 }

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -185,3 +185,16 @@ fn test_setfl_append() {
     assert_eq!(rustix::io::read(&file, &mut buf), Ok(19));
     assert_eq!(&buf, b"uvwdefghijklmnopxyz\0\0\0\0\0\0\0\0\0\0\0\0\0");
 }
+
+#[test]
+fn test_mode() {
+    use rustix::fs::Mode;
+
+    let mode = Mode::from_raw_mode(libc::S_IFSOCK | libc::S_IRUSR);
+    assert_eq!(mode, Mode::RUSR);
+    assert_eq!(mode.bits(), libc::S_IRUSR);
+
+    let mode = Mode::from_raw_mode(libc::S_IFSOCK | libc::S_IRWXU);
+    assert_eq!(mode, Mode::RWXU);
+    assert_eq!(mode.bits(), libc::S_IRWXU);
+}


### PR DESCRIPTION
The `S_IFMT` bits in a `st_mode` field value hold the file type; mask them out when converting the value to a `Mode`. `Mode` can tolerate bits it doesn't recognize, however this does prevent it from being compared for equality in the obvious way.

Fixes #1104.