### PR TITLE
Fixes tests on Solaris.

### DIFF
--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -94,7 +94,7 @@ pub(crate) const O_LARGEFILE: c_int = linux_raw_sys::general::O_LARGEFILE as _;
 
 // Gated under `_LARGEFILE_SOURCE` but automatically set by the kernel.
 // <https://github.com/illumos/illumos-gate/blob/fb2cb638e5604b214d8ea8d4f01ad2e77b437c17/usr/src/ucbhead/sys/fcntl.h#L64>
-#[cfg(target_os = "illumos")]
+#[cfg(solarish)]
 pub(crate) const O_LARGEFILE: c_int = 0x2000;
 
 // TODO: This is new in Linux 6.11; remove when linux-raw-sys is updated.

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -334,7 +334,7 @@ bitflags! {
         /// Note that rustix and/or libc will automatically set this flag when appropriate on
         /// `open(2)` and friends, thus typical users do not need to care about it.
         /// It will may be reported in return of `fcntl_getfl`, though.
-        #[cfg(any(linux_kernel, target_os = "illumos"))]
+        #[cfg(any(linux_kernel, solarish))]
         const LARGEFILE = bitcast!(c::O_LARGEFILE);
 
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -114,7 +114,7 @@ fn test_file() {
 
     // Clear `O_LARGEFILE`, which may be set by rustix on 32-bit Linux or
     // automatically by some kernel on 64-bit (Linux and illumos).
-    #[cfg(any(linux_kernel, target_os = "illumos"))]
+    #[cfg(any(linux_kernel, solarish))]
     let fl = fl - rustix::fs::OFlags::LARGEFILE;
 
     assert_eq!(fl, rustix::fs::OFlags::empty());

--- a/tests/net/dgram.rs
+++ b/tests/net/dgram.rs
@@ -345,7 +345,7 @@ fn net_dgram_v6_bind_any() {
 }
 
 /// Test `sendto` with calling `connect`, on platforms which support that.
-#[cfg(not(any(bsd, target_os = "illumos")))]
+#[cfg(not(any(bsd, solarish)))]
 #[test]
 fn net_dgram_v4_connect_sendto() {
     crate::init();
@@ -439,7 +439,7 @@ fn net_dgram_v4_sendto() {
 }
 
 /// Similar, but with V6.
-#[cfg(not(any(bsd, target_os = "illumos")))]
+#[cfg(not(any(bsd, solarish)))]
 #[test]
 fn net_dgram_v6_connect_sendto() {
     crate::init();
@@ -533,7 +533,7 @@ fn net_dgram_v6_sendto() {
 }
 
 /// Test `sendto_any` with calling connect, on platforms which support that.
-#[cfg(not(any(bsd, target_os = "illumos")))]
+#[cfg(not(any(bsd, solarish)))]
 #[test]
 fn net_dgram_v4_connect_sendto_any() {
     crate::init();
@@ -621,7 +621,7 @@ fn net_dgram_v4_sendto_any() {
 }
 
 /// Similar, but with V6.
-#[cfg(not(any(bsd, target_os = "illumos")))]
+#[cfg(not(any(bsd, solarish)))]
 #[test]
 fn net_dgram_v6_connect_sendto_any() {
     crate::init();

--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -312,9 +312,9 @@ fn test_sockopts_ipv4() {
     assert_eq!(sockopt::get_socket_domain(&s).unwrap(), AddressFamily::INET);
     assert_ne!(sockopt::get_ip_ttl(&s).unwrap(), 0);
     assert_ne!(sockopt::get_ip_ttl(&s).unwrap(), 77);
-    #[cfg(not(any(bsd, windows, target_os = "illumos")))]
+    #[cfg(not(any(bsd, windows, solarish)))]
     assert!(sockopt::get_ip_multicast_loop(&s).unwrap());
-    #[cfg(not(any(bsd, windows, target_os = "illumos")))]
+    #[cfg(not(any(bsd, windows, solarish)))]
     assert_eq!(sockopt::get_ip_multicast_ttl(&s).unwrap(), 1);
 
     // Set the ip ttl.
@@ -323,7 +323,7 @@ fn test_sockopts_ipv4() {
     // Check the ip ttl.
     assert_eq!(sockopt::get_ip_ttl(&s).unwrap(), 77);
 
-    #[cfg(not(any(bsd, windows, target_os = "illumos")))]
+    #[cfg(not(any(bsd, windows, solarish)))]
     {
         // Set the multicast loop flag;
         sockopt::set_ip_multicast_loop(&s, false).unwrap();

--- a/tests/net/unix.rs
+++ b/tests/net/unix.rs
@@ -220,7 +220,7 @@ fn do_test_unix_msg(addr: SocketAddrUnix) {
             // Don't ask me why, but this was seen to fail on FreeBSD.
             // `SocketAddrUnix::path()` returned `None` for some reason.
             // illumos and NetBSD too.
-            #[cfg(not(any(target_os = "freebsd", target_os = "illumos", target_os = "netbsd")))]
+            #[cfg(not(any(solarish, target_os = "freebsd", target_os = "netbsd")))]
             assert_eq!(
                 Some(rustix::net::SocketAddrAny::Unix(addr.clone())),
                 result.address

--- a/tests/net/unix_alloc.rs
+++ b/tests/net/unix_alloc.rs
@@ -218,7 +218,7 @@ fn do_test_unix_msg(addr: SocketAddrUnix) {
             // Don't ask me why, but this was seen to fail on FreeBSD.
             // `SocketAddrUnix::path()` returned `None` for some reason.
             // illumos and NetBSD too.
-            #[cfg(not(any(target_os = "freebsd", target_os = "illumos", target_os = "netbsd")))]
+            #[cfg(not(any(solarish, target_os = "freebsd", target_os = "netbsd")))]
             assert_eq!(
                 Some(rustix::net::SocketAddrAny::Unix(addr.clone())),
                 result.address


### PR DESCRIPTION
Remaining two failing tests need more investigation:
    unix::test_unix_msg_with_combo
    unix_alloc::test_unix_msg_with_combo