### PR TITLE
Rename `Waidid*` to `WaidId*`, for consistency with `WaitId`.

### DIFF
--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -65,7 +65,7 @@ use crate::process::{Resource, Rlimit};
     target_os = "vita",
     target_os = "wasi"
 )))]
-use crate::process::{WaitId, WaitidOptions, WaitidStatus};
+use crate::process::{WaitId, WaitIdOptions, WaitIdStatus};
 use core::mem::MaybeUninit;
 #[cfg(target_os = "linux")]
 use {
@@ -465,7 +465,7 @@ pub(crate) fn _waitpid(
     target_os = "wasi"
 )))]
 #[inline]
-pub(crate) fn waitid(id: WaitId<'_>, options: WaitidOptions) -> io::Result<Option<WaitidStatus>> {
+pub(crate) fn waitid(id: WaitId<'_>, options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
     // Get the id to wait on.
     match id {
         WaitId::All => _waitid_all(options),
@@ -486,7 +486,7 @@ pub(crate) fn waitid(id: WaitId<'_>, options: WaitidOptions) -> io::Result<Optio
     target_os = "wasi"
 )))]
 #[inline]
-fn _waitid_all(options: WaitidOptions) -> io::Result<Option<WaitidStatus>> {
+fn _waitid_all(options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
     // `waitid` can return successfully without initializing the struct (no
     // children found when using `WNOHANG`)
     let mut status = MaybeUninit::<c::siginfo_t>::zeroed();
@@ -510,7 +510,7 @@ fn _waitid_all(options: WaitidOptions) -> io::Result<Option<WaitidStatus>> {
     target_os = "wasi"
 )))]
 #[inline]
-fn _waitid_pid(pid: Pid, options: WaitidOptions) -> io::Result<Option<WaitidStatus>> {
+fn _waitid_pid(pid: Pid, options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
     // `waitid` can return successfully without initializing the struct (no
     // children found when using `WNOHANG`)
     let mut status = MaybeUninit::<c::siginfo_t>::zeroed();
@@ -534,7 +534,7 @@ fn _waitid_pid(pid: Pid, options: WaitidOptions) -> io::Result<Option<WaitidStat
     target_os = "wasi"
 )))]
 #[inline]
-fn _waitid_pgid(pgid: Option<Pid>, options: WaitidOptions) -> io::Result<Option<WaitidStatus>> {
+fn _waitid_pgid(pgid: Option<Pid>, options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
     // `waitid` can return successfully without initializing the struct (no
     // children found when using `WNOHANG`)
     let mut status = MaybeUninit::<c::siginfo_t>::zeroed();
@@ -552,7 +552,7 @@ fn _waitid_pgid(pgid: Option<Pid>, options: WaitidOptions) -> io::Result<Option<
 
 #[cfg(target_os = "linux")]
 #[inline]
-fn _waitid_pidfd(fd: BorrowedFd<'_>, options: WaitidOptions) -> io::Result<Option<WaitidStatus>> {
+fn _waitid_pidfd(fd: BorrowedFd<'_>, options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
     // `waitid` can return successfully without initializing the struct (no
     // children found when using `WNOHANG`)
     let mut status = MaybeUninit::<c::siginfo_t>::zeroed();
@@ -568,7 +568,7 @@ fn _waitid_pidfd(fd: BorrowedFd<'_>, options: WaitidOptions) -> io::Result<Optio
     Ok(unsafe { cvt_waitid_status(status) })
 }
 
-/// Convert a `siginfo_t` to a `WaitidStatus`.
+/// Convert a `siginfo_t` to a `WaitIdStatus`.
 ///
 /// # Safety
 ///
@@ -582,7 +582,7 @@ fn _waitid_pidfd(fd: BorrowedFd<'_>, options: WaitidOptions) -> io::Result<Optio
     target_os = "wasi"
 )))]
 #[inline]
-unsafe fn cvt_waitid_status(status: MaybeUninit<c::siginfo_t>) -> Option<WaitidStatus> {
+unsafe fn cvt_waitid_status(status: MaybeUninit<c::siginfo_t>) -> Option<WaitIdStatus> {
     let status = status.assume_init();
     // `si_pid` is supposedly the better way to check that the struct has been
     // filled, e.g. the Linux manual page says about the `WNOHANG` case “zero
@@ -594,7 +594,7 @@ unsafe fn cvt_waitid_status(status: MaybeUninit<c::siginfo_t>) -> Option<WaitidS
     if status.si_signo == 0 {
         None
     } else {
-        Some(WaitidStatus(status))
+        Some(WaitIdStatus(status))
     }
 }
 

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -21,7 +21,7 @@ use crate::io;
 use crate::pid::RawPid;
 use crate::process::{
     Cpuid, MembarrierCommand, MembarrierQuery, Pid, PidfdFlags, PidfdGetfdFlags, Resource, Rlimit,
-    Uid, WaitId, WaitOptions, WaitStatus, WaitidOptions, WaitidStatus,
+    Uid, WaitId, WaitIdOptions, WaitIdStatus, WaitOptions, WaitStatus,
 };
 use crate::signal::Signal;
 use crate::utils::as_mut_ptr;
@@ -412,7 +412,7 @@ pub(crate) fn _waitpid(
 }
 
 #[inline]
-pub(crate) fn waitid(id: WaitId<'_>, options: WaitidOptions) -> io::Result<Option<WaitidStatus>> {
+pub(crate) fn waitid(id: WaitId<'_>, options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
     // Get the id to wait on.
     match id {
         WaitId::All => _waitid_all(options),
@@ -423,7 +423,7 @@ pub(crate) fn waitid(id: WaitId<'_>, options: WaitidOptions) -> io::Result<Optio
 }
 
 #[inline]
-fn _waitid_all(options: WaitidOptions) -> io::Result<Option<WaitidStatus>> {
+fn _waitid_all(options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
     // `waitid` can return successfully without initializing the struct (no
     // children found when using `WNOHANG`)
     let mut status = MaybeUninit::<c::siginfo_t>::zeroed();
@@ -442,7 +442,7 @@ fn _waitid_all(options: WaitidOptions) -> io::Result<Option<WaitidStatus>> {
 }
 
 #[inline]
-fn _waitid_pid(pid: Pid, options: WaitidOptions) -> io::Result<Option<WaitidStatus>> {
+fn _waitid_pid(pid: Pid, options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
     // `waitid` can return successfully without initializing the struct (no
     // children found when using `WNOHANG`)
     let mut status = MaybeUninit::<c::siginfo_t>::zeroed();
@@ -461,7 +461,7 @@ fn _waitid_pid(pid: Pid, options: WaitidOptions) -> io::Result<Option<WaitidStat
 }
 
 #[inline]
-fn _waitid_pgid(pgid: Option<Pid>, options: WaitidOptions) -> io::Result<Option<WaitidStatus>> {
+fn _waitid_pgid(pgid: Option<Pid>, options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
     // `waitid` can return successfully without initializing the struct (no
     // children found when using `WNOHANG`)
     let mut status = MaybeUninit::<c::siginfo_t>::zeroed();
@@ -480,7 +480,7 @@ fn _waitid_pgid(pgid: Option<Pid>, options: WaitidOptions) -> io::Result<Option<
 }
 
 #[inline]
-fn _waitid_pidfd(fd: BorrowedFd<'_>, options: WaitidOptions) -> io::Result<Option<WaitidStatus>> {
+fn _waitid_pidfd(fd: BorrowedFd<'_>, options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
     // `waitid` can return successfully without initializing the struct (no
     // children found when using `WNOHANG`)
     let mut status = MaybeUninit::<c::siginfo_t>::zeroed();
@@ -498,7 +498,7 @@ fn _waitid_pidfd(fd: BorrowedFd<'_>, options: WaitidOptions) -> io::Result<Optio
     Ok(unsafe { cvt_waitid_status(status) })
 }
 
-/// Convert a `siginfo_t` to a `WaitidStatus`.
+/// Convert a `siginfo_t` to a `WaitIdStatus`.
 ///
 /// # Safety
 ///
@@ -506,12 +506,12 @@ fn _waitid_pidfd(fd: BorrowedFd<'_>, options: WaitidOptions) -> io::Result<Optio
 /// returned successfully.
 #[inline]
 #[rustfmt::skip]
-unsafe fn cvt_waitid_status(status: MaybeUninit<c::siginfo_t>) -> Option<WaitidStatus> {
+unsafe fn cvt_waitid_status(status: MaybeUninit<c::siginfo_t>) -> Option<WaitIdStatus> {
     let status = status.assume_init();
     if status.__bindgen_anon_1.__bindgen_anon_1._sifields._sigchld._pid == 0 {
         None
     } else {
-        Some(WaitidStatus(status))
+        Some(WaitIdStatus(status))
     }
 }
 

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -35,7 +35,7 @@ bitflags! {
     /// Options for modifying the behavior of [`waitid`].
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct WaitidOptions: u32 {
+    pub struct WaitIdOptions: u32 {
         /// Return immediately if no child has exited.
         const NOHANG = bitcast!(backend::process::wait::WNOHANG);
         /// Return if a stopped child has been resumed by delivery of
@@ -135,10 +135,10 @@ impl WaitStatus {
 #[derive(Clone, Copy)]
 #[repr(transparent)]
 #[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "wasi")))]
-pub struct WaitidStatus(pub(crate) backend::c::siginfo_t);
+pub struct WaitIdStatus(pub(crate) backend::c::siginfo_t);
 
 #[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "wasi")))]
-impl WaitidStatus {
+impl WaitIdStatus {
     /// Returns whether the process is currently stopped.
     #[inline]
     pub fn stopped(&self) -> bool {
@@ -363,7 +363,7 @@ pub fn wait(waitopts: WaitOptions) -> io::Result<Option<(Pid, WaitStatus)>> {
 #[inline]
 pub fn waitid<'a>(
     id: impl Into<WaitId<'a>>,
-    options: WaitidOptions,
-) -> io::Result<Option<WaitidStatus>> {
+    options: WaitIdOptions,
+) -> io::Result<Option<WaitIdStatus>> {
     backend::process::syscalls::waitid(id.into(), options)
 }

--- a/tests/process/pidfd.rs
+++ b/tests/process/pidfd.rs
@@ -34,7 +34,7 @@ fn test_pidfd_waitid() {
 
     let status = process::waitid(
         process::WaitId::PidFd(pidfd.as_fd()),
-        process::WaitidOptions::STOPPED,
+        process::WaitIdOptions::STOPPED,
     )
     .expect("failed to wait")
     .unwrap();
@@ -69,7 +69,7 @@ fn test_pidfd_poll() {
     // The child process should not have exited yet.
     match process::waitid(
         process::WaitId::PidFd(pidfd.as_fd()),
-        process::WaitidOptions::EXITED,
+        process::WaitIdOptions::EXITED,
     ) {
         Err(io::Errno::AGAIN) => (),
         Err(e) => panic!("unexpected result: {:?}", e),
@@ -83,7 +83,7 @@ fn test_pidfd_poll() {
     // The child process should have exited.
     let status = process::waitid(
         process::WaitId::PidFd(pidfd.as_fd()),
-        process::WaitidOptions::EXITED,
+        process::WaitIdOptions::EXITED,
     )
     .expect("failed to wait")
     .unwrap();

--- a/tests/process/wait.rs
+++ b/tests/process/wait.rs
@@ -109,7 +109,7 @@ fn test_waitid() {
 
     unsafe { kill(child.id() as _, SIGSTOP) };
 
-    let status = process::waitid(process::WaitId::Pid(pid), process::WaitidOptions::STOPPED)
+    let status = process::waitid(process::WaitId::Pid(pid), process::WaitIdOptions::STOPPED)
         .expect("failed to wait")
         .unwrap();
 
@@ -119,7 +119,7 @@ fn test_waitid() {
 
     unsafe { kill(child.id() as _, SIGCONT) };
 
-    let status = process::waitid(process::WaitId::Pid(pid), process::WaitidOptions::CONTINUED)
+    let status = process::waitid(process::WaitId::Pid(pid), process::WaitIdOptions::CONTINUED)
         .expect("failed to wait")
         .unwrap();
 
@@ -131,7 +131,7 @@ fn test_waitid() {
 
     let status = process::waitid(
         process::WaitId::Pgid(Some(pgid)),
-        process::WaitidOptions::STOPPED,
+        process::WaitIdOptions::STOPPED,
     )
     .expect("failed to wait")
     .unwrap();
@@ -144,7 +144,7 @@ fn test_waitid() {
 
     let status = process::waitid(
         process::WaitId::Pgid(Some(pgid)),
-        process::WaitidOptions::CONTINUED,
+        process::WaitIdOptions::CONTINUED,
     )
     .expect("failed to wait")
     .unwrap();
@@ -153,7 +153,7 @@ fn test_waitid() {
 
     let status = process::waitid(
         process::WaitId::All,
-        process::WaitidOptions::EXITED | process::WaitidOptions::NOHANG,
+        process::WaitIdOptions::EXITED | process::WaitIdOptions::NOHANG,
     )
     .expect("failed to wait");
 
@@ -163,7 +163,7 @@ fn test_waitid() {
 
     let status = process::waitid(
         process::WaitId::Pid(pid),
-        process::WaitidOptions::EXITED | process::WaitidOptions::NOWAIT,
+        process::WaitIdOptions::EXITED | process::WaitIdOptions::NOWAIT,
     )
     .expect("failed to wait")
     .unwrap();
@@ -172,7 +172,7 @@ fn test_waitid() {
     #[cfg(not(any(target_os = "fuchsia", target_os = "netbsd")))]
     assert_eq!(status.terminating_signal(), Some(SIGKILL as _));
 
-    let status = process::waitid(process::WaitId::Pid(pid), process::WaitidOptions::EXITED)
+    let status = process::waitid(process::WaitId::Pid(pid), process::WaitIdOptions::EXITED)
         .expect("failed to wait")
         .unwrap();
 


### PR DESCRIPTION
Vague rule: `Pid` and `Tid` don't capitalize the `I` because they're commonly pronounced as a single syllable as if they're their own word. `WaitId` is pronounced as two syllables, so capitalize the `I`.