### PR TITLE
Reenable the `xdp_umem_reg` size check.

### DIFF
--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1813,11 +1813,8 @@ fn test_sizes() {
     #[cfg(linux_kernel)]
     assert_eq_size!(UCred, libc::ucred);
 
-    // Linux added fields to `xdp_umem_reg` so it's bigger now.
-    /*
     #[cfg(target_os = "linux")]
     assert_eq_size!(super::xdp::XdpUmemReg, c::xdp_umem_reg);
-    */
     #[cfg(target_os = "linux")]
     assert_eq_size!(super::xdp::XdpOptions, c::xdp_options);
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
This reverts commit e38d2af27bf6ba6070d16d5b00ab3067f66f4444.

With https://github.com/bytecodealliance/rustix/pull/1061 merged, the size test for `xdp_umem_reg` can be re-enabled.