### PR TITLE
io: always `impl Error for Errno` in rustc 1.81+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,6 +259,7 @@ check-cfg = [
     'cfg(core_intrinsics)',
     'cfg(criterion)',
     'cfg(document_experimental_runtime_api)',
+    'cfg(error_in_core)',
     'cfg(fix_y2038)',
     'cfg(freebsdlike)',
     'cfg(libc)',

--- a/build.rs
+++ b/build.rs
@@ -71,6 +71,7 @@ fn main() {
         use_feature_or_nothing("core_ffi_c");
         use_feature_or_nothing("alloc_c_string");
         use_feature_or_nothing("alloc_ffi");
+        use_feature_or_nothing("error_in_core");
     }
 
     // Feature needed for testing.

--- a/src/io/errno.rs
+++ b/src/io/errno.rs
@@ -5,6 +5,8 @@
 //! want unrecognized values to create undefined behavior.
 
 use crate::backend;
+#[cfg(all(not(feature = "std"), error_in_core))]
+use core::error;
 use core::{fmt, result};
 #[cfg(feature = "std")]
 use std::error;
@@ -49,7 +51,7 @@ impl fmt::Debug for Errno {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", error_in_core))]
 impl error::Error for Errno {}
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,7 @@
 #![cfg_attr(all(wasi_ext, target_os = "wasi", feature = "std"), feature(wasi_ext))]
 #![cfg_attr(core_ffi_c, feature(core_ffi_c))]
 #![cfg_attr(core_c_str, feature(core_c_str))]
+#![cfg_attr(error_in_core, feature(error_in_core))]
 #![cfg_attr(all(feature = "alloc", alloc_c_string), feature(alloc_c_string))]
 #![cfg_attr(all(feature = "alloc", alloc_ffi), feature(alloc_ffi))]
 #![cfg_attr(not(feature = "std"), no_std)]


### PR DESCRIPTION
In rust 1.81 the feature [`error_in_core`] was stabilized. This makes the `Error` trait available in `core::error` instead of `std::error`, so it can be used in a no-std context, too.

Resolves #1234.

[`error_in_core`]: <https://github.com/rust-lang/rust/issues/103765>