### PR TITLE
Add a changelog entry for the `fcntl_setpipe_size` change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes from 0.38.x to 1.0
 
+`rustix::pipe::fcntl_getpipe_size` now returns the new size, which may be
+greater than the requested size.
+
 `rustix::thread::FutexOperation` and `rustix::thread::futex` are removed. Use
 the functions in the `rustix::thread::futex` module instead.
 

--- a/src/backend/libc/pipe/syscalls.rs
+++ b/src/backend/libc/pipe/syscalls.rs
@@ -112,13 +112,13 @@ pub(crate) fn tee(
 
 #[cfg(linux_kernel)]
 #[inline]
-pub(crate) fn fcntl_getpipe_sz(fd: BorrowedFd<'_>) -> io::Result<usize> {
+pub(crate) fn fcntl_getpipe_size(fd: BorrowedFd<'_>) -> io::Result<usize> {
     unsafe { ret_c_int(c::fcntl(borrowed_fd(fd), c::F_GETPIPE_SZ)).map(|size| size as usize) }
 }
 
 #[cfg(linux_kernel)]
 #[inline]
-pub(crate) fn fcntl_setpipe_sz(fd: BorrowedFd<'_>, size: usize) -> io::Result<usize> {
+pub(crate) fn fcntl_setpipe_size(fd: BorrowedFd<'_>, size: usize) -> io::Result<usize> {
     let size: c::c_int = size.try_into().map_err(|_| io::Errno::PERM)?;
 
     unsafe { ret_c_int(c::fcntl(borrowed_fd(fd), c::F_SETPIPE_SZ, size)).map(|size| size as usize) }

--- a/src/backend/linux_raw/pipe/syscalls.rs
+++ b/src/backend/linux_raw/pipe/syscalls.rs
@@ -99,7 +99,7 @@ pub(crate) fn tee(
 }
 
 #[inline]
-pub(crate) fn fcntl_getpipe_sz(fd: BorrowedFd<'_>) -> io::Result<usize> {
+pub(crate) fn fcntl_getpipe_size(fd: BorrowedFd<'_>) -> io::Result<usize> {
     #[cfg(target_pointer_width = "32")]
     unsafe {
         ret_usize(syscall_readonly!(__NR_fcntl64, fd, c_uint(F_GETPIPE_SZ)))
@@ -111,7 +111,7 @@ pub(crate) fn fcntl_getpipe_sz(fd: BorrowedFd<'_>) -> io::Result<usize> {
 }
 
 #[inline]
-pub(crate) fn fcntl_setpipe_sz(fd: BorrowedFd<'_>, size: usize) -> io::Result<usize> {
+pub(crate) fn fcntl_setpipe_size(fd: BorrowedFd<'_>, size: usize) -> io::Result<usize> {
     let size: c::c_int = size.try_into().map_err(|_| io::Errno::PERM)?;
 
     #[cfg(target_pointer_width = "32")]

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -204,7 +204,7 @@ pub fn tee<FdIn: AsFd, FdOut: AsFd>(
 #[cfg(linux_kernel)]
 #[inline]
 pub fn fcntl_getpipe_size<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
-    backend::pipe::syscalls::fcntl_getpipe_sz(fd.as_fd())
+    backend::pipe::syscalls::fcntl_getpipe_size(fd.as_fd())
 }
 
 /// `fnctl(fd, F_SETPIPE_SZ)`—Set the buffer capacity of a pipe.
@@ -216,5 +216,5 @@ pub fn fcntl_getpipe_size<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
 #[cfg(linux_kernel)]
 #[inline]
 pub fn fcntl_setpipe_size<Fd: AsFd>(fd: Fd, size: usize) -> io::Result<usize> {
-    backend::pipe::syscalls::fcntl_setpipe_sz(fd.as_fd(), size)
+    backend::pipe::syscalls::fcntl_setpipe_size(fd.as_fd(), size)
 }

--- a/tests/pipe/fcntl.rs
+++ b/tests/pipe/fcntl.rs
@@ -29,3 +29,33 @@ fn test_fcntl_setpipe_size() {
     assert_eq!(reader_size, new_size);
     assert_eq!(reader_size, writer_size);
 }
+
+/// Test that we can write up to the pipe buffer size without blocking.
+#[cfg(linux_kernel)]
+#[test]
+fn test_fcntl_pipe_sized_writes() {
+    use rustix::io::{read, write};
+    use rustix::pipe::{fcntl_getpipe_size, fcntl_setpipe_size};
+
+    let (reader, writer) = rustix::pipe::pipe().unwrap();
+
+    let size = fcntl_getpipe_size(&reader).unwrap();
+
+    let ones = vec![1; size];
+    assert_eq!(write(&writer, &ones), Ok(size));
+    let mut buf = vec![2; size];
+    assert_eq!(read(&reader, &mut buf), Ok(size));
+    assert_eq!(buf, ones);
+
+    let size = size * 2;
+    let set_size = fcntl_setpipe_size(&reader, size).unwrap();
+    let get_size = fcntl_getpipe_size(&reader).unwrap();
+    assert_eq!(size, set_size);
+    assert_eq!(size, get_size);
+
+    let ones = vec![1; size];
+    assert_eq!(write(&writer, &ones), Ok(size));
+    let mut buf = vec![2; size];
+    assert_eq!(read(&reader, &mut buf), Ok(size));
+    assert_eq!(buf, ones);
+}


### PR DESCRIPTION
Also add another test, and make the names of the private implementation functions match the names of the public function.