### PR TITLE
Fix `recv_uninit` to handle the `TRUNC` flag.

### DIFF
--- a/src/net/send_recv/mod.rs
+++ b/src/net/send_recv/mod.rs
@@ -75,7 +75,8 @@ pub fn recv<Fd: AsFd>(fd: Fd, buf: &mut [u8], flags: RecvFlags) -> io::Result<us
 ///
 /// Because this interface returns the length via the returned slice, it's
 /// unsable to return the untruncated length that would be returned when the
-/// `RecvFlags::TRUNC` flag is used.
+/// `RecvFlags::TRUNC` flag is used. If you need the untruncated length, use
+/// [`recv`].
 #[inline]
 pub fn recv_uninit<Fd: AsFd>(
     fd: Fd,
@@ -170,7 +171,8 @@ pub fn recvfrom<Fd: AsFd>(
 ///
 /// Because this interface returns the length via the returned slice, it's
 /// unsable to return the untruncated length that would be returned when the
-/// `RecvFlags::TRUNC` flag is used.
+/// `RecvFlags::TRUNC` flag is used. If you need the untruncated length, use
+/// [`recvfrom`].
 #[allow(clippy::type_complexity)]
 #[inline]
 pub fn recvfrom_uninit<Fd: AsFd>(

--- a/tests/net/main.rs
+++ b/tests/net/main.rs
@@ -12,6 +12,8 @@ mod connect_bind_send;
 mod dgram;
 #[cfg(feature = "event")]
 mod poll;
+#[cfg(unix)]
+mod recv_trunc;
 mod sockopt;
 #[cfg(unix)]
 mod unix;

--- a/tests/net/recv_trunc.rs
+++ b/tests/net/recv_trunc.rs
@@ -1,0 +1,29 @@
+use rustix::net::{AddressFamily, RecvFlags, SendFlags, SocketAddrUnix, SocketType};
+use std::mem::MaybeUninit;
+
+/// Test `recv_uninit` with the `RecvFlags::Trunc` flag.
+#[test]
+fn net_recv_uninit_trunc() {
+    crate::init();
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let path = tmpdir.path().join("recv_uninit_trunc");
+    let name = SocketAddrUnix::new(&path).unwrap();
+
+    let receiver = rustix::net::socket(AddressFamily::UNIX, SocketType::DGRAM, None).unwrap();
+    rustix::net::bind_unix(&receiver, &name).expect("bind");
+
+    let sender = rustix::net::socket(AddressFamily::UNIX, SocketType::DGRAM, None).unwrap();
+    let request = b"Hello, World!!!";
+    let n = rustix::net::sendto_unix(&sender, request, SendFlags::empty(), &name).expect("send");
+    assert_eq!(n, request.len());
+    drop(sender);
+
+    let mut response = [MaybeUninit::<u8>::zeroed(); 5];
+    let (init, uninit) =
+        rustix::net::recv_uninit(&receiver, &mut response, RecvFlags::TRUNC).expect("recv_uninit");
+
+    // We used the `TRUNC` flag, so we should have only gotten 5 bytes.
+    assert_eq!(init, b"Hello");
+    assert!(uninit.is_empty());
+}


### PR DESCRIPTION
With the `TRUNC` flag, `recv` returns the untruncated length, which may be longer than the provided buffer. Fix `recv_uninit` and `recvfrom_uninit` to handle this case.

This mean that `recv_uninit` and `recvfrom_uninit` are unable to return the full untruncated length returned by `recv` with the `TRUNC` flag, however it appears that fixing that may require API changes.

Fixes #1153.