### PR TITLE
Fix the name of `c_ispeed`/`c_ospeed` on powerpc musl targets.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,6 +225,7 @@ jobs:
     - run: cargo check -Zbuild-std=core,alloc --target=powerpc64-ibm-aix --features=all-apis --no-default-features
     - run: cargo check -Z build-std --target=mipsel-unknown-linux-gnu --features=all-apis
     - run: cargo check -Z build-std --target=mips64el-unknown-linux-gnuabi64 --features=all-apis
+    - run: cargo check -Z build-std --target=powerpc64le-unknown-linux-musl --features=all-apis
 
 
   test:


### PR DESCRIPTION
Fixes #1157.