### PR TITLE
Backport `fcntl_setpipe_size` fixes to 0.38.

### DIFF
--- a/src/backend/libc/pipe/syscalls.rs
+++ b/src/backend/libc/pipe/syscalls.rs
@@ -112,14 +112,17 @@ pub(crate) fn tee(
 
 #[cfg(linux_kernel)]
 #[inline]
-pub(crate) fn fcntl_getpipe_sz(fd: BorrowedFd<'_>) -> io::Result<usize> {
+pub(crate) fn fcntl_getpipe_size(fd: BorrowedFd<'_>) -> io::Result<usize> {
     unsafe { ret_c_int(c::fcntl(borrowed_fd(fd), c::F_GETPIPE_SZ)).map(|size| size as usize) }
 }
 
 #[cfg(linux_kernel)]
 #[inline]
-pub(crate) fn fcntl_setpipe_sz(fd: BorrowedFd<'_>, size: usize) -> io::Result<()> {
+pub(crate) fn fcntl_setpipe_size(fd: BorrowedFd<'_>, size: usize) -> io::Result<()> {
     let size: c::c_int = size.try_into().map_err(|_| io::Errno::PERM)?;
 
-    unsafe { ret(c::fcntl(borrowed_fd(fd), c::F_SETPIPE_SZ, size)) }
+    unsafe {
+        let _ = ret_c_int(c::fcntl(borrowed_fd(fd), c::F_SETPIPE_SZ, size))?;
+    }
+    Ok(())
 }

--- a/src/backend/linux_raw/pipe/syscalls.rs
+++ b/src/backend/linux_raw/pipe/syscalls.rs
@@ -99,7 +99,7 @@ pub(crate) fn tee(
 }
 
 #[inline]
-pub(crate) fn fcntl_getpipe_sz(fd: BorrowedFd<'_>) -> io::Result<usize> {
+pub(crate) fn fcntl_getpipe_size(fd: BorrowedFd<'_>) -> io::Result<usize> {
     #[cfg(target_pointer_width = "32")]
     unsafe {
         ret_usize(syscall_readonly!(__NR_fcntl64, fd, c_uint(F_GETPIPE_SZ)))
@@ -111,25 +111,27 @@ pub(crate) fn fcntl_getpipe_sz(fd: BorrowedFd<'_>) -> io::Result<usize> {
 }
 
 #[inline]
-pub(crate) fn fcntl_setpipe_sz(fd: BorrowedFd<'_>, size: usize) -> io::Result<()> {
+pub(crate) fn fcntl_setpipe_size(fd: BorrowedFd<'_>, size: usize) -> io::Result<()> {
     let size: c::c_int = size.try_into().map_err(|_| io::Errno::PERM)?;
 
     #[cfg(target_pointer_width = "32")]
     unsafe {
-        ret(syscall_readonly!(
+        let _ = ret_usize(syscall_readonly!(
             __NR_fcntl64,
             fd,
             c_uint(F_SETPIPE_SZ),
             c_int(size)
-        ))
+        ))?;
     }
     #[cfg(target_pointer_width = "64")]
     unsafe {
-        ret(syscall_readonly!(
+        let _ = ret_usize(syscall_readonly!(
             __NR_fcntl,
             fd,
             c_uint(F_SETPIPE_SZ),
             c_int(size)
-        ))
+        ))?;
     }
+
+    Ok(())
 }

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -204,10 +204,14 @@ pub fn tee<FdIn: AsFd, FdOut: AsFd>(
 #[cfg(linux_kernel)]
 #[inline]
 pub fn fcntl_getpipe_size<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
-    backend::pipe::syscalls::fcntl_getpipe_sz(fd.as_fd())
+    backend::pipe::syscalls::fcntl_getpipe_size(fd.as_fd())
 }
 
 /// `fnctl(fd, F_SETPIPE_SZ)`—Set the buffer capacity of a pipe.
+///
+/// The OS may decide to use a larger size than `size`. To know the precise
+/// size, call [`fcntl_getpipe_size`] after setting the size. In future
+/// versions of rustix, this function will return the new size.
 ///
 /// # References
 ///  - [Linux]
@@ -216,5 +220,5 @@ pub fn fcntl_getpipe_size<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
 #[cfg(linux_kernel)]
 #[inline]
 pub fn fcntl_setpipe_size<Fd: AsFd>(fd: Fd, size: usize) -> io::Result<()> {
-    backend::pipe::syscalls::fcntl_setpipe_sz(fd.as_fd(), size)
+    backend::pipe::syscalls::fcntl_setpipe_size(fd.as_fd(), size)
 }

--- a/tests/pipe/fcntl.rs
+++ b/tests/pipe/fcntl.rs
@@ -1,0 +1,58 @@
+#[cfg(linux_kernel)]
+#[test]
+fn test_fcntl_getpipe_size() {
+    use rustix::pipe::fcntl_getpipe_size;
+
+    let (reader, writer) = rustix::pipe::pipe().unwrap();
+
+    let reader_size = fcntl_getpipe_size(&reader).unwrap();
+    let writer_size = fcntl_getpipe_size(&writer).unwrap();
+    assert_eq!(reader_size, writer_size);
+}
+
+#[cfg(linux_kernel)]
+#[test]
+fn test_fcntl_setpipe_size() {
+    use rustix::pipe::{fcntl_getpipe_size, fcntl_setpipe_size};
+
+    let (reader, writer) = rustix::pipe::pipe().unwrap();
+
+    let new_size = 4096 * 2;
+    fcntl_setpipe_size(&reader, new_size).unwrap();
+    let writer_size = fcntl_getpipe_size(&writer).unwrap();
+    assert_eq!(new_size, writer_size);
+
+    let new_size = 4096 * 16;
+    fcntl_setpipe_size(&reader, new_size).unwrap();
+    let writer_size = fcntl_getpipe_size(&writer).unwrap();
+    assert_eq!(new_size, writer_size);
+}
+
+/// Test that we can write up to the pipe buffer size without blocking.
+#[cfg(linux_kernel)]
+#[test]
+fn test_fcntl_pipe_sized_writes() {
+    use rustix::io::{read, write};
+    use rustix::pipe::{fcntl_getpipe_size, fcntl_setpipe_size};
+
+    let (reader, writer) = rustix::pipe::pipe().unwrap();
+
+    let size = fcntl_getpipe_size(&reader).unwrap();
+
+    let ones = vec![1; size];
+    assert_eq!(write(&writer, &ones), Ok(size));
+    let mut buf = vec![2; size];
+    assert_eq!(read(&reader, &mut buf), Ok(size));
+    assert_eq!(buf, ones);
+
+    let size = size * 2;
+    fcntl_setpipe_size(&reader, size).unwrap();
+    let get_size = fcntl_getpipe_size(&reader).unwrap();
+    assert_eq!(size, get_size);
+
+    let ones = vec![1; size];
+    assert_eq!(write(&writer, &ones), Ok(size));
+    let mut buf = vec![2; size];
+    assert_eq!(read(&reader, &mut buf), Ok(size));
+    assert_eq!(buf, ones);
+}

--- a/tests/pipe/main.rs
+++ b/tests/pipe/main.rs
@@ -4,5 +4,6 @@
 #![cfg(not(windows))]
 
 mod basic;
+mod fcntl;
 mod splice;
 mod tee;


### PR DESCRIPTION
Backport parts of #1164 and #1165 to 0.38, but without the change to the public return type, to preserve semver compatibility for 0.38.