### PR TITLE
fcntl_lock should be supported on Solaris

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -36,12 +36,7 @@ use crate::fs::AtFlags;
     target_os = "vita",
 )))]
 use crate::fs::FallocateFlags;
-#[cfg(not(any(
-    target_os = "espidf",
-    target_os = "solaris",
-    target_os = "vita",
-    target_os = "wasi"
-)))]
+#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 use crate::fs::FlockOperation;
 #[cfg(any(linux_kernel, target_os = "freebsd"))]
 use crate::fs::MemfdFlags;
@@ -1257,7 +1252,6 @@ pub(crate) fn fcntl_add_seals(fd: BorrowedFd<'_>, seals: SealFlags) -> io::Resul
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
-    target_os = "solaris",
     target_os = "vita",
     target_os = "wasi"
 )))]

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -949,27 +949,49 @@ bitflags! {
 ///
 /// [`flock`]: crate::fs::flock
 /// [`fcntl_lock`]: crate::fs::fcntl_lock
-#[cfg(not(any(
-    target_os = "espidf",
-    target_os = "solaris",
-    target_os = "vita",
-    target_os = "wasi"
-)))]
+// Solaris doesn't support `flock` and doesn't define `LOCK_SH` etc., but we
+// reuse this `FlockOperation` enum for `fcntl_lock`, so on Solaris we use
+// our own made-up integer values.
+#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u32)]
 pub enum FlockOperation {
     /// `LOCK_SH`
+    #[cfg(not(target_os = "solaris"))]
     LockShared = bitcast!(c::LOCK_SH),
+    /// `LOCK_SH`
+    #[cfg(target_os = "solaris")]
+    LockShared = bitcast!(1),
     /// `LOCK_EX`
+    #[cfg(not(target_os = "solaris"))]
     LockExclusive = bitcast!(c::LOCK_EX),
+    /// `LOCK_EX`
+    #[cfg(target_os = "solaris")]
+    LockExclusive = bitcast!(2),
     /// `LOCK_UN`
+    #[cfg(not(target_os = "solaris"))]
     Unlock = bitcast!(c::LOCK_UN),
+    /// `LOCK_UN`
+    #[cfg(target_os = "solaris")]
+    Unlock = bitcast!(8),
     /// `LOCK_SH | LOCK_NB`
+    #[cfg(not(target_os = "solaris"))]
     NonBlockingLockShared = bitcast!(c::LOCK_SH | c::LOCK_NB),
+    /// `LOCK_SH | LOCK_NB`
+    #[cfg(target_os = "solaris")]
+    NonBlockingLockShared = bitcast!(1 | 4),
     /// `LOCK_EX | LOCK_NB`
+    #[cfg(not(target_os = "solaris"))]
     NonBlockingLockExclusive = bitcast!(c::LOCK_EX | c::LOCK_NB),
+    /// `LOCK_EX | LOCK_NB`
+    #[cfg(target_os = "solaris")]
+    NonBlockingLockExclusive = bitcast!(2 | 4),
     /// `LOCK_UN | LOCK_NB`
+    #[cfg(not(target_os = "solaris"))]
     NonBlockingUnlock = bitcast!(c::LOCK_UN | c::LOCK_NB),
+    /// `LOCK_UN | LOCK_NB`
+    #[cfg(target_os = "solaris")]
+    NonBlockingUnlock = bitcast!(8 | 4),
 }
 
 /// `struct stat` for use with [`statat`] and [`fstat`].

--- a/src/fs/fcntl.rs
+++ b/src/fs/fcntl.rs
@@ -8,7 +8,6 @@
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
-    target_os = "solaris",
     target_os = "vita",
     target_os = "wasi"
 )))]
@@ -102,7 +101,6 @@ pub fn fcntl_add_seals<Fd: AsFd>(fd: Fd, seals: SealFlags) -> io::Result<()> {
     target_os = "espidf",
     target_os = "fuchsia",
     target_os = "redox",
-    target_os = "solaris",
     target_os = "vita",
     target_os = "wasi"
 )))]


### PR DESCRIPTION
Even when Solaris libc doesn't define LOCK_SH, LOCK_EX, LOCK_NB and LOCK_UN (which are flock() related).