### PR TITLE
net/linux_kernel: add unnamed Unix-domain addresses

### DIFF
--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -74,6 +74,26 @@ impl SocketAddrUnix {
         })
     }
 
+    /// Construct a new unnamed address.
+    ///
+    /// The kernel will assign an abstract Unix-domain address to the socket when you call
+    /// [`bind_unix()`][crate::net::bind_unix]. You can inspect the assigned name with
+    /// [`getsockname`][crate::net::getsockname].
+    ///
+    /// # References
+    ///  - [Linux]
+    ///
+    /// [Linux]: https://www.man7.org/linux/man-pages/man7/unix.7.html
+    #[cfg(linux_kernel)]
+    #[inline]
+    pub fn new_unnamed() -> Self {
+        Self {
+            unix: Self::init(),
+            #[cfg(not(any(bsd, target_os = "haiku")))]
+            len: offsetof_sun_path() as _,
+        }
+    }
+
     const fn init() -> c::sockaddr_un {
         c::sockaddr_un {
             #[cfg(any(
@@ -123,15 +143,21 @@ impl SocketAddrUnix {
     #[cfg(linux_kernel)]
     #[inline]
     pub fn abstract_name(&self) -> Option<&[u8]> {
-        let len = self.len();
-        if len != 0 && self.unix.sun_path[0] == 0 {
-            let end = len as usize - offsetof_sun_path();
+        let end = self.len().saturating_sub(offsetof_sun_path());
+        if end > 0 && self.unix.sun_path[0] as u8 == b'\0' {
             let bytes = &self.unix.sun_path[1..end];
-            // SAFETY: `from_raw_parts` to convert from `&[c_char]` to `&[u8]`.
-            unsafe { Some(slice::from_raw_parts(bytes.as_ptr().cast(), bytes.len())) }
+            // SAFETY: Convert `&[c_char]` to `&[u8]`.
+            Some(unsafe { slice::from_raw_parts(bytes.as_ptr().cast::<u8>(), bytes.len()) })
         } else {
             None
         }
+    }
+
+    /// `true` if the socket address is unnamed.
+    #[cfg(linux_kernel)]
+    #[inline]
+    pub fn is_unnamed(&self) -> bool {
+        self.len() == offsetof_sun_path()
     }
 
     #[inline]

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -92,17 +92,10 @@ impl SocketAddrUnix {
     /// For a filesystem path address, return the path.
     #[inline]
     pub fn path(&self) -> Option<&CStr> {
-        let len = self.len();
-        if len != 0 && self.unix.sun_path[0] as u8 != b'\0' {
-            let end = len as usize - offsetof_sun_path();
-            let bytes = &self.unix.sun_path[..end];
-
-            // SAFETY: Convert `&[c_char]` to `&[u8]`.
-            let bytes = unsafe { slice::from_raw_parts(bytes.as_ptr().cast::<u8>(), bytes.len()) };
-
-            // SAFETY: `from_bytes_with_nul_unchecked` since the string is
-            // NUL-terminated.
-            unsafe { Some(CStr::from_bytes_with_nul_unchecked(bytes)) }
+        let bytes = self.bytes()?;
+        if !bytes.is_empty() && bytes[0] != 0 {
+            // SAFETY: `from_bytes_with_nul_unchecked` since the string is NUL-terminated.
+            Some(unsafe { CStr::from_bytes_with_nul_unchecked(bytes) })
         } else {
             None
         }
@@ -111,11 +104,8 @@ impl SocketAddrUnix {
     /// For an abstract address, return the identifier.
     #[inline]
     pub fn abstract_name(&self) -> Option<&[u8]> {
-        let end = self.len().saturating_sub(offsetof_sun_path());
-        if end > 0 && self.unix.sun_path[0] as u8 == b'\0' {
-            let bytes = &self.unix.sun_path[1..end];
-            // SAFETY: Convert `&[c_char]` to `&[u8]`.
-            Some(unsafe { slice::from_raw_parts(bytes.as_ptr().cast::<u8>(), bytes.len()) })
+        if let [0, ref bytes @ ..] = self.bytes()? {
+            Some(bytes)
         } else {
             None
         }
@@ -125,7 +115,7 @@ impl SocketAddrUnix {
     #[cfg(linux_kernel)]
     #[inline]
     pub fn is_unnamed(&self) -> bool {
-        self.len() == offsetof_sun_path()
+        self.bytes() == Some(&[])
     }
 
     #[inline]
@@ -136,6 +126,18 @@ impl SocketAddrUnix {
     #[inline]
     pub(crate) fn len(&self) -> usize {
         self.addr_len() as usize
+    }
+
+    #[inline]
+    fn bytes(&self) -> Option<&[u8]> {
+        let len = self.len() as usize;
+        if len != 0 {
+            let bytes = &self.unix.sun_path[..len - offsetof_sun_path()];
+            // SAFETY: `from_raw_parts` to convert from `&[c_char]` to `&[u8]`.
+            Some(unsafe { slice::from_raw_parts(bytes.as_ptr().cast(), bytes.len()) })
+        } else {
+            None
+        }
     }
 }
 

--- a/tests/net/unix.rs
+++ b/tests/net/unix.rs
@@ -419,6 +419,7 @@ fn test_abstract_unix_msg_unconnected() {
 }
 
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(feature = "pipe")]
 #[test]
 fn test_unix_msg_with_scm_rights() {
     crate::init();
@@ -649,7 +650,7 @@ fn test_unix_peercred_explicit() {
 /// Like `test_unix_peercred_explicit`, but relies on the fact that
 /// `set_socket_passcred` enables passing of the credentials implicitly
 /// instead of passing an explicit message to `sendmsg`.
-#[cfg(all(feature = "process", linux_kernel))]
+#[cfg(all(feature = "pipe", feature = "process", linux_kernel))]
 #[test]
 fn test_unix_peercred_implicit() {
     crate::init();
@@ -707,6 +708,7 @@ fn test_unix_peercred_implicit() {
 /// Like `test_unix_msg_with_scm_rights`, but with multiple file descriptors
 /// over multiple control messages.
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(feature = "pipe")]
 #[test]
 fn test_unix_msg_with_combo() {
     crate::init();
@@ -914,4 +916,26 @@ fn test_unix_msg_with_combo() {
 
     client.join().unwrap();
     server.join().unwrap();
+}
+
+/// Bind socket to an unnamed Unix-domain address, and assert that an abstract Unix-domain name was
+/// assigned by the kernel.
+#[cfg(linux_kernel)]
+#[test]
+fn test_bind_unnamed_address() {
+    let address = SocketAddrUnix::new_unnamed();
+    assert!(address.is_unnamed());
+    assert_eq!(address.abstract_name(), None);
+    assert_eq!(address.path(), None);
+    let sock = socket(AddressFamily::UNIX, SocketType::DGRAM, None).unwrap();
+    bind_unix(&sock, &address).unwrap();
+
+    let address = rustix::net::getsockname(&sock).unwrap();
+    let address = match address {
+        rustix::net::SocketAddrAny::Unix(address) => address,
+        address => panic!("expected Unix address, got {address:?}"),
+    };
+    assert!(!address.is_unnamed());
+    assert_ne!(address.abstract_name(), None);
+    assert_eq!(address.path(), None);
 }

--- a/tests/net/unix_alloc.rs
+++ b/tests/net/unix_alloc.rs
@@ -417,6 +417,7 @@ fn test_abstract_unix_msg_unconnected() {
 }
 
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(feature = "pipe")]
 #[test]
 fn test_unix_msg_with_scm_rights() {
     crate::init();
@@ -652,6 +653,7 @@ fn test_unix_peercred() {
 /// Like `test_unix_msg_with_scm_rights`, but with multiple file descriptors
 /// over multiple control messages.
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(feature = "pipe")]
 #[test]
 fn test_unix_msg_with_combo() {
     crate::init();


### PR DESCRIPTION
I think it would be useful to have unnamed Unix-domain addressed in rustix. This PR adds the methods `SocketAddrUnix::new_unnamed()` and `SocketAddrUnix::is_unnamed()`.

In C it is possible to have an [unnamed Unix-domain] socket name, when you set `len` = 2 = `sizeof(c::socklen_t)`. Then the kernel will choose an abstract Unix-domain name for you when you bind the socket. The same feature present also in Python, when you call [`sock.bind("")`].

Invoking [`SocketAddrUnix::new_abstract_name(b"")`] gives you an empty abstract socket address, i.e. `SocketAddrUnix::len == 3`. The kernel will keep this empty abstract name on calling `bind()`.

[unnamed Unix-domain]: https://manpages.debian.org/bookworm/manpages/unix.7.en.html#unnamed
[`sock.bind("")`]: https://docs.python.org/3.13/library/socket.html#socket.socket.bind
[`SocketAddrUnix::new_abstract_name(b"")`]: https://docs.rs/rustix/0.38.42/rustix/net/struct.SocketAddrUnix.html#method.new_abstract_name