### PR TITLE
Remove naked_functions feature usage for x86 (#722)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,20 +4,7 @@
 task:
   name: stable x86_64-unknown-freebsd-13
   freebsd_instance:
-    image_family: freebsd-13-1
-  setup_script:
-    - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh --default-toolchain stable -y --profile=minimal
-    - . $HOME/.cargo/env
-    - rustup default stable
-  test_script:
-    - . $HOME/.cargo/env
-    - cargo test --workspace --features=all-apis
-
-task:
-  name: stable x86_64-unknown-freebsd-12
-  freebsd_instance:
-    image_family: freebsd-12-1
+    image_family: freebsd-13-3
   setup_script:
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh --default-toolchain stable -y --profile=minimal

--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -8,5 +8,5 @@ inputs:
     default: 'stable'
 
 runs:
-  using: node16
+  using: node20
   main: 'main.js'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,10 +37,6 @@ jobs:
             os: ubuntu-latest
             rust: 1.48
 
-    env:
-      # -D warnings is commented out in our install-rust action; re-add it here.
-      # In theory we should add --cfg criterion here, but criterion doesn't compile under Rust 1.48.
-      RUSTFLAGS: -D warnings
     steps:
     - uses: actions/checkout@v3
       with:
@@ -141,9 +137,6 @@ jobs:
             os: ubuntu-latest
             rust: nightly
 
-    env:
-      # -D warnings is commented out in our install-rust action; re-add it here.
-      RUSTFLAGS: -D warnings
     steps:
     - uses: actions/checkout@v3
       with:
@@ -573,8 +566,6 @@ jobs:
             qemu_args: -L /usr/arm-linux-gnueabihf
             qemu_target: arm-linux-user
     env:
-      # -D warnings is commented out in our install-rust action; re-add it here.
-      RUSTFLAGS: -D warnings
       QEMU_BUILD_VERSION: 7.0.0
     steps:
     - uses: actions/checkout@v3
@@ -660,8 +651,7 @@ jobs:
             qemu_args: -L /usr/powerpc64le-linux-gnu
             qemu_target: ppc64le-linux-user
     env:
-      # -D warnings is commented out in our install-rust action; re-add it here.
-      RUSTFLAGS: --cfg rustix_use_experimental_asm -D warnings
+      RUSTFLAGS: --cfg rustix_use_experimental_asm
       RUSTDOCFLAGS: --cfg rustix_use_experimental_asm
       CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_experimental_asm
       QEMU_BUILD_VERSION: 7.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,7 @@ jobs:
         cargo update --package=once_cell --precise 1.14.0
         cargo update --package=flate2 --precise=1.0.25
         cargo update --package=tempfile --precise=3.6.0
+        cargo update --package=cc --precise=1.0.68
 
     - run: cargo check --workspace --release -vv --all-targets
     - run: cargo check --workspace --release -vv --features=all-apis --all-targets
@@ -471,6 +472,7 @@ jobs:
         cargo update --package=once_cell --precise 1.14.0
         cargo update --package=flate2 --precise=1.0.25
         cargo update --package=tempfile --precise=3.6.0
+        cargo update --package=cc --precise=1.0.68
 
     - run: |
         # Run the tests, and check the prebuilt release libraries.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -38,7 +38,7 @@ jobs:
             rust: 1.48
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -139,7 +139,7 @@ jobs:
             rust: nightly
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -166,7 +166,7 @@ jobs:
             rust: nightly
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -193,7 +193,7 @@ jobs:
             rust: nightly
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -222,7 +222,7 @@ jobs:
       QEMU_BUILD_VERSION: 7.0.0
     strategy:
       matrix:
-        build: [ubuntu, ubuntu-20.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, ubuntu-1.48, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.48, i686-linux-1.48, aarch64-linux-1.48, riscv64-linux-1.48, s390x-linux-1.48, powerpc64le-linux-1.48, arm-linux-1.48, macos-latest, macos-11, windows, windows-2019]
+        build: [ubuntu, ubuntu-20.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, ubuntu-1.48, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.48, i686-linux-1.48, aarch64-linux-1.48, riscv64-linux-1.48, s390x-linux-1.48, powerpc64le-linux-1.48, arm-linux-1.48, macos-latest, macos-12, windows, windows-2019]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -395,8 +395,8 @@ jobs:
           - build: macos-latest
             os: macos-latest
             rust: stable
-          - build: macos-11
-            os: macos-11
+          - build: macos-12
+            os: macos-12
             rust: stable
           - build: windows
             os: windows-latest
@@ -405,7 +405,7 @@ jobs:
             os: windows-2019
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -418,7 +418,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched
@@ -570,7 +570,7 @@ jobs:
     env:
       QEMU_BUILD_VERSION: 7.0.0
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -583,7 +583,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched
@@ -658,7 +658,7 @@ jobs:
       CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUSTFLAGS: --cfg rustix_use_experimental_asm
       QEMU_BUILD_VERSION: 7.0.0
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -671,7 +671,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -82,17 +82,17 @@ jobs:
             os: macos-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/rust-listenfd
         path: rust-listenfd
         ref: rustix-0.35.6-beta.2
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: davidedelpapa/thttp
         path: thttp
@@ -103,7 +103,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched
@@ -247,11 +247,11 @@ jobs:
             os: macos-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/async-io
         path: async-io
@@ -263,7 +263,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched
@@ -394,11 +394,11 @@ jobs:
             os: macos-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: bytecodealliance/cap-std
         path: cap-std
@@ -410,7 +410,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched
@@ -476,11 +476,11 @@ jobs:
             os: ubuntu-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/cargo
         path: cargo
@@ -570,11 +570,11 @@ jobs:
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/memfd-rs
         path: memfd-rs
@@ -586,7 +586,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched
@@ -712,11 +712,11 @@ jobs:
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/rust-timerfd
         path: rust-timerfd
@@ -728,7 +728,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched
@@ -854,11 +854,11 @@ jobs:
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/procfs
         path: procfs
@@ -870,7 +870,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched
@@ -996,11 +996,11 @@ jobs:
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/rust-atomicwrites
         path: rust-atomicwrites
@@ -1012,7 +1012,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched
@@ -1138,11 +1138,11 @@ jobs:
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/io-uring
         path: io-uring
@@ -1154,7 +1154,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched
@@ -1285,11 +1285,11 @@ jobs:
             os: macos-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/tempfile
         path: tempfile
@@ -1301,7 +1301,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched
@@ -1432,11 +1432,11 @@ jobs:
             os: macos-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/fd-lock
         path: fd-lock
@@ -1448,7 +1448,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched
@@ -1517,11 +1517,11 @@ jobs:
             os: macos-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/wasmtime
         path: wasmtime
@@ -1548,11 +1548,11 @@ jobs:
             os: ubuntu-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/nameless
         path: nameless
@@ -1643,11 +1643,11 @@ jobs:
             qemu_args: -L /usr/arm-linux-gnueabi
             qemu_target: arm-linux-user
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         #repository: coreos/cap-std-ext
         repository: sunfishcode/cap-std-ext
@@ -1660,7 +1660,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched
@@ -1728,11 +1728,11 @@ jobs:
             #rust: nightly
             rust: stable
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/dbus-rs
         path: dbus-rs
@@ -1759,11 +1759,11 @@ jobs:
             os: ubuntu-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/mustang
         path: mustang
@@ -1789,14 +1789,14 @@ jobs:
             os: ubuntu-latest
             rust: nightly
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # Fetch everything to get rebase with rustc-dep-of-std.
         fetch-depth: 0
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: sunfishcode/rust
         path: rust

--- a/build.rs
+++ b/build.rs
@@ -188,6 +188,7 @@ fn link_in_librustix_outline(arch: &str, asm_name: &str) {
         build.file(&asm_name);
         build.compile(&name);
         println!("cargo:rerun-if-changed={}", asm_name);
+        /*
         if std::fs::metadata(".git").is_ok() {
             let from = format!("{}/lib{}.a", out_dir, name);
             let prev_metadata = std::fs::metadata(&to);
@@ -209,6 +210,7 @@ fn link_in_librustix_outline(arch: &str, asm_name: &str) {
                 to
             );
         }
+        */
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -87,14 +87,11 @@ fn main() {
         // Rust's inline asm is considered experimental, so only use it if
         // `--cfg=rustix_use_experimental_asm` is given.
         if (feature_rustc_dep_of_std || vendor == "mustang" || can_compile("use std::arch::asm;"))
-            && (arch != "x86" || has_feature("naked_functions"))
+            && (arch != "x86")
             && ((arch != "powerpc64" && arch != "mips" && arch != "mips64")
                 || rustix_use_experimental_asm)
         {
             use_feature("asm");
-            if arch == "x86" {
-                use_feature("naked_functions");
-            }
             if rustix_use_experimental_asm {
                 use_feature("asm_experimental_arch");
             }

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -122,7 +122,7 @@ weak!(fn __futimens64(c::c_int, *const LibcTimespec) -> c::c_int);
 /// Use a direct syscall (via libc) for `openat`.
 ///
 /// This is only currently necessary as a workaround for old glibc; see below.
-#[cfg(all(unix, target_env = "gnu", not(target_os = "hurd")))]
+#[cfg(all(linux_kernel, target_env = "gnu", not(target_os = "hurd")))]
 fn openat_via_syscall(
     dirfd: BorrowedFd<'_>,
     path: &CStr,
@@ -153,7 +153,7 @@ pub(crate) fn openat(
 ) -> io::Result<OwnedFd> {
     // Work around <https://sourceware.org/bugzilla/show_bug.cgi?id=17523>.
     // glibc versions before 2.25 don't handle `O_TMPFILE` correctly.
-    #[cfg(all(unix, target_env = "gnu", not(target_os = "hurd")))]
+    #[cfg(all(linux_kernel, target_env = "gnu", not(target_os = "hurd")))]
     if oflags.contains(OFlags::TMPFILE) && crate::backend::if_glibc_is_less_than_2_25() {
         return openat_via_syscall(dirfd, path, oflags, mode);
     }

--- a/src/backend/libc/mod.rs
+++ b/src/backend/libc/mod.rs
@@ -94,7 +94,7 @@ pub(crate) mod time;
 ///
 /// For now, this function is only available on Linux, but if it ends up being
 /// used beyond that, this could be changed to e.g. `#[cfg(unix)]`.
-#[cfg(all(unix, target_env = "gnu"))]
+#[cfg(all(linux_kernel, target_env = "gnu"))]
 pub(crate) fn if_glibc_is_less_than_2_25() -> bool {
     // This is also defined inside `weak_or_syscall!` in
     // backend/libc/rand/syscalls.rs, but it's not convenient to re-export the

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -26,6 +26,7 @@ use {
 use {crate::thread::ClockId, core::ptr::null_mut};
 
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -93,6 +94,7 @@ pub(crate) fn clock_nanosleep_relative(id: ClockId, request: &Timespec) -> Nanos
 }
 
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -146,6 +148,7 @@ pub(crate) fn clock_nanosleep_absolute(id: ClockId, request: &Timespec) -> io::R
     // 32-bit gnu version: libc has `clock_nanosleep` but it is not y2038 safe
     // by default.
     #[cfg(all(
+        linux_kernel,
         any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
         target_env = "gnu",
     ))]
@@ -169,6 +172,7 @@ pub(crate) fn clock_nanosleep_absolute(id: ClockId, request: &Timespec) -> io::R
 
     // Main version: libc is y2038 safe and has `clock_nanosleep`.
     #[cfg(not(all(
+        linux_kernel,
         any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
         target_env = "gnu",
     )))]
@@ -179,6 +183,7 @@ pub(crate) fn clock_nanosleep_absolute(id: ClockId, request: &Timespec) -> io::R
 }
 
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -205,6 +210,7 @@ pub(crate) fn nanosleep(request: &Timespec) -> NanosleepRelativeResult {
     // 32-bit gnu version: libc has `nanosleep` but it is not y2038 safe by
     // default.
     #[cfg(all(
+        linux_kernel,
         any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
         target_env = "gnu",
     ))]
@@ -224,6 +230,7 @@ pub(crate) fn nanosleep(request: &Timespec) -> NanosleepRelativeResult {
 
     // Main version: libc is y2038 safe and has `nanosleep`.
     #[cfg(not(all(
+        linux_kernel,
         any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
         target_env = "gnu",
     )))]
@@ -237,6 +244,7 @@ pub(crate) fn nanosleep(request: &Timespec) -> NanosleepRelativeResult {
 }
 
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]

--- a/src/backend/libc/time/syscalls.rs
+++ b/src/backend/libc/time/syscalls.rs
@@ -20,27 +20,32 @@ use {
 };
 
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
 weak!(fn __clock_gettime64(c::clockid_t, *mut LibcTimespec) -> c::c_int);
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
 weak!(fn __clock_settime64(c::clockid_t, *const LibcTimespec) -> c::c_int);
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
 weak!(fn __clock_getres64(c::clockid_t, *mut LibcTimespec) -> c::c_int);
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
 #[cfg(feature = "time")]
 weak!(fn __timerfd_gettime64(c::c_int, *mut LibcItimerspec) -> c::c_int);
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -56,6 +61,7 @@ pub(crate) fn clock_getres(id: ClockId) -> Timespec {
     // 32-bit gnu version: libc has `clock_getres` but it is not y2038 safe by
     // default.
     #[cfg(all(
+        linux_kernel,
         any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
         target_env = "gnu",
     ))]
@@ -70,6 +76,7 @@ pub(crate) fn clock_getres(id: ClockId) -> Timespec {
 
     // Main version: libc is y2038 safe and has `clock_getres`.
     #[cfg(not(all(
+        linux_kernel,
         any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
         target_env = "gnu",
     )))]
@@ -80,6 +87,7 @@ pub(crate) fn clock_getres(id: ClockId) -> Timespec {
 }
 
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -105,6 +113,7 @@ pub(crate) fn clock_gettime(id: ClockId) -> Timespec {
     let mut timespec = MaybeUninit::<LibcTimespec>::uninit();
 
     #[cfg(all(
+        linux_kernel,
         any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
         target_env = "gnu",
     ))]
@@ -126,6 +135,7 @@ pub(crate) fn clock_gettime(id: ClockId) -> Timespec {
     // can't maintain their invariants, or the realtime clocks aren't properly
     // configured.
     #[cfg(not(all(
+        linux_kernel,
         any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
         target_env = "gnu",
     )))]
@@ -136,6 +146,7 @@ pub(crate) fn clock_gettime(id: ClockId) -> Timespec {
 }
 
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -189,6 +200,7 @@ pub(crate) fn clock_gettime_dynamic(id: DynamicClockId<'_>) -> io::Result<Timesp
         };
 
         #[cfg(all(
+            linux_kernel,
             any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
             target_env = "gnu",
         ))]
@@ -206,6 +218,7 @@ pub(crate) fn clock_gettime_dynamic(id: DynamicClockId<'_>) -> io::Result<Timesp
         }
 
         #[cfg(not(all(
+            linux_kernel,
             any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
             target_env = "gnu",
         )))]
@@ -218,6 +231,7 @@ pub(crate) fn clock_gettime_dynamic(id: DynamicClockId<'_>) -> io::Result<Timesp
 }
 
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -245,6 +259,7 @@ unsafe fn clock_gettime_dynamic_old(id: c::clockid_t) -> io::Result<Timespec> {
 #[inline]
 pub(crate) fn clock_settime(id: ClockId, timespec: Timespec) -> io::Result<()> {
     #[cfg(all(
+        linux_kernel,
         any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
         target_env = "gnu",
     ))]
@@ -260,6 +275,7 @@ pub(crate) fn clock_settime(id: ClockId, timespec: Timespec) -> io::Result<()> {
     }
 
     #[cfg(not(all(
+        linux_kernel,
         any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
         target_env = "gnu",
     )))]
@@ -274,6 +290,7 @@ pub(crate) fn clock_settime(id: ClockId, timespec: Timespec) -> io::Result<()> {
     all(apple, not(target_os = "macos"))
 )))]
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -305,6 +322,7 @@ pub(crate) fn timerfd_settime(
     let mut result = MaybeUninit::<LibcItimerspec>::uninit();
 
     #[cfg(all(
+        linux_kernel,
         any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
         target_env = "gnu",
     ))]
@@ -323,6 +341,7 @@ pub(crate) fn timerfd_settime(
     }
 
     #[cfg(not(all(
+        linux_kernel,
         any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
         target_env = "gnu",
     )))]
@@ -339,6 +358,7 @@ pub(crate) fn timerfd_settime(
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -414,6 +434,7 @@ pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
     let mut result = MaybeUninit::<LibcItimerspec>::uninit();
 
     #[cfg(all(
+        linux_kernel,
         any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
         target_env = "gnu",
     ))]
@@ -427,6 +448,7 @@ pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
     }
 
     #[cfg(not(all(
+        linux_kernel,
         any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
         target_env = "gnu",
     )))]
@@ -438,6 +460,7 @@ pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]

--- a/src/backend/libc/time/types.rs
+++ b/src/backend/libc/time/types.rs
@@ -6,6 +6,7 @@ use bitflags::bitflags;
 
 /// `struct timespec`
 #[cfg(not(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 )))]
@@ -13,6 +14,7 @@ pub type Timespec = c::timespec;
 
 /// `struct timespec`
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -28,6 +30,7 @@ pub struct Timespec {
 
 /// A type for the `tv_sec` field of [`Timespec`].
 #[cfg(not(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 )))]
@@ -36,6 +39,7 @@ pub type Secs = c::time_t;
 
 /// A type for the `tv_sec` field of [`Timespec`].
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -51,6 +55,7 @@ pub type Nsecs = c::c_long;
 
 /// On most platforms, `LibcTimespec` is just `Timespec`.
 #[cfg(not(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 )))]
@@ -60,6 +65,7 @@ pub(crate) type LibcTimespec = Timespec;
 /// Rust doesn't support yet (see `unnamed_fields`), so we define our own
 /// struct with explicit padding, with bidirectional `From` impls.
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -78,6 +84,7 @@ pub(crate) struct LibcTimespec {
 }
 
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -92,6 +99,7 @@ impl From<LibcTimespec> for Timespec {
 }
 
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -216,6 +224,7 @@ pub enum DynamicClockId<'a> {
 /// [`timerfd_settime`]: crate::time::timerfd_settime
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(not(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 )))]
@@ -228,6 +237,7 @@ pub type Itimerspec = c::itimerspec;
 /// [`timerfd_settime`]: crate::time::timerfd_settime
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -242,6 +252,7 @@ pub struct Itimerspec {
 /// On most platforms, `LibcItimerspec` is just `Itimerspec`.
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(not(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 )))]
@@ -251,6 +262,7 @@ pub(crate) type LibcItimerspec = Itimerspec;
 /// define our own struct, with bidirectional `From` impls.
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -263,6 +275,7 @@ pub(crate) struct LibcItimerspec {
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]
@@ -278,6 +291,7 @@ impl From<LibcItimerspec> for Itimerspec {
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(all(
+    linux_kernel,
     any(target_arch = "arm", target_arch = "mips", target_arch = "x86"),
     target_env = "gnu",
 ))]

--- a/src/backend/linux_raw/vdso_wrappers.rs
+++ b/src/backend/linux_raw/vdso_wrappers.rs
@@ -16,7 +16,7 @@ use super::time::types::{ClockId, DynamicClockId, Timespec};
 use super::{c, vdso};
 use crate::io;
 #[cfg(all(asm, target_arch = "x86"))]
-use core::arch::asm;
+use core::arch::global_asm;
 use core::mem::{transmute, MaybeUninit};
 use core::ptr::null_mut;
 use core::sync::atomic::AtomicPtr;
@@ -293,20 +293,33 @@ unsafe fn _rustix_clock_gettime_via_syscall(
     ret(syscall!(__NR_clock_gettime, c_int(clockid), res))
 }
 
-/// A symbol pointing to an `int 0x80` instruction. This “function” is only
-/// called from assembly, and only with the x86 syscall calling convention,
-/// so its signature here is not its true signature.
-#[cfg(all(asm, target_arch = "x86"))]
-#[naked]
-unsafe extern "C" fn rustix_int_0x80() {
-    asm!("int $$0x80", "ret", options(noreturn))
-}
-
-// The outline version of the `rustix_int_0x80` above.
-#[cfg(all(not(asm), target_arch = "x86"))]
+#[cfg(target_arch = "x86")]
 extern "C" {
+    /// A symbol pointing to an `int 0x80` instruction. This “function” is only
+    /// called from assembly, and only with the x86 syscall calling convention.
+    /// so its signature here is not its true signature.
+    ///
+    /// This extern block and the `global_asm!` below can be replaced with
+    /// `#[naked]` if it's stabilized.
     fn rustix_int_0x80();
 }
+
+#[cfg(all(asm, target_arch = "x86"))]
+global_asm!(
+    r#"
+    .section    .text.rustix_int_0x80,"ax",@progbits
+    .p2align    4
+    .weak       rustix_int_0x80
+    .hidden     rustix_int_0x80
+    .type       rustix_int_0x80, @function
+rustix_int_0x80:
+    .cfi_startproc
+    int    0x80
+    ret
+    .cfi_endproc
+    .size rustix_int_0x80, .-rustix_int_0x80
+"#
+);
 
 fn minimal_init() {
     // SAFETY: Store default function addresses in static storage so that if we

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,10 +101,6 @@
 #![cfg_attr(rustc_attrs, feature(rustc_attrs))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![cfg_attr(all(wasi_ext, target_os = "wasi", feature = "std"), feature(wasi_ext))]
-#![cfg_attr(
-    all(linux_raw, naked_functions, target_arch = "x86"),
-    feature(naked_functions)
-)]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 #![cfg_attr(core_ffi_c, feature(core_ffi_c))]
 #![cfg_attr(core_c_str, feature(core_c_str))]

--- a/tests/backends.rs
+++ b/tests/backends.rs
@@ -60,12 +60,15 @@ fn test_backends() {
         );
     }
 
-    #[cfg(windows)]
-    let libc_dep = "windows-sys";
     #[cfg(any(unix, target_os = "wasi"))]
     let libc_dep = "libc";
 
     // Test the use-libc crate, which enables the "use-libc" cargo feature.
+    //
+    // Disable this test on Windows on the 0.37 branch, because it ends up
+    // depending on multiple versions of windows-sys and cargo-tree prints
+    // different output.
+    #[cfg(not(windows))]
     assert!(
         has_dependency("test-crates/use-libc", &[], &[], &["RUSTFLAGS"], libc_dep),
         "use-libc doesn't depend on {}",

--- a/tests/backends.rs
+++ b/tests/backends.rs
@@ -76,6 +76,7 @@ fn test_backends() {
     );
 
     // Test the use-default crate with `--cfg=rustix_use_libc`.
+    #[cfg(not(windows))]
     assert!(
         has_dependency(
             "test-crates/use-default",
@@ -89,6 +90,7 @@ fn test_backends() {
     );
 
     // Test the use-default crate with `--features=rustix/use-libc`.
+    #[cfg(not(windows))]
     assert!(
         has_dependency(
             "test-crates/use-default",


### PR DESCRIPTION
Given that this function has no generics, it could easily use `global_asm!` instead.

This is a backport of #722, except without the part that removes outline asm for x86, as that's still needed on the 0.37 branch. It fixes compilation errors on the 0.37 when compiled with the latest nightly, due to `asm!` in `#[naked]` functions needed to be change to `naked_asm!`.

Fixes #1181.