### PR TITLE
Simplify match conditions.

### DIFF
--- a/src/fs/statx.rs
+++ b/src/fs/statx.rs
@@ -44,7 +44,7 @@ use compat::statx as _statx;
 ///             let present = (r.stx_attributes_mask & mountroot_flag) > 0;
 ///             Ok(present.then(|| r.stx_attributes & mountroot_flag > 0))
 ///         }
-///         Err(e) if e == rustix::io::Errno::NOSYS => Ok(None),
+///         Err(rustix::io::Errno::NOSYS) => Ok(None),
 ///         Err(e) => Err(e.into()),
 ///     }
 /// }

--- a/tests/fs/renameat.rs
+++ b/tests/fs/renameat.rs
@@ -100,7 +100,7 @@ fn test_renameat_with() {
 
     match renameat_with(&dir, "file", &dir, "red", RenameFlags::empty()) {
         Ok(()) => (),
-        Err(err) if err == rustix::io::Errno::NOSYS => return,
+        Err(rustix::io::Errno::NOSYS) => return,
         Err(err) => unreachable!("unexpected error from renameat_with: {:?}", err),
     }
 

--- a/tests/process/pidfd.rs
+++ b/tests/process/pidfd.rs
@@ -22,7 +22,7 @@ fn test_pidfd_waitid() {
     let pid = process::Pid::from_child(&child);
     let pidfd = match process::pidfd_open(pid, process::PidfdFlags::empty()) {
         Ok(pidfd) => pidfd,
-        Err(e) if e == io::Errno::NOSYS => {
+        Err(io::Errno::NOSYS) => {
             // The kernel does not support pidfds.
             return;
         }
@@ -59,7 +59,7 @@ fn test_pidfd_poll() {
     let pid = process::Pid::from_child(&child);
     let pidfd = match process::pidfd_open(pid, process::PidfdFlags::NONBLOCK) {
         Ok(pidfd) => pidfd,
-        Err(e) if e == io::Errno::NOSYS || e == io::Errno::INVAL => {
+        Err(io::Errno::NOSYS) | Err(io::Errno::INVAL) => {
             // The kernel does not support non-blocking pidfds.
             return;
         }


### PR DESCRIPTION
Use `Err(io::Errno::NOSYS)` inistead of
`Err(err) if err == io::Errno::NOSYS)`.