### PR TITLE
Disable epoll support on Solaris.

### DIFF
--- a/src/backend/libc/conv.rs
+++ b/src/backend/libc/conv.rs
@@ -72,7 +72,7 @@ pub(super) fn ret_c_int(raw: c::c_int) -> io::Result<c::c_int> {
 
 #[cfg(any(
     linux_kernel,
-    all(solarish, feature = "event"),
+    all(target_os = "illumos", feature = "event"),
     all(target_os = "redox", feature = "event")
 ))]
 #[inline]

--- a/src/backend/libc/event/mod.rs
+++ b/src/backend/libc/event/mod.rs
@@ -5,5 +5,5 @@ pub(crate) mod types;
 #[cfg_attr(windows, path = "windows_syscalls.rs")]
 pub(crate) mod syscalls;
 
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 pub mod epoll;

--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -5,7 +5,7 @@ use crate::backend::c;
 use crate::backend::conv::ret;
 use crate::backend::conv::ret_c_int;
 #[cfg(feature = "alloc")]
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 use crate::backend::conv::ret_u32;
 #[cfg(solarish)]
 use crate::event::port::Event;
@@ -22,7 +22,7 @@ use crate::event::PollFd;
 use crate::io;
 #[cfg(solarish)]
 use crate::utils::as_mut_ptr;
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 use crate::utils::as_ptr;
 #[cfg(any(
     all(feature = "alloc", bsd),
@@ -351,13 +351,13 @@ pub(crate) fn pause() {
 }
 
 #[inline]
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 pub(crate) fn epoll_create(flags: super::epoll::CreateFlags) -> io::Result<OwnedFd> {
     unsafe { ret_owned_fd(c::epoll_create1(bitflags_bits!(flags))) }
 }
 
 #[inline]
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 pub(crate) fn epoll_add(
     epoll: BorrowedFd<'_>,
     source: BorrowedFd<'_>,
@@ -378,7 +378,7 @@ pub(crate) fn epoll_add(
 }
 
 #[inline]
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 pub(crate) fn epoll_mod(
     epoll: BorrowedFd<'_>,
     source: BorrowedFd<'_>,
@@ -396,7 +396,7 @@ pub(crate) fn epoll_mod(
 }
 
 #[inline]
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 pub(crate) fn epoll_del(epoll: BorrowedFd<'_>, source: BorrowedFd<'_>) -> io::Result<()> {
     unsafe {
         ret(c::epoll_ctl(
@@ -410,7 +410,7 @@ pub(crate) fn epoll_del(epoll: BorrowedFd<'_>, source: BorrowedFd<'_>) -> io::Re
 
 #[inline]
 #[cfg(feature = "alloc")]
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 pub(crate) fn epoll_wait(
     epoll: BorrowedFd<'_>,
     events: &mut [MaybeUninit<crate::event::epoll::Event>],

--- a/src/event/epoll.rs
+++ b/src/event/epoll.rs
@@ -92,8 +92,10 @@ use core::slice;
 ///
 /// # References
 ///  - [Linux]
+///  - [illumos]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/epoll_create.2.html
+/// [illumos]: https://www.illumos.org/man/3C/epoll_create
 #[inline]
 #[doc(alias = "epoll_create1")]
 pub fn create(flags: epoll::CreateFlags) -> io::Result<OwnedFd> {
@@ -114,8 +116,10 @@ pub fn create(flags: epoll::CreateFlags) -> io::Result<OwnedFd> {
 ///
 /// # References
 ///  - [Linux]
+///  - [illumos]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/epoll_ctl.2.html
+/// [illumos]: https://www.illumos.org/man/3C/epoll_ctl
 /// [faq]: https://man7.org/linux/man-pages/man7/epoll.7.html#:~:text=Will%20closing%20a%20file%20descriptor%20cause%20it%20to%20be%20removed%20from%20all%0A%20%20%20%20%20%20%20%20%20%20epoll%20interest%20lists%3F
 #[doc(alias = "epoll_ctl")]
 #[inline]
@@ -144,8 +148,10 @@ pub fn add(
 ///
 /// # References
 ///  - [Linux]
+///  - [illumos]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/epoll_ctl.2.html
+/// [illumos]: https://www.illumos.org/man/3C/epoll_ctl
 #[doc(alias = "epoll_ctl")]
 #[inline]
 pub fn modify(
@@ -171,8 +177,10 @@ pub fn modify(
 ///
 /// # References
 ///  - [Linux]
+///  - [illumos]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/epoll_ctl.2.html
+/// [illumos]: https://www.illumos.org/man/3C/epoll_ctl
 #[doc(alias = "epoll_ctl")]
 #[inline]
 pub fn delete(epoll: impl AsFd, source: impl AsFd) -> io::Result<()> {
@@ -187,8 +195,10 @@ pub fn delete(epoll: impl AsFd, source: impl AsFd) -> io::Result<()> {
 ///
 /// # References
 ///  - [Linux]
+///  - [illumos]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/epoll_wait.2.html
+/// [illumos]: https://www.illumos.org/man/3C/epoll_wait
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc"), alias = "epoll_wait"))]
 #[inline]

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -1,6 +1,6 @@
 //! Event operations.
 
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 pub mod epoll;
 #[cfg(any(
     linux_kernel,

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -114,10 +114,12 @@ pub fn openpt(flags: OpenptFlags) -> io::Result<OwnedFd> {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
+///  - [illumos]
 ///  - [glibc]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/ptsname.html
 /// [Linux]: https://man7.org/linux/man-pages/man3/ptsname.3.html
+/// [illumos]: https://www.illumos.org/man/3C/ptsname
 /// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Allocation.html#index-ptsname
 #[cfg(all(
     feature = "alloc",

--- a/tests/event/main.rs
+++ b/tests/event/main.rs
@@ -4,7 +4,7 @@
 
 #[cfg(not(feature = "rustc-dep-of-std"))] // TODO
 #[cfg(feature = "net")]
-#[cfg(linux_kernel)]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 mod epoll;
 #[cfg(not(windows))]
 #[cfg(not(target_os = "wasi"))]

--- a/tests/pty/main.rs
+++ b/tests/pty/main.rs
@@ -2,5 +2,11 @@
 
 #![cfg(feature = "pty")]
 
-#[cfg(any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    apple,
+    linux_like,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos"
+))]
 mod openpty;


### PR DESCRIPTION
It appears Solaris doesn't support epoll; only Illumos does. And as of rust-lang/libc#3864, the libc crate won't declare the epoll libc interface on Solaris. So disable epoll support on Solaris in rustix too.