### PR TITLE
RISC-V: fix vDSO getcpu

### DIFF
--- a/src/backend/linux_raw/vdso_wrappers.rs
+++ b/src/backend/linux_raw/vdso_wrappers.rs
@@ -554,7 +554,7 @@ fn init() {
             #[cfg(target_arch = "x86")]
             let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_getcpu"));
             #[cfg(target_arch = "riscv64")]
-            let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__kernel_getcpu"));
+            let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_getcpu"));
             #[cfg(target_arch = "powerpc64")]
             let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_getcpu"));
 


### PR DESCRIPTION
The name should be `__vdso_getcpu`, not `__kernel_getcpu` according to both the [manpage] and real RISC-V hardware.

[manpage]: https://man7.org/linux/man-pages/man7/vdso.7.html