### PR TITLE
Miscellaneous documentation fixes.

### DIFF
--- a/src/fs/inotify.rs
+++ b/src/fs/inotify.rs
@@ -8,9 +8,9 @@
 //! use std::mem::MaybeUninit;
 //!
 //! # fn test() -> io::Result<()> {
-//! // Creeate an inotify object. In this example, we use `NONBLOCK` so that
-//! // the reader fails with `WOULDBLOCk` when no events are ready. Otherwise
-//! // it will block until at least one event is ready.
+//! // Create an inotify object. In this example, we use `NONBLOCK` so that the
+//! // reader fails with `WOULDBLOCk` when no events are ready. Otherwise it
+//! // will block until at least one event is ready.
 //! let inotify = inotify::init(inotify::CreateFlags::NONBLOCK)?;
 //!
 //! // Add a directory to watch.
@@ -20,7 +20,7 @@
 //!     inotify::WatchFlags::ALL_EVENTS,
 //! )?;
 //!
-//! // Generate some events in the watched directory...
+//! // Generate some events in the watched directory…
 //!
 //! // Loop over pending events.
 //! let mut buf = [MaybeUninit::uninit(); 512];
@@ -33,7 +33,7 @@
 //!         Ok(entry) => entry,
 //!     };
 //!
-//!     // Use `entry`...
+//!     // Use `entry`…
 //! }
 //!
 //! # Ok(())

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -643,8 +643,10 @@ const fn new_raw_protocol(u: u32) -> RawProtocol {
 }
 
 /// `IPPROTO_*` and other constants for use with [`socket`], [`socket_with`],
-/// and [`socketpair`] when a nondefault value is desired. See the [`ipproto`],
-/// [`sysproto`], and [`netlink`] modules for possible values.
+/// and [`socketpair`] when a nondefault value is desired.
+///
+/// See the [`ipproto`], [`sysproto`], and [`netlink`] modules for possible
+/// values.
 ///
 /// For the default values, such as `IPPROTO_IP` or `NETLINK_ROUTE`, pass
 /// `None` as the `protocol` argument in these functions.

--- a/src/process/prctl.rs
+++ b/src/process/prctl.rs
@@ -110,10 +110,11 @@ pub fn dumpable_behavior() -> io::Result<DumpableBehavior> {
 
 const PR_SET_DUMPABLE: c_int = 4;
 
-/// Set the state of the `dumpable` attribute, which determines whether the
-/// process can be traced and whether core dumps are produced for the calling
-/// process upon delivery of a signal whose default behavior is to produce a
-/// core dump.
+/// Set the state of the `dumpable` attribute.
+///
+/// This attribute determines whether the process can be traced and whether
+/// core dumps are produced for the calling process upon delivery of a signal
+/// whose default behavior is to produce a core dump.
 ///
 /// A similar function with the same name is available on FreeBSD (as part of
 /// the `procctl` interface), but it has an extra argument which allows to

--- a/src/shm.rs
+++ b/src/shm.rs
@@ -13,7 +13,7 @@
 //! // A type describing the data to be shared.
 //! #[repr(C)]
 //! struct MyBufferType {
-//!     // ...
+//!     // …
 //! }
 //!
 //! // Create the shared memory object.
@@ -43,7 +43,7 @@
 //!     )?
 //! };
 //!
-//! // Use `ptr`...
+//! // Use `ptr`…
 //!
 //! // Remove the shared memory object name.
 //! shm::unlink(shm_path)?;


### PR DESCRIPTION
Fix a typo, fix some warnings from the new
clippy::too_long_first_doc_paragraph, and tidy up.