### PR TITLE
Don't enable the "fs" module implicitly.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ shm = ["fs"]
 time = []
 
 # Enable `rustix::param::*`.
-param = []
+param = ["fs"]
 
 # Enable this to enable `rustix::io::proc_self_*` (on Linux) and `ttyname`.
 procfs = ["once_cell", "itoa", "fs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ shm = ["fs"]
 time = []
 
 # Enable `rustix::param::*`.
-param = ["fs"]
+param = []
 
 # Enable this to enable `rustix::io::proc_self_*` (on Linux) and `ttyname`.
 procfs = ["once_cell", "itoa", "fs"]

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -22,20 +22,7 @@ pub(crate) use linux_raw_sys::general::{
 #[cfg(test)]
 pub(crate) use linux_raw_sys::general::epoll_event;
 
-#[cfg(any(
-    feature = "fs",
-    all(
-        not(feature = "use-libc-auxv"),
-        not(feature = "use-explicitly-provided-auxv"),
-        any(
-            feature = "param",
-            feature = "process",
-            feature = "runtime",
-            feature = "time",
-            target_arch = "x86",
-        )
-    )
-))]
+#[cfg(feature = "fs")]
 pub(crate) use linux_raw_sys::general::{
     AT_FDCWD, NFS_SUPER_MAGIC, O_LARGEFILE, PROC_SUPER_MAGIC, UTIME_NOW, UTIME_OMIT, XATTR_CREATE,
     XATTR_REPLACE,

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -296,20 +296,7 @@ pub(super) fn socklen_t<'a, Num: ArgNumber>(i: socklen_t) -> ArgReg<'a, Num> {
     pass_usize(i as usize)
 }
 
-#[cfg(any(
-    feature = "fs",
-    all(
-        not(feature = "use-libc-auxv"),
-        not(feature = "use-explicitly-provided-auxv"),
-        any(
-            feature = "param",
-            feature = "process",
-            feature = "runtime",
-            feature = "time",
-            target_arch = "x86",
-        )
-    )
-))]
+#[cfg(feature = "fs")]
 pub(crate) mod fs {
     use super::*;
     use crate::fs::{FileType, Mode, OFlags};

--- a/src/backend/linux_raw/mod.rs
+++ b/src/backend/linux_raw/mod.rs
@@ -25,20 +25,7 @@ mod vdso_wrappers;
 
 #[cfg(feature = "event")]
 pub(crate) mod event;
-#[cfg(any(
-    feature = "fs",
-    all(
-        not(feature = "use-libc-auxv"),
-        not(feature = "use-explicitly-provided-auxv"),
-        any(
-            feature = "param",
-            feature = "process",
-            feature = "runtime",
-            feature = "time",
-            target_arch = "x86",
-        )
-    )
-))]
+#[cfg(feature = "fs")]
 pub(crate) mod fs;
 pub(crate) mod io;
 #[cfg(feature = "io_uring")]
@@ -93,21 +80,7 @@ pub(crate) mod c;
 pub(crate) mod pid;
 #[cfg(any(feature = "process", feature = "thread"))]
 pub(crate) mod prctl;
-#[cfg(any(
-    feature = "fs",
-    feature = "process",
-    feature = "thread",
-    all(
-        not(feature = "use-libc-auxv"),
-        not(feature = "use-explicitly-provided-auxv"),
-        any(
-            feature = "param",
-            feature = "runtime",
-            feature = "time",
-            target_arch = "x86",
-        )
-    )
-))]
+#[cfg(any(feature = "fs", feature = "process", feature = "thread"))]
 pub(crate) mod ugid;
 
 /// The maximum number of buffers that can be passed into a vectored I/O system

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,48 +292,6 @@ pub mod time;
 #[cfg_attr(docsrs, doc(cfg(feature = "runtime")))]
 pub mod runtime;
 
-// Temporarily provide some mount functions for use in the fs module for
-// backwards compatibility.
-#[cfg(linux_kernel)]
-#[cfg(all(feature = "fs", not(feature = "mount")))]
-pub(crate) mod mount;
-
-// Declare "fs" as a non-public module if "fs" isn't enabled but we need it for
-// reading procfs.
-#[cfg(not(windows))]
-#[cfg(not(feature = "fs"))]
-#[cfg(all(
-    linux_raw,
-    not(feature = "use-libc-auxv"),
-    not(feature = "use-explicitly-provided-auxv"),
-    any(
-        feature = "param",
-        feature = "process",
-        feature = "runtime",
-        feature = "time",
-        target_arch = "x86",
-    )
-))]
-#[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
-pub(crate) mod fs;
-
-// Similarly, declare `path` as a non-public module if needed.
-#[cfg(not(windows))]
-#[cfg(not(any(feature = "fs", feature = "mount", feature = "net")))]
-#[cfg(all(
-    linux_raw,
-    not(feature = "use-libc-auxv"),
-    not(feature = "use-explicitly-provided-auxv"),
-    any(
-        feature = "param",
-        feature = "process",
-        feature = "runtime",
-        feature = "time",
-        target_arch = "x86",
-    )
-))]
-pub(crate) mod path;
-
 // Private modules used by multiple public modules.
 #[cfg(not(any(windows, target_os = "espidf")))]
 #[cfg(any(feature = "thread", feature = "time", target_arch = "x86"))]
@@ -362,18 +320,6 @@ mod signal;
     feature = "runtime",
     feature = "thread",
     feature = "time",
-    all(
-        linux_raw,
-        not(feature = "use-libc-auxv"),
-        not(feature = "use-explicitly-provided-auxv"),
-        any(
-            feature = "param",
-            feature = "process",
-            feature = "runtime",
-            feature = "time",
-            target_arch = "x86",
-        )
-    )
 ))]
 mod timespec;
 #[cfg(not(any(windows, target_os = "wasi")))]
@@ -381,17 +327,6 @@ mod timespec;
     feature = "fs",
     feature = "process",
     feature = "thread",
-    all(
-        linux_raw,
-        not(feature = "use-libc-auxv"),
-        not(feature = "use-explicitly-provided-auxv"),
-        any(
-            feature = "param",
-            feature = "runtime",
-            feature = "time",
-            target_arch = "x86",
-        )
-    ),
     all(linux_kernel, feature = "net")
 ))]
 mod ugid;


### PR DESCRIPTION
Several configurations used to enable the "fs" module as rustix used to use the "procfs" module for reading the AUXV vector on Linux. Rustix no longer does this, as the "procfs" module's extra checks are incompatible with QEMU on one hand, and not needed by most use cases on the other.

So since those configurations no longer use the "fs" module, we can remove the code that enabled it.