### PR TITLE
Implement the `DT_GNU_HASH` mechanism for vDSO parsing.

### DIFF
--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -41,7 +41,8 @@ use {crate::backend::conv::slice_just_addr_mut, crate::process::Gid};
     target_arch = "x86_64",
     target_arch = "x86",
     target_arch = "riscv64",
-    target_arch = "powerpc64"
+    target_arch = "powerpc64",
+    target_arch = "s390x"
 ))]
 pub(crate) use crate::backend::vdso_wrappers::sched_getcpu;
 
@@ -50,7 +51,8 @@ pub(crate) use crate::backend::vdso_wrappers::sched_getcpu;
     target_arch = "x86_64",
     target_arch = "x86",
     target_arch = "riscv64",
-    target_arch = "powerpc64"
+    target_arch = "powerpc64",
+    target_arch = "s390x"
 )))]
 #[inline]
 pub(crate) fn sched_getcpu() -> usize {

--- a/src/backend/linux_raw/vdso.rs
+++ b/src/backend/linux_raw/vdso.rs
@@ -420,31 +420,103 @@ impl Vdso {
     }
 }
 
+// Disable on MIPS since QEMU on MIPS doesn't provide a vDSO.
 #[cfg(linux_raw)]
 #[test]
+#[cfg_attr(any(target_arch = "mips", target_arch = "mips64"), ignore)]
 fn test_vdso() {
     let vdso = Vdso::new().unwrap();
     assert!(!vdso.symtab.is_null());
     assert!(!vdso.symstrings.is_null());
 
-    #[cfg(target_arch = "x86_64")]
-    let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime"));
-    #[cfg(target_arch = "arm")]
-    let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
-    #[cfg(target_arch = "aarch64")]
-    let ptr = vdso.sym(cstr!("LINUX_2.6.39"), cstr!("__kernel_clock_gettime"));
-    #[cfg(target_arch = "x86")]
-    let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
-    #[cfg(target_arch = "riscv64")]
-    let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_clock_gettime"));
-    #[cfg(target_arch = "powerpc64")]
-    let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_clock_gettime"));
-    #[cfg(target_arch = "s390x")]
-    let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_clock_gettime"));
-    #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-    let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
-    #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
-    let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime"));
+    {
+        #[cfg(target_arch = "x86_64")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime"));
+        #[cfg(target_arch = "arm")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
+        #[cfg(target_arch = "aarch64")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6.39"), cstr!("__kernel_clock_gettime"));
+        #[cfg(target_arch = "x86")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
+        #[cfg(target_arch = "riscv64")]
+        let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_clock_gettime"));
+        #[cfg(target_arch = "powerpc64")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_clock_gettime"));
+        #[cfg(target_arch = "s390x")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_clock_gettime"));
+        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
+        #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime"));
 
-    assert!(!ptr.is_null());
+        assert!(!ptr.is_null());
+    }
+
+    {
+        #[cfg(target_arch = "x86_64")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_getres"));
+        #[cfg(target_arch = "arm")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_getres"));
+        #[cfg(target_arch = "aarch64")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6.39"), cstr!("__kernel_clock_getres"));
+        #[cfg(target_arch = "x86")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_getres"));
+        #[cfg(target_arch = "riscv64")]
+        let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_clock_getres"));
+        #[cfg(target_arch = "powerpc64")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_clock_getres"));
+        #[cfg(target_arch = "s390x")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_clock_getres"));
+        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_getres"));
+        #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_getres"));
+
+        assert!(!ptr.is_null());
+    }
+
+    {
+        #[cfg(target_arch = "x86_64")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
+        #[cfg(target_arch = "arm")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
+        #[cfg(target_arch = "aarch64")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6.39"), cstr!("__kernel_gettimeofday"));
+        #[cfg(target_arch = "x86")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
+        #[cfg(target_arch = "riscv64")]
+        let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_gettimeofday"));
+        #[cfg(target_arch = "powerpc64")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_gettimeofday"));
+        #[cfg(target_arch = "s390x")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_gettimeofday"));
+        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
+        #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
+
+        assert!(!ptr.is_null());
+    }
+
+    #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "x86",
+        target_arch = "riscv64",
+        target_arch = "powerpc64",
+        target_arch = "s390x",
+    ))]
+    {
+        #[cfg(target_arch = "x86_64")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_getcpu"));
+        #[cfg(target_arch = "x86")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_getcpu"));
+        #[cfg(target_arch = "riscv64")]
+        let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_getcpu"));
+        #[cfg(target_arch = "powerpc64")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_getcpu"));
+        #[cfg(target_arch = "s390x")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_getcpu"));
+
+        assert!(!ptr.is_null());
+    }
 }

--- a/src/backend/linux_raw/vdso.rs
+++ b/src/backend/linux_raw/vdso.rs
@@ -343,6 +343,7 @@ impl Vdso {
 
                 let mut i = *self
                     .bucket
+                    .cast::<u32>()
                     .add((ElfHashEntry::from(h1) % self.nbucket) as usize);
                 if i == 0 {
                     return null_mut();
@@ -350,14 +351,15 @@ impl Vdso {
                 h1 |= 1;
                 let mut hashval = self
                     .bucket
+                    .cast::<u32>()
                     .add(self.nbucket as usize)
-                    .add((i - ElfHashEntry::from(*self.gnu_hash.add(1))) as usize);
+                    .add((i - *self.gnu_hash.add(1)) as usize);
                 loop {
                     let sym: &Elf_Sym = &*self.symtab.add(i as usize);
                     let h2 = *hashval;
                     hashval = hashval.add(1);
-                    if ElfHashEntry::from(h1) == (h2 | 1)
-                        && self.check_sym(sym, i, name, version, ver_hash)
+                    if h1 == (h2 | 1)
+                        && self.check_sym(sym, ElfHashEntry::from(i), name, version, ver_hash)
                     {
                         let sum = self.addr_from_elf(sym.st_value).unwrap();
                         assert!(

--- a/src/backend/linux_raw/vdso_wrappers.rs
+++ b/src/backend/linux_raw/vdso_wrappers.rs
@@ -20,7 +20,8 @@ use core::arch::global_asm;
     target_arch = "x86_64",
     target_arch = "x86",
     target_arch = "riscv64",
-    target_arch = "powerpc64"
+    target_arch = "powerpc64",
+    target_arch = "s390x",
 ))]
 use core::ffi::c_void;
 use core::mem::transmute;
@@ -37,7 +38,8 @@ use linux_raw_sys::general::timespec as __kernel_old_timespec;
             target_arch = "x86_64",
             target_arch = "x86",
             target_arch = "riscv64",
-            target_arch = "powerpc64"
+            target_arch = "powerpc64",
+            target_arch = "s390x"
         )
     ),
     feature = "time"
@@ -117,7 +119,8 @@ pub(crate) fn clock_gettime_dynamic(which_clock: DynamicClockId<'_>) -> io::Resu
     target_arch = "x86_64",
     target_arch = "x86",
     target_arch = "riscv64",
-    target_arch = "powerpc64"
+    target_arch = "powerpc64",
+    target_arch = "s390x",
 ))]
 #[inline]
 pub(crate) fn sched_getcpu() -> usize {
@@ -268,7 +271,8 @@ type ClockGettimeType = unsafe extern "C" fn(c::c_int, *mut Timespec) -> c::c_in
     target_arch = "x86_64",
     target_arch = "x86",
     target_arch = "riscv64",
-    target_arch = "powerpc64"
+    target_arch = "powerpc64",
+    target_arch = "s390x",
 ))]
 type GetcpuType = unsafe extern "C" fn(*mut u32, *mut u32, *mut c_void) -> c::c_int;
 
@@ -294,7 +298,8 @@ fn init_clock_gettime() -> ClockGettimeType {
     target_arch = "x86_64",
     target_arch = "x86",
     target_arch = "riscv64",
-    target_arch = "powerpc64"
+    target_arch = "powerpc64",
+    target_arch = "s390x",
 ))]
 #[cold]
 fn init_getcpu() -> GetcpuType {
@@ -324,7 +329,8 @@ static CLOCK_GETTIME: AtomicPtr<Function> = AtomicPtr::new(null_mut());
     target_arch = "x86_64",
     target_arch = "x86",
     target_arch = "riscv64",
-    target_arch = "powerpc64"
+    target_arch = "powerpc64",
+    target_arch = "s390x",
 ))]
 static GETCPU: AtomicPtr<Function> = AtomicPtr::new(null_mut());
 #[cfg(target_arch = "x86")]
@@ -393,7 +399,8 @@ unsafe fn _rustix_clock_gettime_via_syscall(
     target_arch = "x86_64",
     target_arch = "x86",
     target_arch = "riscv64",
-    target_arch = "powerpc64"
+    target_arch = "powerpc64",
+    target_arch = "s390x",
 ))]
 unsafe extern "C" fn rustix_getcpu_via_syscall(
     cpu: *mut u32,
@@ -456,7 +463,8 @@ fn minimal_init() {
         target_arch = "x86_64",
         target_arch = "x86",
         target_arch = "riscv64",
-        target_arch = "powerpc64"
+        target_arch = "powerpc64",
+        target_arch = "s390x",
     ))]
     {
         GETCPU
@@ -542,7 +550,8 @@ fn init() {
             target_arch = "x86_64",
             target_arch = "x86",
             target_arch = "riscv64",
-            target_arch = "powerpc64"
+            target_arch = "powerpc64",
+            target_arch = "s390x",
         ))]
         {
             // Look up the platform-specific `getcpu` symbol as documented
@@ -557,11 +566,14 @@ fn init() {
             let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_getcpu"));
             #[cfg(target_arch = "powerpc64")]
             let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_getcpu"));
+            #[cfg(target_arch = "s390x")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_getcpu"));
 
             #[cfg(any(
                 target_arch = "x86_64",
                 target_arch = "riscv64",
-                target_arch = "powerpc64"
+                target_arch = "powerpc64",
+                target_arch = "s390x"
             ))]
             let ok = true;
 
@@ -576,7 +588,6 @@ fn init() {
                 target_arch = "mips32r6",
                 target_arch = "mips64",
                 target_arch = "mips64r6",
-                target_arch = "s390x",
             ))]
             let ok = false;
 


### PR DESCRIPTION
Linux recently [removed] the `DT_HASH` section from the aarch64 vDSO. To continue to be able to read vDSOs, implement the `DT_GNU_HASH` section, following the logic in [this patch].

[removed]: https://github.com/torvalds/linux/commit/48f6430505c0b0498ee9020ce3cf9558b1caaaeb
[this patch]: https://lkml.org/lkml/2024/12/6/828