### PR TITLE
s390x linux_raw support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -509,7 +509,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, arm-linux]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -548,6 +548,15 @@ jobs:
             qemu: qemu-riscv64
             qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
+          - build: s390x-linux
+            os: ubuntu-latest
+            rust: stable
+            target: s390x-unknown-linux-gnu
+            gcc_package: gcc-s390x-linux-gnu
+            gcc: s390x-linux-gnu-gcc
+            qemu: qemu-s390x
+            qemu_args: -L /usr/s390x-linux-gnu
+            qemu_target: s390x-linux-user
           - build: arm-linux
             os: ubuntu-latest
             rust: stable
@@ -638,7 +647,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [powerpc64le-linux]
+        build: [powerpc64le-linux, s390x-linux]
         include:
           - build: powerpc64le-linux
             os: ubuntu-latest
@@ -649,11 +658,21 @@ jobs:
             qemu: qemu-ppc64le
             qemu_args: -L /usr/powerpc64le-linux-gnu
             qemu_target: ppc64le-linux-user
+          - build: s390x-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: s390x-unknown-linux-gnu
+            gcc_package: gcc-s390x-linux-gnu
+            gcc: s390x-linux-gnu-gcc
+            qemu: qemu-s390x
+            qemu_args: -L /usr/s390x-linux-gnu
+            qemu_target: s390x-linux-user
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.
       RUSTFLAGS: --cfg rustix_use_experimental_asm -D warnings -D elided-lifetimes-in-paths
       RUSTDOCFLAGS: --cfg rustix_use_experimental_asm
       CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_experimental_asm
+      CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_experimental_asm
       QEMU_BUILD_VERSION: 8.1.2
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -12,7 +12,7 @@ jobs:
       QEMU_BUILD_VERSION: 7.0.0
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux, macos-latest]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, mipsel-linux, mips64el-linux, arm-linux, macos-latest]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -69,6 +69,15 @@ jobs:
             qemu: qemu-riscv64
             qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
+          - build: s390x-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: s390x-unknown-linux-gnu
+            gcc_package: gcc-s390x-linux-gnu
+            gcc: s390x-linux-gnu-gcc
+            qemu: qemu-s390x
+            qemu_args: -L /usr/s390x-linux-gnu
+            qemu_target: s390x-linux-user
           - build: arm-linux
             os: ubuntu-latest
             rust: nightly
@@ -177,7 +186,7 @@ jobs:
       QEMU_BUILD_VERSION: 7.0.0
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux, macos-latest]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, mipsel-linux, mips64el-linux, arm-linux, macos-latest]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -234,6 +243,15 @@ jobs:
             qemu: qemu-riscv64
             qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
+          - build: s390x-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: s390x-unknown-linux-gnu
+            gcc_package: gcc-s390x-linux-gnu
+            gcc: s390x-linux-gnu-gcc
+            qemu: qemu-s390x
+            qemu_args: -L /usr/s390x-linux-gnu
+            qemu_target: s390x-linux-user
           - build: arm-linux
             os: ubuntu-latest
             rust: nightly
@@ -324,7 +342,7 @@ jobs:
       QEMU_BUILD_VERSION: 7.0.0
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux, macos-latest]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, mipsel-linux, mips64el-linux, arm-linux, macos-latest]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -381,6 +399,15 @@ jobs:
             qemu: qemu-riscv64
             qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
+          - build: s390x-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: s390x-unknown-linux-gnu
+            gcc_package: gcc-s390x-linux-gnu
+            gcc: s390x-linux-gnu-gcc
+            qemu: qemu-s390x
+            qemu_args: -L /usr/s390x-linux-gnu
+            qemu_target: s390x-linux-user
           - build: arm-linux
             os: ubuntu-latest
             rust: nightly
@@ -503,7 +530,7 @@ jobs:
       QEMU_BUILD_VERSION: 7.0.0
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, mipsel-linux, mips64el-linux, arm-linux]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -560,6 +587,15 @@ jobs:
             qemu: qemu-riscv64
             qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
+          - build: s390x-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: s390x-unknown-linux-gnu
+            gcc_package: gcc-s390x-linux-gnu
+            gcc: s390x-linux-gnu-gcc
+            qemu: qemu-s390x
+            qemu_args: -L /usr/s390x-linux-gnu
+            qemu_target: s390x-linux-user
           - build: arm-linux
             os: ubuntu-latest
             rust: nightly
@@ -647,7 +683,7 @@ jobs:
       QEMU_BUILD_VERSION: 7.0.0
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, mipsel-linux, mips64el-linux, arm-linux]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -702,6 +738,15 @@ jobs:
             qemu: qemu-riscv64
             qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
+          - build: s390x-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: s390x-unknown-linux-gnu
+            gcc_package: gcc-s390x-linux-gnu
+            gcc: s390x-linux-gnu-gcc
+            qemu: qemu-s390x
+            qemu_args: -L /usr/s390x-linux-gnu
+            qemu_target: s390x-linux-user
           - build: arm-linux
             os: ubuntu-latest
             rust: nightly
@@ -789,7 +834,7 @@ jobs:
       QEMU_BUILD_VERSION: 7.0.0
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, mipsel-linux, mips64el-linux, arm-linux]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -844,6 +889,15 @@ jobs:
             qemu: qemu-riscv64
             qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
+          - build: s390x-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: s390x-unknown-linux-gnu
+            gcc_package: gcc-s390x-linux-gnu
+            gcc: s390x-linux-gnu-gcc
+            qemu: qemu-s390x
+            qemu_args: -L /usr/s390x-linux-gnu
+            qemu_target: s390x-linux-user
           - build: arm-linux
             os: ubuntu-latest
             rust: nightly
@@ -931,7 +985,7 @@ jobs:
       QEMU_BUILD_VERSION: 7.0.0
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, mipsel-linux, mips64el-linux, arm-linux]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -986,6 +1040,15 @@ jobs:
             qemu: qemu-riscv64
             qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
+          - build: s390x-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: s390x-unknown-linux-gnu
+            gcc_package: gcc-s390x-linux-gnu
+            gcc: s390x-linux-gnu-gcc
+            qemu: qemu-s390x
+            qemu_args: -L /usr/s390x-linux-gnu
+            qemu_target: s390x-linux-user
           - build: arm-linux
             os: ubuntu-latest
             rust: nightly
@@ -1073,7 +1136,7 @@ jobs:
       QEMU_BUILD_VERSION: 7.0.0
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, mipsel-linux, mips64el-linux, arm-linux]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -1128,6 +1191,15 @@ jobs:
             qemu: qemu-riscv64
             qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
+          - build: s390x-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: s390x-unknown-linux-gnu
+            gcc_package: gcc-s390x-linux-gnu
+            gcc: s390x-linux-gnu-gcc
+            qemu: qemu-s390x
+            qemu_args: -L /usr/s390x-linux-gnu
+            qemu_target: s390x-linux-user
           - build: arm-linux
             os: ubuntu-latest
             rust: nightly
@@ -1215,7 +1287,7 @@ jobs:
       QEMU_BUILD_VERSION: 7.0.0
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux, macos-latest]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, mipsel-linux, mips64el-linux, arm-linux, macos-latest]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -1272,6 +1344,15 @@ jobs:
             qemu: qemu-riscv64
             qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
+          - build: s390x-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: s390x-unknown-linux-gnu
+            gcc_package: gcc-s390x-linux-gnu
+            gcc: s390x-linux-gnu-gcc
+            qemu: qemu-s390x
+            qemu_args: -L /usr/s390x-linux-gnu
+            qemu_target: s390x-linux-user
           - build: arm-linux
             os: ubuntu-latest
             rust: nightly
@@ -1362,7 +1443,7 @@ jobs:
       QEMU_BUILD_VERSION: 7.0.0
     strategy:
       matrix:
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux, macos-latest]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, mipsel-linux, mips64el-linux, arm-linux, macos-latest]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -1419,6 +1500,15 @@ jobs:
             qemu: qemu-riscv64
             qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
+          - build: s390x-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: s390x-unknown-linux-gnu
+            gcc_package: gcc-s390x-linux-gnu
+            gcc: s390x-linux-gnu-gcc
+            qemu: qemu-s390x
+            qemu_args: -L /usr/s390x-linux-gnu
+            qemu_target: s390x-linux-user
           - build: arm-linux
             os: ubuntu-latest
             rust: nightly
@@ -1576,7 +1666,7 @@ jobs:
     strategy:
       matrix:
         # cap-std-ext only builds on Linux at the moment.
-        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, mipsel-linux, mips64el-linux, arm-linux]
+        build: [ubuntu, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, mipsel-linux, mips64el-linux, arm-linux]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -1633,6 +1723,15 @@ jobs:
             qemu: qemu-riscv64
             qemu_args: -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
+          - build: s390x-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: s390x-unknown-linux-gnu
+            gcc_package: gcc-s390x-linux-gnu
+            gcc: s390x-linux-gnu-gcc
+            qemu: qemu-s390x
+            qemu_args: -L /usr/s390x-linux-gnu
+            qemu_target: s390x-linux-user
           - build: arm-linux
             os: ubuntu-latest
             rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ once_cell = { version = "1.5.2", optional = true }
 # addition to the libc backend. The linux_raw backend is used by default. The
 # libc backend can be selected via adding `--cfg=rustix_use_libc` to
 # `RUSTFLAGS` or enabling the `use-libc` cargo feature.
-[target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
+[target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_endian = "little", target_arch = "s390x"), any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "s390x"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
 linux-raw-sys = { version = "0.4.14", default-features = false, features = ["general", "errno", "ioctl", "no_std", "elf"] }
 libc_errno = { package = "errno", version = "0.3.8", default-features = false, optional = true }
 libc = { version = "0.2.156", default-features = false, optional = true }
@@ -44,7 +44,7 @@ libc = { version = "0.2.156", default-features = false, optional = true }
 #
 # On all other Unix-family platforms, and under Miri, we always use the libc
 # backend, so enable its dependencies unconditionally.
-[target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
+[target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_endian = "little", target_arch = "s390x"), any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "s390x"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.8", default-features = false }
 libc = { version = "0.2.156", default-features = false }
 
@@ -52,7 +52,7 @@ libc = { version = "0.2.156", default-features = false }
 #
 # Some syscalls do not have libc wrappers, such as in `io_uring`. For these,
 # the libc backend uses the linux-raw-sys ABI and `libc::syscall`.
-[target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
+[target.'cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_endian = "little", target_arch = "s390x"), any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "s390x"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 linux-raw-sys = { version = "0.4.14", default-features = false, features = ["general", "ioctl", "no_std"] }
 
 # For the libc backend on Windows, use the Winsock API in windows-sys.

--- a/build.rs
+++ b/build.rs
@@ -95,7 +95,8 @@ fn main() {
         || !inline_asm_name_present
         || is_unsupported_abi
         || miri
-        || ((arch == "powerpc64" || arch.starts_with("mips")) && !rustix_use_experimental_asm);
+        || ((arch == "powerpc64" || arch == "s390x" || arch.starts_with("mips"))
+            && !rustix_use_experimental_asm);
     if libc {
         // Use the libc backend.
         use_feature("libc");

--- a/src/backend/linux_raw/arch/mod.rs
+++ b/src/backend/linux_raw/arch/mod.rs
@@ -32,6 +32,7 @@
 #[cfg_attr(target_arch = "mips64r6", path = "mips64r6.rs")]
 #[cfg_attr(target_arch = "powerpc64", path = "powerpc64.rs")]
 #[cfg_attr(target_arch = "riscv64", path = "riscv64.rs")]
+#[cfg_attr(target_arch = "s390x", path = "s390x.rs")]
 #[cfg_attr(target_arch = "x86", path = "x86.rs")]
 #[cfg_attr(target_arch = "x86_64", path = "x86_64.rs")]
 pub(in crate::backend) mod asm;
@@ -47,6 +48,7 @@ pub(in crate::backend) mod asm;
     target_arch = "mips64r6",
     target_arch = "powerpc64",
     target_arch = "riscv64",
+    target_arch = "s390x",
     target_arch = "x86_64",
 ))]
 pub(in crate::backend) use self::asm as choose;

--- a/src/backend/linux_raw/arch/s390x.rs
+++ b/src/backend/linux_raw/arch/s390x.rs
@@ -1,0 +1,287 @@
+//! s390x Linux system calls.
+
+use crate::backend::reg::{
+    ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0,
+};
+use core::arch::asm;
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r1") nr.to_asm(),
+        lateout("r2") r0,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r1") nr.to_asm(),
+        inlateout("r2") a0.to_asm() => r0,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r1") nr.to_asm(),
+        inlateout("r2") a0.to_asm() => r0,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
+    asm!(
+        "svc 0",
+        in("r1") nr.to_asm(),
+        in("r2") a0.to_asm(),
+        options(nostack, preserves_flags, noreturn)
+    )
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r1") nr.to_asm(),
+        inlateout("r2") a0.to_asm() => r0,
+        in("r3") a1.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r1") nr.to_asm(),
+        inlateout("r2") a0.to_asm() => r0,
+        in("r3") a1.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r1") nr.to_asm(),
+        inlateout("r2") a0.to_asm() => r0,
+        in("r3") a1.to_asm(),
+        in("r4") a2.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r1") nr.to_asm(),
+        inlateout("r2") a0.to_asm() => r0,
+        in("r3") a1.to_asm(),
+        in("r4") a2.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r1") nr.to_asm(),
+        inlateout("r2") a0.to_asm() => r0,
+        in("r3") a1.to_asm(),
+        in("r4") a2.to_asm(),
+        in("r5") a3.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r1") nr.to_asm(),
+        inlateout("r2") a0.to_asm() => r0,
+        in("r3") a1.to_asm(),
+        in("r4") a2.to_asm(),
+        in("r5") a3.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r1") nr.to_asm(),
+        inlateout("r2") a0.to_asm() => r0,
+        in("r3") a1.to_asm(),
+        in("r4") a2.to_asm(),
+        in("r5") a3.to_asm(),
+        in("r6") a4.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r1") nr.to_asm(),
+        inlateout("r2") a0.to_asm() => r0,
+        in("r3") a1.to_asm(),
+        in("r4") a2.to_asm(),
+        in("r5") a3.to_asm(),
+        in("r6") a4.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    if nr.nr == linux_raw_sys::general::__NR_mmap as usize {
+        let mut a = [
+            a0.to_asm(),
+            a1.to_asm(),
+            a2.to_asm(),
+            a3.to_asm(),
+            a4.to_asm(),
+            a5.to_asm(),
+        ];
+        return syscall1(nr, a.as_mut_ptr().into());
+    }
+    let r0;
+    asm!(
+        "svc 0",
+        in("r1") nr.to_asm(),
+        inlateout("r2") a0.to_asm() => r0,
+        in("r3") a1.to_asm(),
+        in("r4") a2.to_asm(),
+        in("r5") a3.to_asm(),
+        in("r6") a4.to_asm(),
+        in("r7") a5.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    if nr.nr == linux_raw_sys::general::__NR_mmap as usize {
+        let a = [
+            a0.to_asm(),
+            a1.to_asm(),
+            a2.to_asm(),
+            a3.to_asm(),
+            a4.to_asm(),
+            a5.to_asm(),
+        ];
+        return syscall1_readonly(nr, a.as_ptr().into());
+    }
+    let r0;
+    asm!(
+        "svc 0",
+        in("r1") nr.to_asm(),
+        inlateout("r2") a0.to_asm() => r0,
+        in("r3") a1.to_asm(),
+        in("r4") a2.to_asm(),
+        in("r5") a3.to_asm(),
+        in("r6") a4.to_asm(),
+        in("r7") a5.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}

--- a/src/backend/linux_raw/param/auxv.rs
+++ b/src/backend/linux_raw/param/auxv.rs
@@ -32,6 +32,10 @@ use linux_raw_sys::general::{
 #[cfg(feature = "alloc")]
 use {alloc::borrow::Cow, alloc::vec};
 
+// TODO: Fix linux-raw-sys to define EM_CURRENT for s390x.
+#[cfg(target_arch = "s390x")]
+const EM_CURRENT: u16 = 22; // EM_S390
+
 #[cfg(feature = "param")]
 #[inline]
 pub(crate) fn page_size() -> usize {

--- a/src/backend/linux_raw/reg.rs
+++ b/src/backend/linux_raw/reg.rs
@@ -206,7 +206,7 @@ impl<Num: RetNumber> FromAsm for RetReg<Num> {
 
 #[repr(transparent)]
 pub(super) struct SyscallNumber<'a> {
-    nr: usize,
+    pub(super) nr: usize,
     _phantom: PhantomData<&'a ()>,
 }
 

--- a/src/backend/linux_raw/runtime/syscalls.rs
+++ b/src/backend/linux_raw/runtime/syscalls.rs
@@ -60,6 +60,7 @@ pub(crate) unsafe fn fork() -> io::Result<Fork> {
         target_arch = "mips64r6",
         target_arch = "powerpc64",
         target_arch = "riscv64",
+        target_arch = "s390x",
         target_arch = "x86"
     ))]
     let pid = ret_c_int(syscall_readonly!(

--- a/src/backend/linux_raw/vdso_wrappers.rs
+++ b/src/backend/linux_raw/vdso_wrappers.rs
@@ -505,6 +505,8 @@ fn init() {
             let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_clock_gettime"));
             #[cfg(target_arch = "powerpc64")]
             let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_clock_gettime"));
+            #[cfg(target_arch = "s390x")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_clock_gettime"));
             #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
             let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
             #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
@@ -573,7 +575,8 @@ fn init() {
                 target_arch = "mips",
                 target_arch = "mips32r6",
                 target_arch = "mips64",
-                target_arch = "mips64r6"
+                target_arch = "mips64r6",
+                target_arch = "s390x",
             ))]
             let ok = false;
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -583,13 +583,23 @@ pub const SIGRTMIN: u32 = linux_raw_sys::general::SIGRTMIN;
 #[cfg(linux_raw)]
 pub const SIGRTMAX: u32 = {
     // Use the actual `SIGRTMAX` value on platforms which define it.
-    #[cfg(not(any(target_arch = "arm", target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(not(any(
+        target_arch = "arm",
+        target_arch = "s390x",
+        target_arch = "x86",
+        target_arch = "x86_64",
+    )))]
     {
         linux_raw_sys::general::SIGRTMAX
     }
 
     // On platforms that don't, derive it from `_NSIG`.
-    #[cfg(any(target_arch = "arm", target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "s390x",
+        target_arch = "x86",
+        target_arch = "x86_64",
+    ))]
     {
         linux_raw_sys::general::_NSIG - 1
     }


### PR DESCRIPTION
This is currently implemented under rustix_use_experimental_asm since s390x asm is unstable. However, we might want to wait for stabilization (https://github.com/rust-lang/rust/pull/131258) and implement as non-experimental.

Tested downstream crates (tested with qemu-user 9.1.0): async-io, polling, tempfile, cap-std

FYI @uweigand