### PR TITLE
Work around missing `TCGETS2`/`TCSETS2` on WSL and Android.

### DIFF
--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -190,7 +190,7 @@ pub(crate) use linux_raw_sys::{
         VKILL, VLNEXT, VMIN, VQUIT, VREPRINT, VSTART, VSTOP, VSUSP, VSWTC, VT0, VT1, VTDLY, VTIME,
         VWERASE, XCASE, XTABS,
     },
-    ioctl::{TCGETS2, TCSETS2, TCSETSF2, TCSETSW2, TIOCEXCL, TIOCNXCL},
+    ioctl::{TCGETS, TCGETS2, TCSETS, TCSETS2, TCSETSF2, TCSETSW2, TIOCEXCL, TIOCNXCL},
 };
 
 // On MIPS, `TCSANOW` et al have `TCSETS` added to them, so we need it to

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -810,16 +810,14 @@ pub mod speed {
     /// `u32`.
     ///
     /// On BSD platforms, integer speed values are already the same as their
-    /// encoded values, and on Linux platforms, we use `TCGETS2`/`TCSETS2` and
-    /// the `c_ispeed`/`c_ospeed` fields, except that on Linux on PowerPC on
-    /// QEMU, `TCGETS2`/`TCSETS2` don't set `c_ispeed`/`c_ospeed`.
-    #[cfg(not(any(
-        bsd,
-        all(
-            linux_kernel,
-            not(any(target_arch = "powerpc", target_arch = "powerpc64"))
-        )
-    )))]
+    /// encoded values.
+    ///
+    /// On Linux platforms, we use `TCGETS2`/`TCSETS2` and the
+    /// `c_ispeed`/`c_ospeed` fields. However, on Linux on PowerPC on QEMU,
+    /// `TCGETS2`/`TCSETS2` don't set `c_ispeed`/`c_ospeed`. And, on WSL as of
+    /// this writing, `TCGETS2`/`TCSETS2` are unsupported, so we have a
+    /// fallback that uses `TCGETS`/`TCSETS`.
+    #[cfg(not(bsd))]
     pub(crate) const fn decode(encoded_speed: c::speed_t) -> Option<u32> {
         match encoded_speed {
             c::B0 => Some(0),


### PR DESCRIPTION
WSL appears to be lacking support for `TCGETS2` and `TCSETS2`, so teach rustix's `tcgetattr` and `tcsetattr` how to fall back to `TCGETS` and `TCSETS` as needed.

This approach preserves rustix's ability to support arbitrary speed values, while falling back as needed to support WSL.

This is expected to fix crossterm-rs/crossterm#912.