### PR TITLE
Disable `AF_NCA`, `VSTATUS`, `VERASE2`, and `fcntl_lock` on Solaris.

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -36,7 +36,12 @@ use crate::fs::AtFlags;
     target_os = "vita",
 )))]
 use crate::fs::FallocateFlags;
-#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "solaris",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 use crate::fs::FlockOperation;
 #[cfg(any(linux_kernel, target_os = "freebsd"))]
 use crate::fs::MemfdFlags;
@@ -1252,6 +1257,7 @@ pub(crate) fn fcntl_add_seals(fd: BorrowedFd<'_>, seals: SealFlags) -> io::Resul
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "solaris",
     target_os = "vita",
     target_os = "wasi"
 )))]

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -949,7 +949,12 @@ bitflags! {
 ///
 /// [`flock`]: crate::fs::flock
 /// [`fcntl_lock`]: crate::fs::fcntl_lock
-#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "solaris",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u32)]
 pub enum FlockOperation {

--- a/src/fs/fcntl.rs
+++ b/src/fs/fcntl.rs
@@ -8,6 +8,7 @@
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "solaris",
     target_os = "vita",
     target_os = "wasi"
 )))]
@@ -101,6 +102,7 @@ pub fn fcntl_add_seals<Fd: AsFd>(fd: Fd, seals: SealFlags) -> io::Result<()> {
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "solaris",
     target_os = "vita",
     target_os = "wasi"
 )))]

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -541,7 +541,7 @@ impl AddressFamily {
     #[cfg(solarish)]
     pub const NBS: Self = Self(c::AF_NBS as _);
     /// `AF_NCA`
-    #[cfg(solarish)]
+    #[cfg(target_os = "illumos")]
     pub const NCA: Self = Self(c::AF_NCA as _);
     /// `AF_NDD`
     #[cfg(target_os = "aix")]

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -1192,11 +1192,11 @@ impl SpecialCodeIndex {
     pub const VDSUSP: Self = Self(c::VDSUSP as usize);
 
     /// `VSTATUS`
-    #[cfg(any(bsd, solarish, target_os = "hurd"))]
+    #[cfg(any(bsd, target_os = "hurd", target_os = "illumos"))]
     pub const VSTATUS: Self = Self(c::VSTATUS as usize);
 
     /// `VERASE2`
-    #[cfg(any(freebsdlike, solarish))]
+    #[cfg(any(freebsdlike, target_os = "illumos"))]
     pub const VERASE2: Self = Self(c::VERASE2 as usize);
 }
 
@@ -1272,9 +1272,9 @@ impl core::fmt::Debug for SpecialCodeIndex {
                 target_os = "nto"
             ))]
             Self::VDSUSP => write!(f, "VDSUSP"),
-            #[cfg(any(bsd, solarish, target_os = "hurd"))]
+            #[cfg(any(bsd, target_os = "hurd", target_os = "illumos"))]
             Self::VSTATUS => write!(f, "VSTATUS"),
-            #[cfg(any(freebsdlike, solarish))]
+            #[cfg(any(freebsdlike, target_os = "illumos"))]
             Self::VERASE2 => write!(f, "VERASE2"),
 
             _ => write!(f, "unknown"),


### PR DESCRIPTION
Recent versions of libc 0.2.x have removed these declarations on Solaris, so remove the code that uses them from rustix.