### PR TITLE
Switch to the well-known feature name for `docsrs`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,6 @@ harness = false
 
 [package.metadata.docs.rs]
 features = ["all-apis"]
-rustdoc-args = ["--cfg", "doc_cfg"]
 targets = [
     "x86_64-unknown-linux-gnu",
     "i686-unknown-linux-gnu",
@@ -262,7 +261,6 @@ check-cfg = [
     'cfg(core_ffi_c)',
     'cfg(core_intrinsics)',
     'cfg(criterion)',
-    'cfg(doc_cfg)',
     'cfg(document_experimental_runtime_api)',
     'cfg(fix_y2038)',
     'cfg(freebsdlike)',

--- a/src/backend/libc/event/epoll.rs
+++ b/src/backend/libc/event/epoll.rs
@@ -261,7 +261,7 @@ pub fn delete(epoll: impl AsFd, source: impl AsFd) -> io::Result<()> {
 /// For each event of interest, an element is written to `events`. On
 /// success, this returns the number of written elements.
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn wait(epoll: impl AsFd, event_list: &mut EventVec, timeout: c::c_int) -> io::Result<()> {
     // SAFETY: We're calling `epoll_wait` via FFI and we know how it
     // behaves.

--- a/src/backend/libc/fs/dir.rs
+++ b/src/backend/libc/fs/dir.rs
@@ -220,7 +220,7 @@ impl Dir {
     /// `fchdir(self)`
     #[cfg(feature = "process")]
     #[cfg(not(any(target_os = "fuchsia", target_os = "vita", target_os = "wasi")))]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "process")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "process")))]
     #[inline]
     pub fn chdir(&self) -> io::Result<()> {
         fchdir(unsafe { BorrowedFd::borrow_raw(c::dirfd(self.libc_dir.as_ptr())) })

--- a/src/backend/linux_raw/event/epoll.rs
+++ b/src/backend/linux_raw/event/epoll.rs
@@ -270,7 +270,7 @@ pub fn delete(epoll: impl AsFd, source: impl AsFd) -> io::Result<()> {
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/epoll_wait.2.html
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc"), alias = "epoll_wait"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc"), alias = "epoll_wait"))]
 #[inline]
 pub fn wait(epoll: impl AsFd, event_list: &mut EventVec, timeout: c::c_int) -> io::Result<()> {
     // SAFETY: We're calling `epoll_wait` via FFI and we know how it

--- a/src/backend/linux_raw/fs/dir.rs
+++ b/src/backend/linux_raw/fs/dir.rs
@@ -234,7 +234,7 @@ impl Dir {
 
     /// `fchdir(self)`
     #[cfg(feature = "process")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "process")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "process")))]
     #[inline]
     pub fn chdir(&self) -> io::Result<()> {
         fchdir(&self.fd)

--- a/src/io/is_read_write.rs
+++ b/src/io/is_read_write.rs
@@ -13,7 +13,7 @@ use backend::fd::AsFd;
 ///
 /// [`is_file_read_write`]: crate::fs::is_file_read_write
 #[inline]
-#[cfg_attr(doc_cfg, doc(cfg(all(feature = "fs", feature = "net"))))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "fs", feature = "net"))))]
 pub fn is_read_write<Fd: AsFd>(fd: Fd) -> io::Result<(bool, bool)> {
     backend::io::syscalls::is_read_write(fd.as_fd())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@
 #![allow(stable_features)]
 #![cfg_attr(linux_raw, deny(unsafe_code))]
 #![cfg_attr(rustc_attrs, feature(rustc_attrs))]
-#![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(all(wasi_ext, target_os = "wasi", feature = "std"), feature(wasi_ext))]
 #![cfg_attr(core_ffi_c, feature(core_ffi_c))]
 #![cfg_attr(core_c_str, feature(core_c_str))]
@@ -196,63 +196,63 @@ pub mod fd {
 
 // The public API modules.
 #[cfg(feature = "event")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "event")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "event")))]
 pub mod event;
 #[cfg(not(windows))]
 pub mod ffi;
 #[cfg(not(windows))]
 #[cfg(feature = "fs")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
 pub mod fs;
 pub mod io;
 #[cfg(linux_kernel)]
 #[cfg(feature = "io_uring")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "io_uring")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "io_uring")))]
 pub mod io_uring;
 pub mod ioctl;
 #[cfg(not(any(windows, target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 #[cfg(feature = "mm")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "mm")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "mm")))]
 pub mod mm;
 #[cfg(linux_kernel)]
 #[cfg(feature = "mount")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "mount")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "mount")))]
 pub mod mount;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[cfg(feature = "net")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "net")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "net")))]
 pub mod net;
 #[cfg(not(any(windows, target_os = "espidf")))]
 #[cfg(feature = "param")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "param")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "param")))]
 pub mod param;
 #[cfg(not(windows))]
 #[cfg(any(feature = "fs", feature = "mount", feature = "net"))]
 #[cfg_attr(
-    doc_cfg,
+    docsrs,
     doc(cfg(any(feature = "fs", feature = "mount", feature = "net")))
 )]
 pub mod path;
 #[cfg(feature = "pipe")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "pipe")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "pipe")))]
 #[cfg(not(any(windows, target_os = "wasi")))]
 pub mod pipe;
 #[cfg(not(windows))]
 #[cfg(feature = "process")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "process")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "process")))]
 pub mod process;
 #[cfg(feature = "procfs")]
 #[cfg(linux_kernel)]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "procfs")))]
 pub mod procfs;
 #[cfg(not(windows))]
 #[cfg(not(target_os = "wasi"))]
 #[cfg(feature = "pty")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "pty")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "pty")))]
 pub mod pty;
 #[cfg(not(windows))]
 #[cfg(feature = "rand")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "rand")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 pub mod rand;
 #[cfg(not(any(
     windows,
@@ -262,27 +262,27 @@ pub mod rand;
     target_os = "wasi"
 )))]
 #[cfg(feature = "shm")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "shm")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "shm")))]
 pub mod shm;
 #[cfg(not(windows))]
 #[cfg(feature = "stdio")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "stdio")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "stdio")))]
 pub mod stdio;
 #[cfg(feature = "system")]
 #[cfg(not(any(windows, target_os = "wasi")))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "system")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "system")))]
 pub mod system;
 #[cfg(not(any(windows, target_os = "vita")))]
 #[cfg(feature = "termios")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "termios")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "termios")))]
 pub mod termios;
 #[cfg(not(windows))]
 #[cfg(feature = "thread")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "thread")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "thread")))]
 pub mod thread;
 #[cfg(not(any(windows, target_os = "espidf")))]
 #[cfg(feature = "time")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "time")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 pub mod time;
 
 // "runtime" is also a public API module, but it's only for libc-like users.
@@ -290,7 +290,7 @@ pub mod time;
 #[cfg(feature = "runtime")]
 #[cfg(linux_raw)]
 #[cfg_attr(not(document_experimental_runtime_api), doc(hidden))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "runtime")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "runtime")))]
 pub mod runtime;
 
 // Temporarily provide some mount functions for use in the fs module for
@@ -315,7 +315,7 @@ pub(crate) mod mount;
         target_arch = "x86",
     )
 ))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
 pub(crate) mod fs;
 
 // Similarly, declare `path` as a non-public module if needed.

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -6,7 +6,7 @@ mod dec_int;
 
 pub use arg::{option_into_with_c_str, Arg};
 #[cfg(feature = "itoa")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "itoa")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "itoa")))]
 pub use dec_int::DecInt;
 
 pub(crate) const SMALL_PATH_BUFFER_SIZE: usize = 256;

--- a/src/process/chdir.rs
+++ b/src/process/chdir.rs
@@ -21,7 +21,7 @@ use {
 /// [Linux]: https://man7.org/linux/man-pages/man2/chdir.2.html
 #[inline]
 #[cfg(feature = "fs")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
 pub fn chdir<P: path::Arg>(path: P) -> io::Result<()> {
     path.into_with_c_str(backend::process::syscalls::chdir)
 }
@@ -52,7 +52,7 @@ pub fn fchdir<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 /// [Linux]: https://man7.org/linux/man-pages/man3/getcwd.3.html
 #[cfg(all(feature = "alloc", feature = "fs"))]
 #[cfg(not(target_os = "wasi"))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
 #[inline]
 pub fn getcwd<B: Into<Vec<u8>>>(reuse: B) -> io::Result<CString> {
     _getcwd(reuse.into())

--- a/src/process/chroot.rs
+++ b/src/process/chroot.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "fs")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
 use crate::{backend, io, path};
 
 /// `chroot(path)`—Change the process root directory.
@@ -9,7 +9,7 @@ use crate::{backend, io, path};
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/chroot.2.html
 #[cfg(feature = "fs")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
 #[inline]
 pub fn chroot<P: path::Arg>(path: P) -> io::Result<()> {
     path.into_with_c_str(backend::process::syscalls::chroot)

--- a/src/process/pivot_root.rs
+++ b/src/process/pivot_root.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "fs")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
 use crate::{backend, io, path};
 
 /// `pivot_root(new_root, put_old)`—Change the root mount.
@@ -9,7 +9,7 @@ use crate::{backend, io, path};
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/pivot_root.2.html
 #[cfg(feature = "fs")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
 #[inline]
 pub fn pivot_root<P: path::Arg, Q: path::Arg>(new_root: P, put_old: Q) -> io::Result<()> {
     new_root.into_with_c_str(|new_root| {

--- a/src/process/umask.rs
+++ b/src/process/umask.rs
@@ -14,7 +14,7 @@ use crate::fs::Mode;
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/umask.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/umask.2.html
 #[cfg(feature = "fs")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
 #[inline]
 pub fn umask(mask: Mode) -> Mode {
     backend::process::syscalls::umask(mask)

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -309,7 +309,7 @@ fn proc_self() -> io::Result<(BorrowedFd<'static>, &'static Stat)> {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man5/proc.5.html
-#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "procfs")))]
 pub fn proc_self_fd() -> io::Result<BorrowedFd<'static>> {
     static PROC_SELF_FD: StaticFd = StaticFd::new();
 
@@ -378,7 +378,7 @@ fn proc_self_fdinfo() -> io::Result<(BorrowedFd<'static>, &'static Stat)> {
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man5/proc.5.html
 #[inline]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "procfs")))]
 pub fn proc_self_fdinfo_fd<Fd: AsFd>(fd: Fd) -> io::Result<OwnedFd> {
     _proc_self_fdinfo(fd.as_fd())
 }
@@ -406,7 +406,7 @@ fn _proc_self_fdinfo(fd: BorrowedFd<'_>) -> io::Result<OwnedFd> {
 /// [Linux]: https://man7.org/linux/man-pages/man5/proc.5.html
 /// [Linux pagemap]: https://www.kernel.org/doc/Documentation/vm/pagemap.txt
 #[inline]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "procfs")))]
 pub fn proc_self_pagemap() -> io::Result<OwnedFd> {
     proc_self_file(cstr!("pagemap"))
 }
@@ -421,7 +421,7 @@ pub fn proc_self_pagemap() -> io::Result<OwnedFd> {
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man5/proc.5.html
 #[inline]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "procfs")))]
 pub fn proc_self_maps() -> io::Result<OwnedFd> {
     proc_self_file(cstr!("maps"))
 }
@@ -436,7 +436,7 @@ pub fn proc_self_maps() -> io::Result<OwnedFd> {
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man5/proc.5.html
 #[inline]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "procfs")))]
 pub fn proc_self_status() -> io::Result<OwnedFd> {
     proc_self_file(cstr!("status"))
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -338,7 +338,7 @@ pub enum Fork {
 /// [Linux]: https://man7.org/linux/man-pages/man2/execveat.2.html
 #[inline]
 #[cfg(feature = "fs")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "fs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
 pub unsafe fn execveat<Fd: AsFd>(
     dirfd: Fd,
     path: &CStr,

--- a/src/termios/tty.rs
+++ b/src/termios/tty.rs
@@ -34,7 +34,7 @@ pub fn isatty<Fd: AsFd>(fd: Fd) -> bool {
 /// [Linux]: https://man7.org/linux/man-pages/man3/ttyname.3.html
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 #[cfg(all(feature = "alloc", feature = "procfs"))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "procfs")))]
 #[doc(alias = "ttyname_r")]
 #[inline]
 pub fn ttyname<Fd: AsFd, B: Into<Vec<u8>>>(dirfd: Fd, reuse: B) -> io::Result<CString> {


### PR DESCRIPTION
Switch from using a custom `doc_cfg` feature to using the existing `docsrs` feature.