### PR TITLE
Clarify `getppid` documentation: explain how `None` can occur

### DIFF
--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -113,6 +113,9 @@ pub fn getpid() -> Pid {
 
 /// `getppid()`—Returns the parent process' ID.
 ///
+/// This will return `None` if the current process has no parent (or no parent accessible in the
+/// current PID namespace), such as if the current process is an init process (PID 1).
+///
 /// # References
 ///  - [POSIX]
 ///  - [Linux]


### PR DESCRIPTION
The `getppid` syscall can never fail, but rustix returns PID 0 as
`None`.

closes: #1204
