### PR TITLE
Rename `Shutdown::ReadWrite` to `Shutdown::Both`.

### DIFF
--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1442,7 +1442,7 @@ pub enum Shutdown {
     /// `SHUT_WR`—Disable further write operations.
     Write = c::SHUT_WR as _,
     /// `SHUT_RDWR`—Disable further read and write operations.
-    ReadWrite = c::SHUT_RDWR as _,
+    Both = c::SHUT_RDWR as _,
 }
 
 bitflags! {


### PR DESCRIPTION
This better [aligns with std].

[aligns with std]: https://doc.rust-lang.org/stable/std/net/enum.Shutdown.html#variant.Both