### PR TITLE
Add a `rustix::fs::STATX_ATTR_MOUNT_ROOT` constant.

### DIFF
--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -14,6 +14,12 @@ pub(crate) const PROC_SUPER_MAGIC: u32 = 0x0000_9fa0;
 #[cfg(all(linux_kernel, target_env = "musl"))]
 pub(crate) const NFS_SUPER_MAGIC: u32 = 0x0000_6969;
 
+/// `STATX_ATTR_MOUNT_ROOT`—Address of the root of a mount
+#[cfg(all(linux_kernel, target_env = "musl"))]
+pub(crate) const STATX_ATTR_MOUNT_ROOT: c_int = 0x2000;
+#[cfg(all(linux_kernel, target_env = "gnu"))]
+pub(crate) const STATX_ATTR_MOUNT_ROOT: c_int = libc::STATX_ATTR_MOUNT_ROOT;
+
 #[cfg(feature = "process")]
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 pub(crate) const EXIT_SIGNALED_SIGABRT: c_int = 128 + SIGABRT as c_int;

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -37,6 +37,12 @@ pub(crate) use linux_raw_sys::general::epoll_event;
         )
     )
 ))]
+#[cfg(any(target_env = "musl", target_env = "gnu"))]
+pub(crate) use linux_raw_sys::general::{
+    AT_FDCWD, NFS_SUPER_MAGIC, O_LARGEFILE, PROC_SUPER_MAGIC, STATX_ATTR_MOUNT_ROOT, UTIME_NOW,
+    UTIME_OMIT, XATTR_CREATE, XATTR_REPLACE,
+};
+#[cfg(not(any(target_env = "musl", target_env = "gnu")))]
 pub(crate) use linux_raw_sys::general::{
     AT_FDCWD, NFS_SUPER_MAGIC, O_LARGEFILE, PROC_SUPER_MAGIC, UTIME_NOW, UTIME_OMIT, XATTR_CREATE,
     XATTR_REPLACE,

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -116,6 +116,8 @@ pub use sendfile::sendfile;
 pub use special::*;
 #[cfg(linux_kernel)]
 pub use statx::statx;
+#[cfg(all(linux_kernel, any(target_env = "musl", target_env = "gnu")))]
+pub use statx::STATX_ATTR_MOUNT_ROOT;
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "redox",

--- a/src/fs/statx.rs
+++ b/src/fs/statx.rs
@@ -10,6 +10,11 @@ use backend::fs::syscalls::statx as _statx;
 #[cfg(not(feature = "linux_4_11"))]
 use compat::statx as _statx;
 
+/// `STATX_ATTR_MOUNT_ROOT`—Address of the root of a mount
+#[allow(dead_code)]
+#[cfg(all(linux_kernel, any(target_env = "musl", target_env = "gnu")))]
+pub const STATX_ATTR_MOUNT_ROOT: u32 = backend::c::STATX_ATTR_MOUNT_ROOT as u32;
+
 /// `statx(dirfd, path, flags, mask, statxbuf)`
 ///
 /// This function returns [`io::Errno::NOSYS`] if `statx` is not available on


### PR DESCRIPTION
Add a `STATX_ATTR_MOUNT_ROOT` constant for Linux with musl libc compatibility.

(Note: This is my first contribution to rustix, so I assume that I may have placed const declarations in the wrong place. I will gladly fix any issues with this MR. Thank you!)