### PR TITLE
fix: enable wasip2 feature for wasm32-wasip2 target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 keywords = ["api", "file", "network", "safe", "syscall"]
 categories = ["os::unix-apis", "date-and-time", "filesystem", "network-programming"]
 include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md", "benches"]
-rust-version = "1.63"
+rust-version = "1.82"
 
 [dependencies]
 bitflags = { version = "2.4.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 keywords = ["api", "file", "network", "safe", "syscall"]
 categories = ["os::unix-apis", "date-and-time", "filesystem", "network-programming"]
 include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md", "benches"]
-rust-version = "1.82"
+rust-version = "1.63"
 
 [dependencies]
 bitflags = { version = "2.4.0", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// wasip2 conditionally gates stdlib APIs.
+// https://github.com/rust-lang/rust/issues/130323
+#![cfg_attr(all(target_os = "wasi", target_env = "p2"), feature(wasip2))]
 //! `rustix` provides efficient memory-safe and [I/O-safe] wrappers to
 //! POSIX-like, Unix-like, Linux, and Winsock syscall-like APIs, with
 //! configurable backends.


### PR DESCRIPTION
* Updating MSRV to 1.82 as that the first version with the wasip2 target
* wasip2 will require +nightly until https://github.com/rust-lang/rust/issues/130323 is resolved and/or `std::os::wasip2` is available in stable. (please correct me if I'm wrong about that)