### PR TITLE
Fix several bugs in qemu.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -484,7 +484,9 @@ jobs:
         patch -p1 < $GITHUB_WORKSPACE/ci/s390x-stat-have-nsec.patch
         patch -p1 < $GITHUB_WORKSPACE/ci/aarch64-o-largefile.patch
         patch -p1 < $GITHUB_WORKSPACE/ci/tcgets2-tcsets2.patch
+        patch -p1 < $GITHUB_WORKSPACE/ci/tiocgsid.patch
         patch -p1 < $GITHUB_WORKSPACE/ci/more-sockopts.patch
+        patch -p1 < $GITHUB_WORKSPACE/ci/pidfd-open.patch
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         ninja -C build install
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
@@ -621,7 +623,9 @@ jobs:
         patch -p1 < $GITHUB_WORKSPACE/ci/s390x-stat-have-nsec.patch
         patch -p1 < $GITHUB_WORKSPACE/ci/aarch64-o-largefile.patch
         patch -p1 < $GITHUB_WORKSPACE/ci/tcgets2-tcsets2.patch
+        patch -p1 < $GITHUB_WORKSPACE/ci/tiocgsid.patch
         patch -p1 < $GITHUB_WORKSPACE/ci/more-sockopts.patch
+        patch -p1 < $GITHUB_WORKSPACE/ci/pidfd-open.patch
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         ninja -C build install
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
@@ -715,7 +719,9 @@ jobs:
         patch -p1 < $GITHUB_WORKSPACE/ci/s390x-stat-have-nsec.patch
         patch -p1 < $GITHUB_WORKSPACE/ci/aarch64-o-largefile.patch
         patch -p1 < $GITHUB_WORKSPACE/ci/tcgets2-tcsets2.patch
+        patch -p1 < $GITHUB_WORKSPACE/ci/tiocgsid.patch
         patch -p1 < $GITHUB_WORKSPACE/ci/more-sockopts.patch
+        patch -p1 < $GITHUB_WORKSPACE/ci/pidfd-open.patch
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         ninja -C build install
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'

--- a/ci/more-sockopts.patch
+++ b/ci/more-sockopts.patch
@@ -18,6 +18,19 @@ diff -ur -x roms -x build a/linux-user/generic/sockbits.h b/linux-user/generic/s
 +#define TARGET_SO_COOKIE               57
 +#endif
  #endif
+diff -ur -x roms -x build a/linux-user/mips/sockbits.h b/linux-user/mips/sockbits.h
+--- a/linux-user/mips/sockbits.h
++++ b/linux-user/mips/sockbits.h
+@@ -73,6 +73,9 @@
+ #define TARGET_SO_RCVBUFFORCE          33
+ #define TARGET_SO_PASSSEC              34
+ 
++#define TARGET_SO_INCOMING_CPU         49
++#define TARGET_SO_COOKIE               57
++
+ /** sock_type - Socket types
+  *
+  * Please notice that for binary compat reasons MIPS has to
 diff -ur -x roms -x build a/linux-user/syscall.c b/linux-user/syscall.c
 --- a/linux-user/syscall.c
 +++ b/linux-user/syscall.c

--- a/ci/pidfd-open.patch
+++ b/ci/pidfd-open.patch
@@ -1,0 +1,19 @@
+From Dan Gohman <dev@sunfishcode.online>
+Subject: [PATCH] Fix the flags argument of `pidfd_open`.
+
+This corrects the flags value of `pidfd_open` to avoid passing
+target flags to the host. Currently the only flag is `PIDFD_NONBLOCK`
+so we use the `fcntl_flags_tbl` to translate it.
+
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -9477,7 +9477,8 @@
+ #endif
+ #if defined(__NR_pidfd_open) && defined(TARGET_NR_pidfd_open)
+     case TARGET_NR_pidfd_open:
+-        return get_errno(pidfd_open(arg1, arg2));
++        return get_errno(pidfd_open(arg1,
++			    target_to_host_bitmask(arg2, fcntl_flags_tbl)));
+ #endif
+ #if defined(__NR_pidfd_send_signal) && defined(TARGET_NR_pidfd_send_signal)
+     case TARGET_NR_pidfd_send_signal:

--- a/ci/tiocgsid.patch
+++ b/ci/tiocgsid.patch
@@ -1,0 +1,17 @@
+From Dan Gohman <dev@sunfishcode.online>
+Subject: [PATCH] Fix the definition of `TIOCGSID`.
+
+This corrects the value of `TIOCGSID`.
+
+diff -ur a/linux-user/ioctls.h b/linux-user/ioctls.h
+--- a/linux-user/ioctls.h
++++ b/linux-user/ioctls.h
+@@ -22,7 +28,7 @@
+      IOCTL(TIOCSCTTY, 0, TYPE_INT)
+      IOCTL(TIOCGPGRP, IOC_R, MK_PTR(TYPE_INT))
+      IOCTL(TIOCSPGRP, IOC_W, MK_PTR(TYPE_INT))
+-     IOCTL(TIOCGSID, IOC_W, MK_PTR(TYPE_INT))
++     IOCTL(TIOCGSID, IOC_R, MK_PTR(TYPE_INT))
+      IOCTL(TIOCOUTQ, IOC_R, MK_PTR(TYPE_INT))
+      IOCTL(TIOCSTI, IOC_W, MK_PTR(TYPE_INT))
+      IOCTL(TIOCMGET, IOC_R, MK_PTR(TYPE_INT))

--- a/tests/process/pidfd.rs
+++ b/tests/process/pidfd.rs
@@ -71,8 +71,9 @@ fn test_pidfd_poll() {
         process::WaitId::PidFd(pidfd.as_fd()),
         process::WaitidOptions::EXITED,
     ) {
-        Err(e) if e == io::Errno::AGAIN => (),
-        _ => panic!("unexpected result"),
+        Err(io::Errno::AGAIN) => (),
+        Err(e) => panic!("unexpected result: {:?}", e),
+        Ok(_) => panic!("unexpected success"),
     }
 
     // Wait for the child process to exit.


### PR DESCRIPTION
Fix the value of `TIOCGSID`.

Translate the flags argument to `pidfd_open` from target to host flags, which fixes the value of `PIDFD_NONBLOCK` on platforms where the value differs, such as mips64.

Define `TARGET_SO_INCOMING_CPU` and `TARGET_SO_COOKIE` for mips/mips64 in qemu.