### PR TITLE
Check for a missing `DT_HASH` section in the VDSO parser (#1254)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -428,7 +428,7 @@ jobs:
       run: |
         set -ex
         sudo apt-get update
-        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build libglib2.0-dev
         upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
         echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
       if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
@@ -593,7 +593,7 @@ jobs:
       run: |
         set -ex
         sudo apt-get update
-        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build libglib2.0-dev
         upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
         echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
       if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'
@@ -681,7 +681,7 @@ jobs:
       run: |
         set -ex
         sudo apt-get update
-        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build libglib2.0-dev
         upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
         echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
       if: matrix.gcc_package != '' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,13 +80,20 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-riscv64-linux-gnu gcc-arm-linux-gnueabi musl-tools
 
+    - name: Use specific dependency versions for rustix 0.37 compatibility.
+      run: |
+        cargo update --package=tempfile --precise=3.6.0
+
     - name: Use specific dependency versions for Rust 1.48 compatibility.
       if: matrix.rust == '1.48'
       run: |
-        cargo update --package=tempfile --precise=3.6.0
         cargo update --package=once_cell --precise 1.14.0
         cargo update --package=flate2 --precise=1.0.25
         cargo update --package=cc --precise=1.0.68
+
+    - name: Use specific dependency versions for rustix 0.37 compatibility.
+      run: |
+        cargo update --package=libc --precise=0.2.151
 
     - run: cargo check --workspace --release -vv --all-targets
     - run: cargo check --workspace --release -vv --features=all-apis --all-targets
@@ -465,13 +472,20 @@ jobs:
         ninja -C build install
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
+    - name: Use specific dependency versions for rustix 0.37 compatibility.
+      run: |
+        cargo update --package=tempfile --precise=3.6.0
+
     - name: Use specific dependency versions for Rust 1.48 compatibility.
       if: matrix.rust == '1.48'
       run: |
         cargo update --package=once_cell --precise 1.14.0
         cargo update --package=flate2 --precise=1.0.25
-        cargo update --package=tempfile --precise=3.6.0
         cargo update --package=cc --precise=1.0.68
+
+    - name: Use specific dependency versions for rustix 0.37 compatibility.
+      run: |
+        cargo update --package=libc --precise=0.2.151
 
     - run: |
         # Run the tests, and check the prebuilt release libraries.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,11 +69,10 @@ jobs:
         sparcv9-sun-solaris
         aarch64-linux-android
         aarch64-apple-ios
-        wasm32-wasi
     - if: matrix.rust != '1.48'
-      run: rustup target add x86_64-unknown-fuchsia
+      run: rustup target add x86_64-unknown-fuchsia wasm32-wasip1
     - if: matrix.rust == '1.48'
-      run: rustup target add x86_64-fuchsia
+      run: rustup target add x86_64-fuchsia wasm32-wasi
 
     - name: Install cross-compilation tools
       run: |
@@ -125,7 +124,7 @@ jobs:
     # Omit --all-targets for WASI until all the dev-dependencies support WASI
     # on stable.
     - if: matrix.rust != '1.48'
-      run: cargo check --workspace --release -vv --target=wasm32-wasi --features=all-apis
+      run: cargo check --workspace --release -vv --target=wasm32-wasip1 --features=all-apis
 
   check_no_default_features:
     name: Check --no-default-features
@@ -175,10 +174,10 @@ jobs:
     - run: >
         rustup target add
         x86_64-unknown-redox
-        wasm32-wasi
+        wasm32-wasip1
         thumbv7neon-unknown-linux-gnueabihf
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-redox --features=all-apis
-    - run: cargo check --workspace --release -vv --target=wasm32-wasi --features=all-apis
+    - run: cargo check --workspace --release -vv --target=wasm32-wasip1 --features=all-apis
     - run: cargo check --workspace --release -vv --target=thumbv7neon-unknown-linux-gnueabihf --features=all-apis
 
   check_tier3:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,9 +83,9 @@ jobs:
     - name: Use specific dependency versions for Rust 1.48 compatibility.
       if: matrix.rust == '1.48'
       run: |
+        cargo update --package=tempfile --precise=3.6.0
         cargo update --package=once_cell --precise 1.14.0
         cargo update --package=flate2 --precise=1.0.25
-        cargo update --package=tempfile --precise=3.6.0
         cargo update --package=cc --precise=1.0.68
 
     - run: cargo check --workspace --release -vv --all-targets

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -221,7 +221,7 @@ jobs:
       QEMU_BUILD_VERSION: 7.0.0
     strategy:
       matrix:
-        build: [ubuntu, ubuntu-20.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, ubuntu-1.48, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.48, i686-linux-1.48, aarch64-linux-1.48, riscv64-linux-1.48, s390x-linux-1.48, powerpc64le-linux-1.48, arm-linux-1.48, macos-latest, macos-12, windows, windows-2019]
+        build: [ubuntu, ubuntu-20.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, ubuntu-1.48, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.48, i686-linux-1.48, aarch64-linux-1.48, riscv64-linux-1.48, s390x-linux-1.48, powerpc64le-linux-1.48, arm-linux-1.48, macos-latest, macos-13, windows, windows-2019]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -394,8 +394,8 @@ jobs:
           - build: macos-latest
             os: macos-latest
             rust: stable
-          - build: macos-12
-            os: macos-12
+          - build: macos-13
+            os: macos-13
             rust: stable
           - build: windows
             os: windows-latest

--- a/src/backend/linux_raw/vdso.rs
+++ b/src/backend/linux_raw/vdso.rs
@@ -1,7 +1,7 @@
 //! Parse the Linux vDSO.
 //!
 //! The following code is transliterated from
-//! tools/testing/selftests/vDSO/parse_vdso.c in Linux 5.11, which is licensed
+//! tools/testing/selftests/vDSO/parse_vdso.c in Linux 6.12, which is licensed
 //! with Creative Commons Zero License, version 1.0,
 //! available at <https://creativecommons.org/publicdomain/zero/1.0/legalcode>
 //!
@@ -20,6 +20,11 @@ use core::ffi::c_void;
 use core::mem::size_of;
 use core::ptr::{null, null_mut};
 
+#[cfg(target_arch = "s390x")]
+type ElfHashEntry = u64;
+#[cfg(not(target_arch = "s390x"))]
+type ElfHashEntry = u32;
+
 pub(super) struct Vdso {
     // Load information
     load_addr: *const Elf_Ehdr,
@@ -29,17 +34,19 @@ pub(super) struct Vdso {
     // Symbol table
     symtab: *const Elf_Sym,
     symstrings: *const u8,
-    bucket: *const u32,
-    chain: *const u32,
-    nbucket: u32,
-    //nchain: u32,
+    bucket: *const ElfHashEntry,
+    chain: *const ElfHashEntry,
+    nbucket: ElfHashEntry,
+    //nchain: ElfHashEntry,
 
     // Version table
     versym: *const u16,
     verdef: *const Elf_Verdef,
 }
 
-// Straight from the ELF specification.
+/// Straight from the ELF specification...and then tweaked slightly, in order to
+/// avoid a few clang warnings.
+/// (And then translated to Rust).
 fn elf_hash(name: &CStr) -> u32 {
     let mut h: u32 = 0;
     for b in name.to_bytes() {
@@ -129,7 +136,7 @@ fn init_from_sysinfo_ehdr() -> Option<Vdso> {
         }
 
         // Fish out the useful bits of the dynamic table.
-        let mut hash: *const u32 = null();
+        let mut hash: *const ElfHashEntry = null();
         vdso.symstrings = null();
         vdso.symtab = null();
         vdso.versym = null();
@@ -152,7 +159,8 @@ fn init_from_sysinfo_ehdr() -> Option<Vdso> {
                 }
                 DT_HASH => {
                     hash =
-                        check_raw_pointer::<u32>(vdso.addr_from_elf(d.d_val)? as *mut _)?.as_ptr();
+                        check_raw_pointer::<ElfHashEntry>(vdso.addr_from_elf(d.d_val)? as *mut _)?
+                            .as_ptr();
                 }
                 DT_VERSYM => {
                     vdso.versym =
@@ -173,8 +181,12 @@ fn init_from_sysinfo_ehdr() -> Option<Vdso> {
             }
             i = i.checked_add(1)?;
         }
-        // The upstream code checks `symstrings`, `symtab`, and `hash` for null;
-        // here, `check_raw_pointer` has already done that.
+        // `check_raw_pointer` will have checked these pointers for null,
+        // however they could still be null if the expected dynamic table
+        // entries are absent.
+        if vdso.symstrings.is_null() || vdso.symtab.is_null() || hash.is_null() {
+            return None; // Failed
+        }
 
         if vdso.verdef.is_null() {
             vdso.versym = null();
@@ -257,16 +269,20 @@ impl Vdso {
 
         // SAFETY: The pointers in `self` must be valid.
         unsafe {
-            let mut chain = *self.bucket.add((name_hash % self.nbucket) as usize);
+            let mut chain = *self
+                .bucket
+                .add((ElfHashEntry::from(name_hash) % self.nbucket) as usize);
 
-            while chain != STN_UNDEF {
+            while chain != ElfHashEntry::from(STN_UNDEF) {
                 let sym = &*self.symtab.add(chain as usize);
 
                 // Check for a defined global or weak function w/ right name.
                 //
-                // The reference parser in Linux's parse_vdso.c requires
-                // symbols to have type `STT_FUNC`, but on powerpc64, the vDSO
-                // uses `STT_NOTYPE`, so allow that too.
+                // Accept `STT_NOTYPE` in addition to `STT_FUNC` for the symbol
+                // type, for compatibility with some versions of Linux on
+                // PowerPC64. See [this commit] in Linux for more background.
+                //
+                // [this commit]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/tools/testing/selftests/vDSO/parse_vdso.c?id=0161bd38c24312853ed5ae9a425a1c41c4ac674a
                 if (ELF_ST_TYPE(sym.st_info) != STT_FUNC &&
                         ELF_ST_TYPE(sym.st_info) != STT_NOTYPE)
                     || (ELF_ST_BIND(sym.st_info) != STB_GLOBAL
@@ -307,4 +323,34 @@ impl Vdso {
     unsafe fn addr_from_elf(&self, elf_addr: usize) -> Option<*const c_void> {
         self.base_plus(elf_addr.wrapping_add(self.pv_offset))
     }
+}
+
+#[cfg(linux_raw)]
+#[test]
+#[ignore] // Until rustix is updated to the new vDSO format.
+fn test_vdso() {
+    let vdso = Vdso::new().unwrap();
+    assert!(!vdso.symtab.is_null());
+    assert!(!vdso.symstrings.is_null());
+
+    #[cfg(target_arch = "x86_64")]
+    let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime"));
+    #[cfg(target_arch = "arm")]
+    let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
+    #[cfg(target_arch = "aarch64")]
+    let ptr = vdso.sym(cstr!("LINUX_2.6.39"), cstr!("__kernel_clock_gettime"));
+    #[cfg(target_arch = "x86")]
+    let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
+    #[cfg(target_arch = "riscv64")]
+    let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_clock_gettime"));
+    #[cfg(target_arch = "powerpc64")]
+    let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_clock_gettime"));
+    #[cfg(target_arch = "s390x")]
+    let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_clock_gettime"));
+    #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+    let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
+    #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
+    let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime"));
+
+    assert!(!ptr.is_null());
 }


### PR DESCRIPTION
* Check for a missing `DT_HASH` section in the VDSO parser

Fix a missing check for a null hash table pointer, which can happen if the vDSO lacks a `DT_HASH` entry.

Also, incorporate the changes in the latest upstream version of thee reference parse_vdso.c code.

* Fix type differences on s390x.

* Add more tests.