### PR TITLE
Fix `port_getn` calling.

### DIFF
--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -314,6 +314,9 @@ pub(crate) fn port_getn(
     events: &mut Vec<Event>,
     mut nget: u32,
 ) -> io::Result<()> {
+    if events.capacity() == 0 {
+        return Ok(());
+    }
     let timeout = timeout.map_or(null_mut(), as_mut_ptr);
     unsafe {
         ret(c::port_getn(

--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -319,7 +319,7 @@ pub(crate) fn port_getn(
         ret(c::port_getn(
             borrowed_fd(port),
             events.as_mut_ptr().cast(),
-            events.len().try_into().unwrap(),
+            events.capacity().try_into().unwrap(),
             &mut nget,
             timeout,
         ))?;


### PR DESCRIPTION
The `max` passed to `port_getn` should be the capacity of the buffer, not the length.

If `max` is zero, `nget` is the events avaliable in the port. Then the calling to `set_len` will be unsound.

Ref: https://illumos.org/man/3C/port_getn