### PR TITLE
Backport patches to 0.38

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,9 +79,11 @@ jobs:
         sparcv9-sun-solaris
         aarch64-linux-android
         aarch64-apple-ios
-        wasm32-wasi
     - if: matrix.rust != '1.63'
-      run: rustup target add x86_64-unknown-fuchsia
+      run: >
+        rustup target add
+        wasm32-wasip1
+        x86_64-unknown-fuchsia
     - if: matrix.rust == '1.63'
       run: rustup target add x86_64-fuchsia
 
@@ -98,6 +100,8 @@ jobs:
     - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin --features=all-apis --all-targets
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-freebsd --features=all-apis --all-targets
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-netbsd --features=all-apis --all-targets
+    - if: matrix.rust != '1.63'
+      run: cargo check --workspace --release -vv --target=wasm32-wasip1 --features=all-apis
     - if: matrix.rust != '1.63'
       run: cargo check --workspace --release -vv --target=x86_64-unknown-fuchsia --features=all-apis --all-targets
     - if: matrix.rust == '1.63'
@@ -121,7 +125,6 @@ jobs:
     - run: cargo check --workspace --release -vv --target=sparcv9-sun-solaris --features=all-apis --all-targets
     - run: cargo check --workspace --release -vv --target=aarch64-apple-ios --features=all-apis --all-targets
     - run: cargo check --workspace --release -vv --target=aarch64-linux-android --features=all-apis --all-targets
-    - run: cargo check --workspace --release -vv --target=wasm32-wasi --features=all-apis
 
   check_no_default_features:
     name: Check --no-default-features
@@ -176,10 +179,10 @@ jobs:
     - run: >
         rustup target add
         x86_64-unknown-redox
-        wasm32-wasi
+        wasm32-wasip1
         thumbv7neon-unknown-linux-gnueabihf
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-redox --features=all-apis
-    - run: cargo check --workspace --release -vv --target=wasm32-wasi --features=all-apis
+    - run: cargo check --workspace --release -vv --target=wasm32-wasip1 --features=all-apis
     - run: cargo check --workspace --release -vv --target=thumbv7neon-unknown-linux-gnueabihf --features=all-apis
 
   check_tier3:

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -1618,7 +1618,7 @@ jobs:
         ref: rustix-0.35.6-beta.2
         submodules: true
 
-    - run: rustup target add wasm32-wasi
+    - run: rustup target add wasm32-wasip1
     - run: cd wasmtime && cargo update
     - run: sed -i'.bak' 's/^version = "'`cd wasmtime && cargo tree --edges=normal |head -1 |sed 's/^[[:alnum:]_-]* v\([[:alnum:].-]*\) (.*/\1/'`'"$/version = '`grep -A1 '^name = "rustix"' wasmtime/Cargo.lock |grep ^version |sed 's/^[^"]*//'`'/' Cargo.toml
     - run: cd wasmtime && echo '[patch.crates-io]' >> Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ targets = [
     "x86_64-unknown-redox",
     "x86_64-unknown-haiku",
     "wasm32-unknown-emscripten",
-    "wasm32-wasi",
+    "wasm32-wasip1",
 ]
 
 [features]

--- a/src/backend/libc/conv.rs
+++ b/src/backend/libc/conv.rs
@@ -72,7 +72,7 @@ pub(super) fn ret_c_int(raw: c::c_int) -> io::Result<c::c_int> {
 
 #[cfg(any(
     linux_kernel,
-    all(solarish, feature = "event"),
+    all(target_os = "illumos", feature = "event"),
     all(target_os = "redox", feature = "event")
 ))]
 #[inline]

--- a/src/backend/libc/event/mod.rs
+++ b/src/backend/libc/event/mod.rs
@@ -5,5 +5,5 @@ pub(crate) mod types;
 #[cfg_attr(windows, path = "windows_syscalls.rs")]
 pub(crate) mod syscalls;
 
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 pub mod epoll;

--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -5,7 +5,7 @@ use crate::backend::c;
 use crate::backend::conv::ret;
 use crate::backend::conv::ret_c_int;
 #[cfg(feature = "alloc")]
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 use crate::backend::conv::ret_u32;
 #[cfg(solarish)]
 use crate::event::port::Event;
@@ -22,7 +22,7 @@ use crate::event::PollFd;
 use crate::io;
 #[cfg(solarish)]
 use crate::utils::as_mut_ptr;
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 use crate::utils::as_ptr;
 #[cfg(any(
     all(feature = "alloc", bsd),
@@ -351,13 +351,13 @@ pub(crate) fn pause() {
 }
 
 #[inline]
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 pub(crate) fn epoll_create(flags: super::epoll::CreateFlags) -> io::Result<OwnedFd> {
     unsafe { ret_owned_fd(c::epoll_create1(bitflags_bits!(flags))) }
 }
 
 #[inline]
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 pub(crate) fn epoll_add(
     epoll: BorrowedFd<'_>,
     source: BorrowedFd<'_>,
@@ -378,7 +378,7 @@ pub(crate) fn epoll_add(
 }
 
 #[inline]
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 pub(crate) fn epoll_mod(
     epoll: BorrowedFd<'_>,
     source: BorrowedFd<'_>,
@@ -396,7 +396,7 @@ pub(crate) fn epoll_mod(
 }
 
 #[inline]
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 pub(crate) fn epoll_del(epoll: BorrowedFd<'_>, source: BorrowedFd<'_>) -> io::Result<()> {
     unsafe {
         ret(c::epoll_ctl(
@@ -410,7 +410,7 @@ pub(crate) fn epoll_del(epoll: BorrowedFd<'_>, source: BorrowedFd<'_>) -> io::Re
 
 #[inline]
 #[cfg(feature = "alloc")]
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 pub(crate) fn epoll_wait(
     epoll: BorrowedFd<'_>,
     events: &mut [MaybeUninit<crate::event::epoll::Event>],

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -36,7 +36,12 @@ use crate::fs::AtFlags;
     target_os = "vita",
 )))]
 use crate::fs::FallocateFlags;
-#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "solaris",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 use crate::fs::FlockOperation;
 #[cfg(any(linux_kernel, target_os = "freebsd"))]
 use crate::fs::MemfdFlags;
@@ -1252,6 +1257,7 @@ pub(crate) fn fcntl_add_seals(fd: BorrowedFd<'_>, seals: SealFlags) -> io::Resul
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "solaris",
     target_os = "vita",
     target_os = "wasi"
 )))]

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -949,7 +949,12 @@ bitflags! {
 ///
 /// [`flock`]: crate::fs::flock
 /// [`fcntl_lock`]: crate::fs::fcntl_lock
-#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "solaris",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u32)]
 pub enum FlockOperation {

--- a/src/event/epoll.rs
+++ b/src/event/epoll.rs
@@ -92,8 +92,10 @@ use core::slice;
 ///
 /// # References
 ///  - [Linux]
+///  - [illumos]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/epoll_create.2.html
+/// [illumos]: https://www.illumos.org/man/3C/epoll_create
 #[inline]
 #[doc(alias = "epoll_create1")]
 pub fn create(flags: epoll::CreateFlags) -> io::Result<OwnedFd> {
@@ -114,8 +116,10 @@ pub fn create(flags: epoll::CreateFlags) -> io::Result<OwnedFd> {
 ///
 /// # References
 ///  - [Linux]
+///  - [illumos]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/epoll_ctl.2.html
+/// [illumos]: https://www.illumos.org/man/3C/epoll_ctl
 /// [faq]: https://man7.org/linux/man-pages/man7/epoll.7.html#:~:text=Will%20closing%20a%20file%20descriptor%20cause%20it%20to%20be%20removed%20from%20all%0A%20%20%20%20%20%20%20%20%20%20epoll%20interest%20lists%3F
 #[doc(alias = "epoll_ctl")]
 #[inline]
@@ -144,8 +148,10 @@ pub fn add(
 ///
 /// # References
 ///  - [Linux]
+///  - [illumos]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/epoll_ctl.2.html
+/// [illumos]: https://www.illumos.org/man/3C/epoll_ctl
 #[doc(alias = "epoll_ctl")]
 #[inline]
 pub fn modify(
@@ -171,8 +177,10 @@ pub fn modify(
 ///
 /// # References
 ///  - [Linux]
+///  - [illumos]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/epoll_ctl.2.html
+/// [illumos]: https://www.illumos.org/man/3C/epoll_ctl
 #[doc(alias = "epoll_ctl")]
 #[inline]
 pub fn delete(epoll: impl AsFd, source: impl AsFd) -> io::Result<()> {
@@ -187,8 +195,10 @@ pub fn delete(epoll: impl AsFd, source: impl AsFd) -> io::Result<()> {
 ///
 /// # References
 ///  - [Linux]
+///  - [illumos]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/epoll_wait.2.html
+/// [illumos]: https://www.illumos.org/man/3C/epoll_wait
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc"), alias = "epoll_wait"))]
 #[inline]

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -1,6 +1,6 @@
 //! Event operations.
 
-#[cfg(any(linux_kernel, solarish, target_os = "redox"))]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 pub mod epoll;
 #[cfg(any(
     linux_kernel,

--- a/src/fs/fcntl.rs
+++ b/src/fs/fcntl.rs
@@ -8,6 +8,7 @@
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "solaris",
     target_os = "vita",
     target_os = "wasi"
 )))]
@@ -101,6 +102,7 @@ pub fn fcntl_add_seals<Fd: AsFd>(fd: Fd, seals: SealFlags) -> io::Result<()> {
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "solaris",
     target_os = "vita",
     target_os = "wasi"
 )))]

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -541,7 +541,7 @@ impl AddressFamily {
     #[cfg(solarish)]
     pub const NBS: Self = Self(c::AF_NBS as _);
     /// `AF_NCA`
-    #[cfg(solarish)]
+    #[cfg(target_os = "illumos")]
     pub const NCA: Self = Self(c::AF_NCA as _);
     /// `AF_NDD`
     #[cfg(target_os = "aix")]

--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -113,6 +113,9 @@ pub fn getpid() -> Pid {
 
 /// `getppid()`—Returns the parent process' ID.
 ///
+/// This will return `None` if the current process has no parent (or no parent accessible in the
+/// current PID namespace), such as if the current process is an init process (PID 1).
+///
 /// # References
 ///  - [POSIX]
 ///  - [Linux]

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -114,10 +114,12 @@ pub fn openpt(flags: OpenptFlags) -> io::Result<OwnedFd> {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
+///  - [illumos]
 ///  - [glibc]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/ptsname.html
 /// [Linux]: https://man7.org/linux/man-pages/man3/ptsname.3.html
+/// [illumos]: https://www.illumos.org/man/3C/ptsname
 /// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Allocation.html#index-ptsname
 #[cfg(all(
     feature = "alloc",

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -1192,11 +1192,11 @@ impl SpecialCodeIndex {
     pub const VDSUSP: Self = Self(c::VDSUSP as usize);
 
     /// `VSTATUS`
-    #[cfg(any(bsd, solarish, target_os = "hurd"))]
+    #[cfg(any(bsd, target_os = "hurd", target_os = "illumos"))]
     pub const VSTATUS: Self = Self(c::VSTATUS as usize);
 
     /// `VERASE2`
-    #[cfg(any(freebsdlike, solarish))]
+    #[cfg(any(freebsdlike, target_os = "illumos"))]
     pub const VERASE2: Self = Self(c::VERASE2 as usize);
 }
 
@@ -1272,9 +1272,9 @@ impl core::fmt::Debug for SpecialCodeIndex {
                 target_os = "nto"
             ))]
             Self::VDSUSP => write!(f, "VDSUSP"),
-            #[cfg(any(bsd, solarish, target_os = "hurd"))]
+            #[cfg(any(bsd, target_os = "hurd", target_os = "illumos"))]
             Self::VSTATUS => write!(f, "VSTATUS"),
-            #[cfg(any(freebsdlike, solarish))]
+            #[cfg(any(freebsdlike, target_os = "illumos"))]
             Self::VERASE2 => write!(f, "VERASE2"),
 
             _ => write!(f, "unknown"),

--- a/tests/event/main.rs
+++ b/tests/event/main.rs
@@ -4,7 +4,7 @@
 
 #[cfg(not(feature = "rustc-dep-of-std"))] // TODO
 #[cfg(feature = "net")]
-#[cfg(linux_kernel)]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 mod epoll;
 #[cfg(not(windows))]
 #[cfg(not(target_os = "wasi"))]

--- a/tests/pty/main.rs
+++ b/tests/pty/main.rs
@@ -2,5 +2,11 @@
 
 #![cfg(feature = "pty")]
 
-#[cfg(any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia"))]
+#[cfg(any(
+    apple,
+    linux_like,
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos"
+))]
 mod openpty;


### PR DESCRIPTION
The primary motivation for this is to fix compilation errors when compiling with recent libc versions, which removed several declarations on solaris.
