### PR TITLE
Fall back to `TCGETS` if `TCGETS2` fails

### DIFF
--- a/ci/tcgets2-tcsets2.patch
+++ b/ci/tcgets2-tcsets2.patch
@@ -6,15 +6,22 @@ This implements the `TCGETS2` and `TCSETS2` ioctls.
 diff -ur a/linux-user/ioctls.h b/linux-user/ioctls.h
 --- a/linux-user/ioctls.h
 +++ b/linux-user/ioctls.h
-@@ -2,6 +2,8 @@
+@@ -1,5 +1,15 @@
+      /* emulated ioctl list */
  
-      IOCTL(TCGETS, IOC_R, MK_PTR(MK_STRUCT(STRUCT_termios)))
-      IOCTL(TCSETS, IOC_W, MK_PTR(MK_STRUCT(STRUCT_termios)))
++     /*
++      * Put `TCGETS2`/`TCGETS2` before `TCGETS`/`TCSETS` so that on targets
++      * where these have the same value, we find the `TCGETS2`/`TCSETS2`
++      * entries first, which ensures that we set the `c_ispeed` and `c_ospeed`
++      * fields if the target needed them.
++      */
 +     IOCTL(TCGETS2, IOC_R, MK_PTR(MK_STRUCT(STRUCT_termios2)))
 +     IOCTL(TCSETS2, IOC_W, MK_PTR(MK_STRUCT(STRUCT_termios2)))
++     IOCTL(TCSETSF2, IOC_W, MK_PTR(MK_STRUCT(STRUCT_termios2)))
++     IOCTL(TCSETSW2, IOC_W, MK_PTR(MK_STRUCT(STRUCT_termios2)))
+      IOCTL(TCGETS, IOC_R, MK_PTR(MK_STRUCT(STRUCT_termios)))
+      IOCTL(TCSETS, IOC_W, MK_PTR(MK_STRUCT(STRUCT_termios)))
       IOCTL(TCSETSF, IOC_W, MK_PTR(MK_STRUCT(STRUCT_termios)))
-      IOCTL(TCSETSW, IOC_W, MK_PTR(MK_STRUCT(STRUCT_termios)))
-      IOCTL(TIOCGWINSZ, IOC_R, MK_PTR(MK_STRUCT(STRUCT_winsize)))
 diff -ur a/linux-user/ppc/termbits.h b/linux-user/ppc/termbits.h
 --- a/linux-user/ppc/termbits.h
 +++ b/linux-user/ppc/termbits.h
@@ -53,12 +60,14 @@ diff -ur a/linux-user/ppc/termbits.h b/linux-user/ppc/termbits.h
  
  #define TARGET_CSIZE	00001400
  #define   TARGET_CS5	00000000
-@@ -178,6 +192,8 @@
+@@ -178,6 +192,10 @@
  #define TARGET_TCSETS		TARGET_IOW('t', 20, struct target_termios)
  #define TARGET_TCSETSW		TARGET_IOW('t', 21, struct target_termios)
  #define TARGET_TCSETSF		TARGET_IOW('t', 22, struct target_termios)
 +#define TARGET_TCGETS2		TARGET_TCGETS
 +#define TARGET_TCSETS2		TARGET_TCSETS
++#define TARGET_TCSETSW2		TARGET_TCSETSW
++#define TARGET_TCSETSF2		TARGET_TCSETSF
  
  #define TARGET_TCGETA		TARGET_IOR('t', 23, struct target_termio)
  #define TARGET_TCSETA		TARGET_IOW('t', 24, struct target_termio)
@@ -157,6 +166,15 @@ diff -ur a/linux-user/strace.c b/linux-user/strace.c
  
  #undef UNUSED
  
+@@ -4161,7 +4161,7 @@
+     int target_size;
+ 
+     for (ie = ioctl_entries; ie->target_cmd != 0; ie++) {
+-        if (ie->target_cmd == arg1) {
++        if (ie->target_cmd == (int)arg1) {
+             break;
+         }
+     }
 diff -ur a/linux-user/syscall.c b/linux-user/syscall.c
 --- a/linux-user/syscall.c
 +++ b/linux-user/syscall.c
@@ -326,3 +344,60 @@ diff -ur a/linux-user/user-internals.h b/linux-user/user-internals.h
  
  /* ARM EABI and MIPS expect 64bit types aligned even on pairs or registers */
  #ifdef TARGET_ARM
+diff -ur -x build -x roms a/linux-user/mips/termbits.h b/linux-user/mips/termbits.h
+--- a/linux-user/mips/termbits.h
++++ b/linux-user/mips/termbits.h
+@@ -18,6 +18,17 @@
+     target_cc_t c_cc[TARGET_NCCS];         /* control characters */
+ };
+ 
++struct target_termios2 {
++    target_tcflag_t c_iflag;               /* input mode flags */
++    target_tcflag_t c_oflag;               /* output mode flags */
++    target_tcflag_t c_cflag;               /* control mode flags */
++    target_tcflag_t c_lflag;               /* local mode flags */
++    target_cc_t c_line;                    /* line discipline */
++    target_cc_t c_cc[TARGET_NCCS];         /* control characters */
++    target_speed_t c_ispeed;               /* input speed */
++    target_speed_t c_ospeed;               /* output speed */
++};
++
+ /* c_iflag bits */
+ #define TARGET_IGNBRK  0000001
+ #define TARGET_BRKINT  0000002
+@@ -117,6 +128,7 @@
+ #define  TARGET_B3500000 0010016
+ #define  TARGET_B4000000 0010017
+ #define TARGET_CIBAUD    002003600000  /* input baud rate (not used) */
++#define TARGET_IBSHIFT 16
+ #define TARGET_CMSPAR    010000000000  /* mark or space (stick) parity */
+ #define TARGET_CRTSCTS   020000000000  /* flow control */
+ 
+@@ -217,9 +229,9 @@
+ #define TARGET_TIOCSETP        0x7409
+ #define TARGET_TIOCSETN        0x740a			/* TIOCSETP wo flush */
+ 
+-/* #define TARGET_TIOCSETA	TARGET_IOW('t', 20, struct termios) set termios struct */
+-/* #define TARGET_TIOCSETAW	TARGET_IOW('t', 21, struct termios) drain output, set */
+-/* #define TARGET_TIOCSETAF	TARGET_IOW('t', 22, struct termios) drn out, fls in, set */
++/* #define TARGET_TIOCSETA	TARGET_IOW('t', 20, struct target_termios) set termios struct */
++/* #define TARGET_TIOCSETAW	TARGET_IOW('t', 21, struct target_termios) drain output, set */
++/* #define TARGET_TIOCSETAF	TARGET_IOW('t', 22, struct target_termios) drn out, fls in, set */
+ /* #define TARGET_TIOCGETD	TARGET_IOR('t', 26, int)	get line discipline */
+ /* #define TARGET_TIOCSETD	TARGET_IOW('t', 27, int)	set line discipline */
+ 						/* 127-124 compat */
+@@ -227,10 +239,10 @@
+ #define TARGET_TIOCSBRK	0x5427  /* BSD compatibility */
+ #define TARGET_TIOCCBRK	0x5428  /* BSD compatibility */
+ #define TARGET_TIOCGSID	0x7416  /* Return the session ID of FD */
+-#define TARGET_TCGETS2          TARGET_IOR('T', 0x2A, struct termios2)
+-#define TARGET_TCSETS2          TARGET_IOW('T', 0x2B, struct termios2)
+-#define TARGET_TCSETSW2         TARGET_IOW('T', 0x2C, struct termios2)
+-#define TARGET_TCSETSF2         TARGET_IOW('T', 0x2D, struct termios2)
++#define TARGET_TCGETS2          TARGET_IOR('T', 0x2A, struct target_termios2)
++#define TARGET_TCSETS2          TARGET_IOW('T', 0x2B, struct target_termios2)
++#define TARGET_TCSETSW2         TARGET_IOW('T', 0x2C, struct target_termios2)
++#define TARGET_TCSETSF2         TARGET_IOW('T', 0x2D, struct target_termios2)
+ #define TARGET_TIOCGRS485       TARGET_IOR('T', 0x2E, struct serial_rs485)
+ #define TARGET_TIOCSRS485       TARGET_IOWR('T', 0x2F, struct serial_rs485)
+ #define TARGET_TIOCGPTN	TARGET_IOR('T',0x30, unsigned int) /* Get Pty Number (of pty-mux device) */

--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -102,18 +102,25 @@ pub(crate) const O_LARGEFILE: c_int = 0x2000;
 pub(crate) const MAP_DROPPABLE: u32 = 0x8;
 
 // On PowerPC, the regular `termios` has the `termios2` fields and there is no
-// `termios2`. linux-raw-sys has aliases `termios2` to `termios` to cover this
-// difference, but we still need to manually import it since `libc` doesn't
-// have this.
+// `termios2`, so we define aliases.
 #[cfg(all(
     linux_kernel,
     feature = "termios",
     any(target_arch = "powerpc", target_arch = "powerpc64")
 ))]
-pub(crate) use {
-    linux_raw_sys::general::{termios2, CIBAUD},
-    linux_raw_sys::ioctl::{TCGETS2, TCSETS2, TCSETSF2, TCSETSW2},
+pub(crate) use libc::{
+    termios as termios2, TCGETS as TCGETS2, TCSETS as TCSETS2, TCSETSF as TCSETSF2,
+    TCSETSW as TCSETSW2,
 };
+
+// And PowerPC doesn't define `CIBAUD`, but it does define `IBSHIFT`, so we can
+// compute `CIBAUD` ourselves.
+#[cfg(all(
+    linux_kernel,
+    feature = "termios",
+    any(target_arch = "powerpc", target_arch = "powerpc64")
+))]
+pub(crate) const CIBAUD: u32 = libc::CBAUD << libc::IBSHIFT;
 
 // Automatically enable “large file” support (LFS) features.
 

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -248,7 +248,7 @@ pub(crate) fn tcsetattr(
     not(any(target_arch = "powerpc", target_arch = "powerpc64"))
 ))]
 #[cold]
-pub(crate) fn tcsetattr_fallback(
+fn tcsetattr_fallback(
     fd: BorrowedFd<'_>,
     optional_actions: OptionalActions,
     termios2: &c::termios2,

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -200,8 +200,8 @@ pub(crate) fn tcsetattr(
             .c_cc
             .copy_from_slice(&termios.special_codes.0[..nccs]);
 
-        // Translate from `optional_actions` into a `TCSETS2` ioctl request code.
-        // On MIPS, `optional_actions` has `TCSETS` added to it.
+        // Translate from `optional_actions` into a `TCSETS2` ioctl request
+        // code. On MIPS, `optional_actions` has `TCSETS` added to it.
         let request = c::TCSETS2 as c::c_ulong
             + if cfg!(any(
                 target_arch = "mips",
@@ -253,18 +253,16 @@ pub(crate) fn tcsetattr_fallback(
     optional_actions: OptionalActions,
     termios2: &c::termios2,
 ) -> io::Result<()> {
-    // `TCSETS` silently accepts a `BOTHER` in the `c_cflag` even though it
-    // doesn't read the `c_ispeed` or `c_ospeed` fields, so we detect this
-    // case and fail as needed.
+    // `TCSETS` silently accepts `BOTHER` in `c_cflag` even though it doesn't
+    // read `c_ispeed`/`c_ospeed`, so detect this case and fail if needed.
     let encoded_out = termios2.c_cflag & c::CBAUD;
     let encoded_in = (termios2.c_cflag & c::CIBAUD) >> c::IBSHIFT;
     if encoded_out == c::BOTHER || encoded_in == c::BOTHER {
         return Err(io::Errno::RANGE);
     }
 
-    // Translate from `optional_actions` into a `TCSETS` ioctl request
-    // code. On MIPS, `optional_actions` already has `TCSETS` added to
-    // it.
+    // Translate from `optional_actions` into a `TCSETS` ioctl request code. On
+    // MIPS, `optional_actions` already has `TCSETS` added to it.
     let request = if cfg!(any(
         target_arch = "mips",
         target_arch = "mips32r6",

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -200,8 +200,8 @@ pub(crate) fn tcsetattr(
             .c_cc
             .copy_from_slice(&termios.special_codes.0[..nccs]);
 
-        // Translate from `optional_actions` into a `TCGETS2` ioctl request code.
-        // On MIPS, `optional_actions` has `TCGETS` added to it.
+        // Translate from `optional_actions` into a `TCSETS2` ioctl request code.
+        // On MIPS, `optional_actions` has `TCSETS` added to it.
         let request = c::TCSETS2 as c::c_ulong
             + if cfg!(any(
                 target_arch = "mips",
@@ -221,7 +221,7 @@ pub(crate) fn tcsetattr(
 
                 // Similar to `tcgetattr_fallback`, `NOTTY` or `ACCESS` might
                 // mean the OS doesn't support `TCSETS2`. Fall back to the old
-                // `TCGETS`.
+                // `TCSETS`.
                 #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
                 Err(io::Errno::NOTTY) | Err(io::Errno::ACCESS) => {
                     tcsetattr_fallback(fd, optional_actions, &termios2)
@@ -262,8 +262,8 @@ pub(crate) fn tcsetattr_fallback(
         return Err(io::Errno::RANGE);
     }
 
-    // Translate from `optional_actions` into a `TCGETS` ioctl request
-    // code. On MIPS, `optional_actions` already has `TCGETS` added to
+    // Translate from `optional_actions` into a `TCSETS` ioctl request
+    // code. On MIPS, `optional_actions` already has `TCSETS` added to
     // it.
     let request = if cfg!(any(
         target_arch = "mips",

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -34,7 +34,6 @@ pub(crate) fn tcgetattr(fd: BorrowedFd<'_>) -> io::Result<Termios> {
     #[cfg(linux_kernel)]
     {
         use crate::termios::{ControlModes, InputModes, LocalModes, OutputModes, SpecialCodes};
-        use crate::utils::default_array;
 
         let mut termios2 = MaybeUninit::<c::termios2>::uninit();
         let ptr = termios2.as_mut_ptr();
@@ -67,7 +66,7 @@ pub(crate) fn tcgetattr(fd: BorrowedFd<'_>) -> io::Result<Termios> {
             control_modes: ControlModes::from_bits_retain(termios2.c_cflag),
             local_modes: LocalModes::from_bits_retain(termios2.c_lflag),
             line_discipline: termios2.c_line,
-            special_codes: SpecialCodes(default_array()),
+            special_codes: SpecialCodes(Default::default()),
             input_speed: termios2.c_ispeed,
             output_speed: termios2.c_ospeed,
         };
@@ -174,7 +173,6 @@ pub(crate) fn tcsetattr(
     #[cfg(linux_kernel)]
     {
         use crate::termios::speed;
-        use crate::utils::default_array;
 
         let output_speed = termios.output_speed();
         let input_speed = termios.input_speed();
@@ -184,7 +182,7 @@ pub(crate) fn tcsetattr(
             c_cflag: termios.control_modes.bits(),
             c_lflag: termios.local_modes.bits(),
             c_line: termios.line_discipline,
-            c_cc: default_array(),
+            c_cc: Default::default(),
             c_ispeed: input_speed,
             c_ospeed: output_speed,
         };
@@ -195,6 +193,7 @@ pub(crate) fn tcsetattr(
         termios2.c_cflag |= speed::encode(output_speed).unwrap_or(c::BOTHER);
         termios2.c_cflag &= !c::CIBAUD;
         termios2.c_cflag |= speed::encode(input_speed).unwrap_or(c::BOTHER) << c::IBSHIFT;
+
         let nccs = termios2.c_cc.len();
         termios2
             .c_cc

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -216,7 +216,7 @@ pub(crate) fn tcsetattr(
 
         // SAFETY: This invokes the `TCSETS2` ioctl.
         unsafe {
-            match ret(c::ioctl(borrowed_fd(fd), request, &termios2)) {
+            match ret(c::ioctl(borrowed_fd(fd), request as _, &termios2)) {
                 Ok(()) => Ok(()),
 
                 // Similar to `tcgetattr_fallback`, `NOTTY` or `ACCESS` might

--- a/src/backend/linux_raw/arch/mips.rs
+++ b/src/backend/linux_raw/arch/mips.rs
@@ -3,7 +3,7 @@
 //! On mipsel, Linux indicates success or failure using `$a3` rather
 //! than by returning a negative error code as most other architectures do.
 //!
-//! Mips-family platforms have a special calling convention for `__NR_pipe`,
+//! MIPS-family platforms have a special calling convention for `__NR_pipe`,
 //! however we use `__NR_pipe2` instead to avoid having to implement it.
 
 use crate::backend::reg::{

--- a/src/backend/linux_raw/arch/mips32r6.rs
+++ b/src/backend/linux_raw/arch/mips32r6.rs
@@ -3,7 +3,7 @@
 //! On mipsisa32r6el, Linux indicates success or failure using `$a3` rather
 //! than by returning a negative error code as most other architectures do.
 //!
-//! Mips-family platforms have a special calling convention for `__NR_pipe`,
+//! MIPS-family platforms have a special calling convention for `__NR_pipe`,
 //! however we use `__NR_pipe2` instead to avoid having to implement it.
 
 use crate::backend::reg::{

--- a/src/backend/linux_raw/arch/mips64.rs
+++ b/src/backend/linux_raw/arch/mips64.rs
@@ -3,7 +3,7 @@
 //! On mips64el, Linux indicates success or failure using `$a3` (`$7`) rather
 //! than by returning a negative error code as most other architectures do.
 //!
-//! Mips-family platforms have a special calling convention for `__NR_pipe`,
+//! MIPS-family platforms have a special calling convention for `__NR_pipe`,
 //! however we use `__NR_pipe2` instead to avoid having to implement it.
 
 use crate::backend::reg::{

--- a/src/backend/linux_raw/arch/mips64r6.rs
+++ b/src/backend/linux_raw/arch/mips64r6.rs
@@ -4,7 +4,7 @@
 //! rather than by returning a negative error code as most other architectures
 //! do.
 //!
-//! Mips-family platforms have a special calling convention for `__NR_pipe`,
+//! MIPS-family platforms have a special calling convention for `__NR_pipe`,
 //! however we use `__NR_pipe2` instead to avoid having to implement it.
 //!
 //! Note that MIPS R6 inline assembly currently doesn't differ from MIPS,

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -190,21 +190,11 @@ pub(crate) use linux_raw_sys::{
         VKILL, VLNEXT, VMIN, VQUIT, VREPRINT, VSTART, VSTOP, VSUSP, VSWTC, VT0, VT1, VTDLY, VTIME,
         VWERASE, XCASE, XTABS,
     },
-    ioctl::{TCGETS2, TCSETS2, TCSETSF2, TCSETSW2, TIOCEXCL, TIOCNXCL},
+    ioctl::{
+        TCFLSH, TCGETS, TCGETS2, TCSBRK, TCSETS, TCSETS2, TCSETSF2, TCSETSW2, TCXONC, TIOCEXCL,
+        TIOCGPGRP, TIOCGSID, TIOCGWINSZ, TIOCNXCL, TIOCSPGRP, TIOCSWINSZ,
+    },
 };
-
-// On MIPS, `TCSANOW` et al have `TCSETS` added to them, so we need it to
-// subtract it out.
-#[cfg(all(
-    feature = "termios",
-    any(
-        target_arch = "mips",
-        target_arch = "mips32r6",
-        target_arch = "mips64",
-        target_arch = "mips64r6"
-    )
-))]
-pub(crate) use linux_raw_sys::ioctl::TCSETS;
 
 // Define our own `uid_t` and `gid_t` if the kernel's versions are not 32-bit.
 #[cfg(any(target_arch = "arm", target_arch = "sparc", target_arch = "x86"))]

--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -120,8 +120,8 @@ pub(crate) fn tcsetattr(
     optional_actions: OptionalActions,
     termios: &Termios,
 ) -> io::Result<()> {
-    // Translate from `optional_actions` into a `TCGETS2` ioctl request code.
-    // On MIPS, `optional_actions` has `TCGETS` added to it.
+    // Translate from `optional_actions` into a `TCSETS2` ioctl request code.
+    // On MIPS, `optional_actions` has `TCSETS` added to it.
     let request = c::TCSETS2
         + if cfg!(any(
             target_arch = "mips",
@@ -145,7 +145,7 @@ pub(crate) fn tcsetattr(
             Ok(()) => Ok(()),
 
             // Similar to `tcgetattr_fallback`, `NOTTY` or `ACCESS` might mean
-            // the OS doesn't support `TCSETS2`. Fall back to the old `TCGETS`.
+            // the OS doesn't support `TCSETS2`. Fall back to the old `TCSETS`.
             #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
             Err(io::Errno::NOTTY) | Err(io::Errno::ACCESS) => {
                 tcsetattr_fallback(fd, optional_actions, termios)

--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -164,9 +164,8 @@ fn tcsetattr_fallback(
     optional_actions: OptionalActions,
     termios: &Termios,
 ) -> io::Result<()> {
-    // `TCSETS` silently accepts a `BOTHER` in the `c_cflag` even though it
-    // doesn't read the `c_ispeed` or `c_ospeed` fields, so we detect this
-    // case and fail as needed.
+    // `TCSETS` silently accepts `BOTHER` in `c_cflag` even though it doesn't
+    // read `c_ispeed`/`c_ospeed`, so detect this case and fail if needed.
     let control_modes_bits = termios.control_modes.bits();
     let encoded_out = control_modes_bits & c::CBAUD;
     let encoded_in = (control_modes_bits & c::CIBAUD) >> c::IBSHIFT;
@@ -174,8 +173,8 @@ fn tcsetattr_fallback(
         return Err(io::Errno::RANGE);
     }
 
-    // Translate from `optional_actions` into a `TCSETS` ioctl request
-    // code. On MIPS, `optional_actions` already has `TCSETS` added to it.
+    // Translate from `optional_actions` into a `TCSETS` ioctl request code. On
+    // MIPS, `optional_actions` already has `TCSETS` added to it.
     let request = if cfg!(any(
         target_arch = "mips",
         target_arch = "mips32r6",

--- a/src/fs/ioctl.rs
+++ b/src/fs/ioctl.rs
@@ -44,7 +44,7 @@ pub fn ioctl_blkpbszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
 
 /// `ioctl(fd, FICLONE, src_fd)`—Share data between open files.
 ///
-/// This ioctl is not available on Sparc platforms.
+/// This ioctl is not available on SPARC platforms.
 ///
 /// # References
 ///  - [Linux]

--- a/src/termios/tc.rs
+++ b/src/termios/tc.rs
@@ -9,6 +9,11 @@ pub use crate::pid::Pid;
 ///
 /// Also known as the `TCGETS` (or `TCGETS2` on Linux) operation with `ioctl`.
 ///
+/// On Linux, this uses `TCGETS2`. If that fails in a way that indicates that
+/// the host doesn't support it, this falls back to the old `TCGETS`, manually
+/// initializes the fields that `TCGETS` doesn't initialize, and fails with
+/// `io::Errno::RANGE` if the input or output speeds cannot be supported.
+///
 /// # References
 ///  - [POSIX `tcgetattr`]
 ///  - [Linux `ioctl_tty`]
@@ -83,6 +88,10 @@ pub fn tcsetpgrp<Fd: AsFd>(fd: Fd, pid: Pid) -> io::Result<()> {
 /// `tcsetattr(fd)`—Set terminal attributes.
 ///
 /// Also known as the `TCSETS` (or `TCSETS2` on Linux) operation with `ioctl`.
+///
+/// On Linux, this uses `TCSETS2`. If that fails in a way that indicates that
+/// the host doesn't support it, this falls back to the old `TCSETS`, and fails
+/// with `io::Errno::RANGE` if the input or output speeds cannot be supported.
 ///
 /// # References
 ///  - [POSIX `tcsetattr`]

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -1115,6 +1115,7 @@ impl core::ops::IndexMut<SpecialCodeIndex> for SpecialCodes {
 }
 
 /// Indices for use with [`Termios::special_codes`].
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct SpecialCodeIndex(usize);
 
 #[rustfmt::skip]
@@ -1181,6 +1182,43 @@ impl SpecialCodeIndex {
 
     /// `VEOL2`
     pub const VEOL2: Self = Self(c::VEOL2 as usize);
+}
+
+impl core::fmt::Debug for SpecialCodeIndex {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match *self {
+            Self::VINTR => write!(f, "VINTR"),
+            Self::VQUIT => write!(f, "VQUIT"),
+            Self::VERASE => write!(f, "VERASE"),
+            Self::VKILL => write!(f, "VKILL"),
+            Self::VEOF => write!(f, "VEOF"),
+            Self::VTIME => write!(f, "VTIME"),
+            Self::VMIN => write!(f, "VMIN"),
+            #[cfg(not(any(
+                bsd,
+                solarish,
+                target_os = "aix",
+                target_os = "haiku",
+                target_os = "hurd",
+                target_os = "nto",
+            )))]
+            Self::VSWTC => write!(f, "VSWTC"),
+            Self::VSTART => write!(f, "VSTART"),
+            Self::VSTOP => write!(f, "VSTOP"),
+            Self::VSUSP => write!(f, "VSUSP"),
+            Self::VEOL => write!(f, "VEOL"),
+            #[cfg(not(target_os = "haiku"))]
+            Self::VREPRINT => write!(f, "VREPRINT"),
+            #[cfg(not(any(target_os = "aix", target_os = "haiku")))]
+            Self::VDISCARD => write!(f, "VDISCARD"),
+            #[cfg(not(any(target_os = "aix", target_os = "haiku")))]
+            Self::VWERASE => write!(f, "VWERASE"),
+            #[cfg(not(target_os = "haiku"))]
+            Self::VLNEXT => write!(f, "VLNEXT"),
+            Self::VEOL2 => write!(f, "VEOL2"),
+            _ => write!(f, "unknown"),
+        }
+    }
 }
 
 /// `TCSA*` values for use with [`tcsetattr`].

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -1191,18 +1191,33 @@ impl core::fmt::Debug for SpecialCodeIndex {
             Self::VQUIT => write!(f, "VQUIT"),
             Self::VERASE => write!(f, "VERASE"),
             Self::VKILL => write!(f, "VKILL"),
-            #[cfg(not(solarish))]
+            #[cfg(not(any(
+                solarish,
+                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64"))
+            )))]
             Self::VEOF => write!(f, "VEOF"),
-            #[cfg(not(solarish))]
+            #[cfg(not(any(
+                solarish,
+                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64"))
+            )))]
             Self::VTIME => write!(f, "VTIME"),
-            #[cfg(not(solarish))]
+            #[cfg(not(any(
+                solarish,
+                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64"))
+            )))]
             Self::VMIN => write!(f, "VMIN"),
 
-            // On Solarish platforms, `VMIN` and `VTIME` have the same value
-            // as `VEOF` and `VEOL`.
-            #[cfg(solarish)]
+            // On Solarish platforms, and Linux on SPARC, `VMIN` and `VTIME`
+            // have the same value as `VEOF` and `VEOL`.
+            #[cfg(any(
+                solarish,
+                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64"))
+            ))]
             Self::VMIN => write!(f, "VMIN/VEOF"),
-            #[cfg(solarish)]
+            #[cfg(any(
+                solarish,
+                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64"))
+            ))]
             Self::VTIME => write!(f, "VTIME/VEOL"),
 
             #[cfg(not(any(
@@ -1217,7 +1232,10 @@ impl core::fmt::Debug for SpecialCodeIndex {
             Self::VSTART => write!(f, "VSTART"),
             Self::VSTOP => write!(f, "VSTOP"),
             Self::VSUSP => write!(f, "VSUSP"),
-            #[cfg(not(solarish))]
+            #[cfg(not(any(
+                solarish,
+                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64"))
+            )))]
             Self::VEOL => write!(f, "VEOL"),
             #[cfg(not(target_os = "haiku"))]
             Self::VREPRINT => write!(f, "VREPRINT"),
@@ -1344,7 +1362,7 @@ fn termios_layouts() {
 
     #[cfg(not(linux_raw))]
     {
-        // On Mips, Sparc, and Android, the libc lacks the ospeed and ispeed
+        // On MIPS, SPARC, and Android, the libc lacks the ospeed and ispeed
         // fields.
         #[cfg(all(
             not(all(

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -1193,6 +1193,7 @@ impl core::fmt::Debug for SpecialCodeIndex {
             Self::VKILL => write!(f, "VKILL"),
             #[cfg(not(solarish))]
             Self::VEOF => write!(f, "VEOF"),
+            #[cfg(not(solarish))]
             Self::VTIME => write!(f, "VTIME"),
             #[cfg(not(solarish))]
             Self::VMIN => write!(f, "VMIN"),

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -1191,9 +1191,19 @@ impl core::fmt::Debug for SpecialCodeIndex {
             Self::VQUIT => write!(f, "VQUIT"),
             Self::VERASE => write!(f, "VERASE"),
             Self::VKILL => write!(f, "VKILL"),
+            #[cfg(not(solarish))]
             Self::VEOF => write!(f, "VEOF"),
             Self::VTIME => write!(f, "VTIME"),
+            #[cfg(not(solarish))]
             Self::VMIN => write!(f, "VMIN"),
+
+            // On Solarish platforms, `VMIN` and `VTIME` have the same value
+            // as `VEOF` and `VEOL`.
+            #[cfg(solarish)]
+            Self::VMIN => write!(f, "VMIN/VEOF"),
+            #[cfg(solarish)]
+            Self::VTIME => write!(f, "VTIME/VEOL"),
+
             #[cfg(not(any(
                 bsd,
                 solarish,
@@ -1206,6 +1216,7 @@ impl core::fmt::Debug for SpecialCodeIndex {
             Self::VSTART => write!(f, "VSTART"),
             Self::VSTOP => write!(f, "VSTOP"),
             Self::VSUSP => write!(f, "VSUSP"),
+            #[cfg(not(solarish))]
             Self::VEOL => write!(f, "VEOL"),
             #[cfg(not(target_os = "haiku"))]
             Self::VREPRINT => write!(f, "VREPRINT"),

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -810,15 +810,17 @@ pub mod speed {
     /// `u32`.
     ///
     /// On BSD platforms, integer speed values are already the same as their
-    /// encoded values, and on Linux platforms, we use `TCGETS2`/`TCSETS2` and
-    /// the `c_ispeed`/`c_ospeed` fields, except that on Linux on PowerPC on
-    /// QEMU, `TCGETS2`/`TCSETS2` don't set `c_ispeed`/`c_ospeed`.
+    /// encoded values.
+    ///
+    /// On Linux on PowerPC, `TCGETS`/`TCSETS` support the `c_ispeed` and
+    /// `c_ospeed` fields.
+    ///
+    /// On Linux on architectures other than PowerPC, `TCGETS`/`TCSETS` don't
+    /// support the `c_ispeed` and `c_ospeed` fields, so we have to fall back
+    /// to `TCGETS2`/`TCSETS2` to support them.
     #[cfg(not(any(
         bsd,
-        all(
-            linux_kernel,
-            not(any(target_arch = "powerpc", target_arch = "powerpc64"))
-        )
+        all(linux_kernel, any(target_arch = "powerpc", target_arch = "powerpc64"))
     )))]
     pub(crate) const fn decode(encoded_speed: c::speed_t) -> Option<u32> {
         match encoded_speed {

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -1182,6 +1182,22 @@ impl SpecialCodeIndex {
 
     /// `VEOL2`
     pub const VEOL2: Self = Self(c::VEOL2 as usize);
+
+    /// `VSWTCH`
+    #[cfg(any(solarish, target_os = "haiku", target_os = "nto"))]
+    pub const VSWTCH: Self = Self(c::VSWTCH as usize);
+
+    /// `VDSUSP`
+    #[cfg(any(bsd, solarish, target_os = "aix", target_os = "hurd", target_os = "nto"))]
+    pub const VDSUSP: Self = Self(c::VDSUSP as usize);
+
+    /// `VSTATUS`
+    #[cfg(any(bsd, solarish, target_os = "hurd"))]
+    pub const VSTATUS: Self = Self(c::VSTATUS as usize);
+
+    /// `VERASE2`
+    #[cfg(any(freebsdlike, solarish))]
+    pub const VERASE2: Self = Self(c::VERASE2 as usize);
 }
 
 impl core::fmt::Debug for SpecialCodeIndex {
@@ -1246,6 +1262,21 @@ impl core::fmt::Debug for SpecialCodeIndex {
             #[cfg(not(target_os = "haiku"))]
             Self::VLNEXT => write!(f, "VLNEXT"),
             Self::VEOL2 => write!(f, "VEOL2"),
+            #[cfg(any(solarish, target_os = "haiku", target_os = "nto"))]
+            Self::VSWTCH => write!(f, "VSWTCH"),
+            #[cfg(any(
+                bsd,
+                solarish,
+                target_os = "aix",
+                target_os = "hurd",
+                target_os = "nto"
+            ))]
+            Self::VDSUSP => write!(f, "VDSUSP"),
+            #[cfg(any(bsd, solarish, target_os = "hurd"))]
+            Self::VSTATUS => write!(f, "VSTATUS"),
+            #[cfg(any(freebsdlike, solarish))]
+            Self::VERASE2 => write!(f, "VERASE2"),
+
             _ => write!(f, "unknown"),
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -50,12 +50,6 @@ pub(crate) fn check_raw_pointer<T>(value: *mut c_void) -> Option<NonNull<T>> {
     NonNull::new(value.cast())
 }
 
-/// Create an array value containing all default values, inferring the type.
-#[inline]
-pub(crate) fn default_array<T: Default + Copy, const N: usize>() -> [T; N] {
-    [T::default(); N]
-}
-
 /// Create a union value containing a default value in one of its arms.
 ///
 /// The field names a union field which must have the same size as the union

--- a/tests/fs/ioctl.rs
+++ b/tests/fs/ioctl.rs
@@ -1,4 +1,4 @@
-// Sparc lacks `FICLONE`.
+// SPARC lacks `FICLONE`.
 #[cfg(all(linux_kernel, not(any(target_arch = "sparc", target_arch = "sparc64"))))]
 #[test]
 fn test_ioctl_ficlone() {

--- a/tests/termios/termios.rs
+++ b/tests/termios/termios.rs
@@ -143,7 +143,13 @@ fn test_termios_special_codes() {
         Err(err) => panic!("{:?}", err),
     };
 
+    // Check some initial values of `special_codes`. On Linux, `VINTR`'s code
+    // is set to ETX. On BSD's, it appears to be set to zero for
+    // pseudo-terminals.
+    #[cfg(linux_kernel)]
     assert_eq!(tio.special_codes[SpecialCodeIndex::VINTR], 3);
+    #[cfg(bsd)]
+    assert_eq!(tio.special_codes[SpecialCodeIndex::VINTR], 0);
     assert_eq!(tio.special_codes[SpecialCodeIndex::VEOL], 0);
 
     tio.special_codes[SpecialCodeIndex::VINTR] = 47;

--- a/tests/termios/termios.rs
+++ b/tests/termios/termios.rs
@@ -126,11 +126,50 @@ fn test_termios_speeds() {
     assert_eq!(new_tio.input_speed(), speed::B134);
     assert_eq!(new_tio.output_speed(), speed::B134);
 
+    // Check various speeds.
+    for custom_speed in [speed::B50, speed::B19200, speed::B38400] {
+        tio.set_speed(custom_speed).unwrap();
+        assert_eq!(tio.input_speed(), custom_speed);
+        assert_eq!(tio.output_speed(), custom_speed);
+        tcsetattr(&pty, OptionalActions::Now, &tio).unwrap();
+
+        let new_tio = tcgetattr(&pty).unwrap();
+        assert_eq!(new_tio.input_speed(), custom_speed);
+        assert_eq!(new_tio.output_speed(), custom_speed);
+    }
+
+    // Similar, but using `set_input_speed` and `set_output_speed` instead
+    // of `set_speed`.
+    for custom_speed in [speed::B50, speed::B19200, speed::B38400] {
+        tio.set_input_speed(custom_speed).unwrap();
+        tio.set_output_speed(custom_speed).unwrap();
+        assert_eq!(tio.input_speed(), custom_speed);
+        assert_eq!(tio.output_speed(), custom_speed);
+        tcsetattr(&pty, OptionalActions::Now, &tio).unwrap();
+
+        let new_tio = tcgetattr(&pty).unwrap();
+        assert_eq!(new_tio.input_speed(), custom_speed);
+        assert_eq!(new_tio.output_speed(), custom_speed);
+    }
+
     // These platforms are known to support arbitrary not-pre-defined-by-POSIX
     // speeds.
     #[cfg(any(bsd, linux_kernel))]
     {
-        for custom_speed in [51, 31250, libc::B50 as _] {
+        for custom_speed in [speed::B50, 51, 31250, 74880, 256000] {
+            tio.set_speed(custom_speed).unwrap();
+            assert_eq!(tio.input_speed(), custom_speed);
+            assert_eq!(tio.output_speed(), custom_speed);
+            tcsetattr(&pty, OptionalActions::Now, &tio).unwrap();
+
+            let new_tio = tcgetattr(&pty).unwrap();
+            assert_eq!(new_tio.input_speed(), custom_speed);
+            assert_eq!(new_tio.output_speed(), custom_speed);
+        }
+
+        // Similar, but using `set_input_speed` and `set_output_speed` instead
+        // of `set_speed`.
+        for custom_speed in [speed::B50, 51, 31250, 74880, 256000] {
             tio.set_input_speed(custom_speed).unwrap();
             tio.set_output_speed(custom_speed).unwrap();
             assert_eq!(tio.input_speed(), custom_speed);
@@ -162,7 +201,7 @@ fn test_termios_speeds() {
     #[cfg(any(bsd, linux_kernel))]
     {
         tio.set_output_speed(speed::B134).unwrap();
-        for custom_speed in [51, 31250, libc::B50 as _] {
+        for custom_speed in [speed::B50, 51, 31250, 74880, 256000] {
             tio.set_input_speed(custom_speed).unwrap();
             assert_eq!(tio.input_speed(), custom_speed);
             assert_eq!(tio.output_speed(), speed::B134);
@@ -174,7 +213,7 @@ fn test_termios_speeds() {
         }
 
         tio.set_input_speed(speed::B150).unwrap();
-        for custom_speed in [51, 31250, libc::B50 as _] {
+        for custom_speed in [speed::B50, 51, 31250, 74880, 256000] {
             tio.set_output_speed(custom_speed).unwrap();
             assert_eq!(tio.input_speed(), speed::B150);
             assert_eq!(tio.output_speed(), custom_speed);

--- a/tests/termios/termios.rs
+++ b/tests/termios/termios.rs
@@ -156,7 +156,7 @@ fn test_termios_speeds() {
     // speeds.
     #[cfg(any(bsd, linux_kernel))]
     {
-        for custom_speed in [speed::B50, 51, 31250, 74880, 256000] {
+        for custom_speed in [speed::B50, 51, 31250, 74880, 115199] {
             tio.set_speed(custom_speed).unwrap();
             assert_eq!(tio.input_speed(), custom_speed);
             assert_eq!(tio.output_speed(), custom_speed);
@@ -169,7 +169,7 @@ fn test_termios_speeds() {
 
         // Similar, but using `set_input_speed` and `set_output_speed` instead
         // of `set_speed`.
-        for custom_speed in [speed::B50, 51, 31250, 74880, 256000] {
+        for custom_speed in [speed::B50, 51, 31250, 74880, 115199] {
             tio.set_input_speed(custom_speed).unwrap();
             tio.set_output_speed(custom_speed).unwrap();
             assert_eq!(tio.input_speed(), custom_speed);
@@ -201,7 +201,7 @@ fn test_termios_speeds() {
     #[cfg(any(bsd, linux_kernel))]
     {
         tio.set_output_speed(speed::B134).unwrap();
-        for custom_speed in [speed::B50, 51, 31250, 74880, 256000] {
+        for custom_speed in [speed::B50, 51, 31250, 74880, 115199] {
             tio.set_input_speed(custom_speed).unwrap();
             assert_eq!(tio.input_speed(), custom_speed);
             assert_eq!(tio.output_speed(), speed::B134);
@@ -213,7 +213,7 @@ fn test_termios_speeds() {
         }
 
         tio.set_input_speed(speed::B150).unwrap();
-        for custom_speed in [speed::B50, 51, 31250, 74880, 256000] {
+        for custom_speed in [speed::B50, 51, 31250, 74880, 115199] {
             tio.set_output_speed(custom_speed).unwrap();
             assert_eq!(tio.input_speed(), speed::B150);
             assert_eq!(tio.output_speed(), custom_speed);

--- a/tests/termios/termios.rs
+++ b/tests/termios/termios.rs
@@ -103,12 +103,12 @@ fn test_termios_modes() {
     };
 
     assert!(!tio.local_modes.contains(LocalModes::TOSTOP));
-    assert!(!tio.output_modes.contains(OutputModes::OFILL));
+    assert!(!tio.output_modes.contains(OutputModes::ONOCR));
     assert!(!tio.input_modes.contains(InputModes::IGNBRK));
     assert!(!tio.control_modes.contains(ControlModes::CRTSCTS));
 
     tio.local_modes.insert(LocalModes::TOSTOP);
-    tio.output_modes.insert(OutputModes::OFILL);
+    tio.output_modes.insert(OutputModes::ONOCR);
     tio.input_modes.insert(InputModes::IGNBRK);
     tio.control_modes.insert(ControlModes::CRTSCTS);
 
@@ -117,7 +117,7 @@ fn test_termios_modes() {
     let new_tio = tcgetattr(&pty).unwrap();
 
     assert!(new_tio.local_modes.contains(LocalModes::TOSTOP));
-    assert!(new_tio.output_modes.contains(OutputModes::OFILL));
+    assert!(new_tio.output_modes.contains(OutputModes::ONOCR));
     assert!(new_tio.input_modes.contains(InputModes::IGNBRK));
     assert!(new_tio.control_modes.contains(ControlModes::CRTSCTS));
 }


### PR DESCRIPTION
Switch `tcgetattr`/`tcsetattr` from using `TCGETS2`/`TCSETS2` first to using `TCGETS`/`TCSETS` first. Have `tcgetattr` fall back to `TCGETS2` if the `TCGETS` flags indicate that a custom speed is in used.

glibc and musl have not yet migrated to `TCGETS2`/`TCSETS2`, and as a result, seccomp sandboxes and Linux-like environments such as WSL don't always support them.

Also, fix some bugs in QEMU related to the handling of termios syscalls. This eliminates the need for having rustix do extra fixups on PowerPC.

This is expected to fix crossterm-rs/crossterm#912.