### PR TITLE
Make APIs preserve strict provenance.

### DIFF
--- a/examples/kq.rs
+++ b/examples/kq.rs
@@ -5,6 +5,7 @@ fn main() -> std::io::Result<()> {
     use rustix::event::kqueue::*;
     #[cfg(feature = "fs")]
     use rustix::{fd::AsRawFd, fs};
+    use std::ptr::null_mut;
 
     let kq = kqueue()?;
     let mut out = Vec::with_capacity(10);
@@ -25,7 +26,7 @@ fn main() -> std::io::Result<()> {
                 times: 0,
             },
             EventFlags::ADD,
-            0,
+            null_mut(),
         ),
         #[cfg(feature = "fs")]
         Event::new(
@@ -34,7 +35,7 @@ fn main() -> std::io::Result<()> {
                 flags: VnodeEvents::WRITE | VnodeEvents::LINK | VnodeEvents::EXTEND,
             },
             EventFlags::ADD | EventFlags::CLEAR,
-            0,
+            null_mut(),
         ),
         Event::new(
             EventFilter::Timer {
@@ -42,7 +43,7 @@ fn main() -> std::io::Result<()> {
                 timer: Some(core::time::Duration::from_secs(1)),
             },
             EventFlags::ADD,
-            0,
+            null_mut(),
         ),
         Event::new(
             EventFilter::Timer {
@@ -50,7 +51,7 @@ fn main() -> std::io::Result<()> {
                 timer: Some(core::time::Duration::from_secs(2)),
             },
             EventFlags::ADD | EventFlags::ONESHOT,
-            0,
+            null_mut(),
         ),
     ];
 

--- a/src/event/kqueue.rs
+++ b/src/event/kqueue.rs
@@ -93,7 +93,7 @@ impl Event {
     /// Get the user data for this event.
     pub fn udata(&self) -> *mut c::c_void {
         // On NetBSD, udata is an isize and not a pointer.
-        self.inner.udata
+        self.inner.udata as _
     }
 
     /// Get the raw data for this event.

--- a/src/event/kqueue.rs
+++ b/src/event/kqueue.rs
@@ -24,7 +24,7 @@ pub struct Event {
 impl Event {
     /// Create a new `Event`.
     #[allow(clippy::needless_update)]
-    pub fn new(filter: EventFilter, flags: EventFlags, udata: isize) -> Event {
+    pub fn new(filter: EventFilter, flags: EventFlags, udata: *mut c::c_void) -> Event {
         let (ident, data, filter, fflags) = match filter {
             EventFilter::Read(fd) => (fd as uintptr_t, 0, c::EVFILT_READ, 0),
             EventFilter::Write(fd) => (fd as _, 0, c::EVFILT_WRITE, 0),
@@ -78,7 +78,6 @@ impl Event {
                 },
                 udata: {
                     // On NetBSD, udata is an `isize` and not a pointer.
-                    // TODO: Strict provenance, prevent int-to-ptr cast.
                     udata as _
                 },
                 ..unsafe { zeroed() }
@@ -92,11 +91,9 @@ impl Event {
     }
 
     /// Get the user data for this event.
-    pub fn udata(&self) -> isize {
+    pub fn udata(&self) -> *mut c::c_void {
         // On NetBSD, udata is an isize and not a pointer.
-        // TODO: Strict provenance, prevent ptr-to-int cast.
-
-        self.inner.udata as _
+        self.inner.udata
     }
 
     /// Get the raw data for this event.

--- a/tests/io/ioctl.rs
+++ b/tests/io/ioctl.rs
@@ -26,7 +26,7 @@ fn test_int_setter() {
 
     // SAFETY: TUNSETOFFLOAD is defined for TUN.
     unsafe {
-        let code = IntegerSetter::<BadOpcode<{ TUNSETOFFLOAD }>>::new(0);
+        let code = IntegerSetter::<BadOpcode<{ TUNSETOFFLOAD }>>::new_usize(0);
         assert!(ioctl(&tun, code).is_err());
     }
 }


### PR DESCRIPTION
Modify the kqueue and ioctl APIs to preserve strict provenance when handling pointer values.