### PR TITLE
Remove the "libc-extra-traits" feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ the functions in the `rustix::thread::futex` module instead.
 The `SLAVE` flag in `rustix::mount::MountPropagationFlags` is renamed
 to `DOWNSTREAM`.
 
-The "cc" feature is removed. It hasn't had any effect for several
-major releases.
+The "cc" and "libc-extra-traits" features are removed. The "cc" feature hasn't
+had any effect for several major releases. If you need the traits provided
+by "libc-extra-traits", you should instead depend on libc directly and enable
+its "extra_traits" feature.
 
 All explicitly deprecated functions and types have been removed. Their
 deprecation messages will have identified alternatives.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,14 +118,10 @@ default = ["std", "use-libc-auxv"]
 
 # This enables use of std. Disabling this enables `#![no_std]`, and requires
 # Rust 1.64 or newer.
-std = ["bitflags/std", "alloc", "libc?/std", "libc_errno?/std", "libc-extra-traits"]
+std = ["bitflags/std", "alloc", "libc?/std", "libc_errno?/std"]
 
 # Enable this to request the libc backend.
-use-libc = ["libc_errno", "libc", "libc-extra-traits"]
-
-# Enable `extra_traits` in libc types, to provide `Debug`, `Hash`, and other
-# trait impls for libc types.
-libc-extra-traits = ["libc?/extra_traits"]
+use-libc = ["libc_errno", "libc"]
 
 # Enable `rustix::event::*`.
 event = []

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -19,6 +19,8 @@ use {
 };
 
 #[cfg(feature = "termios")]
+#[cfg(all(not(windows), feature = "stdio"))]
+#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 struct DebugWinsize(rustix::termios::Winsize);
 
 #[cfg(feature = "termios")]

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -24,6 +24,8 @@ use {
 struct DebugWinsize(rustix::termios::Winsize);
 
 #[cfg(feature = "termios")]
+#[cfg(all(not(windows), feature = "stdio"))]
+#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 impl core::fmt::Debug for DebugWinsize {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut d = f.debug_struct("Winsize");

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -18,8 +18,10 @@ use {
     rustix::stdio::{stderr, stdin, stdout},
 };
 
+#[cfg(feature = "termios")]
 struct DebugWinsize(rustix::termios::Winsize);
 
+#[cfg(feature = "termios")]
 impl core::fmt::Debug for DebugWinsize {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut d = f.debug_struct("Winsize");

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -18,6 +18,19 @@ use {
     rustix::stdio::{stderr, stdin, stdout},
 };
 
+struct DebugWinsize(rustix::termios::Winsize);
+
+impl core::fmt::Debug for DebugWinsize {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut d = f.debug_struct("Winsize");
+        d.field("ws_row", &self.0.ws_row);
+        d.field("ws_col", &self.0.ws_col);
+        d.field("ws_xpixel", &self.0.ws_xpixel);
+        d.field("ws_ypixel", &self.0.ws_ypixel);
+        d.finish()
+    }
+}
+
 #[cfg(all(not(windows), feature = "stdio"))]
 fn main() -> io::Result<()> {
     let (stdin, stdout, stderr) = (stdin(), stdout(), stderr());
@@ -54,7 +67,10 @@ fn show<Fd: AsFd>(fd: Fd) -> io::Result<()> {
         println!(" - process group: {:?}", rustix::termios::tcgetpgrp(fd)?);
 
         #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
-        println!(" - winsize: {:?}", rustix::termios::tcgetwinsize(fd)?);
+        println!(
+            " - winsize: {:?}",
+            DebugWinsize(rustix::termios::tcgetwinsize(fd)?)
+        );
 
         #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
         {

--- a/examples/time.rs
+++ b/examples/time.rs
@@ -1,8 +1,12 @@
 //! A command which prints the current values of the realtime and monotonic
 //! clocks it's given.
 
+#[cfg(not(any(windows, target_os = "espidf")))]
+#[cfg(feature = "time")]
 struct DebugTimespec(rustix::time::Timespec);
 
+#[cfg(not(any(windows, target_os = "espidf")))]
+#[cfg(feature = "time")]
 impl core::fmt::Debug for DebugTimespec {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut d = f.debug_struct("Timespec");

--- a/examples/time.rs
+++ b/examples/time.rs
@@ -1,13 +1,30 @@
 //! A command which prints the current values of the realtime and monotonic
 //! clocks it's given.
 
+struct DebugTimespec(rustix::time::Timespec);
+
+impl core::fmt::Debug for DebugTimespec {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut d = f.debug_struct("Timespec");
+        d.field("tv_sec", &self.0.tv_sec);
+        d.field("tv_nsec", &self.0.tv_nsec);
+        d.finish()
+    }
+}
+
 #[cfg(not(any(windows, target_os = "espidf")))]
 #[cfg(feature = "time")]
 fn main() {
     use rustix::time::{clock_gettime, ClockId};
 
-    println!("Real time: {:?}", clock_gettime(ClockId::Realtime));
-    println!("Monotonic time: {:?}", clock_gettime(ClockId::Monotonic));
+    println!(
+        "Real time: {:?}",
+        DebugTimespec(clock_gettime(ClockId::Realtime))
+    );
+    println!(
+        "Monotonic time: {:?}",
+        DebugTimespec(clock_gettime(ClockId::Monotonic))
+    );
 
     #[cfg(any(freebsdlike, target_os = "openbsd"))]
     println!("Uptime: {:?}", clock_gettime(ClockId::Uptime));
@@ -15,31 +32,31 @@ fn main() {
     #[cfg(not(any(solarish, target_os = "netbsd", target_os = "redox")))]
     println!(
         "Process CPU time: {:?}",
-        clock_gettime(ClockId::ProcessCPUTime)
+        DebugTimespec(clock_gettime(ClockId::ProcessCPUTime))
     );
 
     #[cfg(not(any(solarish, target_os = "netbsd", target_os = "redox")))]
     println!(
         "Thread CPU time: {:?}",
-        clock_gettime(ClockId::ThreadCPUTime)
+        DebugTimespec(clock_gettime(ClockId::ThreadCPUTime))
     );
 
     #[cfg(any(linux_kernel, target_os = "freebsd"))]
     println!(
         "Realtime (coarse): {:?}",
-        clock_gettime(ClockId::RealtimeCoarse)
+        DebugTimespec(clock_gettime(ClockId::RealtimeCoarse))
     );
 
     #[cfg(any(linux_kernel, target_os = "freebsd"))]
     println!(
         "Monotonic (coarse): {:?}",
-        clock_gettime(ClockId::MonotonicCoarse)
+        DebugTimespec(clock_gettime(ClockId::MonotonicCoarse))
     );
 
     #[cfg(linux_kernel)]
     println!(
         "Monotonic (raw): {:?}",
-        clock_gettime(ClockId::MonotonicRaw)
+        DebugTimespec(clock_gettime(ClockId::MonotonicRaw))
     );
 }
 

--- a/tests/time/dynamic_clocks.rs
+++ b/tests/time/dynamic_clocks.rs
@@ -10,7 +10,7 @@ fn test_known_clocks() {
 #[test]
 fn test_dynamic_clocks() {
     let file = std::fs::File::open("Cargo.toml").unwrap();
-    clock_gettime_dynamic(DynamicClockId::Dynamic(file.as_fd())).unwrap_err();
+    assert!(clock_gettime_dynamic(DynamicClockId::Dynamic(file.as_fd())).is_err());
 }
 
 #[cfg(linux_kernel)]

--- a/tests/time/timespec.rs
+++ b/tests/time/timespec.rs
@@ -12,7 +12,7 @@ fn test_timespec_layout() {
     // Test that `Timespec` implements `Copy` and `Debug`.
     let _y = Timespec { tv_sec, tv_nsec };
     let _z = Timespec { tv_sec, tv_nsec };
-    dbg!(&x);
+    dbg!(x.tv_sec, x.tv_nsec);
 
     #[cfg(not(target_os = "redox"))]
     #[cfg(feature = "fs")]


### PR DESCRIPTION
rustix itself doesn't depend on libc/extra-traits being enabled. If users need it, they can enable it for themselves.