### PR TITLE
Enable a few features on more platforms.

### DIFF
--- a/src/backend/libc/conv.rs
+++ b/src/backend/libc/conv.rs
@@ -70,7 +70,11 @@ pub(super) fn ret_c_int(raw: c::c_int) -> io::Result<c::c_int> {
     }
 }
 
-#[cfg(any(linux_kernel, all(target_os = "redox", feature = "event")))]
+#[cfg(any(
+    linux_kernel,
+    all(solarish, feature = "event"),
+    all(target_os = "redox", feature = "event")
+))]
 #[inline]
 pub(super) fn ret_u32(raw: c::c_int) -> io::Result<u32> {
     if raw == -1 {

--- a/src/backend/libc/event/mod.rs
+++ b/src/backend/libc/event/mod.rs
@@ -5,5 +5,5 @@ pub(crate) mod types;
 #[cfg_attr(windows, path = "windows_syscalls.rs")]
 pub(crate) mod syscalls;
 
-#[cfg(any(linux_kernel, target_os = "redox"))]
+#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
 pub mod epoll;

--- a/src/backend/libc/event/poll_fd.rs
+++ b/src/backend/libc/event/poll_fd.rs
@@ -41,8 +41,8 @@ bitflags! {
         const NVAL = c::POLLNVAL;
         /// `POLLRDHUP`
         #[cfg(any(
-            solarish,
             target_os = "freebsd",
+            target_os = "illumos",
             all(
                 linux_kernel,
                 not(any(target_arch = "sparc", target_arch = "sparc64"))

--- a/src/backend/libc/event/poll_fd.rs
+++ b/src/backend/libc/event/poll_fd.rs
@@ -40,10 +40,14 @@ bitflags! {
         #[cfg(not(target_os = "espidf"))]
         const NVAL = c::POLLNVAL;
         /// `POLLRDHUP`
-        #[cfg(all(
-            linux_kernel,
-            not(any(target_arch = "sparc", target_arch = "sparc64"))),
-        )]
+        #[cfg(any(
+            solarish,
+            target_os = "freebsd",
+            all(
+                linux_kernel,
+                not(any(target_arch = "sparc", target_arch = "sparc64"))
+            ),
+        ))]
         const RDHUP = c::POLLRDHUP;
 
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>

--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -5,7 +5,7 @@ use crate::backend::c;
 use crate::backend::conv::ret;
 use crate::backend::conv::ret_c_int;
 #[cfg(feature = "alloc")]
-#[cfg(any(linux_kernel, target_os = "redox"))]
+#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
 use crate::backend::conv::ret_u32;
 #[cfg(solarish)]
 use crate::event::port::Event;
@@ -22,7 +22,7 @@ use crate::event::PollFd;
 use crate::io;
 #[cfg(solarish)]
 use crate::utils::as_mut_ptr;
-#[cfg(any(linux_kernel, target_os = "redox"))]
+#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
 use crate::utils::as_ptr;
 #[cfg(any(
     all(feature = "alloc", bsd),
@@ -351,13 +351,13 @@ pub(crate) fn pause() {
 }
 
 #[inline]
-#[cfg(any(linux_kernel, target_os = "redox"))]
+#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
 pub(crate) fn epoll_create(flags: super::epoll::CreateFlags) -> io::Result<OwnedFd> {
     unsafe { ret_owned_fd(c::epoll_create1(bitflags_bits!(flags))) }
 }
 
 #[inline]
-#[cfg(any(linux_kernel, target_os = "redox"))]
+#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
 pub(crate) fn epoll_add(
     epoll: BorrowedFd<'_>,
     source: BorrowedFd<'_>,
@@ -378,7 +378,7 @@ pub(crate) fn epoll_add(
 }
 
 #[inline]
-#[cfg(any(linux_kernel, target_os = "redox"))]
+#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
 pub(crate) fn epoll_mod(
     epoll: BorrowedFd<'_>,
     source: BorrowedFd<'_>,
@@ -396,7 +396,7 @@ pub(crate) fn epoll_mod(
 }
 
 #[inline]
-#[cfg(any(linux_kernel, target_os = "redox"))]
+#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
 pub(crate) fn epoll_del(epoll: BorrowedFd<'_>, source: BorrowedFd<'_>) -> io::Result<()> {
     unsafe {
         ret(c::epoll_ctl(
@@ -410,7 +410,7 @@ pub(crate) fn epoll_del(epoll: BorrowedFd<'_>, source: BorrowedFd<'_>) -> io::Re
 
 #[inline]
 #[cfg(feature = "alloc")]
-#[cfg(any(linux_kernel, target_os = "redox"))]
+#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
 pub(crate) fn epoll_wait(
     epoll: BorrowedFd<'_>,
     events: &mut [MaybeUninit<crate::event::epoll::Event>],

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -40,7 +40,7 @@ bitflags! {
         const SYMLINK_NOFOLLOW = bitcast!(c::AT_SYMLINK_NOFOLLOW);
 
         /// `AT_EACCESS`
-        #[cfg(not(any(target_os = "emscripten", target_os = "android")))]
+        #[cfg(not(target_os = "android"))]
         const EACCESS = bitcast!(c::AT_EACCESS);
 
         /// `AT_REMOVEDIR`

--- a/src/backend/libc/pty/syscalls.rs
+++ b/src/backend/libc/pty/syscalls.rs
@@ -6,7 +6,13 @@ use crate::fd::BorrowedFd;
 use crate::io;
 #[cfg(all(
     feature = "alloc",
-    any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia")
+    any(
+        apple,
+        linux_like,
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "illumos"
+    )
 ))]
 use {
     crate::ffi::{CStr, CString},
@@ -26,7 +32,13 @@ pub(crate) fn openpt(flags: OpenptFlags) -> io::Result<OwnedFd> {
 
 #[cfg(all(
     feature = "alloc",
-    any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia")
+    any(
+        apple,
+        linux_like,
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "illumos"
+    )
 ))]
 #[inline]
 pub(crate) fn ptsname(fd: BorrowedFd<'_>, mut buffer: Vec<u8>) -> io::Result<CString> {
@@ -38,7 +50,7 @@ pub(crate) fn ptsname(fd: BorrowedFd<'_>, mut buffer: Vec<u8>) -> io::Result<CSt
 
     loop {
         // On platforms with `ptsname_r`, use it.
-        #[cfg(any(linux_like, target_os = "fuchsia"))]
+        #[cfg(any(linux_like, target_os = "fuchsia", target_os = "illumos"))]
         let r = unsafe { c::ptsname_r(borrowed_fd(fd), buffer.as_mut_ptr().cast(), buffer.len()) };
 
         // FreeBSD 12 doesn't have `ptsname_r`.

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -1,6 +1,6 @@
 //! Event operations.
 
-#[cfg(any(linux_kernel, target_os = "redox"))]
+#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
 pub mod epoll;
 #[cfg(any(
     linux_kernel,

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -13,7 +13,13 @@ use crate::fs::OFlags;
 use crate::{backend, io};
 #[cfg(all(
     feature = "alloc",
-    any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia")
+    any(
+        apple,
+        linux_like,
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "illumos"
+    )
 ))]
 use {crate::ffi::CString, alloc::vec::Vec};
 
@@ -115,7 +121,13 @@ pub fn openpt(flags: OpenptFlags) -> io::Result<OwnedFd> {
 /// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Allocation.html#index-ptsname
 #[cfg(all(
     feature = "alloc",
-    any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia")
+    any(
+        apple,
+        linux_like,
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "illumos"
+    )
 ))]
 #[inline]
 #[doc(alias = "ptsname_r")]


### PR DESCRIPTION
Define `PollFlags::RDHUP` on FreeBSD, `AT_EACCESS` on Emscripten, and `ptsname` on Illumos.