### PR TITLE
Rename sockopts getters to remove the "get_".

### DIFF
--- a/src/backend/libc/net/sockopt.rs
+++ b/src/backend/libc/net/sockopt.rs
@@ -153,7 +153,7 @@ fn setsockopt_raw<T>(
 }
 
 #[inline]
-pub(crate) fn get_socket_type(fd: BorrowedFd<'_>) -> io::Result<SocketType> {
+pub(crate) fn socket_type(fd: BorrowedFd<'_>) -> io::Result<SocketType> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_TYPE)
 }
 
@@ -163,7 +163,7 @@ pub(crate) fn set_socket_reuseaddr(fd: BorrowedFd<'_>, reuseaddr: bool) -> io::R
 }
 
 #[inline]
-pub(crate) fn get_socket_reuseaddr(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn socket_reuseaddr(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_REUSEADDR).map(to_bool)
 }
 
@@ -173,7 +173,7 @@ pub(crate) fn set_socket_broadcast(fd: BorrowedFd<'_>, broadcast: bool) -> io::R
 }
 
 #[inline]
-pub(crate) fn get_socket_broadcast(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn socket_broadcast(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_BROADCAST).map(to_bool)
 }
 
@@ -193,7 +193,7 @@ pub(crate) fn set_socket_linger(fd: BorrowedFd<'_>, linger: Option<Duration>) ->
 }
 
 #[inline]
-pub(crate) fn get_socket_linger(fd: BorrowedFd<'_>) -> io::Result<Option<Duration>> {
+pub(crate) fn socket_linger(fd: BorrowedFd<'_>) -> io::Result<Option<Duration>> {
     let linger: c::linger = getsockopt(fd, c::SOL_SOCKET, c::SO_LINGER)?;
     Ok((linger.l_onoff != 0).then(|| Duration::from_secs(linger.l_linger as u64)))
 }
@@ -206,7 +206,7 @@ pub(crate) fn set_socket_passcred(fd: BorrowedFd<'_>, passcred: bool) -> io::Res
 
 #[cfg(linux_kernel)]
 #[inline]
-pub(crate) fn get_socket_passcred(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn socket_passcred(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_PASSCRED).map(to_bool)
 }
 
@@ -276,7 +276,7 @@ pub(crate) fn set_socket_timeout(
 }
 
 #[inline]
-pub(crate) fn get_socket_timeout(fd: BorrowedFd<'_>, id: Timeout) -> io::Result<Option<Duration>> {
+pub(crate) fn socket_timeout(fd: BorrowedFd<'_>, id: Timeout) -> io::Result<Option<Duration>> {
     let optname = match id {
         Timeout::Recv => c::SO_RCVTIMEO,
         Timeout::Send => c::SO_SNDTIMEO,
@@ -308,7 +308,7 @@ pub(crate) fn get_socket_timeout(fd: BorrowedFd<'_>, id: Timeout) -> io::Result<
 
 #[cfg(any(apple, freebsdlike, target_os = "netbsd"))]
 #[inline]
-pub(crate) fn get_socket_nosigpipe(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn socket_nosigpipe(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_NOSIGPIPE).map(to_bool)
 }
 
@@ -319,7 +319,7 @@ pub(crate) fn set_socket_nosigpipe(fd: BorrowedFd<'_>, val: bool) -> io::Result<
 }
 
 #[inline]
-pub(crate) fn get_socket_error(fd: BorrowedFd<'_>) -> io::Result<Result<(), io::Errno>> {
+pub(crate) fn socket_error(fd: BorrowedFd<'_>) -> io::Result<Result<(), io::Errno>> {
     let err: c::c_int = getsockopt(fd, c::SOL_SOCKET, c::SO_ERROR)?;
     Ok(if err == 0 {
         Ok(())
@@ -334,7 +334,7 @@ pub(crate) fn set_socket_keepalive(fd: BorrowedFd<'_>, keepalive: bool) -> io::R
 }
 
 #[inline]
-pub(crate) fn get_socket_keepalive(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn socket_keepalive(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_KEEPALIVE).map(to_bool)
 }
 
@@ -352,7 +352,7 @@ pub(crate) fn set_socket_recv_buffer_size_force(fd: BorrowedFd<'_>, size: usize)
 }
 
 #[inline]
-pub(crate) fn get_socket_recv_buffer_size(fd: BorrowedFd<'_>) -> io::Result<usize> {
+pub(crate) fn socket_recv_buffer_size(fd: BorrowedFd<'_>) -> io::Result<usize> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_RCVBUF).map(|size: u32| size as usize)
 }
 
@@ -363,7 +363,7 @@ pub(crate) fn set_socket_send_buffer_size(fd: BorrowedFd<'_>, size: usize) -> io
 }
 
 #[inline]
-pub(crate) fn get_socket_send_buffer_size(fd: BorrowedFd<'_>) -> io::Result<usize> {
+pub(crate) fn socket_send_buffer_size(fd: BorrowedFd<'_>) -> io::Result<usize> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_SNDBUF).map(|size: u32| size as usize)
 }
 
@@ -381,7 +381,7 @@ pub(crate) fn get_socket_send_buffer_size(fd: BorrowedFd<'_>) -> io::Result<usiz
     target_os = "nto",
     target_os = "vita",
 )))]
-pub(crate) fn get_socket_domain(fd: BorrowedFd<'_>) -> io::Result<AddressFamily> {
+pub(crate) fn socket_domain(fd: BorrowedFd<'_>) -> io::Result<AddressFamily> {
     let domain: c::c_int = getsockopt(fd, c::SOL_SOCKET, c::SO_DOMAIN)?;
     Ok(AddressFamily(
         domain.try_into().map_err(|_| io::Errno::OPNOTSUPP)?,
@@ -390,7 +390,7 @@ pub(crate) fn get_socket_domain(fd: BorrowedFd<'_>) -> io::Result<AddressFamily>
 
 #[inline]
 #[cfg(not(apple))] // Apple platforms declare the constant, but do not actually implement it.
-pub(crate) fn get_socket_acceptconn(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn socket_acceptconn(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_ACCEPTCONN).map(to_bool)
 }
 
@@ -400,7 +400,7 @@ pub(crate) fn set_socket_oobinline(fd: BorrowedFd<'_>, value: bool) -> io::Resul
 }
 
 #[inline]
-pub(crate) fn get_socket_oobinline(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn socket_oobinline(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_OOBINLINE).map(to_bool)
 }
 
@@ -412,7 +412,7 @@ pub(crate) fn set_socket_reuseport(fd: BorrowedFd<'_>, value: bool) -> io::Resul
 
 #[cfg(not(any(solarish, windows)))]
 #[inline]
-pub(crate) fn get_socket_reuseport(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn socket_reuseport(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_REUSEPORT).map(to_bool)
 }
 
@@ -424,7 +424,7 @@ pub(crate) fn set_socket_reuseport_lb(fd: BorrowedFd<'_>, value: bool) -> io::Re
 
 #[cfg(target_os = "freebsd")]
 #[inline]
-pub(crate) fn get_socket_reuseport_lb(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn socket_reuseport_lb(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_REUSEPORT_LB).map(to_bool)
 }
 
@@ -437,20 +437,20 @@ pub(crate) fn get_socket_reuseport_lb(fd: BorrowedFd<'_>) -> io::Result<bool> {
     target_env = "newlib"
 ))]
 #[inline]
-pub(crate) fn get_socket_protocol(fd: BorrowedFd<'_>) -> io::Result<Option<Protocol>> {
+pub(crate) fn socket_protocol(fd: BorrowedFd<'_>) -> io::Result<Option<Protocol>> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_PROTOCOL)
         .map(|raw| RawProtocol::new(raw).map(Protocol::from_raw))
 }
 
 #[cfg(target_os = "linux")]
 #[inline]
-pub(crate) fn get_socket_cookie(fd: BorrowedFd<'_>) -> io::Result<u64> {
+pub(crate) fn socket_cookie(fd: BorrowedFd<'_>) -> io::Result<u64> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_COOKIE)
 }
 
 #[cfg(target_os = "linux")]
 #[inline]
-pub(crate) fn get_socket_incoming_cpu(fd: BorrowedFd<'_>) -> io::Result<u32> {
+pub(crate) fn socket_incoming_cpu(fd: BorrowedFd<'_>) -> io::Result<u32> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_INCOMING_CPU)
 }
 
@@ -466,7 +466,7 @@ pub(crate) fn set_ip_ttl(fd: BorrowedFd<'_>, ttl: u32) -> io::Result<()> {
 }
 
 #[inline]
-pub(crate) fn get_ip_ttl(fd: BorrowedFd<'_>) -> io::Result<u32> {
+pub(crate) fn ip_ttl(fd: BorrowedFd<'_>) -> io::Result<u32> {
     getsockopt(fd, c::IPPROTO_IP, c::IP_TTL)
 }
 
@@ -476,7 +476,7 @@ pub(crate) fn set_ipv6_v6only(fd: BorrowedFd<'_>, only_v6: bool) -> io::Result<(
 }
 
 #[inline]
-pub(crate) fn get_ipv6_v6only(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn ipv6_v6only(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::IPPROTO_IPV6, c::IPV6_V6ONLY).map(to_bool)
 }
 
@@ -491,7 +491,7 @@ pub(crate) fn set_ip_multicast_loop(fd: BorrowedFd<'_>, multicast_loop: bool) ->
 }
 
 #[inline]
-pub(crate) fn get_ip_multicast_loop(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn ip_multicast_loop(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::IPPROTO_IP, c::IP_MULTICAST_LOOP).map(to_bool)
 }
 
@@ -501,7 +501,7 @@ pub(crate) fn set_ip_multicast_ttl(fd: BorrowedFd<'_>, multicast_ttl: u32) -> io
 }
 
 #[inline]
-pub(crate) fn get_ip_multicast_ttl(fd: BorrowedFd<'_>) -> io::Result<u32> {
+pub(crate) fn ip_multicast_ttl(fd: BorrowedFd<'_>) -> io::Result<u32> {
     getsockopt(fd, c::IPPROTO_IP, c::IP_MULTICAST_TTL)
 }
 
@@ -516,7 +516,7 @@ pub(crate) fn set_ipv6_multicast_loop(fd: BorrowedFd<'_>, multicast_loop: bool) 
 }
 
 #[inline]
-pub(crate) fn get_ipv6_multicast_loop(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn ipv6_multicast_loop(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::IPPROTO_IPV6, c::IPV6_MULTICAST_LOOP).map(to_bool)
 }
 
@@ -526,7 +526,7 @@ pub(crate) fn set_ipv6_multicast_hops(fd: BorrowedFd<'_>, multicast_hops: u32) -
 }
 
 #[inline]
-pub(crate) fn get_ipv6_multicast_hops(fd: BorrowedFd<'_>) -> io::Result<u32> {
+pub(crate) fn ipv6_multicast_hops(fd: BorrowedFd<'_>) -> io::Result<u32> {
     getsockopt(fd, c::IPPROTO_IP, c::IPV6_MULTICAST_HOPS)
 }
 
@@ -665,7 +665,7 @@ pub(crate) fn set_ipv6_drop_membership(
 }
 
 #[inline]
-pub(crate) fn get_ipv6_unicast_hops(fd: BorrowedFd<'_>) -> io::Result<u8> {
+pub(crate) fn ipv6_unicast_hops(fd: BorrowedFd<'_>) -> io::Result<u8> {
     getsockopt(fd, c::IPPROTO_IPV6, c::IPV6_UNICAST_HOPS).map(|hops: c::c_int| hops as u8)
 }
 
@@ -702,7 +702,7 @@ pub(crate) fn set_ip_tos(fd: BorrowedFd<'_>, value: u8) -> io::Result<()> {
     target_env = "newlib"
 ))]
 #[inline]
-pub(crate) fn get_ip_tos(fd: BorrowedFd<'_>) -> io::Result<u8> {
+pub(crate) fn ip_tos(fd: BorrowedFd<'_>) -> io::Result<u8> {
     let value: i32 = getsockopt(fd, c::IPPROTO_IP, c::IP_TOS)?;
     Ok(value as u8)
 }
@@ -715,7 +715,7 @@ pub(crate) fn set_ip_recvtos(fd: BorrowedFd<'_>, value: bool) -> io::Result<()> 
 
 #[cfg(any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia"))]
 #[inline]
-pub(crate) fn get_ip_recvtos(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn ip_recvtos(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::IPPROTO_IP, c::IP_RECVTOS).map(to_bool)
 }
 
@@ -739,7 +739,7 @@ pub(crate) fn set_ipv6_recvtclass(fd: BorrowedFd<'_>, value: bool) -> io::Result
     target_os = "nto"
 ))]
 #[inline]
-pub(crate) fn get_ipv6_recvtclass(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn ipv6_recvtclass(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::IPPROTO_IPV6, c::IPV6_RECVTCLASS).map(to_bool)
 }
 
@@ -751,7 +751,7 @@ pub(crate) fn set_ip_freebind(fd: BorrowedFd<'_>, value: bool) -> io::Result<()>
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[inline]
-pub(crate) fn get_ip_freebind(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn ip_freebind(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::IPPROTO_IP, c::IP_FREEBIND).map(to_bool)
 }
 
@@ -763,13 +763,13 @@ pub(crate) fn set_ipv6_freebind(fd: BorrowedFd<'_>, value: bool) -> io::Result<(
 
 #[cfg(linux_kernel)]
 #[inline]
-pub(crate) fn get_ipv6_freebind(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn ipv6_freebind(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::IPPROTO_IPV6, c::IPV6_FREEBIND).map(to_bool)
 }
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[inline]
-pub(crate) fn get_ip_original_dst(fd: BorrowedFd<'_>) -> io::Result<SocketAddrV4> {
+pub(crate) fn ip_original_dst(fd: BorrowedFd<'_>) -> io::Result<SocketAddrV4> {
     let level = c::IPPROTO_IP;
     let optname = c::SO_ORIGINAL_DST;
     let mut value = MaybeUninit::<SocketAddrStorage>::uninit();
@@ -786,7 +786,7 @@ pub(crate) fn get_ip_original_dst(fd: BorrowedFd<'_>) -> io::Result<SocketAddrV4
 
 #[cfg(linux_kernel)]
 #[inline]
-pub(crate) fn get_ipv6_original_dst(fd: BorrowedFd<'_>) -> io::Result<SocketAddrV6> {
+pub(crate) fn ipv6_original_dst(fd: BorrowedFd<'_>) -> io::Result<SocketAddrV6> {
     let level = c::IPPROTO_IPV6;
     let optname = c::IP6T_SO_ORIGINAL_DST;
     let mut value = MaybeUninit::<SocketAddrStorage>::uninit();
@@ -821,7 +821,7 @@ pub(crate) fn set_ipv6_tclass(fd: BorrowedFd<'_>, value: u32) -> io::Result<()> 
     target_os = "vita"
 )))]
 #[inline]
-pub(crate) fn get_ipv6_tclass(fd: BorrowedFd<'_>) -> io::Result<u32> {
+pub(crate) fn ipv6_tclass(fd: BorrowedFd<'_>) -> io::Result<u32> {
     getsockopt(fd, c::IPPROTO_IPV6, c::IPV6_TCLASS)
 }
 
@@ -831,7 +831,7 @@ pub(crate) fn set_tcp_nodelay(fd: BorrowedFd<'_>, nodelay: bool) -> io::Result<(
 }
 
 #[inline]
-pub(crate) fn get_tcp_nodelay(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn tcp_nodelay(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::IPPROTO_TCP, c::TCP_NODELAY).map(to_bool)
 }
 
@@ -843,7 +843,7 @@ pub(crate) fn set_tcp_keepcnt(fd: BorrowedFd<'_>, count: u32) -> io::Result<()> 
 
 #[inline]
 #[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
-pub(crate) fn get_tcp_keepcnt(fd: BorrowedFd<'_>) -> io::Result<u32> {
+pub(crate) fn tcp_keepcnt(fd: BorrowedFd<'_>) -> io::Result<u32> {
     getsockopt(fd, c::IPPROTO_TCP, c::TCP_KEEPCNT)
 }
 
@@ -856,7 +856,7 @@ pub(crate) fn set_tcp_keepidle(fd: BorrowedFd<'_>, duration: Duration) -> io::Re
 
 #[inline]
 #[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
-pub(crate) fn get_tcp_keepidle(fd: BorrowedFd<'_>) -> io::Result<Duration> {
+pub(crate) fn tcp_keepidle(fd: BorrowedFd<'_>) -> io::Result<Duration> {
     let secs: c::c_uint = getsockopt(fd, c::IPPROTO_TCP, TCP_KEEPIDLE)?;
     Ok(Duration::from_secs(secs as u64))
 }
@@ -870,7 +870,7 @@ pub(crate) fn set_tcp_keepintvl(fd: BorrowedFd<'_>, duration: Duration) -> io::R
 
 #[inline]
 #[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
-pub(crate) fn get_tcp_keepintvl(fd: BorrowedFd<'_>) -> io::Result<Duration> {
+pub(crate) fn tcp_keepintvl(fd: BorrowedFd<'_>) -> io::Result<Duration> {
     let secs: c::c_uint = getsockopt(fd, c::IPPROTO_TCP, c::TCP_KEEPINTVL)?;
     Ok(Duration::from_secs(secs as u64))
 }
@@ -883,7 +883,7 @@ pub(crate) fn set_tcp_user_timeout(fd: BorrowedFd<'_>, value: u32) -> io::Result
 
 #[inline]
 #[cfg(any(linux_like, target_os = "fuchsia"))]
-pub(crate) fn get_tcp_user_timeout(fd: BorrowedFd<'_>) -> io::Result<u32> {
+pub(crate) fn tcp_user_timeout(fd: BorrowedFd<'_>) -> io::Result<u32> {
     getsockopt(fd, c::IPPROTO_TCP, c::TCP_USER_TIMEOUT)
 }
 
@@ -895,7 +895,7 @@ pub(crate) fn set_tcp_quickack(fd: BorrowedFd<'_>, value: bool) -> io::Result<()
 
 #[cfg(any(linux_like, target_os = "fuchsia"))]
 #[inline]
-pub(crate) fn get_tcp_quickack(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn tcp_quickack(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::IPPROTO_TCP, c::TCP_QUICKACK).map(to_bool)
 }
 
@@ -921,7 +921,7 @@ pub(crate) fn set_tcp_congestion(fd: BorrowedFd<'_>, value: &str) -> io::Result<
     target_os = "illumos"
 ))]
 #[inline]
-pub(crate) fn get_tcp_congestion(fd: BorrowedFd<'_>) -> io::Result<String> {
+pub(crate) fn tcp_congestion(fd: BorrowedFd<'_>) -> io::Result<String> {
     const OPTLEN: c::socklen_t = 16;
 
     let level = c::IPPROTO_TCP;
@@ -954,7 +954,7 @@ pub(crate) fn set_tcp_thin_linear_timeouts(fd: BorrowedFd<'_>, value: bool) -> i
 
 #[cfg(any(linux_like, target_os = "fuchsia"))]
 #[inline]
-pub(crate) fn get_tcp_thin_linear_timeouts(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn tcp_thin_linear_timeouts(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::IPPROTO_TCP, c::TCP_THIN_LINEAR_TIMEOUTS).map(to_bool)
 }
 
@@ -966,13 +966,13 @@ pub(crate) fn set_tcp_cork(fd: BorrowedFd<'_>, value: bool) -> io::Result<()> {
 
 #[cfg(any(linux_like, solarish, target_os = "fuchsia"))]
 #[inline]
-pub(crate) fn get_tcp_cork(fd: BorrowedFd<'_>) -> io::Result<bool> {
+pub(crate) fn tcp_cork(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::IPPROTO_TCP, c::TCP_CORK).map(to_bool)
 }
 
 #[cfg(linux_kernel)]
 #[inline]
-pub(crate) fn get_socket_peercred(fd: BorrowedFd<'_>) -> io::Result<UCred> {
+pub(crate) fn socket_peercred(fd: BorrowedFd<'_>) -> io::Result<UCred> {
     getsockopt(fd, c::SOL_SOCKET, c::SO_PEERCRED)
 }
 
@@ -1008,7 +1008,7 @@ pub(crate) fn set_xdp_rx_ring_size(fd: BorrowedFd<'_>, value: u32) -> io::Result
 
 #[cfg(target_os = "linux")]
 #[inline]
-pub(crate) fn get_xdp_mmap_offsets(fd: BorrowedFd<'_>) -> io::Result<XdpMmapOffsets> {
+pub(crate) fn xdp_mmap_offsets(fd: BorrowedFd<'_>) -> io::Result<XdpMmapOffsets> {
     // The kernel will write `xdp_mmap_offsets` or `xdp_mmap_offsets_v1` to the
     // supplied pointer, depending on the kernel version. Both structs only
     // contain u64 values. By using the larger of both as the parameter, we can
@@ -1095,7 +1095,7 @@ pub(crate) fn get_xdp_mmap_offsets(fd: BorrowedFd<'_>) -> io::Result<XdpMmapOffs
 
 #[cfg(target_os = "linux")]
 #[inline]
-pub(crate) fn get_xdp_statistics(fd: BorrowedFd<'_>) -> io::Result<XdpStatistics> {
+pub(crate) fn xdp_statistics(fd: BorrowedFd<'_>) -> io::Result<XdpStatistics> {
     let mut optlen = core::mem::size_of::<xdp_statistics>().try_into().unwrap();
     debug_assert!(
         optlen as usize >= core::mem::size_of::<c::c_int>(),
@@ -1138,7 +1138,7 @@ pub(crate) fn get_xdp_statistics(fd: BorrowedFd<'_>) -> io::Result<XdpStatistics
 
 #[cfg(target_os = "linux")]
 #[inline]
-pub(crate) fn get_xdp_options(fd: BorrowedFd<'_>) -> io::Result<XdpOptionsFlags> {
+pub(crate) fn xdp_options(fd: BorrowedFd<'_>) -> io::Result<XdpOptionsFlags> {
     getsockopt(fd, c::SOL_XDP, c::XDP_OPTIONS)
 }
 

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -204,8 +204,8 @@ pub enum Timeout {
 /// [module-level documentation]: self#references-for-get_socket_-and-set_socket_-functions
 #[inline]
 #[doc(alias = "SO_TYPE")]
-pub fn get_socket_type<Fd: AsFd>(fd: Fd) -> io::Result<SocketType> {
-    backend::net::sockopt::get_socket_type(fd.as_fd())
+pub fn socket_type<Fd: AsFd>(fd: Fd) -> io::Result<SocketType> {
+    backend::net::sockopt::socket_type(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, value)`—Set whether local
@@ -227,8 +227,8 @@ pub fn set_socket_reuseaddr<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 /// [module-level documentation]: self#references-for-get_socket_-and-set_socket_-functions
 #[inline]
 #[doc(alias = "SO_REUSEADDR")]
-pub fn get_socket_reuseaddr<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_socket_reuseaddr(fd.as_fd())
+pub fn socket_reuseaddr<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::socket_reuseaddr(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_BROADCAST, value)`
@@ -249,8 +249,8 @@ pub fn set_socket_broadcast<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 /// [module-level documentation]: self#references-for-get_socket_-and-set_socket_-functions
 #[inline]
 #[doc(alias = "SO_BROADCAST")]
-pub fn get_socket_broadcast<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_socket_broadcast(fd.as_fd())
+pub fn socket_broadcast<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::socket_broadcast(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_LINGER, value)`
@@ -271,8 +271,8 @@ pub fn set_socket_linger<Fd: AsFd>(fd: Fd, value: Option<Duration>) -> io::Resul
 /// [module-level documentation]: self#references-for-get_socket_-and-set_socket_-functions
 #[inline]
 #[doc(alias = "SO_LINGER")]
-pub fn get_socket_linger<Fd: AsFd>(fd: Fd) -> io::Result<Option<Duration>> {
-    backend::net::sockopt::get_socket_linger(fd.as_fd())
+pub fn socket_linger<Fd: AsFd>(fd: Fd) -> io::Result<Option<Duration>> {
+    backend::net::sockopt::socket_linger(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_PASSCRED, value)`
@@ -295,8 +295,8 @@ pub fn set_socket_passcred<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 #[cfg(linux_kernel)]
 #[inline]
 #[doc(alias = "SO_PASSCRED")]
-pub fn get_socket_passcred<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_socket_passcred(fd.as_fd())
+pub fn socket_passcred<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::socket_passcred(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_SOCKET, id, value)`—Set the sending or receiving
@@ -324,8 +324,8 @@ pub fn set_socket_timeout<Fd: AsFd>(
 #[inline]
 #[doc(alias = "SO_RCVTIMEO")]
 #[doc(alias = "SO_SNDTIMEO")]
-pub fn get_socket_timeout<Fd: AsFd>(fd: Fd, id: Timeout) -> io::Result<Option<Duration>> {
-    backend::net::sockopt::get_socket_timeout(fd.as_fd(), id)
+pub fn socket_timeout<Fd: AsFd>(fd: Fd, id: Timeout) -> io::Result<Option<Duration>> {
+    backend::net::sockopt::socket_timeout(fd.as_fd(), id)
 }
 
 /// `getsockopt(fd, SOL_SOCKET, SO_ERROR)`
@@ -335,8 +335,8 @@ pub fn get_socket_timeout<Fd: AsFd>(fd: Fd, id: Timeout) -> io::Result<Option<Du
 /// [module-level documentation]: self#references-for-get_socket_-and-set_socket_-functions
 #[inline]
 #[doc(alias = "SO_ERROR")]
-pub fn get_socket_error<Fd: AsFd>(fd: Fd) -> io::Result<Result<(), io::Errno>> {
-    backend::net::sockopt::get_socket_error(fd.as_fd())
+pub fn socket_error<Fd: AsFd>(fd: Fd) -> io::Result<Result<(), io::Errno>> {
+    backend::net::sockopt::socket_error(fd.as_fd())
 }
 
 /// `getsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE)`
@@ -347,8 +347,8 @@ pub fn get_socket_error<Fd: AsFd>(fd: Fd) -> io::Result<Result<(), io::Errno>> {
 #[cfg(any(apple, freebsdlike, target_os = "netbsd"))]
 #[doc(alias = "SO_NOSIGPIPE")]
 #[inline]
-pub fn get_socket_nosigpipe<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_socket_nosigpipe(fd.as_fd())
+pub fn socket_nosigpipe<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::socket_nosigpipe(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, value)`
@@ -381,8 +381,8 @@ pub fn set_socket_keepalive<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 /// [module-level documentation]: self#references-for-get_socket_-and-set_socket_-functions
 #[inline]
 #[doc(alias = "SO_KEEPALIVE")]
-pub fn get_socket_keepalive<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_socket_keepalive(fd.as_fd())
+pub fn socket_keepalive<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::socket_keepalive(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_RCVBUF, value)`
@@ -415,8 +415,8 @@ pub fn set_socket_recv_buffer_size_force<Fd: AsFd>(fd: Fd, value: usize) -> io::
 /// [module-level documentation]: self#references-for-get_socket_-and-set_socket_-functions
 #[inline]
 #[doc(alias = "SO_RCVBUF")]
-pub fn get_socket_recv_buffer_size<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
-    backend::net::sockopt::get_socket_recv_buffer_size(fd.as_fd())
+pub fn socket_recv_buffer_size<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
+    backend::net::sockopt::socket_recv_buffer_size(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_SNDBUF, value)`
@@ -437,8 +437,8 @@ pub fn set_socket_send_buffer_size<Fd: AsFd>(fd: Fd, value: usize) -> io::Result
 /// [module-level documentation]: self#references-for-get_socket_-and-set_socket_-functions
 #[inline]
 #[doc(alias = "SO_SNDBUF")]
-pub fn get_socket_send_buffer_size<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
-    backend::net::sockopt::get_socket_send_buffer_size(fd.as_fd())
+pub fn socket_send_buffer_size<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
+    backend::net::sockopt::socket_send_buffer_size(fd.as_fd())
 }
 
 /// `getsockopt(fd, SOL_SOCKET, SO_DOMAIN)`
@@ -461,8 +461,8 @@ pub fn get_socket_send_buffer_size<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
 )))]
 #[inline]
 #[doc(alias = "SO_DOMAIN")]
-pub fn get_socket_domain<Fd: AsFd>(fd: Fd) -> io::Result<AddressFamily> {
-    backend::net::sockopt::get_socket_domain(fd.as_fd())
+pub fn socket_domain<Fd: AsFd>(fd: Fd) -> io::Result<AddressFamily> {
+    backend::net::sockopt::socket_domain(fd.as_fd())
 }
 
 /// `getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN)`
@@ -473,8 +473,8 @@ pub fn get_socket_domain<Fd: AsFd>(fd: Fd) -> io::Result<AddressFamily> {
 #[cfg(not(apple))] // Apple platforms declare the constant, but do not actually implement it.
 #[inline]
 #[doc(alias = "SO_ACCEPTCONN")]
-pub fn get_socket_acceptconn<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_socket_acceptconn(fd.as_fd())
+pub fn socket_acceptconn<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::socket_acceptconn(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_OOBINLINE, value)`
@@ -495,8 +495,8 @@ pub fn set_socket_oobinline<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 /// [module-level documentation]: self#references-for-get_socket_-and-set_socket_-functions
 #[inline]
 #[doc(alias = "SO_OOBINLINE")]
-pub fn get_socket_oobinline<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_socket_oobinline(fd.as_fd())
+pub fn socket_oobinline<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::socket_oobinline(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, value)`
@@ -520,8 +520,8 @@ pub fn set_socket_reuseport<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 #[cfg(not(any(solarish, windows)))]
 #[inline]
 #[doc(alias = "SO_REUSEPORT")]
-pub fn get_socket_reuseport<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_socket_reuseport(fd.as_fd())
+pub fn socket_reuseport<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::socket_reuseport(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_REUSEPORT_LB, value)`
@@ -544,8 +544,8 @@ pub fn set_socket_reuseport_lb<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> 
 #[cfg(target_os = "freebsd")]
 #[inline]
 #[doc(alias = "SO_REUSEPORT_LB")]
-pub fn get_socket_reuseport_lb<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_socket_reuseport_lb(fd.as_fd())
+pub fn socket_reuseport_lb<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::socket_reuseport_lb(fd.as_fd())
 }
 
 /// `getsockopt(fd, SOL_SOCKET, SO_PROTOCOL)`
@@ -563,8 +563,8 @@ pub fn get_socket_reuseport_lb<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
 ))]
 #[inline]
 #[doc(alias = "SO_PROTOCOL")]
-pub fn get_socket_protocol<Fd: AsFd>(fd: Fd) -> io::Result<Option<Protocol>> {
-    backend::net::sockopt::get_socket_protocol(fd.as_fd())
+pub fn socket_protocol<Fd: AsFd>(fd: Fd) -> io::Result<Option<Protocol>> {
+    backend::net::sockopt::socket_protocol(fd.as_fd())
 }
 
 /// `getsockopt(fd, SOL_SOCKET, SO_COOKIE)`
@@ -575,8 +575,8 @@ pub fn get_socket_protocol<Fd: AsFd>(fd: Fd) -> io::Result<Option<Protocol>> {
 #[cfg(target_os = "linux")]
 #[inline]
 #[doc(alias = "SO_COOKIE")]
-pub fn get_socket_cookie<Fd: AsFd>(fd: Fd) -> io::Result<u64> {
-    backend::net::sockopt::get_socket_cookie(fd.as_fd())
+pub fn socket_cookie<Fd: AsFd>(fd: Fd) -> io::Result<u64> {
+    backend::net::sockopt::socket_cookie(fd.as_fd())
 }
 
 /// `getsockopt(fd, SOL_SOCKET, SO_INCOMING_CPU)`
@@ -587,8 +587,8 @@ pub fn get_socket_cookie<Fd: AsFd>(fd: Fd) -> io::Result<u64> {
 #[cfg(target_os = "linux")]
 #[inline]
 #[doc(alias = "SO_INCOMING_CPU")]
-pub fn get_socket_incoming_cpu<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
-    backend::net::sockopt::get_socket_incoming_cpu(fd.as_fd())
+pub fn socket_incoming_cpu<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
+    backend::net::sockopt::socket_incoming_cpu(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_SOCKET, SO_INCOMING_CPU, value)`
@@ -621,8 +621,8 @@ pub fn set_ip_ttl<Fd: AsFd>(fd: Fd, value: u32) -> io::Result<()> {
 /// [module-level documentation]: self#references-for-get_ip_-and-set_ip_-functions
 #[inline]
 #[doc(alias = "IP_TTL")]
-pub fn get_ip_ttl<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
-    backend::net::sockopt::get_ip_ttl(fd.as_fd())
+pub fn ip_ttl<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
+    backend::net::sockopt::ip_ttl(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, value)`
@@ -643,8 +643,8 @@ pub fn set_ipv6_v6only<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 /// [module-level documentation]: self#references-for-get_ipv6_-and-set_ipv6_-functions
 #[inline]
 #[doc(alias = "IPV6_V6ONLY")]
-pub fn get_ipv6_v6only<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_ipv6_v6only(fd.as_fd())
+pub fn ipv6_v6only<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::ipv6_v6only(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_IP, IP_MULTICAST_LOOP, value)`
@@ -665,8 +665,8 @@ pub fn set_ip_multicast_loop<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 /// [module-level documentation]: self#references-for-get_ip_-and-set_ip_-functions
 #[inline]
 #[doc(alias = "IP_MULTICAST_LOOP")]
-pub fn get_ip_multicast_loop<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_ip_multicast_loop(fd.as_fd())
+pub fn ip_multicast_loop<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::ip_multicast_loop(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_IP, IP_MULTICAST_TTL, value)`
@@ -687,8 +687,8 @@ pub fn set_ip_multicast_ttl<Fd: AsFd>(fd: Fd, value: u32) -> io::Result<()> {
 /// [module-level documentation]: self#references-for-get_ip_-and-set_ip_-functions
 #[inline]
 #[doc(alias = "IP_MULTICAST_TTL")]
-pub fn get_ip_multicast_ttl<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
-    backend::net::sockopt::get_ip_multicast_ttl(fd.as_fd())
+pub fn ip_multicast_ttl<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
+    backend::net::sockopt::ip_multicast_ttl(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, value)`
@@ -709,8 +709,8 @@ pub fn set_ipv6_multicast_loop<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> 
 /// [module-level documentation]: self#references-for-get_ipv6_-and-set_ipv6_-functions
 #[inline]
 #[doc(alias = "IPV6_MULTICAST_LOOP")]
-pub fn get_ipv6_multicast_loop<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_ipv6_multicast_loop(fd.as_fd())
+pub fn ipv6_multicast_loop<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::ipv6_multicast_loop(fd.as_fd())
 }
 
 /// `getsockopt(fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS)`
@@ -720,8 +720,8 @@ pub fn get_ipv6_multicast_loop<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
 /// [module-level documentation]: self#references-for-get_ipv6_-and-set_ipv6_-functions
 #[inline]
 #[doc(alias = "IPV6_UNICAST_HOPS")]
-pub fn get_ipv6_unicast_hops<Fd: AsFd>(fd: Fd) -> io::Result<u8> {
-    backend::net::sockopt::get_ipv6_unicast_hops(fd.as_fd())
+pub fn ipv6_unicast_hops<Fd: AsFd>(fd: Fd) -> io::Result<u8> {
+    backend::net::sockopt::ipv6_unicast_hops(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, value)`
@@ -753,8 +753,8 @@ pub fn set_ipv6_multicast_hops<Fd: AsFd>(fd: Fd, value: u32) -> io::Result<()> {
 /// [module-level documentation]: self#references-for-get_ipv6_-and-set_ipv6_-functions
 #[inline]
 #[doc(alias = "IPV6_MULTICAST_HOPS")]
-pub fn get_ipv6_multicast_hops<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
-    backend::net::sockopt::get_ipv6_multicast_hops(fd.as_fd())
+pub fn ipv6_multicast_hops<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
+    backend::net::sockopt::ipv6_multicast_hops(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, multiaddr, interface)`
@@ -968,8 +968,8 @@ pub fn set_ip_tos<Fd: AsFd>(fd: Fd, value: u8) -> io::Result<()> {
 ))]
 #[inline]
 #[doc(alias = "IP_TOS")]
-pub fn get_ip_tos<Fd: AsFd>(fd: Fd) -> io::Result<u8> {
-    backend::net::sockopt::get_ip_tos(fd.as_fd())
+pub fn ip_tos<Fd: AsFd>(fd: Fd) -> io::Result<u8> {
+    backend::net::sockopt::ip_tos(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_IP, IP_RECVTOS, value)`
@@ -992,8 +992,8 @@ pub fn set_ip_recvtos<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 #[cfg(any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia"))]
 #[inline]
 #[doc(alias = "IP_RECVTOS")]
-pub fn get_ip_recvtos<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_ip_recvtos(fd.as_fd())
+pub fn ip_recvtos<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::ip_recvtos(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_IPV6, IPV6_RECVTCLASS, value)`
@@ -1028,8 +1028,8 @@ pub fn set_ipv6_recvtclass<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 ))]
 #[inline]
 #[doc(alias = "IPV6_RECVTCLASS")]
-pub fn get_ipv6_recvtclass<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_ipv6_recvtclass(fd.as_fd())
+pub fn ipv6_recvtclass<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::ipv6_recvtclass(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_IP, IP_FREEBIND, value)`
@@ -1052,8 +1052,8 @@ pub fn set_ip_freebind<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[inline]
 #[doc(alias = "IP_FREEBIND")]
-pub fn get_ip_freebind<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_ip_freebind(fd.as_fd())
+pub fn ip_freebind<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::ip_freebind(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_IPV6, IPV6_FREEBIND, value)`
@@ -1076,8 +1076,8 @@ pub fn set_ipv6_freebind<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 #[cfg(linux_kernel)]
 #[inline]
 #[doc(alias = "IPV6_FREEBIND")]
-pub fn get_ipv6_freebind<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_ipv6_freebind(fd.as_fd())
+pub fn ipv6_freebind<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::ipv6_freebind(fd.as_fd())
 }
 
 /// `getsockopt(fd, IPPROTO_IP, SO_ORIGINAL_DST)`
@@ -1091,8 +1091,8 @@ pub fn get_ipv6_freebind<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[inline]
 #[doc(alias = "SO_ORIGINAL_DST")]
-pub fn get_ip_original_dst<Fd: AsFd>(fd: Fd) -> io::Result<SocketAddrV4> {
-    backend::net::sockopt::get_ip_original_dst(fd.as_fd())
+pub fn ip_original_dst<Fd: AsFd>(fd: Fd) -> io::Result<SocketAddrV4> {
+    backend::net::sockopt::ip_original_dst(fd.as_fd())
 }
 
 /// `getsockopt(fd, IPPROTO_IPV6, IP6T_SO_ORIGINAL_DST)`
@@ -1106,8 +1106,8 @@ pub fn get_ip_original_dst<Fd: AsFd>(fd: Fd) -> io::Result<SocketAddrV4> {
 #[cfg(linux_kernel)]
 #[inline]
 #[doc(alias = "IP6T_SO_ORIGINAL_DST")]
-pub fn get_ipv6_original_dst<Fd: AsFd>(fd: Fd) -> io::Result<SocketAddrV6> {
-    backend::net::sockopt::get_ipv6_original_dst(fd.as_fd())
+pub fn ipv6_original_dst<Fd: AsFd>(fd: Fd) -> io::Result<SocketAddrV6> {
+    backend::net::sockopt::ipv6_original_dst(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_IPV6, IPV6_TCLASS, value)`
@@ -1142,8 +1142,8 @@ pub fn set_ipv6_tclass<Fd: AsFd>(fd: Fd, value: u32) -> io::Result<()> {
 )))]
 #[inline]
 #[doc(alias = "IPV6_TCLASS")]
-pub fn get_ipv6_tclass<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
-    backend::net::sockopt::get_ipv6_tclass(fd.as_fd())
+pub fn ipv6_tclass<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
+    backend::net::sockopt::ipv6_tclass(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, value)`
@@ -1164,8 +1164,8 @@ pub fn set_tcp_nodelay<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 /// [module-level documentation]: self#references-for-get_tcp_-and-set_tcp_-functions
 #[inline]
 #[doc(alias = "TCP_NODELAY")]
-pub fn get_tcp_nodelay<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_tcp_nodelay(fd.as_fd())
+pub fn tcp_nodelay<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::tcp_nodelay(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, value)`
@@ -1188,8 +1188,8 @@ pub fn set_tcp_keepcnt<Fd: AsFd>(fd: Fd, value: u32) -> io::Result<()> {
 #[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
 #[inline]
 #[doc(alias = "TCP_KEEPCNT")]
-pub fn get_tcp_keepcnt<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
-    backend::net::sockopt::get_tcp_keepcnt(fd.as_fd())
+pub fn tcp_keepcnt<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
+    backend::net::sockopt::tcp_keepcnt(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, value)`
@@ -1216,8 +1216,8 @@ pub fn set_tcp_keepidle<Fd: AsFd>(fd: Fd, value: Duration) -> io::Result<()> {
 #[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
 #[inline]
 #[doc(alias = "TCP_KEEPIDLE")]
-pub fn get_tcp_keepidle<Fd: AsFd>(fd: Fd) -> io::Result<Duration> {
-    backend::net::sockopt::get_tcp_keepidle(fd.as_fd())
+pub fn tcp_keepidle<Fd: AsFd>(fd: Fd) -> io::Result<Duration> {
+    backend::net::sockopt::tcp_keepidle(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, value)`
@@ -1240,8 +1240,8 @@ pub fn set_tcp_keepintvl<Fd: AsFd>(fd: Fd, value: Duration) -> io::Result<()> {
 #[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
 #[inline]
 #[doc(alias = "TCP_KEEPINTVL")]
-pub fn get_tcp_keepintvl<Fd: AsFd>(fd: Fd) -> io::Result<Duration> {
-    backend::net::sockopt::get_tcp_keepintvl(fd.as_fd())
+pub fn tcp_keepintvl<Fd: AsFd>(fd: Fd) -> io::Result<Duration> {
+    backend::net::sockopt::tcp_keepintvl(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, value)`
@@ -1264,8 +1264,8 @@ pub fn set_tcp_user_timeout<Fd: AsFd>(fd: Fd, value: u32) -> io::Result<()> {
 #[cfg(any(linux_like, target_os = "fuchsia"))]
 #[inline]
 #[doc(alias = "TCP_USER_TIMEOUT")]
-pub fn get_tcp_user_timeout<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
-    backend::net::sockopt::get_tcp_user_timeout(fd.as_fd())
+pub fn tcp_user_timeout<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
+    backend::net::sockopt::tcp_user_timeout(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_TCP, TCP_QUICKACK, value)`
@@ -1288,8 +1288,8 @@ pub fn set_tcp_quickack<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 #[cfg(any(linux_like, target_os = "fuchsia"))]
 #[inline]
 #[doc(alias = "TCP_QUICKACK")]
-pub fn get_tcp_quickack<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_tcp_quickack(fd.as_fd())
+pub fn tcp_quickack<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::tcp_quickack(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_TCP, TCP_CONGESTION, value)`
@@ -1323,8 +1323,8 @@ pub fn set_tcp_congestion<Fd: AsFd>(fd: Fd, value: &str) -> io::Result<()> {
 ))]
 #[inline]
 #[doc(alias = "TCP_CONGESTION")]
-pub fn get_tcp_congestion<Fd: AsFd>(fd: Fd) -> io::Result<String> {
-    backend::net::sockopt::get_tcp_congestion(fd.as_fd())
+pub fn tcp_congestion<Fd: AsFd>(fd: Fd) -> io::Result<String> {
+    backend::net::sockopt::tcp_congestion(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_TCP, TCP_THIN_LINEAR_TIMEOUTS, value)`
@@ -1347,8 +1347,8 @@ pub fn set_tcp_thin_linear_timeouts<Fd: AsFd>(fd: Fd, value: bool) -> io::Result
 #[cfg(any(linux_like, target_os = "fuchsia"))]
 #[inline]
 #[doc(alias = "TCP_THIN_LINEAR_TIMEOUTS")]
-pub fn get_tcp_thin_linear_timeouts<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_tcp_thin_linear_timeouts(fd.as_fd())
+pub fn tcp_thin_linear_timeouts<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::tcp_thin_linear_timeouts(fd.as_fd())
 }
 
 /// `setsockopt(fd, IPPROTO_TCP, TCP_CORK, value)`
@@ -1371,8 +1371,8 @@ pub fn set_tcp_cork<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 #[cfg(any(linux_like, solarish, target_os = "fuchsia"))]
 #[inline]
 #[doc(alias = "TCP_CORK")]
-pub fn get_tcp_cork<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
-    backend::net::sockopt::get_tcp_cork(fd.as_fd())
+pub fn tcp_cork<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
+    backend::net::sockopt::tcp_cork(fd.as_fd())
 }
 
 /// `getsockopt(fd, SOL_SOCKET, SO_PEERCRED)`—Get credentials of Unix domain
@@ -1384,8 +1384,8 @@ pub fn get_tcp_cork<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
 /// [Linux `unix`]: https://man7.org/linux/man-pages/man7/unix.7.html
 #[cfg(linux_kernel)]
 #[doc(alias = "SO_PEERCRED")]
-pub fn get_socket_peercred<Fd: AsFd>(fd: Fd) -> io::Result<super::UCred> {
-    backend::net::sockopt::get_socket_peercred(fd.as_fd())
+pub fn socket_peercred<Fd: AsFd>(fd: Fd) -> io::Result<super::UCred> {
+    backend::net::sockopt::socket_peercred(fd.as_fd())
 }
 
 /// `setsockopt(fd, SOL_XDP, XDP_UMEM_REG, value)`
@@ -1458,8 +1458,8 @@ pub fn set_xdp_rx_ring_size<Fd: AsFd>(fd: Fd, value: u32) -> io::Result<()> {
 /// [Linux]: https://www.kernel.org/doc/html/next/networking/af_xdp.html
 #[cfg(target_os = "linux")]
 #[doc(alias = "XDP_MMAP_OFFSETS")]
-pub fn get_xdp_mmap_offsets<Fd: AsFd>(fd: Fd) -> io::Result<XdpMmapOffsets> {
-    backend::net::sockopt::get_xdp_mmap_offsets(fd.as_fd())
+pub fn xdp_mmap_offsets<Fd: AsFd>(fd: Fd) -> io::Result<XdpMmapOffsets> {
+    backend::net::sockopt::xdp_mmap_offsets(fd.as_fd())
 }
 
 /// `getsockopt(fd, SOL_XDP, XDP_STATISTICS)`
@@ -1470,8 +1470,8 @@ pub fn get_xdp_mmap_offsets<Fd: AsFd>(fd: Fd) -> io::Result<XdpMmapOffsets> {
 /// [Linux]: https://www.kernel.org/doc/html/next/networking/af_xdp.html#xdp-statistics-getsockopt
 #[cfg(target_os = "linux")]
 #[doc(alias = "XDP_STATISTICS")]
-pub fn get_xdp_statistics<Fd: AsFd>(fd: Fd) -> io::Result<XdpStatistics> {
-    backend::net::sockopt::get_xdp_statistics(fd.as_fd())
+pub fn xdp_statistics<Fd: AsFd>(fd: Fd) -> io::Result<XdpStatistics> {
+    backend::net::sockopt::xdp_statistics(fd.as_fd())
 }
 
 /// `getsockopt(fd, SOL_XDP, XDP_OPTIONS)`
@@ -1482,8 +1482,8 @@ pub fn get_xdp_statistics<Fd: AsFd>(fd: Fd) -> io::Result<XdpStatistics> {
 /// [Linux]: https://www.kernel.org/doc/html/next/networking/af_xdp.html#xdp-options-getsockopt
 #[cfg(target_os = "linux")]
 #[doc(alias = "XDP_OPTIONS")]
-pub fn get_xdp_options<Fd: AsFd>(fd: Fd) -> io::Result<XdpOptionsFlags> {
-    backend::net::sockopt::get_xdp_options(fd.as_fd())
+pub fn xdp_options<Fd: AsFd>(fd: Fd) -> io::Result<XdpOptionsFlags> {
+    backend::net::sockopt::xdp_options(fd.as_fd())
 }
 
 #[cfg(test)]

--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -15,10 +15,10 @@ use std::time::Duration;
 // Test `socket` socket options.
 fn test_sockopts_socket(s: &OwnedFd) {
     // On a new socket we shouldn't have a timeout yet.
-    assert!(sockopt::get_socket_timeout(s, sockopt::Timeout::Recv)
+    assert!(sockopt::socket_timeout(s, sockopt::Timeout::Recv)
         .unwrap()
         .is_none());
-    assert_eq!(sockopt::get_socket_type(s).unwrap(), SocketType::STREAM);
+    assert_eq!(sockopt::socket_type(s).unwrap(), SocketType::STREAM);
     #[cfg(any(
         linux_kernel,
         target_os = "freebsd",
@@ -28,24 +28,24 @@ fn test_sockopts_socket(s: &OwnedFd) {
         target_env = "newlib"
     ))]
     {
-        assert_eq!(sockopt::get_socket_protocol(s).unwrap(), Some(ipproto::TCP));
+        assert_eq!(sockopt::socket_protocol(s).unwrap(), Some(ipproto::TCP));
     }
-    assert!(!sockopt::get_socket_reuseaddr(s).unwrap());
+    assert!(!sockopt::socket_reuseaddr(s).unwrap());
     #[cfg(not(windows))]
-    assert!(!sockopt::get_socket_broadcast(s).unwrap());
+    assert!(!sockopt::socket_broadcast(s).unwrap());
     // On a new socket we shouldn't have a linger yet.
-    assert!(sockopt::get_socket_linger(s).unwrap().is_none());
+    assert!(sockopt::socket_linger(s).unwrap().is_none());
     #[cfg(linux_kernel)]
-    assert!(!sockopt::get_socket_passcred(s).unwrap());
+    assert!(!sockopt::socket_passcred(s).unwrap());
 
     // On a new socket we shouldn't have an error yet.
-    assert_eq!(sockopt::get_socket_error(s).unwrap(), Ok(()));
-    assert!(!sockopt::get_socket_keepalive(s).unwrap());
-    assert_ne!(sockopt::get_socket_recv_buffer_size(s).unwrap(), 0);
-    assert_ne!(sockopt::get_socket_send_buffer_size(s).unwrap(), 0);
+    assert_eq!(sockopt::socket_error(s).unwrap(), Ok(()));
+    assert!(!sockopt::socket_keepalive(s).unwrap());
+    assert_ne!(sockopt::socket_recv_buffer_size(s).unwrap(), 0);
+    assert_ne!(sockopt::socket_send_buffer_size(s).unwrap(), 0);
 
     #[cfg(not(apple))]
-    assert!(!sockopt::get_socket_acceptconn(s).unwrap());
+    assert!(!sockopt::socket_acceptconn(s).unwrap());
 
     // Set a timeout.
     sockopt::set_socket_timeout(s, sockopt::Timeout::Recv, Some(Duration::new(1, 1))).unwrap();
@@ -53,7 +53,7 @@ fn test_sockopts_socket(s: &OwnedFd) {
     // Check that we have a timeout of at least the time we set.
     if cfg!(not(any(target_os = "freebsd", target_os = "netbsd"))) {
         assert!(
-            sockopt::get_socket_timeout(s, sockopt::Timeout::Recv)
+            sockopt::socket_timeout(s, sockopt::Timeout::Recv)
                 .unwrap()
                 .unwrap()
                 >= Duration::new(1, 1)
@@ -62,7 +62,7 @@ fn test_sockopts_socket(s: &OwnedFd) {
         // On FreeBSD ≤ 12 and NetBSD, it appears the system rounds the timeout
         // down.
         assert!(
-            sockopt::get_socket_timeout(s, sockopt::Timeout::Recv)
+            sockopt::socket_timeout(s, sockopt::Timeout::Recv)
                 .unwrap()
                 .unwrap()
                 >= Duration::new(1, 0)
@@ -75,7 +75,7 @@ fn test_sockopts_socket(s: &OwnedFd) {
 
     // Check that we have a timeout of at least the time we set.
     assert!(
-        sockopt::get_socket_timeout(s, sockopt::Timeout::Recv)
+        sockopt::socket_timeout(s, sockopt::Timeout::Recv)
             .unwrap()
             .unwrap()
             >= Duration::new(1, 10000000)
@@ -85,7 +85,7 @@ fn test_sockopts_socket(s: &OwnedFd) {
     sockopt::set_socket_reuseaddr(s, true).unwrap();
 
     // Check that the reuse address flag is set.
-    assert!(sockopt::get_socket_reuseaddr(s).unwrap());
+    assert!(sockopt::socket_reuseaddr(s).unwrap());
 
     #[cfg(not(windows))]
     {
@@ -95,20 +95,20 @@ fn test_sockopts_socket(s: &OwnedFd) {
         // Check that the broadcast flag is set. This has no effect on stream
         // sockets, and not all platforms even remember the value.
         #[cfg(not(bsd))]
-        assert!(sockopt::get_socket_broadcast(s).unwrap());
+        assert!(sockopt::socket_broadcast(s).unwrap());
     }
 
     // Set the keepalive flag;
     sockopt::set_socket_keepalive(s, true).unwrap();
 
     // Check that the keepalive flag is set.
-    assert!(sockopt::get_socket_keepalive(s).unwrap());
+    assert!(sockopt::socket_keepalive(s).unwrap());
 
     // Set a linger.
     sockopt::set_socket_linger(s, Some(Duration::new(1, 1))).unwrap();
 
     // Check that we have a linger of at least the time we set.
-    assert!(sockopt::get_socket_linger(s).unwrap().unwrap() >= Duration::new(1, 1));
+    assert!(sockopt::socket_linger(s).unwrap().unwrap() >= Duration::new(1, 1));
 
     #[cfg(linux_kernel)]
     {
@@ -116,46 +116,46 @@ fn test_sockopts_socket(s: &OwnedFd) {
         sockopt::set_socket_passcred(s, true).unwrap();
 
         // Check that the passcred flag is set.
-        assert!(sockopt::get_socket_passcred(s).unwrap());
+        assert!(sockopt::socket_passcred(s).unwrap());
     }
 
     // Set the receive buffer size.
-    let size = sockopt::get_socket_recv_buffer_size(s).unwrap();
+    let size = sockopt::socket_recv_buffer_size(s).unwrap();
     sockopt::set_socket_recv_buffer_size(s, size * 2).unwrap();
 
     // Check that the receive buffer size is set.
-    assert!(sockopt::get_socket_recv_buffer_size(s).unwrap() >= size * 2);
+    assert!(sockopt::socket_recv_buffer_size(s).unwrap() >= size * 2);
 
     // Set the send buffer size.
-    let size = sockopt::get_socket_send_buffer_size(s).unwrap();
+    let size = sockopt::socket_send_buffer_size(s).unwrap();
     sockopt::set_socket_send_buffer_size(s, size * 2).unwrap();
 
     // Check that the send buffer size is set.
-    assert!(sockopt::get_socket_send_buffer_size(s).unwrap() >= size * 2);
+    assert!(sockopt::socket_send_buffer_size(s).unwrap() >= size * 2);
 
     // Check that the oobinline flag is not initially set.
-    assert!(!sockopt::get_socket_oobinline(s).unwrap());
+    assert!(!sockopt::socket_oobinline(s).unwrap());
 
     // Set the oobinline flag;
     sockopt::set_socket_oobinline(s, true).unwrap();
 
     // Check that the oobinline flag is set.
-    assert!(sockopt::get_socket_oobinline(s).unwrap());
+    assert!(sockopt::socket_oobinline(s).unwrap());
 
     // Check the initial value of `SO_REUSEPORT`, set it, and check it.
     #[cfg(not(any(solarish, windows)))]
     {
-        assert!(!sockopt::get_socket_reuseport(s).unwrap());
+        assert!(!sockopt::socket_reuseport(s).unwrap());
         sockopt::set_socket_reuseport(s, true).unwrap();
-        assert!(sockopt::get_socket_reuseport(s).unwrap());
+        assert!(sockopt::socket_reuseport(s).unwrap());
     }
 
     // Check the initial value of `SO_REUSEPORT_LB`, set it, and check it.
     #[cfg(target_os = "freebsd")]
     {
-        assert!(!sockopt::get_socket_reuseport_lb(s).unwrap());
+        assert!(!sockopt::socket_reuseport_lb(s).unwrap());
         sockopt::set_socket_reuseport_lb(s, true).unwrap();
-        assert!(sockopt::get_socket_reuseport_lb(s).unwrap());
+        assert!(sockopt::socket_reuseport_lb(s).unwrap());
     }
 
     // Not much we can check with `get_socket_cookie`, but make sure we can
@@ -163,25 +163,25 @@ fn test_sockopts_socket(s: &OwnedFd) {
     #[cfg(target_os = "linux")]
     {
         assert_eq!(
-            sockopt::get_socket_cookie(s).unwrap(),
-            sockopt::get_socket_cookie(s).unwrap()
+            sockopt::socket_cookie(s).unwrap(),
+            sockopt::socket_cookie(s).unwrap()
         );
     }
 
     // Check the initial value of `SO_INCOMING_CPU`, set it, and check it.
     #[cfg(target_os = "linux")]
     {
-        assert_eq!(sockopt::get_socket_incoming_cpu(s).unwrap(), u32::MAX);
+        assert_eq!(sockopt::socket_incoming_cpu(s).unwrap(), u32::MAX);
         sockopt::set_socket_incoming_cpu(s, 3).unwrap();
-        assert_eq!(sockopt::get_socket_incoming_cpu(s).unwrap(), 3);
+        assert_eq!(sockopt::socket_incoming_cpu(s).unwrap(), 3);
     }
 
     // Check the initial value of `SO_NOSIGPIPE`, set it, and check it.
     #[cfg(any(apple, freebsdlike, target_os = "netbsd"))]
     {
-        assert_eq!(sockopt::get_socket_nosigpipe(s).unwrap(), false);
+        assert_eq!(sockopt::socket_nosigpipe(s).unwrap(), false);
         sockopt::set_socket_nosigpipe(s, true).unwrap();
-        assert_eq!(sockopt::get_socket_nosigpipe(s).unwrap(), true);
+        assert_eq!(sockopt::socket_nosigpipe(s).unwrap(), true);
     }
 }
 
@@ -189,31 +189,31 @@ fn test_sockopts_socket(s: &OwnedFd) {
 fn test_sockopts_tcp(s: &OwnedFd) {
     #[cfg(any(linux_like, target_os = "fuchsia"))]
     {
-        assert_eq!(sockopt::get_tcp_user_timeout(s).unwrap(), 0);
+        assert_eq!(sockopt::tcp_user_timeout(s).unwrap(), 0);
         sockopt::set_tcp_user_timeout(s, 7).unwrap();
-        assert_eq!(sockopt::get_tcp_user_timeout(s).unwrap(), 7);
+        assert_eq!(sockopt::tcp_user_timeout(s).unwrap(), 7);
     }
 
-    assert!(!sockopt::get_tcp_nodelay(s).unwrap());
+    assert!(!sockopt::tcp_nodelay(s).unwrap());
 
     #[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
     {
-        assert!(sockopt::get_tcp_keepcnt(s).is_ok());
-        assert!(sockopt::get_tcp_keepidle(s).is_ok());
-        assert!(sockopt::get_tcp_keepintvl(s).is_ok());
+        assert!(sockopt::tcp_keepcnt(s).is_ok());
+        assert!(sockopt::tcp_keepidle(s).is_ok());
+        assert!(sockopt::tcp_keepintvl(s).is_ok());
     }
 
     // Set the nodelay flag.
     sockopt::set_tcp_nodelay(s, true).unwrap();
 
     // Check that the nodelay flag is set.
-    assert!(sockopt::get_tcp_nodelay(s).unwrap());
+    assert!(sockopt::tcp_nodelay(s).unwrap());
 
     // Clear the nodelay flag.
     sockopt::set_tcp_nodelay(s, false).unwrap();
 
     // Check that the nodelay flag is cleared.
-    assert!(!sockopt::get_tcp_nodelay(s).unwrap());
+    assert!(!sockopt::tcp_nodelay(s).unwrap());
 
     #[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
     {
@@ -223,32 +223,23 @@ fn test_sockopts_tcp(s: &OwnedFd) {
         sockopt::set_tcp_keepintvl(s, Duration::from_secs(60)).unwrap();
 
         // Check keepalive values:
-        assert_eq!(sockopt::get_tcp_keepcnt(s).unwrap(), 42);
-        assert_eq!(
-            sockopt::get_tcp_keepidle(s).unwrap(),
-            Duration::from_secs(3601)
-        );
-        assert_eq!(
-            sockopt::get_tcp_keepintvl(s).unwrap(),
-            Duration::from_secs(60)
-        );
+        assert_eq!(sockopt::tcp_keepcnt(s).unwrap(), 42);
+        assert_eq!(sockopt::tcp_keepidle(s).unwrap(), Duration::from_secs(3601));
+        assert_eq!(sockopt::tcp_keepintvl(s).unwrap(), Duration::from_secs(60));
 
         #[cfg(not(target_os = "illumos"))]
         {
             sockopt::set_tcp_keepintvl(s, Duration::from_secs(61)).unwrap();
-            assert_eq!(
-                sockopt::get_tcp_keepintvl(s).unwrap(),
-                Duration::from_secs(61)
-            );
+            assert_eq!(sockopt::tcp_keepintvl(s).unwrap(), Duration::from_secs(61));
         }
     }
 
     // Check the initial value of `TCP_QUICKACK`, set it, and check it.
     #[cfg(any(linux_like, target_os = "fuchsia"))]
     {
-        assert!(sockopt::get_tcp_quickack(s).unwrap());
+        assert!(sockopt::tcp_quickack(s).unwrap());
         sockopt::set_tcp_quickack(s, false).unwrap();
-        assert!(!sockopt::get_tcp_quickack(s).unwrap());
+        assert!(!sockopt::tcp_quickack(s).unwrap());
     }
 
     // Check the initial value of `TCP_CONGESTION`, set it, and check it.
@@ -264,12 +255,12 @@ fn test_sockopts_tcp(s: &OwnedFd) {
     ))]
     #[cfg(feature = "alloc")]
     {
-        let algo = sockopt::get_tcp_congestion(s).unwrap();
+        let algo = sockopt::tcp_congestion(s).unwrap();
         assert!(!algo.is_empty());
         #[cfg(linux_like)]
         {
             sockopt::set_tcp_congestion(s, "reno").unwrap();
-            assert_eq!(sockopt::get_tcp_congestion(s).unwrap(), "reno");
+            assert_eq!(sockopt::tcp_congestion(s).unwrap(), "reno");
         }
     }
 
@@ -277,17 +268,17 @@ fn test_sockopts_tcp(s: &OwnedFd) {
     // it.
     #[cfg(any(linux_like, target_os = "fuchsia"))]
     {
-        assert!(!sockopt::get_tcp_thin_linear_timeouts(s).unwrap());
+        assert!(!sockopt::tcp_thin_linear_timeouts(s).unwrap());
         sockopt::set_tcp_thin_linear_timeouts(s, true).unwrap();
-        assert!(sockopt::get_tcp_thin_linear_timeouts(s).unwrap());
+        assert!(sockopt::tcp_thin_linear_timeouts(s).unwrap());
     }
 
     // Check the initial value of `TCP_CORK`, set it, and check it.
     #[cfg(any(linux_like, solarish, target_os = "fuchsia"))]
     {
-        assert!(!sockopt::get_tcp_cork(s).unwrap());
+        assert!(!sockopt::tcp_cork(s).unwrap());
         sockopt::set_tcp_cork(s, true).unwrap();
-        assert!(sockopt::get_tcp_cork(s).unwrap());
+        assert!(sockopt::tcp_cork(s).unwrap());
     }
 }
 
@@ -309,19 +300,19 @@ fn test_sockopts_ipv4() {
         target_os = "netbsd",
         target_os = "nto",
     )))]
-    assert_eq!(sockopt::get_socket_domain(&s).unwrap(), AddressFamily::INET);
-    assert_ne!(sockopt::get_ip_ttl(&s).unwrap(), 0);
-    assert_ne!(sockopt::get_ip_ttl(&s).unwrap(), 77);
+    assert_eq!(sockopt::socket_domain(&s).unwrap(), AddressFamily::INET);
+    assert_ne!(sockopt::ip_ttl(&s).unwrap(), 0);
+    assert_ne!(sockopt::ip_ttl(&s).unwrap(), 77);
     #[cfg(not(any(bsd, windows, solarish)))]
-    assert!(sockopt::get_ip_multicast_loop(&s).unwrap());
+    assert!(sockopt::ip_multicast_loop(&s).unwrap());
     #[cfg(not(any(bsd, windows, solarish)))]
-    assert_eq!(sockopt::get_ip_multicast_ttl(&s).unwrap(), 1);
+    assert_eq!(sockopt::ip_multicast_ttl(&s).unwrap(), 1);
 
     // Set the ip ttl.
     sockopt::set_ip_ttl(&s, 77).unwrap();
 
     // Check the ip ttl.
-    assert_eq!(sockopt::get_ip_ttl(&s).unwrap(), 77);
+    assert_eq!(sockopt::ip_ttl(&s).unwrap(), 77);
 
     #[cfg(not(any(bsd, windows, solarish)))]
     {
@@ -329,7 +320,7 @@ fn test_sockopts_ipv4() {
         sockopt::set_ip_multicast_loop(&s, false).unwrap();
 
         // Check that the multicast loop flag is set.
-        assert!(!sockopt::get_ip_multicast_loop(&s).unwrap());
+        assert!(!sockopt::ip_multicast_loop(&s).unwrap());
     }
 
     // Check the initial value of `IP_TOS`, set it, and check it.
@@ -343,36 +334,36 @@ fn test_sockopts_ipv4() {
         target_env = "newlib"
     ))]
     {
-        assert_eq!(sockopt::get_ip_tos(&s).unwrap(), 0);
+        assert_eq!(sockopt::ip_tos(&s).unwrap(), 0);
 
         #[cfg(any(linux_like, target_os = "aix", target_os = "nto"))]
         {
             sockopt::set_ip_tos(&s, libc::IPTOS_THROUGHPUT).unwrap();
-            assert_eq!(sockopt::get_ip_tos(&s).unwrap(), libc::IPTOS_THROUGHPUT);
+            assert_eq!(sockopt::ip_tos(&s).unwrap(), libc::IPTOS_THROUGHPUT);
         }
     }
 
     // Check the initial value of `IP_RECVTOS`, set it, and check it.
     #[cfg(any(apple, linux_like, target_os = "freebsd", target_os = "fuchsia"))]
     {
-        assert!(!sockopt::get_ip_recvtos(&s).unwrap());
+        assert!(!sockopt::ip_recvtos(&s).unwrap());
         sockopt::set_ip_recvtos(&s, true).unwrap();
-        assert!(sockopt::get_ip_recvtos(&s).unwrap());
+        assert!(sockopt::ip_recvtos(&s).unwrap());
     }
 
     // Check the initial value of `IP_FREEBIND`, set it, and check it.
     #[cfg(any(linux_kernel, target_os = "fuchsia"))]
     {
-        assert!(!sockopt::get_ip_freebind(&s).unwrap());
+        assert!(!sockopt::ip_freebind(&s).unwrap());
         sockopt::set_ip_freebind(&s, true).unwrap();
-        assert!(sockopt::get_ip_freebind(&s).unwrap());
+        assert!(sockopt::ip_freebind(&s).unwrap());
     }
 
     // Check that we can query `SO_ORIGINAL_DST`.
     #[cfg(any(linux_kernel, target_os = "fuchsia"))]
     {
         assert!(matches!(
-            sockopt::get_ip_original_dst(&s),
+            sockopt::ip_original_dst(&s),
             Err(io::Errno::NOENT | io::Errno::NOPROTOOPT)
         ));
     }
@@ -398,25 +389,22 @@ fn test_sockopts_ipv6() {
         target_os = "netbsd",
         target_os = "nto",
     )))]
-    assert_eq!(
-        sockopt::get_socket_domain(&s).unwrap(),
-        AddressFamily::INET6
-    );
+    assert_eq!(sockopt::socket_domain(&s).unwrap(), AddressFamily::INET6);
 
-    assert_ne!(sockopt::get_ipv6_unicast_hops(&s).unwrap(), 0);
-    match sockopt::get_ipv6_multicast_loop(&s) {
+    assert_ne!(sockopt::ipv6_unicast_hops(&s).unwrap(), 0);
+    match sockopt::ipv6_multicast_loop(&s) {
         Ok(multicast_loop) => assert!(multicast_loop),
         Err(io::Errno::OPNOTSUPP) => (),
         Err(io::Errno::INVAL) => (),
         Err(io::Errno::NOPROTOOPT) => (),
         Err(err) => panic!("{:?}", err),
     }
-    assert_ne!(sockopt::get_ipv6_unicast_hops(&s).unwrap(), 0);
+    assert_ne!(sockopt::ipv6_unicast_hops(&s).unwrap(), 0);
 
     // On NetBSD, `get_ipv6_multicasthops` returns 1 here. It's not evident
     // why it differs from other OS's.
     #[cfg(not(target_os = "netbsd"))]
-    match sockopt::get_ipv6_multicast_hops(&s) {
+    match sockopt::ipv6_multicast_hops(&s) {
         Ok(hops) => assert_eq!(hops, 0),
         Err(io::Errno::NOPROTOOPT) => (),
         Err(io::Errno::INVAL) => (),
@@ -424,17 +412,17 @@ fn test_sockopts_ipv6() {
     };
 
     // Set the IPV4 V6OONLY value.
-    let v6only = rustix::net::sockopt::get_ipv6_v6only(&s).unwrap();
+    let v6only = rustix::net::sockopt::ipv6_v6only(&s).unwrap();
     sockopt::set_ipv6_v6only(&s, !v6only).unwrap();
 
     // Check that the IPV6 V6ONLY value is set.
-    assert_eq!(sockopt::get_ipv6_v6only(&s).unwrap(), !v6only);
+    assert_eq!(sockopt::ipv6_v6only(&s).unwrap(), !v6only);
 
     // Set the IPV6 multicast loop value.
     match sockopt::set_ipv6_multicast_loop(&s, false) {
         Ok(()) => {
             // Check that the IPV6 multicast loop value is set.
-            match sockopt::get_ipv6_multicast_loop(&s) {
+            match sockopt::ipv6_multicast_loop(&s) {
                 Ok(multicast_loop) => assert!(!multicast_loop),
                 Err(err) => panic!("{:?}", err),
             }
@@ -449,13 +437,13 @@ fn test_sockopts_ipv6() {
     sockopt::set_ipv6_unicast_hops(&s, None).unwrap();
 
     // Check that the IPV6 unicast hops value is set.
-    assert_ne!(sockopt::get_ipv6_unicast_hops(&s).unwrap(), 0);
+    assert_ne!(sockopt::ipv6_unicast_hops(&s).unwrap(), 0);
 
     // Set the IPV6 unicast hops value to a specific value.
     sockopt::set_ipv6_unicast_hops(&s, Some(8)).unwrap();
 
     // Check that the IPV6 unicast hops value is set.
-    assert_eq!(sockopt::get_ipv6_unicast_hops(&s).unwrap(), 8);
+    assert_eq!(sockopt::ipv6_unicast_hops(&s).unwrap(), 8);
 
     // Check the initial value of `IPV6_RECVTCLASS`, set it, and check it.
     #[cfg(any(
@@ -466,32 +454,32 @@ fn test_sockopts_ipv6() {
         target_os = "nto"
     ))]
     {
-        assert!(!sockopt::get_ipv6_recvtclass(&s).unwrap());
+        assert!(!sockopt::ipv6_recvtclass(&s).unwrap());
         sockopt::set_ipv6_recvtclass(&s, true).unwrap();
-        assert!(sockopt::get_ipv6_recvtclass(&s).unwrap());
+        assert!(sockopt::ipv6_recvtclass(&s).unwrap());
     }
 
     // Check the initial value of `IPV6_FREEBIND`, set it, and check it.
     #[cfg(linux_kernel)]
     {
-        assert!(!sockopt::get_ipv6_freebind(&s).unwrap());
+        assert!(!sockopt::ipv6_freebind(&s).unwrap());
         sockopt::set_ipv6_freebind(&s, true).unwrap();
-        assert!(sockopt::get_ipv6_freebind(&s).unwrap());
+        assert!(sockopt::ipv6_freebind(&s).unwrap());
     }
 
     // Check the initial value of `IPV6_TCLASS`, set it, and check it.
     #[cfg(not(any(solarish, windows, target_os = "espidf", target_os = "haiku")))]
     {
-        assert_eq!(sockopt::get_ipv6_tclass(&s).unwrap(), 0);
+        assert_eq!(sockopt::ipv6_tclass(&s).unwrap(), 0);
         sockopt::set_ipv6_tclass(&s, 12).unwrap();
-        assert_eq!(sockopt::get_ipv6_tclass(&s).unwrap(), 12);
+        assert_eq!(sockopt::ipv6_tclass(&s).unwrap(), 12);
     }
 
     // Check that we can query `IP6T_SO_ORIGINAL_DST`.
     #[cfg(linux_kernel)]
     {
         assert!(matches!(
-            sockopt::get_ipv6_original_dst(&s),
+            sockopt::ipv6_original_dst(&s),
             Err(io::Errno::NOENT | io::Errno::NOPROTOOPT)
         ));
     }

--- a/tests/net/unix.rs
+++ b/tests/net/unix.rs
@@ -612,7 +612,7 @@ fn test_unix_peercred_explicit() {
 
     sockopt::set_socket_passcred(&recv_sock, true).unwrap();
 
-    let ucred = sockopt::get_socket_peercred(&send_sock).unwrap();
+    let ucred = sockopt::socket_peercred(&send_sock).unwrap();
     let msg = SendAncillaryMessage::ScmCredentials(ucred);
     let mut space = [0; rustix::cmsg_space!(ScmCredentials(1))];
     let mut cmsg_buffer = SendAncillaryBuffer::new(&mut space);
@@ -669,7 +669,7 @@ fn test_unix_peercred_implicit() {
 
     sockopt::set_socket_passcred(&recv_sock, true).unwrap();
 
-    let ucred = sockopt::get_socket_peercred(&send_sock).unwrap();
+    let ucred = sockopt::socket_peercred(&send_sock).unwrap();
     assert_eq!(ucred.pid, getpid());
     assert_eq!(ucred.uid, getuid());
     assert_eq!(ucred.gid, getgid());

--- a/tests/net/unix_alloc.rs
+++ b/tests/net/unix_alloc.rs
@@ -611,7 +611,7 @@ fn test_unix_peercred() {
 
     sockopt::set_socket_passcred(&recv_sock, true).unwrap();
 
-    let ucred = sockopt::get_socket_peercred(&send_sock).unwrap();
+    let ucred = sockopt::socket_peercred(&send_sock).unwrap();
     assert_eq!(ucred.pid, getpid());
     assert_eq!(ucred.uid, getuid());
     assert_eq!(ucred.gid, getgid());


### PR DESCRIPTION
This better aligns them with [Rust conventions], and they're all in a dedicated `sockopts` module so the chance of collision is low.

[Rust conventions]: https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter