### PR TITLE
Disable the `futex` deprecation for now.

### DIFF
--- a/src/backend/libc/thread/futex.rs
+++ b/src/backend/libc/thread/futex.rs
@@ -51,6 +51,8 @@ pub(crate) enum Operation {
 /// `FUTEX_*` operations for use with the [`futex`] function.
 ///
 /// [`futex`]: fn@crate::thread::futex
+// TODO: Deprecate this now that we have a new typed API.
+/*
 #[deprecated(
     since = "0.38.35",
     note = "
@@ -58,6 +60,7 @@ pub(crate) enum Operation {
     individual functions available to perform futex operations with improved
     type safety. See the `rustix::thread::futex` module."
 )]
+*/
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u32)]
 pub enum FutexOperation {

--- a/src/backend/linux_raw/thread/futex.rs
+++ b/src/backend/linux_raw/thread/futex.rs
@@ -53,6 +53,8 @@ pub(crate) enum Operation {
 /// `FUTEX_*` operations for use with the [`futex`] function.
 ///
 /// [`futex`]: fn@crate::thread::futex
+// TODO: Deprecate this now that we have a new typed API.
+/*
 #[deprecated(
     since = "0.38.35",
     note = "
@@ -60,6 +62,7 @@ pub(crate) enum Operation {
     individual functions available to perform futex operations with improved
     type safety. See the `rustix::thread::futex` module."
 )]
+*/
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u32)]
 pub enum FutexOperation {


### PR DESCRIPTION
There are significant numbers of users using `futex`, so don't deprecate the old API for now.