### PR TITLE
Replace the `io_uring_register_files_skip` function with a constant.

### DIFF
--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -164,11 +164,11 @@ pub(super) unsafe fn raw_fd<'a, Num: ArgNumber>(fd: RawFd) -> ArgReg<'a, Num> {
     #[cfg(feature = "fs")]
     debug_assert!(fd == crate::fs::CWD.as_raw_fd() || fd == crate::fs::ABS.as_raw_fd() || fd >= 0);
 
-    // Don't pass the `io_uring_register_files_skip` sentry value this way.
+    // Don't pass the `IO_URING_REGISTER_FILES_SKIP` sentry value this way.
     #[cfg(feature = "io_uring")]
     debug_assert_ne!(
         fd,
-        crate::io_uring::io_uring_register_files_skip().as_raw_fd()
+        crate::io_uring::IO_URING_REGISTER_FILES_SKIP.as_raw_fd()
     );
 
     // Linux doesn't look at the high bits beyond the `c_int`, so use

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -939,16 +939,12 @@ pub const IORING_OFF_CQ_RING: u64 = sys::IORING_OFF_CQ_RING as _;
 pub const IORING_OFF_SQES: u64 = sys::IORING_OFF_SQES as _;
 
 /// `IORING_REGISTER_FILES_SKIP`
-#[inline]
 #[doc(alias = "IORING_REGISTER_FILES_SKIP")]
-pub const fn io_uring_register_files_skip() -> BorrowedFd<'static> {
-    let files_skip = sys::IORING_REGISTER_FILES_SKIP as RawFd;
-
-    // SAFETY: `IORING_REGISTER_FILES_SKIP` is a reserved value that is never
-    // dynamically allocated, so it'll remain valid for the duration of
-    // `'static`.
-    unsafe { BorrowedFd::<'static>::borrow_raw(files_skip) }
-}
+// SAFETY: `IORING_REGISTER_FILES_SKIP` is a reserved value that is never
+// dynamically allocated, so it'll remain valid for the duration of
+// `'static`.
+pub const IO_URING_REGISTER_FILES_SKIP: BorrowedFd<'static> =
+    unsafe { BorrowedFd::<'static>::borrow_raw(sys::IORING_REGISTER_FILES_SKIP as RawFd) };
 
 /// `IORING_NOTIF_USAGE_ZC_COPIED` (since Linux 6.2)
 pub const IORING_NOTIF_USAGE_ZC_COPIED: i32 = sys::IORING_NOTIF_USAGE_ZC_COPIED as _;


### PR DESCRIPTION
Instead of a `const fn`, add a `IO_URING_REGISTER_FILES_SKIP` constant, similar to the `CWD` constant.