### PR TITLE
Rename a flag in `MountPropagationFlags`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ the functions in the `rustix::thread::futex` module instead.
 `rustix::process::waitpid`'s return type changed from `WaitStatus` to
 `(Pid, WaitStatus)`, to additionally return the pid of the child.
 
+The `SLAVE` flag in `rustix::mount::MountPropagationFlags` is renamed
+to `DOWNSTREAM`.
+
 The "cc" feature is removed. It hasn't had any effect for several
 major releases.
 

--- a/src/backend/libc/mount/types.rs
+++ b/src/backend/libc/mount/types.rs
@@ -310,8 +310,16 @@ bitflags! {
         const SHARED = c::MS_SHARED;
         /// `MS_PRIVATE`
         const PRIVATE = c::MS_PRIVATE;
-        /// `MS_SLAVE`
-        const SLAVE = c::MS_SLAVE;
+        /// Mark a mount as a downstream of its current peer group.
+        ///
+        /// Mount and unmount events propagate from the upstream peer group
+        /// into the downstream.
+        ///
+        /// In Linux documentation, this flag is named <code>MS_SLAVE</code>,
+        /// and the concepts of “upstream” and “downstream” are called
+        /// “master” and “slave”.
+        #[doc(alias = "SLAVE")]
+        const DOWNSTREAM = c::MS_SLAVE;
         /// `MS_UNBINDABLE`
         const UNBINDABLE = c::MS_UNBINDABLE;
         /// `MS_REC`

--- a/src/backend/linux_raw/mount/types.rs
+++ b/src/backend/linux_raw/mount/types.rs
@@ -303,8 +303,16 @@ bitflags! {
         const SHARED = linux_raw_sys::general::MS_SHARED;
         /// `MS_PRIVATE`
         const PRIVATE = linux_raw_sys::general::MS_PRIVATE;
-        /// `MS_SLAVE`
-        const SLAVE = linux_raw_sys::general::MS_SLAVE;
+        /// Mark a mount as a downstream of its current peer group.
+        ///
+        /// Mount and unmount events propagate from the upstream peer group
+        /// into the downstream.
+        ///
+        /// In Linux documentation, this flag is named <code>MS_SLAVE</code>,
+        /// and the concepts of “upstream” and “downstream” are called
+        /// “master” and “slave”.
+        #[doc(alias = "SLAVE")]
+        const DOWNSTREAM = linux_raw_sys::general::MS_SLAVE;
         /// `MS_UNBINDABLE`
         const UNBINDABLE = linux_raw_sys::general::MS_UNBINDABLE;
         /// `MS_REC`


### PR DESCRIPTION
Rename `MountPropagationFlags`' `SLAVE` flag to `DOWNSTREAM`, to avoid propagating "master/slave" terminology.

This differs from the Linux flag name and the terminology used in Linux's documentation, so add notes documenting the difference.