### PR TITLE
Fix `elided_lifetimes_in_paths` warnings.

### DIFF
--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -200,7 +200,7 @@ pub(crate) fn epoll_create(flags: super::epoll::CreateFlags) -> io::Result<Owned
 #[cfg(any(linux_kernel, target_os = "redox"))]
 pub(crate) fn epoll_add(
     epoll: BorrowedFd<'_>,
-    source: BorrowedFd,
+    source: BorrowedFd<'_>,
     event: &crate::event::epoll::Event,
 ) -> io::Result<()> {
     // We use our own `Event` struct instead of libc's because
@@ -221,7 +221,7 @@ pub(crate) fn epoll_add(
 #[cfg(any(linux_kernel, target_os = "redox"))]
 pub(crate) fn epoll_mod(
     epoll: BorrowedFd<'_>,
-    source: BorrowedFd,
+    source: BorrowedFd<'_>,
     event: &crate::event::epoll::Event,
 ) -> io::Result<()> {
     unsafe {
@@ -237,7 +237,7 @@ pub(crate) fn epoll_mod(
 
 #[inline]
 #[cfg(any(linux_kernel, target_os = "redox"))]
-pub(crate) fn epoll_del(epoll: BorrowedFd<'_>, source: BorrowedFd) -> io::Result<()> {
+pub(crate) fn epoll_del(epoll: BorrowedFd<'_>, source: BorrowedFd<'_>) -> io::Result<()> {
     unsafe {
         ret(c::epoll_ctl(
             borrowed_fd(epoll),

--- a/src/backend/linux_raw/event/syscalls.rs
+++ b/src/backend/linux_raw/event/syscalls.rs
@@ -59,7 +59,7 @@ pub(crate) fn epoll_create(flags: epoll::CreateFlags) -> io::Result<OwnedFd> {
 #[inline]
 pub(crate) fn epoll_add(
     epfd: BorrowedFd<'_>,
-    fd: BorrowedFd,
+    fd: BorrowedFd<'_>,
     event: &epoll::Event,
 ) -> io::Result<()> {
     // SAFETY: `__NR_epoll_ctl` with `EPOLL_CTL_ADD` doesn't modify any user
@@ -78,7 +78,7 @@ pub(crate) fn epoll_add(
 #[inline]
 pub(crate) fn epoll_mod(
     epfd: BorrowedFd<'_>,
-    fd: BorrowedFd,
+    fd: BorrowedFd<'_>,
     event: &epoll::Event,
 ) -> io::Result<()> {
     // SAFETY: `__NR_epoll_ctl` with `EPOLL_CTL_MOD` doesn't modify any user
@@ -95,7 +95,7 @@ pub(crate) fn epoll_mod(
 }
 
 #[inline]
-pub(crate) fn epoll_del(epfd: BorrowedFd<'_>, fd: BorrowedFd) -> io::Result<()> {
+pub(crate) fn epoll_del(epfd: BorrowedFd<'_>, fd: BorrowedFd<'_>) -> io::Result<()> {
     // SAFETY: `__NR_epoll_ctl` with `EPOLL_CTL_DEL` doesn't access any user
     // memory.
     unsafe {

--- a/src/fs/inotify.rs
+++ b/src/fs/inotify.rs
@@ -182,7 +182,7 @@ impl<'buf, Fd: AsFd> Reader<'buf, Fd> {
     ///    error occurs.
     #[allow(unsafe_code)]
     #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> io::Result<InotifyEvent> {
+    pub fn next(&mut self) -> io::Result<InotifyEvent<'_>> {
         if self.is_buffer_empty() {
             match read_uninit(self.fd.as_fd(), self.buf).map(|(init, _)| init.len()) {
                 Ok(0) => return Err(Errno::INVAL),


### PR DESCRIPTION
Fix `elided_lifetimes_in_paths` warnings that are enabled in the libstd build.