### PR TITLE
Re-enable several cross-compilation targets in CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -208,34 +208,25 @@ jobs:
     - run: rustup component add rust-src
     - run: cargo check -Z build-std --target x86_64-unknown-openbsd --all-targets --features=all-apis
     - run: cargo check -Z build-std --target mips64-openwrt-linux-musl --all-targets --features=all-apis
-    # Temporarily disable this because the target appears to have breakage on nightly.
-    # - run: cargo check -Z build-std --target x86_64-unknown-dragonfly --all-targets --features=all-apis
+    - run: cargo check -Z build-std --target x86_64-unknown-dragonfly --all-targets --features=all-apis
     - run: cargo check -Z build-std --target sparc-unknown-linux-gnu --all-targets --features=all-apis
-    # Temporarily disable this because the target appears to have changed and needs
-    # fixes and we transitively dev-depend on what can be an older version of rustix.
-    #- run: cargo check -Z build-std --target armv7-unknown-freebsd --all-targets --features=all-apis
-    # Omit --all-targets on gnu_ilp32 because dev-dependency tempfile depends on an older rustix
-    - run: cargo check -Z build-std --target aarch64-unknown-linux-gnu_ilp32 --features=all-apis
+    - run: cargo check -Z build-std --target armv7-unknown-freebsd --all-targets --features=all-apis
+    - run: cargo check -Z build-std --target aarch64-unknown-linux-gnu_ilp32 --all-targets --features=all-apis
     # Omit --all-targets on haiku because not all the tests build yet.
-    # Temporarily disable this because the target appears to have breakage on nightly.
-    #- run: cargo check -Z build-std --target x86_64-unknown-haiku --features=all-apis
-    # Temporarily disable this because the target appears to have breakage on nightly.
-    #- run: cargo check -Z build-std --target x86_64-uwp-windows-msvc --all-targets --features=all-apis
+    - run: cargo check -Z build-std --target x86_64-unknown-haiku --features=all-apis
+    - run: cargo check -Z build-std --target x86_64-uwp-windows-msvc --all-targets --features=all-apis
     # Temporarily disable riscv32imc-esp-espidf due to std using SOMAXCONN.
     #- run: cargo check -Z build-std --target=riscv32imc-esp-espidf --features=all-apis
     - run: cargo check -Z build-std --target=aarch64-unknown-nto-qnx710 --features=all-apis
     - run: cargo check -Z build-std --target=x86_64-pc-nto-qnx710 --features=all-apis
     # Temporarily disable --features=all-apis, which doesn't build yet.
-    # Temporarily disable this because the target appears to have breakage on nightly.
-    #- run: cargo check -Z build-std --target=armv6k-nintendo-3ds
+    - run: cargo check -Z build-std --target=armv6k-nintendo-3ds
     # Temporarily disable armv7-sony-vita-newlibeabihf due to std using SOMAXCONN.
     #- run: cargo check -Z build-std --target=armv7-sony-vita-newlibeabihf --features=all-apis
     # `std` doesn't appear to build on AIX yet, so test in `no_std` mode.
     - run: cargo check -Zbuild-std=core,alloc --target=powerpc64-ibm-aix --features=all-apis --no-default-features
-    # Disable MIPS entirely for now as it fails with errors like
-    # "Undefined temporary symbol $BB342_17".
-    #- run: cargo check -Z build-std --target=mipsel-unknown-linux-gnu --features=all-apis
-    #- run: cargo check -Z build-std --target=mips64el-unknown-linux-gnuabi64 --features=all-apis
+    - run: cargo check -Z build-std --target=mipsel-unknown-linux-gnu --features=all-apis
+    - run: cargo check -Z build-std --target=mips64el-unknown-linux-gnuabi64 --features=all-apis
 
 
   test:

--- a/build.rs
+++ b/build.rs
@@ -12,7 +12,7 @@ fn main() {
     // Gather target information.
     let arch = var("CARGO_CFG_TARGET_ARCH").unwrap();
     let env = var("CARGO_CFG_TARGET_ENV").unwrap();
-    let abi = var("CARGO_CFG_TARGET_ABI").unwrap();
+    let abi = var("CARGO_CFG_TARGET_ABI");
     let inline_asm_name = format!("{}/{}.rs", ASM_PATH, arch);
     let inline_asm_name_present = std::fs::metadata(inline_asm_name).is_ok();
     let os = var("CARGO_CFG_TARGET_OS").unwrap();
@@ -150,14 +150,14 @@ fn main() {
             || arch == "sparc"
             || arch == "x86"
             || (arch == "wasm32" && os == "emscripten")
-            || (arch == "aarch64" && os == "linux" && abi == "ilp32"))
+            || (arch == "aarch64" && os == "linux" && abi == Ok("ilp32".to_string())))
         && (apple
             || os == "android"
             || os == "emscripten"
             || os == "haiku"
             || env == "gnu"
             || (env == "musl" && arch == "x86")
-            || (arch == "aarch64" && os == "linux" && abi == "ilp32"))
+            || (arch == "aarch64" && os == "linux" && abi == Ok("ilp32".to_string())))
     {
         use_feature("fix_y2038");
     }

--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,7 @@ fn main() {
     // Gather target information.
     let arch = var("CARGO_CFG_TARGET_ARCH").unwrap();
     let env = var("CARGO_CFG_TARGET_ENV").unwrap();
+    let abi = var("CARGO_CFG_TARGET_ABI").unwrap();
     let inline_asm_name = format!("{}/{}.rs", ASM_PATH, arch);
     let inline_asm_name_present = std::fs::metadata(inline_asm_name).is_ok();
     let os = var("CARGO_CFG_TARGET_OS").unwrap();
@@ -148,13 +149,15 @@ fn main() {
             || arch == "mips"
             || arch == "sparc"
             || arch == "x86"
-            || (arch == "wasm32" && os == "emscripten"))
+            || (arch == "wasm32" && os == "emscripten")
+            || (arch == "aarch64" && os == "linux" && abi == "ilp32"))
         && (apple
             || os == "android"
             || os == "emscripten"
             || os == "haiku"
             || env == "gnu"
-            || (env == "musl" && arch == "x86"))
+            || (env == "musl" && arch == "x86")
+            || (arch == "aarch64" && os == "linux" && abi == "ilp32"))
     {
         use_feature("fix_y2038");
     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,6 +1,10 @@
 //! Utilities related to FFI bindings.
 
 // If we have std, use it.
+#[cfg(windows)]
+#[cfg(feature = "std")]
+pub use std::os::raw::{c_char, c_int, c_long, c_short, c_uint, c_ulong, c_ushort};
+#[cfg(not(windows))]
 #[cfg(feature = "std")]
 pub use {
     std::ffi::{CStr, CString, FromBytesWithNulError, NulError},
@@ -9,7 +13,12 @@ pub use {
 
 // If we don't have std, we can depend on core and alloc having these features
 // in Rust 1.64+.
+#[cfg(not(windows))]
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 pub use alloc::ffi::{CString, NulError};
+#[cfg(windows)]
+#[cfg(not(feature = "std"))]
+pub use core::ffi::{c_char, c_int, c_long, c_short, c_uint, c_ulong, c_ushort, c_void};
+#[cfg(not(windows))]
 #[cfg(not(feature = "std"))]
 pub use core::ffi::{c_char, CStr, FromBytesWithNulError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,6 @@ pub mod fd {
 #[cfg(feature = "event")]
 #[cfg_attr(docsrs, doc(cfg(feature = "event")))]
 pub mod event;
-#[cfg(not(windows))]
 pub mod ffi;
 #[cfg(not(windows))]
 #[cfg(feature = "fs")]


### PR DESCRIPTION
These targets previously had breakage on nightly, but appear to build now.

This requires enabing more of rustix::ffi on Windows.