### PR TITLE
Enable some rustix features on wasm32-wasip2.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,13 @@
-// wasip2 conditionally gates stdlib APIs.
+// wasip2 conditionally gates stdlib APIs such as `OsStrExt`.
 // https://github.com/rust-lang/rust/issues/130323
-#![cfg_attr(all(target_os = "wasi", target_env = "p2"), feature(wasip2))]
+#![cfg_attr(
+    all(
+        target_os = "wasi",
+        target_env = "p2",
+        any(feature = "fs", feature = "mount", feature = "net")
+    ),
+    feature(wasip2)
+)]
 //! `rustix` provides efficient memory-safe and [I/O-safe] wrappers to
 //! POSIX-like, Unix-like, Linux, and Winsock syscall-like APIs, with
 //! configurable backends.

--- a/src/maybe_polyfill/std/mod.rs
+++ b/src/maybe_polyfill/std/mod.rs
@@ -21,12 +21,10 @@ pub mod os {
     pub mod fd {
         // Change  to use `std::os::fd` when MSRV becomes 1.66 or higher.
 
+        #[cfg(target_os = "wasi")]
+        pub use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
         #[cfg(unix)]
         pub use std::os::unix::io::{
-            AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd,
-        };
-        #[cfg(target_os = "wasi")]
-        pub use std::os::wasi::io::{
             AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd,
         };
     }

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -44,7 +44,7 @@ const INVALID: *mut c_void = 1 as *mut c_void;
 macro_rules! weak {
     ($vis:vis fn $name:ident($($t:ty),*) -> $ret:ty) => (
         #[allow(non_upper_case_globals)]
-        $vis static $name: $crate::weak::Weak<extern "C" fn($($t),*) -> $ret> =
+        $vis static $name: $crate::weak::Weak<unsafe extern "C" fn($($t),*) -> $ret> =
             $crate::weak::Weak::new(concat!(stringify!($name), '\0'));
     )
 }

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -44,7 +44,7 @@ const INVALID: *mut c_void = 1 as *mut c_void;
 macro_rules! weak {
     ($vis:vis fn $name:ident($($t:ty),*) -> $ret:ty) => (
         #[allow(non_upper_case_globals)]
-        $vis static $name: $crate::weak::Weak<unsafe extern fn($($t),*) -> $ret> =
+        $vis static $name: $crate::weak::Weak<extern "C" fn($($t),*) -> $ret> =
             $crate::weak::Weak::new(concat!(stringify!($name), '\0'));
     )
 }

--- a/tests/param/weak.rs
+++ b/tests/param/weak.rs
@@ -42,7 +42,7 @@ const INVALID: *mut c_void = 1 as *mut c_void;
 macro_rules! weak {
     ($vis:vis fn $name:ident($($t:ty),*) -> $ret:ty) => (
         #[allow(non_upper_case_globals)]
-        $vis static $name: $crate::weak::Weak<unsafe extern fn($($t),*) -> $ret> =
+        $vis static $name: $crate::weak::Weak<extern "C" fn($($t),*) -> $ret> =
             $crate::weak::Weak::new(concat!(stringify!($name), '\0'));
     )
 }

--- a/tests/param/weak.rs
+++ b/tests/param/weak.rs
@@ -42,7 +42,7 @@ const INVALID: *mut c_void = 1 as *mut c_void;
 macro_rules! weak {
     ($vis:vis fn $name:ident($($t:ty),*) -> $ret:ty) => (
         #[allow(non_upper_case_globals)]
-        $vis static $name: $crate::weak::Weak<extern "C" fn($($t),*) -> $ret> =
+        $vis static $name: $crate::weak::Weak<unsafe extern "C" fn($($t),*) -> $ret> =
             $crate::weak::Weak::new(concat!(stringify!($name), '\0'));
     )
 }


### PR DESCRIPTION
Enable features that don't depend on `OsStrExt` to be used on wasm32-wasip2 on stable Rust.