### PR TITLE
Use MaybeUninit in DecInt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.63"
 
 [dependencies]
 bitflags = { version = "2.4.0", default-features = false }
-itoa = { version = "1.0.1", default-features = false, optional = true }
+itoa = { version = "1.0.12", default-features = false, optional = true }
 
 # Special dependencies used in rustc-dep-of-std mode.
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.63"
 
 [dependencies]
 bitflags = { version = "2.4.0", default-features = false }
-itoa = { version = "1.0.12", default-features = false, optional = true }
+itoa = { version = "1.0.13", default-features = false, optional = true }
 
 # Special dependencies used in rustc-dep-of-std mode.
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }

--- a/src/path/dec_int.rs
+++ b/src/path/dec_int.rs
@@ -50,19 +50,17 @@ impl DecInt {
 
         let mut str_buf = Buffer::new();
         let str_buf = str_buf.format(i);
-        {
-            assert!(
-                str_buf.len() < buf.len(),
-                "{str_buf}{} unsupported.",
-                core::any::type_name::<Int>()
-            );
+        assert!(
+            str_buf.len() < buf.len(),
+            "{str_buf}{} unsupported.",
+            core::any::type_name::<Int>()
+        );
 
-            buf[..str_buf.len()].copy_from_slice(unsafe {
-                // SAFETY: you can always go from init to uninit
-                mem::transmute::<&[u8], &[MaybeUninit<u8>]>(str_buf.as_bytes())
-            });
-            buf[str_buf.len()] = MaybeUninit::new(0);
-        }
+        buf[..str_buf.len()].copy_from_slice(unsafe {
+            // SAFETY: you can always go from init to uninit
+            mem::transmute::<&[u8], &[MaybeUninit<u8>]>(str_buf.as_bytes())
+        });
+        buf[str_buf.len()] = MaybeUninit::new(0);
 
         Self {
             buf,

--- a/src/path/dec_int.rs
+++ b/src/path/dec_int.rs
@@ -8,7 +8,7 @@
 
 use crate::backend::fd::{AsFd, AsRawFd};
 use crate::ffi::CStr;
-use core::fmt::Write;
+use core::mem::MaybeUninit;
 use itoa::{Buffer, Integer};
 #[cfg(all(feature = "std", unix))]
 use std::os::unix::ffi::OsStrExt;
@@ -38,7 +38,7 @@ use {core::fmt, std::ffi::OsStr, std::path::Path};
 pub struct DecInt {
     // 20 `u8`s is enough to hold the decimal ASCII representation of any
     // `u64`, and we add one for a NUL terminator for `as_c_str`.
-    buf: [u8; 20 + 1],
+    buf: [MaybeUninit<u8>; 20 + 1],
     len: usize,
 }
 
@@ -46,13 +46,20 @@ impl DecInt {
     /// Construct a new path component from an integer.
     #[inline]
     pub fn new<Int: Integer>(i: Int) -> Self {
-        let mut me = DecIntWriter(Self {
-            buf: [0; 20 + 1],
-            len: 0,
+        let mut buf = [MaybeUninit::uninit(); 20 + 1];
+
+        let mut str_buf = Buffer::new();
+        let str_buf = str_buf.format(i);
+        buf[..str_buf.len()].copy_from_slice(unsafe {
+            // SAFETY: you can always go from init to uninit
+            core::mem::transmute::<&[u8], &[MaybeUninit<u8>]>(str_buf.as_bytes())
         });
-        let mut buf = Buffer::new();
-        me.write_str(buf.format(i)).unwrap();
-        me.0
+        buf[str_buf.len()] = MaybeUninit::new(0);
+
+        Self {
+            buf,
+            len: str_buf.len(),
+        }
     }
 
     /// Construct a new path component from a file descriptor.
@@ -72,7 +79,7 @@ impl DecInt {
     /// Return the raw byte buffer as a `&CStr`.
     #[inline]
     pub fn as_c_str(&self) -> &CStr {
-        let bytes_with_nul = &self.buf[..=self.len];
+        let bytes_with_nul = self.as_bytes_with_nul();
         debug_assert!(CStr::from_bytes_with_nul(bytes_with_nul).is_ok());
 
         // SAFETY: `self.buf` holds a single decimal ASCII representation and
@@ -80,28 +87,19 @@ impl DecInt {
         unsafe { CStr::from_bytes_with_nul_unchecked(bytes_with_nul) }
     }
 
+    /// Return the raw byte buffer including the NUL byte.
+    #[inline]
+    pub fn as_bytes_with_nul(&self) -> &[u8] {
+        let init = &self.buf[..=self.len];
+        // SAFETY: we're guaranteed to have initialized len+1 bytes.
+        unsafe { core::mem::transmute::<&[MaybeUninit<u8>], &[u8]>(init) }
+    }
+
     /// Return the raw byte buffer.
     #[inline]
     pub fn as_bytes(&self) -> &[u8] {
-        &self.buf[..self.len]
-    }
-}
-
-/// A wrapper around `DecInt` that implements `Write` without exposing this
-/// implementation to `DecInt`'s public API.
-struct DecIntWriter(DecInt);
-
-impl core::fmt::Write for DecIntWriter {
-    #[inline]
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        match self.0.buf.get_mut(self.0.len..self.0.len + s.len()) {
-            Some(slice) => {
-                slice.copy_from_slice(s.as_bytes());
-                self.0.len += s.len();
-                Ok(())
-            }
-            None => Err(core::fmt::Error),
-        }
+        let bytes = self.as_bytes_with_nul();
+        &bytes[..bytes.len() - 1]
     }
 }
 
@@ -109,7 +107,7 @@ impl core::fmt::Write for DecIntWriter {
 impl AsRef<Path> for DecInt {
     #[inline]
     fn as_ref(&self) -> &Path {
-        let as_os_str: &OsStr = OsStrExt::from_bytes(&self.buf[..self.len]);
+        let as_os_str: &OsStr = OsStrExt::from_bytes(self.as_bytes());
         Path::new(as_os_str)
     }
 }

--- a/src/path/dec_int.rs
+++ b/src/path/dec_int.rs
@@ -37,7 +37,7 @@ use {core::fmt, std::ffi::OsStr, std::path::Path};
 /// ```
 #[derive(Clone)]
 pub struct DecInt {
-    // Enough to hold an i64 and NUL terminator.
+    // Enough to hold an {u,i}64 and NUL terminator.
     buf: [MaybeUninit<u8>; "-9223372036854775808\0".len()],
     len: usize,
 }
@@ -72,6 +72,7 @@ impl DecInt {
                     _ => unreachable!(),
                 }
             };
+            // This optimizes out the assertion and bounds checks.
             if str_buf.len() > max_buf_size {
                 unsafe { core::hint::unreachable_unchecked() }
             }

--- a/src/path/dec_int.rs
+++ b/src/path/dec_int.rs
@@ -37,9 +37,10 @@ use {core::fmt, std::ffi::OsStr, std::path::Path};
 #[derive(Clone)]
 pub struct DecInt {
     // Enough to hold an {u,i}64 and NUL terminator.
-    buf: [MaybeUninit<u8>; "-9223372036854775808\0".len()],
+    buf: [MaybeUninit<u8>; u64::MAX_STR_LEN + 1],
     len: usize,
 }
+const _: () = assert!(u64::MAX_STR_LEN == i64::MAX_STR_LEN);
 
 impl DecInt {
     /// Construct a new path component from an integer.

--- a/src/path/dec_int.rs
+++ b/src/path/dec_int.rs
@@ -8,7 +8,8 @@
 
 use crate::backend::fd::{AsFd, AsRawFd};
 use crate::ffi::CStr;
-use core::mem::MaybeUninit;
+use core::any::TypeId;
+use core::mem::{self, MaybeUninit};
 use itoa::{Buffer, Integer};
 #[cfg(all(feature = "std", unix))]
 use std::os::unix::ffi::OsStrExt;
@@ -36,25 +37,56 @@ use {core::fmt, std::ffi::OsStr, std::path::Path};
 /// ```
 #[derive(Clone)]
 pub struct DecInt {
-    // 20 `u8`s is enough to hold the decimal ASCII representation of any
-    // `u64`, and we add one for a NUL terminator for `as_c_str`.
-    buf: [MaybeUninit<u8>; 20 + 1],
+    // Enough to hold an i64 and NUL terminator.
+    buf: [MaybeUninit<u8>; "-9223372036854775808\0".len()],
     len: usize,
 }
 
 impl DecInt {
     /// Construct a new path component from an integer.
     #[inline]
-    pub fn new<Int: Integer>(i: Int) -> Self {
-        let mut buf = [MaybeUninit::uninit(); 20 + 1];
+    pub fn new<Int: Integer + 'static>(i: Int) -> Self {
+        let mut buf = [MaybeUninit::uninit(); 21];
 
         let mut str_buf = Buffer::new();
         let str_buf = str_buf.format(i);
-        buf[..str_buf.len()].copy_from_slice(unsafe {
-            // SAFETY: you can always go from init to uninit
-            core::mem::transmute::<&[u8], &[MaybeUninit<u8>]>(str_buf.as_bytes())
-        });
-        buf[str_buf.len()] = MaybeUninit::new(0);
+        {
+            let max_buf_size = {
+                let bits = match TypeId::of::<Int>() {
+                    id if [TypeId::of::<i8>(), TypeId::of::<u8>()].contains(&id) => u8::BITS,
+                    id if [TypeId::of::<i16>(), TypeId::of::<u16>()].contains(&id) => u16::BITS,
+                    id if [TypeId::of::<i32>(), TypeId::of::<u32>()].contains(&id) => u32::BITS,
+                    id if [TypeId::of::<i64>(), TypeId::of::<u64>()].contains(&id) => u64::BITS,
+                    id if [TypeId::of::<i128>(), TypeId::of::<u128>()].contains(&id) => u128::BITS,
+                    id if [TypeId::of::<isize>(), TypeId::of::<usize>()].contains(&id) => {
+                        usize::BITS
+                    }
+                    _ => unreachable!(),
+                };
+                match bits {
+                    8 => "-128".len(),
+                    16 => "-32768".len(),
+                    32 => "-2147483648".len(),
+                    64 => "-9223372036854775808".len(),
+                    128 => "-170141183460469231731687303715884105728".len(),
+                    _ => unreachable!(),
+                }
+            };
+            if str_buf.len() > max_buf_size {
+                unsafe { core::hint::unreachable_unchecked() }
+            }
+            assert!(
+                str_buf.len() < buf.len(),
+                "{str_buf}{} unsupported.",
+                core::any::type_name::<Int>()
+            );
+
+            buf[..str_buf.len()].copy_from_slice(unsafe {
+                // SAFETY: you can always go from init to uninit
+                mem::transmute::<&[u8], &[MaybeUninit<u8>]>(str_buf.as_bytes())
+            });
+            buf[str_buf.len()] = MaybeUninit::new(0);
+        }
 
         Self {
             buf,
@@ -92,7 +124,7 @@ impl DecInt {
     pub fn as_bytes_with_nul(&self) -> &[u8] {
         let init = &self.buf[..=self.len];
         // SAFETY: we're guaranteed to have initialized len+1 bytes.
-        unsafe { core::mem::transmute::<&[MaybeUninit<u8>], &[u8]>(init) }
+        unsafe { mem::transmute::<&[MaybeUninit<u8>], &[u8]>(init) }
     }
 
     /// Return the raw byte buffer.

--- a/tests/path/dec_int.rs
+++ b/tests/path/dec_int.rs
@@ -34,7 +34,12 @@ fn test_dec_int() {
 
 #[test]
 #[should_panic]
-fn test_unsupported_dec_int() {
+fn test_unsupported_max_u128_dec_int() {
     check!(u128::MAX);
+}
+
+#[test]
+#[should_panic]
+fn test_unsupported_min_u128_dec_int() {
     check!(i128::MIN);
 }

--- a/tests/path/dec_int.rs
+++ b/tests/path/dec_int.rs
@@ -1,20 +1,40 @@
 use rustix::path::DecInt;
 
+macro_rules! check {
+    ($i:expr) => {
+        let i = $i;
+        assert_eq!(DecInt::new(i).as_ref().to_str().unwrap(), i.to_string());
+    };
+}
+
 #[test]
 fn test_dec_int() {
-    assert_eq!(DecInt::new(0).as_ref().to_str().unwrap(), "0");
-    assert_eq!(DecInt::new(-1).as_ref().to_str().unwrap(), "-1");
-    assert_eq!(DecInt::new(789).as_ref().to_str().unwrap(), "789");
-    assert_eq!(
-        DecInt::new(i64::MIN).as_ref().to_str().unwrap(),
-        i64::MIN.to_string()
-    );
-    assert_eq!(
-        DecInt::new(i64::MAX).as_ref().to_str().unwrap(),
-        i64::MAX.to_string()
-    );
-    assert_eq!(
-        DecInt::new(u64::MAX).as_ref().to_str().unwrap(),
-        u64::MAX.to_string()
-    );
+    check!(0);
+    check!(-1);
+    check!(789);
+
+    check!(u8::MAX);
+    check!(i8::MIN);
+    check!(u16::MAX);
+    check!(i16::MIN);
+    check!(u32::MAX);
+    check!(i32::MIN);
+    check!(u64::MAX);
+    check!(i64::MIN);
+    #[cfg(any(
+        target_pointer_width = "16",
+        target_pointer_width = "32",
+        target_pointer_width = "64"
+    ))]
+    {
+        check!(usize::MAX);
+        check!(isize::MIN);
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_unsupported_dec_int() {
+    check!(u128::MAX);
+    check!(i128::MIN);
 }


### PR DESCRIPTION
Double checked with `cargo miri t --workspace --features all-apis -- dec_int`. Also got rid of the `fmt::Write` impl as that's confusingly complicated.