### PR TITLE
Fix tests on illumos.

### DIFF
--- a/src/event/epoll.rs
+++ b/src/event/epoll.rs
@@ -259,6 +259,10 @@ impl<'a> Iterator for Iter<'a> {
     repr(packed)
 )]
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    all(solarish, any(target_arch = "x86", target_arch = "x86_64")),
+    repr(packed(4))
+)]
 pub struct Event {
     /// Which specific event(s) occurred.
     pub flags: EventFlags,
@@ -451,7 +455,6 @@ mod tests {
 
     #[test]
     fn test_epoll_layouts() {
-        check_renamed_type!(Event, epoll_event);
         check_renamed_type!(Event, epoll_event);
         check_renamed_struct_renamed_field!(Event, epoll_event, flags, events);
         #[cfg(libc)]

--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -128,10 +128,10 @@ fn test_sockopts_socket(s: &OwnedFd) {
 
     // Set the send buffer size.
     let size = sockopt::get_socket_send_buffer_size(s).unwrap();
-    sockopt::set_socket_send_buffer_size(s, size * 4).unwrap();
+    sockopt::set_socket_send_buffer_size(s, size * 2).unwrap();
 
     // Check that the send buffer size is set.
-    assert!(sockopt::get_socket_send_buffer_size(s).unwrap() >= size * 4);
+    assert!(sockopt::get_socket_send_buffer_size(s).unwrap() >= size * 2);
 
     // Check that the oobinline flag is not initially set.
     assert!(!sockopt::get_socket_oobinline(s).unwrap());


### PR DESCRIPTION
Fix the layout of `epoll::Event` on x86 and x86_64 on illumos to match libc's layout.

Adjust tests in tests/net/sockopt.rs to avoid using a buffer larger than supported on illumos.

And change tests/pty/openpty.rs to avoid expecting we can write an EOF to a pty on illumos, as that doesn't appear to work.