### PR TITLE
Add O_RSYNC + fallocate on solarish, and fadvise on illumos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ once_cell = { version = "1.5.2", optional = true }
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_endian = "little", target_arch = "s390x"), any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "s390x"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
 linux-raw-sys = { version = "0.4.14", default-features = false, features = ["general", "errno", "ioctl", "no_std", "elf"] }
 libc_errno = { package = "errno", version = "0.3.8", default-features = false, optional = true }
-libc = { version = "0.2.156", default-features = false, optional = true }
+libc = { version = "0.2.161", default-features = false, optional = true }
 
 # Dependencies for platforms where only libc is supported:
 #
@@ -46,7 +46,7 @@ libc = { version = "0.2.156", default-features = false, optional = true }
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_endian = "little", target_arch = "s390x"), any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "s390x"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.8", default-features = false }
-libc = { version = "0.2.156", default-features = false }
+libc = { version = "0.2.161", default-features = false }
 
 # Additional dependencies for Linux with the libc backend:
 #
@@ -74,7 +74,7 @@ default-features = false
 
 [dev-dependencies]
 tempfile = "3.5.0"
-libc = "0.2.156"
+libc = "0.2.161"
 libc_errno = { package = "errno", version = "0.3.8", default-features = false }
 serial_test = "2.0.0"
 memoffset = "0.9.0"

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -17,7 +17,7 @@ use crate::fs::Access;
 #[cfg(not(any(
     apple,
     netbsdlike,
-    solarish,
+    target_os = "solaris",
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "haiku",
@@ -29,7 +29,6 @@ use crate::fs::Advice;
 use crate::fs::AtFlags;
 #[cfg(not(any(
     netbsdlike,
-    solarish,
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "nto",
@@ -1196,7 +1195,7 @@ pub(crate) fn copy_file_range(
 #[cfg(not(any(
     apple,
     netbsdlike,
-    solarish,
+    target_os = "solaris",
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "haiku",
@@ -1614,7 +1613,6 @@ fn futimens_old(fd: BorrowedFd<'_>, times: &Timestamps) -> io::Result<()> {
 #[cfg(not(any(
     apple,
     netbsdlike,
-    solarish,
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "nto",

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -270,6 +270,7 @@ bitflags! {
         #[cfg(any(
             linux_kernel,
             netbsdlike,
+            solarish,
             target_os = "emscripten",
             target_os = "wasi",
         ))]
@@ -562,7 +563,7 @@ impl FileType {
 #[cfg(not(any(
     apple,
     netbsdlike,
-    solarish,
+    target_os = "solaris",
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "haiku",
@@ -796,7 +797,6 @@ bitflags! {
 
 #[cfg(not(any(
     netbsdlike,
-    solarish,
     target_os = "espidf",
     target_os = "nto",
     target_os = "redox",
@@ -812,6 +812,7 @@ bitflags! {
         /// `FALLOC_FL_KEEP_SIZE`
         #[cfg(not(any(
             bsd,
+            solarish,
             target_os = "aix",
             target_os = "haiku",
             target_os = "hurd",
@@ -821,6 +822,7 @@ bitflags! {
         /// `FALLOC_FL_PUNCH_HOLE`
         #[cfg(not(any(
             bsd,
+            solarish,
             target_os = "aix",
             target_os = "haiku",
             target_os = "hurd",
@@ -830,6 +832,7 @@ bitflags! {
         /// `FALLOC_FL_NO_HIDE_STALE`
         #[cfg(not(any(
             bsd,
+            solarish,
             target_os = "aix",
             target_os = "emscripten",
             target_os = "fuchsia",
@@ -843,6 +846,7 @@ bitflags! {
         /// `FALLOC_FL_COLLAPSE_RANGE`
         #[cfg(not(any(
             bsd,
+            solarish,
             target_os = "aix",
             target_os = "haiku",
             target_os = "hurd",
@@ -853,6 +857,7 @@ bitflags! {
         /// `FALLOC_FL_ZERO_RANGE`
         #[cfg(not(any(
             bsd,
+            solarish,
             target_os = "aix",
             target_os = "haiku",
             target_os = "hurd",
@@ -863,6 +868,7 @@ bitflags! {
         /// `FALLOC_FL_INSERT_RANGE`
         #[cfg(not(any(
             bsd,
+            solarish,
             target_os = "aix",
             target_os = "haiku",
             target_os = "hurd",
@@ -873,6 +879,7 @@ bitflags! {
         /// `FALLOC_FL_UNSHARE_RANGE`
         #[cfg(not(any(
             bsd,
+            solarish,
             target_os = "aix",
             target_os = "haiku",
             target_os = "hurd",

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -9,7 +9,6 @@ use crate::{backend, io};
 use backend::fd::{AsFd, BorrowedFd};
 #[cfg(not(any(
     netbsdlike,
-    solarish,
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "nto",
@@ -241,7 +240,6 @@ pub fn futimens<Fd: AsFd>(fd: Fd, times: &Timestamps) -> io::Result<()> {
 /// [Linux `posix_fallocate`]: https://man7.org/linux/man-pages/man3/posix_fallocate.3.html
 #[cfg(not(any(
     netbsdlike,
-    solarish,
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "nto",

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -15,7 +15,7 @@ mod dir;
 #[cfg(not(any(
     apple,
     netbsdlike,
-    solarish,
+    target_os = "solaris",
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "haiku",
@@ -81,7 +81,7 @@ pub use dir::{Dir, DirEntry};
 #[cfg(not(any(
     apple,
     netbsdlike,
-    solarish,
+    target_os = "solaris",
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "haiku",

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -84,7 +84,7 @@ fn test_file() {
     #[cfg(not(any(
         apple,
         netbsdlike,
-        solarish,
+        target_os = "solaris",
         target_os = "dragonfly",
         target_os = "espidf",
         target_os = "haiku",

--- a/tests/fs/invalid_offset.rs
+++ b/tests/fs/invalid_offset.rs
@@ -34,7 +34,6 @@ fn invalid_offset_seek() {
 
 #[cfg(not(any(
     netbsdlike,
-    solarish,
     target_os = "dragonfly",
     target_os = "nto",
     target_os = "redox"
@@ -61,7 +60,7 @@ fn invalid_offset_fallocate() {
 #[cfg(not(any(
     apple,
     netbsdlike,
-    solarish,
+    target_os = "solaris",
     target_os = "dragonfly",
     target_os = "haiku",
     target_os = "redox",


### PR DESCRIPTION
These functions were added to libc 0.2.161, and are required by some downstream crates.