### PR TITLE
Update glibc documentation URLs

### DIFF
--- a/src/backend/libc/io/errno.rs
+++ b/src/backend/libc/io/errno.rs
@@ -30,7 +30,7 @@ use libc_errno::errno;
 /// [OpenBSD]: https://man.openbsd.org/errno.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=errno&section=2
 /// [illumos]: https://illumos.org/man/3C/errno
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Error-Codes.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Error-Codes.html
 #[repr(transparent)]
 #[doc(alias = "errno")]
 #[derive(Eq, PartialEq, Hash, Copy, Clone)]

--- a/src/backend/linux_raw/io/errno.rs
+++ b/src/backend/linux_raw/io/errno.rs
@@ -40,7 +40,7 @@ use linux_raw_sys::errno;
 /// [OpenBSD]: https://man.openbsd.org/errno.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=errno&section=2
 /// [illumos]: https://illumos.org/man/3C/errno
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Error-Codes.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Error-Codes.html
 #[repr(transparent)]
 #[doc(alias = "errno")]
 #[derive(Eq, PartialEq, Hash, Copy, Clone)]

--- a/src/fs/memfd_create.rs
+++ b/src/fs/memfd_create.rs
@@ -10,7 +10,7 @@ use backend::fs::types::MemfdFlags;
 ///  - [FreeBSD]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/memfd_create.2.html
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Memory_002dmapped-I_002fO.html#index-memfd_005fcreate
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Memory_002dmapped-I_002fO.html#index-memfd_005fcreate
 /// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?memfd_create
 #[inline]
 pub fn memfd_create<P: path::Arg>(name: P, flags: MemfdFlags) -> io::Result<OwnedFd> {

--- a/src/io/close.rs
+++ b/src/io/close.rs
@@ -43,7 +43,7 @@ use backend::fd::RawFd;
 /// [OpenBSD]: https://man.openbsd.org/close.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=close&section=2
 /// [illumos]: https://illumos.org/man/2/close
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Opening-and-Closing-Files.html#index-close
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Opening-and-Closing-Files.html#index-close
 ///
 /// # Safety
 ///

--- a/src/io/dup.rs
+++ b/src/io/dup.rs
@@ -38,7 +38,7 @@ pub use backend::io::types::DupFlags;
 /// [OpenBSD]: https://man.openbsd.org/dup.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=dup&section=2
 /// [illumos]: https://illumos.org/man/2/dup
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Duplicating-Descriptors.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Duplicating-Descriptors.html
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 pub fn dup<Fd: AsFd>(fd: Fd) -> io::Result<OwnedFd> {
@@ -80,7 +80,7 @@ pub fn dup<Fd: AsFd>(fd: Fd) -> io::Result<OwnedFd> {
 /// [OpenBSD]: https://man.openbsd.org/dup2.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=dup2&section=2
 /// [illumos]: https://illumos.org/man/2/dup
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Duplicating-Descriptors.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Duplicating-Descriptors.html
 /// [`stdio::dup2_stdin`]: https://docs.rs/rustix/*/rustix/stdio/fn.dup2_stdin.html
 /// [`stdio::dup2_stdout`]: https://docs.rs/rustix/*/rustix/stdio/fn.dup2_stdout.html
 /// [`stdio::dup2_stderr`]: https://docs.rs/rustix/*/rustix/stdio/fn.dup2_stderr.html

--- a/src/io/fcntl.rs
+++ b/src/io/fcntl.rs
@@ -34,7 +34,7 @@ pub use backend::io::types::FdFlags;
 /// [OpenBSD]: https://man.openbsd.org/fcntl.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=fcntl&section=2
 /// [illumos]: https://illumos.org/man/2/fcntl
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Control-Operations.html#index-fcntl-function
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Control-Operations.html#index-fcntl-function
 #[inline]
 #[doc(alias = "F_GETFD")]
 pub fn fcntl_getfd<Fd: AsFd>(fd: Fd) -> io::Result<FdFlags> {
@@ -62,7 +62,7 @@ pub fn fcntl_getfd<Fd: AsFd>(fd: Fd) -> io::Result<FdFlags> {
 /// [OpenBSD]: https://man.openbsd.org/fcntl.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=fcntl&section=2
 /// [illumos]: https://illumos.org/man/2/fcntl
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Control-Operations.html#index-fcntl-function
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Control-Operations.html#index-fcntl-function
 #[inline]
 #[doc(alias = "F_SETFD")]
 pub fn fcntl_setfd<Fd: AsFd>(fd: Fd, flags: FdFlags) -> io::Result<()> {
@@ -97,7 +97,7 @@ pub fn fcntl_setfd<Fd: AsFd>(fd: Fd, flags: FdFlags) -> io::Result<()> {
 /// [OpenBSD]: https://man.openbsd.org/fcntl.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=fcntl&section=2
 /// [illumos]: https://illumos.org/man/2/fcntl
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Control-Operations.html#index-fcntl-function
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Control-Operations.html#index-fcntl-function
 /// [file description]: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap03.html#tag_03_258
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 #[inline]
@@ -133,7 +133,7 @@ pub fn fcntl_dupfd_cloexec<Fd: AsFd>(fd: Fd, min: RawFd) -> io::Result<OwnedFd> 
 /// [OpenBSD]: https://man.openbsd.org/fcntl.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=fcntl&section=2
 /// [illumos]: https://illumos.org/man/2/fcntl
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Control-Operations.html#index-fcntl-function
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Control-Operations.html#index-fcntl-function
 /// [file description]: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap03.html#tag_03_258
 #[cfg(target_os = "espidf")]
 #[inline]

--- a/src/io/read_write.rs
+++ b/src/io/read_write.rs
@@ -38,7 +38,7 @@ pub use backend::io::types::ReadWriteFlags;
 /// [OpenBSD]: https://man.openbsd.org/read.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=read&section=2
 /// [illumos]: https://illumos.org/man/2/read
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/I_002fO-Primitives.html#index-reading-from-a-file-descriptor
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/I_002fO-Primitives.html#index-reading-from-a-file-descriptor
 #[inline]
 pub fn read<Fd: AsFd>(fd: Fd, buf: &mut [u8]) -> io::Result<usize> {
     unsafe { backend::io::syscalls::read(fd.as_fd(), buf.as_mut_ptr(), buf.len()) }
@@ -84,7 +84,7 @@ pub fn read_uninit<Fd: AsFd>(
 /// [OpenBSD]: https://man.openbsd.org/write.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=write&section=2
 /// [illumos]: https://illumos.org/man/2/write
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/I_002fO-Primitives.html#index-writing-to-a-file-descriptor
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/I_002fO-Primitives.html#index-writing-to-a-file-descriptor
 #[inline]
 pub fn write<Fd: AsFd>(fd: Fd, buf: &[u8]) -> io::Result<usize> {
     backend::io::syscalls::write(fd.as_fd(), buf)
@@ -104,6 +104,7 @@ pub fn write<Fd: AsFd>(fd: Fd, buf: &[u8]) -> io::Result<usize> {
 ///  - [OpenBSD]
 ///  - [DragonFly BSD]
 ///  - [illumos]
+///  - [glibc]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/pread.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/pread.2.html
@@ -113,6 +114,7 @@ pub fn write<Fd: AsFd>(fd: Fd, buf: &[u8]) -> io::Result<usize> {
 /// [OpenBSD]: https://man.openbsd.org/pread.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=pread&section=2
 /// [illumos]: https://illumos.org/man/2/pread
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/I_002fO-Primitives.html#index-pread64
 #[inline]
 pub fn pread<Fd: AsFd>(fd: Fd, buf: &mut [u8], offset: u64) -> io::Result<usize> {
     unsafe { backend::io::syscalls::pread(fd.as_fd(), buf.as_mut_ptr(), buf.len(), offset) }
@@ -150,6 +152,7 @@ pub fn pread_uninit<Fd: AsFd>(
 ///  - [OpenBSD]
 ///  - [DragonFly BSD]
 ///  - [illumos]
+///  - [glibc]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/pwrite.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/pwrite.2.html
@@ -159,6 +162,7 @@ pub fn pread_uninit<Fd: AsFd>(
 /// [OpenBSD]: https://man.openbsd.org/pwrite.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=pwrite&section=2
 /// [illumos]: https://illumos.org/man/2/pwrite
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/I_002fO-Primitives.html#index-pwrite64
 #[inline]
 pub fn pwrite<Fd: AsFd>(fd: Fd, buf: &[u8], offset: u64) -> io::Result<usize> {
     backend::io::syscalls::pwrite(fd.as_fd(), buf, offset)
@@ -175,6 +179,7 @@ pub fn pwrite<Fd: AsFd>(fd: Fd, buf: &[u8], offset: u64) -> io::Result<usize> {
 ///  - [OpenBSD]
 ///  - [DragonFly BSD]
 ///  - [illumos]
+///  - [glibc]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/readv.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/readv.2.html
@@ -184,6 +189,7 @@ pub fn pwrite<Fd: AsFd>(fd: Fd, buf: &[u8], offset: u64) -> io::Result<usize> {
 /// [OpenBSD]: https://man.openbsd.org/readv.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=readv&section=2
 /// [illumos]: https://illumos.org/man/2/readv
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Scatter_002dGather.html#index-readv
 #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
 #[inline]
 pub fn readv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
@@ -201,6 +207,7 @@ pub fn readv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize>
 ///  - [OpenBSD]
 ///  - [DragonFly BSD]
 ///  - [illumos]
+///  - [glibc]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/writev.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/writev.2.html
@@ -210,6 +217,7 @@ pub fn readv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize>
 /// [OpenBSD]: https://man.openbsd.org/writev.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=writev&section=2
 /// [illumos]: https://illumos.org/man/2/writev
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Scatter_002dGather.html#index-writev
 #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
 #[inline]
 pub fn writev<Fd: AsFd>(fd: Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
@@ -226,6 +234,7 @@ pub fn writev<Fd: AsFd>(fd: Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
 ///  - [OpenBSD]
 ///  - [DragonFly BSD]
 ///  - [illumos]
+///  - [glibc]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/preadv.2.html
 /// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=preadv&sektion=2
@@ -233,6 +242,7 @@ pub fn writev<Fd: AsFd>(fd: Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
 /// [OpenBSD]: https://man.openbsd.org/preadv.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=preadv&section=2
 /// [illumos]: https://illumos.org/man/2/preadv
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Scatter_002dGather.html#index-preadv64
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "haiku",
@@ -261,6 +271,7 @@ pub fn preadv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io:
 ///  - [OpenBSD]
 ///  - [DragonFly BSD]
 ///  - [illumos]
+///  - [glibc]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/pwritev.2.html
 /// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=pwritev&sektion=2
@@ -268,6 +279,7 @@ pub fn preadv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io:
 /// [OpenBSD]: https://man.openbsd.org/pwritev.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=pwritev&section=2
 /// [illumos]: https://illumos.org/man/2/pwritev
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/I_002fO-Primitives.html#index-pwrite64
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "haiku",
@@ -288,8 +300,10 @@ pub fn pwritev<Fd: AsFd>(fd: Fd, bufs: &[IoSlice<'_>], offset: u64) -> io::Resul
 ///
 /// # References
 ///  - [Linux]
+///  - [glibc]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/preadv2.2.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Scatter_002dGather.html#index-preadv64v2
 #[cfg(linux_kernel)]
 #[inline]
 pub fn preadv2<Fd: AsFd>(
@@ -307,8 +321,10 @@ pub fn preadv2<Fd: AsFd>(
 ///
 /// # References
 ///  - [Linux]
+///  - [glibc]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/pwritev2.2.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Scatter_002dGather.html#index-pwritev64v2
 #[cfg(linux_kernel)]
 #[inline]
 pub fn pwritev2<Fd: AsFd>(

--- a/src/mm/madvise.rs
+++ b/src/mm/madvise.rs
@@ -41,7 +41,7 @@ pub use backend::mm::types::Advice;
 /// [OpenBSD]: https://man.openbsd.org/madvise.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=madvise&section=2
 /// [illumos]: https://illumos.org/man/3C/madvise
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Memory_002dmapped-I_002fO.html#index-madvise
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Memory_002dmapped-I_002fO.html#index-madvise
 #[inline]
 #[doc(alias = "posix_madvise")]
 pub unsafe fn madvise(addr: *mut c_void, len: usize, advice: Advice) -> io::Result<()> {

--- a/src/mm/mmap.rs
+++ b/src/mm/mmap.rs
@@ -73,7 +73,7 @@ impl MapFlags {
 /// [OpenBSD]: https://man.openbsd.org/mmap.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=mmap&section=2
 /// [illumos]: https://illumos.org/man/2/mmap
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Memory_002dmapped-I_002fO.html#index-mmap
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Memory_002dmapped-I_002fO.html#index-mmap
 #[inline]
 pub unsafe fn mmap<Fd: AsFd>(
     ptr: *mut c_void,
@@ -114,7 +114,7 @@ pub unsafe fn mmap<Fd: AsFd>(
 /// [OpenBSD]: https://man.openbsd.org/mmap.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=mmap&section=2
 /// [illumos]: https://illumos.org/man/2/mmap
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Memory_002dmapped-I_002fO.html#index-mmap
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Memory_002dmapped-I_002fO.html#index-mmap
 #[inline]
 #[doc(alias = "mmap")]
 pub unsafe fn mmap_anonymous(
@@ -151,7 +151,7 @@ pub unsafe fn mmap_anonymous(
 /// [OpenBSD]: https://man.openbsd.org/munmap.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=munmap&section=2
 /// [illumos]: https://illumos.org/man/2/munmap
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Memory_002dmapped-I_002fO.html#index-munmap
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Memory_002dmapped-I_002fO.html#index-munmap
 #[inline]
 pub unsafe fn munmap(ptr: *mut c_void, len: usize) -> io::Result<()> {
     backend::mm::syscalls::munmap(ptr, len)
@@ -272,7 +272,7 @@ pub unsafe fn mprotect(ptr: *mut c_void, len: usize, flags: MprotectFlags) -> io
 /// [OpenBSD]: https://man.openbsd.org/mlock.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=mlock&section=2
 /// [illumos]: https://illumos.org/man/3C/mlock
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Page-Lock-Functions.html#index-mlock
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Page-Lock-Functions.html#index-mlock
 #[inline]
 pub unsafe fn mlock(ptr: *mut c_void, len: usize) -> io::Result<()> {
     backend::mm::syscalls::mlock(ptr, len)
@@ -298,7 +298,7 @@ pub unsafe fn mlock(ptr: *mut c_void, len: usize) -> io::Result<()> {
 ///  - [glibc]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/mlock2.2.html
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Page-Lock-Functions.html#index-mlock2
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Page-Lock-Functions.html#index-mlock2
 #[cfg(linux_kernel)]
 #[inline]
 #[doc(alias = "mlock2")]
@@ -337,7 +337,7 @@ pub unsafe fn mlock_with(ptr: *mut c_void, len: usize, flags: MlockFlags) -> io:
 /// [OpenBSD]: https://man.openbsd.org/munlock.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=munlock&section=2
 /// [illumos]: https://illumos.org/man/3C/munlock
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Page-Lock-Functions.html#index-munlock
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Page-Lock-Functions.html#index-munlock
 #[inline]
 pub unsafe fn munlock(ptr: *mut c_void, len: usize) -> io::Result<()> {
     backend::mm::syscalls::munlock(ptr, len)
@@ -368,7 +368,7 @@ pub unsafe fn munlock(ptr: *mut c_void, len: usize) -> io::Result<()> {
 /// [OpenBSD]: https://man.openbsd.org/mlockall.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=mlockall&section=2
 /// [illumos]: https://illumos.org/man/3C/mlockall
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Page-Lock-Functions.html#index-mlockall
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Page-Lock-Functions.html#index-mlockall
 #[cfg(any(linux_kernel, freebsdlike, netbsdlike))]
 #[inline]
 pub fn mlockall(flags: MlockAllFlags) -> io::Result<()> {
@@ -401,7 +401,7 @@ pub fn mlockall(flags: MlockAllFlags) -> io::Result<()> {
 /// [OpenBSD]: https://man.openbsd.org/munlockall.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=munlockall&section=2
 /// [illumos]: https://illumos.org/man/3C/munlockall
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Page-Lock-Functions.html#index-munlockall
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Page-Lock-Functions.html#index-munlockall
 #[cfg(any(linux_kernel, freebsdlike, netbsdlike))]
 #[inline]
 pub fn munlockall() -> io::Result<()> {

--- a/src/mm/msync.rs
+++ b/src/mm/msync.rs
@@ -39,7 +39,7 @@ pub use backend::mm::types::MsyncFlags;
 /// [OpenBSD]: https://man.openbsd.org/msync.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=msync&section=2
 /// [illumos]: https://illumos.org/man/3C/msync
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Memory_002dmapped-I_002fO.html#index-msync
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Memory_002dmapped-I_002fO.html#index-msync
 #[inline]
 pub unsafe fn msync(addr: *mut c_void, len: usize, flags: MsyncFlags) -> io::Result<()> {
     backend::mm::syscalls::msync(addr, len, flags)

--- a/src/net/send_recv/mod.rs
+++ b/src/net/send_recv/mod.rs
@@ -61,7 +61,7 @@ pub use msg::*;
 /// [OpenBSD]: https://man.openbsd.org/recv.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=recv&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/recv
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Receiving-Data.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Receiving-Data.html
 #[inline]
 pub fn recv<Fd: AsFd>(fd: Fd, buf: &mut [u8], flags: RecvFlags) -> io::Result<usize> {
     unsafe { backend::net::syscalls::recv(fd.as_fd(), buf.as_mut_ptr(), buf.len(), flags) }
@@ -117,7 +117,7 @@ pub fn recv_uninit<Fd: AsFd>(
 /// [OpenBSD]: https://man.openbsd.org/send.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=send&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/send
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Sending-Data.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Sending-Data.html
 #[inline]
 pub fn send<Fd: AsFd>(fd: Fd, buf: &[u8], flags: SendFlags) -> io::Result<usize> {
     backend::net::syscalls::send(fd.as_fd(), buf, flags)
@@ -152,7 +152,7 @@ pub fn send<Fd: AsFd>(fd: Fd, buf: &[u8], flags: SendFlags) -> io::Result<usize>
 /// [OpenBSD]: https://man.openbsd.org/recvfrom.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=recvfrom&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/recvfrom
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Receiving-Datagrams.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Receiving-Datagrams.html
 #[inline]
 pub fn recvfrom<Fd: AsFd>(
     fd: Fd,
@@ -221,7 +221,7 @@ pub fn recvfrom_uninit<Fd: AsFd>(
 /// [OpenBSD]: https://man.openbsd.org/sendto.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=sendto&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/sendto
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Sending-Datagrams.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Sending-Datagrams.html
 pub fn sendto<Fd: AsFd>(
     fd: Fd,
     buf: &[u8],
@@ -269,7 +269,7 @@ fn _sendto(
 /// [OpenBSD]: https://man.openbsd.org/sendto.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=sendto&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/sendto
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Sending-Datagrams.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Sending-Datagrams.html
 pub fn sendto_any<Fd: AsFd>(
     fd: Fd,
     buf: &[u8],
@@ -321,7 +321,7 @@ fn _sendto_any(
 /// [OpenBSD]: https://man.openbsd.org/sendto.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=sendto&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/sendto
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Sending-Datagrams.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Sending-Datagrams.html
 #[inline]
 #[doc(alias = "sendto")]
 pub fn sendto_v4<Fd: AsFd>(
@@ -359,7 +359,7 @@ pub fn sendto_v4<Fd: AsFd>(
 /// [OpenBSD]: https://man.openbsd.org/sendto.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=sendto&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/sendto
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Sending-Datagrams.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Sending-Datagrams.html
 #[inline]
 #[doc(alias = "sendto")]
 pub fn sendto_v6<Fd: AsFd>(
@@ -397,7 +397,7 @@ pub fn sendto_v6<Fd: AsFd>(
 /// [OpenBSD]: https://man.openbsd.org/sendto.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=sendto&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/sendto
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Sending-Datagrams.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Sending-Datagrams.html
 #[cfg(unix)]
 #[inline]
 #[doc(alias = "sendto")]

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -41,7 +41,7 @@ pub use backend::net::addr::SocketAddrUnix;
 /// [OpenBSD]: https://man.openbsd.org/socket.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=socket&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/socket
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Creating-a-Socket.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Creating-a-Socket.html
 #[inline]
 pub fn socket(
     domain: AddressFamily,
@@ -84,7 +84,7 @@ pub fn socket(
 /// [OpenBSD]: https://man.openbsd.org/socket.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=socket&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/socket
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Creating-a-Socket.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Creating-a-Socket.html
 #[doc(alias("socket"))]
 #[inline]
 pub fn socket_with(
@@ -121,7 +121,7 @@ pub fn socket_with(
 /// [OpenBSD]: https://man.openbsd.org/bind.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=bind&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/bind
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Setting-Address.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Setting-Address.html
 pub fn bind<Fd: AsFd>(sockfd: Fd, addr: &SocketAddr) -> io::Result<()> {
     _bind(sockfd.as_fd(), addr)
 }
@@ -158,7 +158,7 @@ fn _bind(sockfd: BorrowedFd<'_>, addr: &SocketAddr) -> io::Result<()> {
 /// [OpenBSD]: https://man.openbsd.org/bind.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=bind&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/bind
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Setting-Address.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Setting-Address.html
 #[doc(alias = "bind")]
 pub fn bind_any<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrAny) -> io::Result<()> {
     _bind_any(sockfd.as_fd(), addr)
@@ -201,7 +201,7 @@ fn _bind_any(sockfd: BorrowedFd<'_>, addr: &SocketAddrAny) -> io::Result<()> {
 /// [OpenBSD]: https://man.openbsd.org/bind.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=bind&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/bind
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Setting-Address.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Setting-Address.html
 #[inline]
 #[doc(alias = "bind")]
 pub fn bind_v4<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrV4) -> io::Result<()> {
@@ -234,7 +234,7 @@ pub fn bind_v4<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrV4) -> io::Result<()> {
 /// [OpenBSD]: https://man.openbsd.org/bind.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=bind&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/bind
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Setting-Address.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Setting-Address.html
 #[inline]
 #[doc(alias = "bind")]
 pub fn bind_v6<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrV6) -> io::Result<()> {
@@ -267,7 +267,7 @@ pub fn bind_v6<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrV6) -> io::Result<()> {
 /// [OpenBSD]: https://man.openbsd.org/bind.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=bind&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/bind
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Setting-Address.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Setting-Address.html
 #[cfg(unix)]
 #[inline]
 #[doc(alias = "bind")]
@@ -318,7 +318,7 @@ pub fn bind_xdp<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrXdp) -> io::Result<()> {
 /// [OpenBSD]: https://man.openbsd.org/connect.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=connect&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/connect
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Connecting.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Connecting.html
 /// [`Errno::WOULDBLOCK`]: io::Errno::WOULDBLOCK
 pub fn connect<Fd: AsFd>(sockfd: Fd, addr: &SocketAddr) -> io::Result<()> {
     _connect(sockfd.as_fd(), addr)
@@ -356,7 +356,7 @@ fn _connect(sockfd: BorrowedFd<'_>, addr: &SocketAddr) -> io::Result<()> {
 /// [OpenBSD]: https://man.openbsd.org/connect.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=connect&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/connect
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Connecting.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Connecting.html
 #[doc(alias = "connect")]
 pub fn connect_any<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrAny) -> io::Result<()> {
     _connect_any(sockfd.as_fd(), addr)
@@ -399,7 +399,7 @@ fn _connect_any(sockfd: BorrowedFd<'_>, addr: &SocketAddrAny) -> io::Result<()> 
 /// [OpenBSD]: https://man.openbsd.org/connect.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=connect&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/connect
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Connecting.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Connecting.html
 #[inline]
 #[doc(alias = "connect")]
 pub fn connect_v4<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrV4) -> io::Result<()> {
@@ -432,7 +432,7 @@ pub fn connect_v4<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrV4) -> io::Result<()> {
 /// [OpenBSD]: https://man.openbsd.org/connect.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=connect&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/connect
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Connecting.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Connecting.html
 #[inline]
 #[doc(alias = "connect")]
 pub fn connect_v6<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrV6) -> io::Result<()> {
@@ -465,7 +465,7 @@ pub fn connect_v6<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrV6) -> io::Result<()> {
 /// [OpenBSD]: https://man.openbsd.org/connect.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=connect&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/connect
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Connecting.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Connecting.html
 #[cfg(unix)]
 #[inline]
 #[doc(alias = "connect")]
@@ -502,7 +502,7 @@ pub fn connect_unix<Fd: AsFd>(sockfd: Fd, addr: &SocketAddrUnix) -> io::Result<(
 /// [OpenBSD]: https://man.openbsd.org/connect.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=connect&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/connect
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Connecting.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Connecting.html
 /// [`Errno::AFNOSUPPORT`]: io::Errno::AFNOSUPPORT
 /// [`Errno::INVAL`]: io::Errno::INVAL
 #[inline]
@@ -536,7 +536,7 @@ pub fn connect_unspec<Fd: AsFd>(sockfd: Fd) -> io::Result<()> {
 /// [OpenBSD]: https://man.openbsd.org/listen.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=listen&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/listen
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Listening.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Listening.html
 #[inline]
 pub fn listen<Fd: AsFd>(sockfd: Fd, backlog: i32) -> io::Result<()> {
     backend::net::syscalls::listen(sockfd.as_fd(), backlog)
@@ -573,7 +573,7 @@ pub fn listen<Fd: AsFd>(sockfd: Fd, backlog: i32) -> io::Result<()> {
 /// [OpenBSD]: https://man.openbsd.org/accept.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=accept&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/accept
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Accepting-Connections.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Accepting-Connections.html
 #[inline]
 pub fn accept<Fd: AsFd>(sockfd: Fd) -> io::Result<OwnedFd> {
     backend::net::syscalls::accept(sockfd.as_fd())
@@ -639,7 +639,7 @@ pub fn accept_with<Fd: AsFd>(sockfd: Fd, flags: SocketFlags) -> io::Result<Owned
 /// [OpenBSD]: https://man.openbsd.org/accept.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=accept&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/accept
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Accepting-Connections.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Accepting-Connections.html
 #[inline]
 #[doc(alias = "accept")]
 pub fn acceptfrom<Fd: AsFd>(sockfd: Fd) -> io::Result<(OwnedFd, Option<SocketAddrAny>)> {
@@ -702,7 +702,7 @@ pub fn acceptfrom_with<Fd: AsFd>(
 /// [OpenBSD]: https://man.openbsd.org/shutdown.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=shutdown&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/shutdown
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Closing-a-Socket.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Closing-a-Socket.html
 #[inline]
 pub fn shutdown<Fd: AsFd>(sockfd: Fd, how: Shutdown) -> io::Result<()> {
     backend::net::syscalls::shutdown(sockfd.as_fd(), how)
@@ -731,7 +731,7 @@ pub fn shutdown<Fd: AsFd>(sockfd: Fd, how: Shutdown) -> io::Result<()> {
 /// [OpenBSD]: https://man.openbsd.org/getsockname.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=getsockname&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/getsockname
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Reading-Address.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Reading-Address.html
 #[inline]
 pub fn getsockname<Fd: AsFd>(sockfd: Fd) -> io::Result<SocketAddrAny> {
     backend::net::syscalls::getsockname(sockfd.as_fd())
@@ -763,7 +763,7 @@ pub fn getsockname<Fd: AsFd>(sockfd: Fd) -> io::Result<SocketAddrAny> {
 /// [OpenBSD]: https://man.openbsd.org/getpeername.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=getpeername&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/getpeername
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Who-is-Connected.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Who-is-Connected.html
 #[inline]
 pub fn getpeername<Fd: AsFd>(sockfd: Fd) -> io::Result<Option<SocketAddrAny>> {
     backend::net::syscalls::getpeername(sockfd.as_fd())

--- a/src/net/socketpair.rs
+++ b/src/net/socketpair.rs
@@ -24,7 +24,7 @@ use crate::{backend, io};
 /// [OpenBSD]: https://man.openbsd.org/socketpair.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=socketpair&section=2
 /// [illumos]: https://illumos.org/man/3SOCKET/socketpair
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Socket-Pairs.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Socket-Pairs.html
 #[inline]
 pub fn socketpair(
     domain: AddressFamily,

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -25,7 +25,7 @@
 //! [OpenBSD `getsockopt`]: https://man.openbsd.org/getsockopt.2
 //! [DragonFly BSD `getsockopt`]: https://man.dragonflybsd.org/?command=getsockopt&section=2
 //! [illumos `getsockopt`]: https://illumos.org/man/3SOCKET/getsockopt
-//! [glibc `getsockopt`]: https://www.gnu.org/software/libc/manual/html_node/Socket-Option-Functions.html
+//! [glibc `getsockopt`]: https://sourceware.org/glibc/manual/latest/html_node/Socket-Option-Functions.html
 //!
 //! # References for all `set_*` functions:
 //!
@@ -49,7 +49,7 @@
 //! [OpenBSD `setsockopt`]: https://man.openbsd.org/setsockopt.2
 //! [DragonFly BSD `setsockopt`]: https://man.dragonflybsd.org/?command=setsockopt&section=2
 //! [illumos `setsockopt`]: https://illumos.org/man/3SOCKET/setsockopt
-//! [glibc `setsockopt`]: https://www.gnu.org/software/libc/manual/html_node/Socket-Option-Functions.html
+//! [glibc `setsockopt`]: https://sourceware.org/glibc/manual/latest/html_node/Socket-Option-Functions.html
 //!
 //! # References for `get_socket_*` and `set_socket_*` functions:
 //!
@@ -63,7 +63,7 @@
 //! [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/sys_socket.h.html
 //! [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
 //! [Winsock `SOL_SOCKET` options]: https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
-//! [glibc `SOL_SOCKET` options]: https://www.gnu.org/software/libc/manual/html_node/Socket_002dLevel-Options.html
+//! [glibc `SOL_SOCKET` options]: https://sourceware.org/glibc/manual/latest/html_node/Socket_002dLevel-Options.html
 //!
 //! # References for `get_ip_*` and `set_ip_*` functions:
 //!

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -71,7 +71,7 @@ pub const PIPE_BUF: usize = c::PIPE_BUF;
 /// [OpenBSD]: https://man.openbsd.org/pipe.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=pipe&section=2
 /// [illumos]: https://illumos.org/man/2/pipe
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Creating-a-Pipe.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Creating-a-Pipe.html
 #[inline]
 pub fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     backend::pipe::syscalls::pipe()

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -112,7 +112,7 @@ pub fn openpt(flags: OpenptFlags) -> io::Result<OwnedFd> {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/ptsname.html
 /// [Linux]: https://man7.org/linux/man-pages/man3/ptsname.3.html
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Allocation.html#index-ptsname
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Allocation.html#index-ptsname
 #[cfg(all(
     feature = "alloc",
     any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia")
@@ -132,7 +132,7 @@ pub fn ptsname<Fd: AsFd, B: Into<Vec<u8>>>(fd: Fd, reuse: B) -> io::Result<CStri
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/unlockpt.html
 /// [Linux]: https://man7.org/linux/man-pages/man3/unlockpt.3.html
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Allocation.html#index-unlockpt
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Allocation.html#index-unlockpt
 #[inline]
 pub fn unlockpt<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     backend::pty::syscalls::unlockpt(fd.as_fd())
@@ -152,7 +152,7 @@ pub fn unlockpt<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/grantpt.html
 /// [Linux]: https://man7.org/linux/man-pages/man3/grantpt.3.html
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Allocation.html#index-grantpt
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Allocation.html#index-grantpt
 /// [`Signal::Child`]: crate::process::Signal::Child
 #[inline]
 pub fn grantpt<Fd: AsFd>(fd: Fd) -> io::Result<()> {

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -49,7 +49,7 @@ use {
 /// [OpenBSD]: https://man.openbsd.org/stdin.4
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=stdin&section=4
 /// [illumos]: https://illumos.org/man/4FS/stdin
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html#index-stdin
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Standard-Streams.html#index-stdin
 #[cfg(feature = "std")]
 #[doc(alias = "STDIN_FILENO")]
 #[inline]
@@ -95,7 +95,7 @@ pub const fn stdin() -> BorrowedFd<'static> {
 /// [OpenBSD]: https://man.openbsd.org/stdin.4
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=stdin&section=4
 /// [illumos]: https://illumos.org/man/4FS/stdin
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html#index-stdin
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Standard-Streams.html#index-stdin
 #[cfg(not(feature = "std"))]
 #[doc(alias = "STDIN_FILENO")]
 #[inline]
@@ -135,7 +135,7 @@ pub const unsafe fn stdin() -> BorrowedFd<'static> {
 /// [OpenBSD]: https://man.openbsd.org/stdin.4
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=stdin&section=4
 /// [illumos]: https://illumos.org/man/4FS/stdin
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html#index-stdin
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Standard-Streams.html#index-stdin
 #[doc(alias = "STDIN_FILENO")]
 #[inline]
 pub unsafe fn take_stdin() -> OwnedFd {
@@ -171,7 +171,7 @@ pub unsafe fn take_stdin() -> OwnedFd {
 /// [OpenBSD]: https://man.openbsd.org/stdout.4
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=stdout&section=4
 /// [illumos]: https://illumos.org/man/4FS/stdout
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html#index-stdout
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Standard-Streams.html#index-stdout
 #[cfg(feature = "std")]
 #[doc(alias = "STDOUT_FILENO")]
 #[inline]
@@ -217,7 +217,7 @@ pub const fn stdout() -> BorrowedFd<'static> {
 /// [OpenBSD]: https://man.openbsd.org/stdout.4
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=stdout&section=4
 /// [illumos]: https://illumos.org/man/4FS/stdout
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html#index-stdout
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Standard-Streams.html#index-stdout
 #[cfg(not(feature = "std"))]
 #[doc(alias = "STDOUT_FILENO")]
 #[inline]
@@ -257,7 +257,7 @@ pub const unsafe fn stdout() -> BorrowedFd<'static> {
 /// [OpenBSD]: https://man.openbsd.org/stdout.4
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=stdout&section=4
 /// [illumos]: https://illumos.org/man/4FS/stdout
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html#index-stdout
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Standard-Streams.html#index-stdout
 #[doc(alias = "STDOUT_FILENO")]
 #[inline]
 pub unsafe fn take_stdout() -> OwnedFd {
@@ -287,7 +287,7 @@ pub unsafe fn take_stdout() -> OwnedFd {
 /// [OpenBSD]: https://man.openbsd.org/stderr.4
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=stderr&section=4
 /// [illumos]: https://illumos.org/man/4FS/stderr
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html#index-stderr
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Standard-Streams.html#index-stderr
 #[cfg(feature = "std")]
 #[doc(alias = "STDERR_FILENO")]
 #[inline]
@@ -327,7 +327,7 @@ pub const fn stderr() -> BorrowedFd<'static> {
 /// [OpenBSD]: https://man.openbsd.org/stderr.4
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=stderr&section=4
 /// [illumos]: https://illumos.org/man/4FS/stderr
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html#index-stderr
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Standard-Streams.html#index-stderr
 #[cfg(not(feature = "std"))]
 #[doc(alias = "STDERR_FILENO")]
 #[inline]
@@ -372,7 +372,7 @@ pub const unsafe fn stderr() -> BorrowedFd<'static> {
 /// [OpenBSD]: https://man.openbsd.org/stderr.4
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=stderr&section=4
 /// [illumos]: https://illumos.org/man/4FS/stderr
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html#index-stderr
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Standard-Streams.html#index-stderr
 #[doc(alias = "STDERR_FILENO")]
 #[inline]
 pub unsafe fn take_stderr() -> OwnedFd {
@@ -404,7 +404,7 @@ pub unsafe fn take_stderr() -> OwnedFd {
 /// [OpenBSD]: https://man.openbsd.org/stdin.4
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=stdin&section=4
 /// [illumos]: https://illumos.org/man/4FS/stdin
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html#index-stdin
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Standard-Streams.html#index-stdin
 #[doc(alias = "STDIN_FILENO")]
 #[inline]
 pub const fn raw_stdin() -> RawFd {
@@ -436,7 +436,7 @@ pub const fn raw_stdin() -> RawFd {
 /// [OpenBSD]: https://man.openbsd.org/stdout.4
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=stdout&section=4
 /// [illumos]: https://illumos.org/man/4FS/stdout
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html#index-stdout
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Standard-Streams.html#index-stdout
 #[doc(alias = "STDOUT_FILENO")]
 #[inline]
 pub const fn raw_stdout() -> RawFd {
@@ -468,7 +468,7 @@ pub const fn raw_stdout() -> RawFd {
 /// [OpenBSD]: https://man.openbsd.org/stderr.4
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=stderr&section=4
 /// [illumos]: https://illumos.org/man/4FS/stderr
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html#index-stderr
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Standard-Streams.html#index-stderr
 #[doc(alias = "STDERR_FILENO")]
 #[inline]
 pub const fn raw_stderr() -> RawFd {

--- a/src/system.rs
+++ b/src/system.rs
@@ -46,7 +46,7 @@ use c::c_int;
 /// [OpenBSD]: https://man.openbsd.org/uname.3
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=uname&section=3
 /// [illumos]: https://illumos.org/man/2/uname
-/// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Platform-Type.html
+/// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Platform-Type.html
 #[doc(alias = "gethostname")]
 #[inline]
 pub fn uname() -> Uname {


### PR DESCRIPTION
According to [this page], the official site for the glibc documentation is [here] now. Update URLs accordingly.

And add links for glibc's documentation for `pread`, `pwrite`, `readv`, `writev`, `preadv2` and `pwritev2`.

[this page]: https://www.gnu.org/software/libc/manual/
[here]: https://sourceware.org/glibc/manual/