### PR TITLE
Reorganize Stat, Statx, and SockaddrStorage

### DIFF
--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -486,7 +486,7 @@ pub(super) use readwrite_pv64v2::{preadv64v2 as preadv2, pwritev64v2 as pwritev2
 
 // Rust's libc crate lacks statx for Non-glibc targets.
 #[cfg(feature = "fs")]
-#[cfg(all(linux_like, not(target_env = "gnu")))]
+#[cfg(all(linux_like, not(any(target_os = "android", target_env = "gnu"))))]
 mod statx_flags {
     pub(crate) use linux_raw_sys::general::{
         STATX_ALL, STATX_ATIME, STATX_BASIC_STATS, STATX_BLOCKS, STATX_BTIME, STATX_CTIME,
@@ -501,5 +501,9 @@ mod statx_flags {
     };
 }
 #[cfg(feature = "fs")]
-#[cfg(all(linux_like, not(target_env = "gnu")))]
+#[cfg(all(linux_like, not(any(target_os = "android", target_env = "gnu"))))]
 pub(crate) use statx_flags::*;
+
+#[cfg(feature = "fs")]
+#[cfg(target_os = "android")]
+pub(crate) use libc::__fsid_t as fsid_t;

--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -486,7 +486,10 @@ pub(super) use readwrite_pv64v2::{preadv64v2 as preadv2, pwritev64v2 as pwritev2
 
 // Rust's libc crate lacks statx for Non-glibc targets.
 #[cfg(feature = "fs")]
-#[cfg(all(linux_like, not(any(target_os = "android", target_env = "gnu"))))]
+#[cfg(all(
+    linux_like,
+    not(any(target_os = "android", target_os = "emscripten", target_env = "gnu"))
+))]
 mod statx_flags {
     pub(crate) use linux_raw_sys::general::{
         STATX_ALL, STATX_ATIME, STATX_BASIC_STATS, STATX_BLOCKS, STATX_BTIME, STATX_CTIME,
@@ -501,7 +504,10 @@ mod statx_flags {
     };
 }
 #[cfg(feature = "fs")]
-#[cfg(all(linux_like, not(any(target_os = "android", target_env = "gnu"))))]
+#[cfg(all(
+    linux_like,
+    not(any(target_os = "android", target_os = "emscripten", target_env = "gnu"))
+))]
 pub(crate) use statx_flags::*;
 
 #[cfg(feature = "fs")]

--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -483,3 +483,23 @@ mod readwrite_pv64v2 {
     all(target_os = "linux", not(target_env = "gnu")),
 ))]
 pub(super) use readwrite_pv64v2::{preadv64v2 as preadv2, pwritev64v2 as pwritev2};
+
+// Rust's libc crate lacks statx for Non-glibc targets.
+#[cfg(feature = "fs")]
+#[cfg(all(linux_like, not(target_env = "gnu")))]
+mod statx_flags {
+    pub(crate) use linux_raw_sys::general::{
+        STATX_ALL, STATX_ATIME, STATX_BASIC_STATS, STATX_BLOCKS, STATX_BTIME, STATX_CTIME,
+        STATX_DIOALIGN, STATX_GID, STATX_INO, STATX_MNT_ID, STATX_MODE, STATX_MTIME, STATX_NLINK,
+        STATX_SIZE, STATX_TYPE, STATX_UID,
+    };
+
+    pub(crate) use linux_raw_sys::general::{
+        STATX_ATTR_APPEND, STATX_ATTR_AUTOMOUNT, STATX_ATTR_COMPRESSED, STATX_ATTR_DAX,
+        STATX_ATTR_ENCRYPTED, STATX_ATTR_IMMUTABLE, STATX_ATTR_MOUNT_ROOT, STATX_ATTR_NODUMP,
+        STATX_ATTR_VERITY,
+    };
+}
+#[cfg(feature = "fs")]
+#[cfg(all(linux_like, not(target_env = "gnu")))]
+pub(crate) use statx_flags::*;

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -947,7 +947,7 @@ pub type StatFs = c::statfs;
 pub type StatFs = c::statfs64;
 
 /// `fsid_t` for use with `StatFs`.
-#[cfg(not(target_os = "illumos"))]
+#[cfg(not(any(target_os = "illumos", target_os = "redox")))]
 pub type Fsid = c::fsid_t;
 
 /// `struct statvfs` for use with [`statvfs`] and [`fstatvfs`].

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -947,7 +947,12 @@ pub type StatFs = c::statfs;
 pub type StatFs = c::statfs64;
 
 /// `fsid_t` for use with `StatFs`.
-#[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "haiku",
+    target_os = "illumos",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 pub type Fsid = c::fsid_t;
 
 /// `struct statvfs` for use with [`statvfs`] and [`fstatvfs`].

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -948,8 +948,8 @@ pub type StatFs = c::statfs64;
 
 /// `fsid_t` for use with `StatFs`.
 #[cfg(not(any(
+    solarish,
     target_os = "haiku",
-    target_os = "illumos",
     target_os = "nto",
     target_os = "redox",
     target_os = "wasi"

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -674,128 +674,6 @@ bitflags! {
     }
 }
 
-#[cfg(all(target_os = "linux", target_env = "gnu"))]
-bitflags! {
-    /// `STATX_*` constants for use with [`statx`].
-    ///
-    /// [`statx`]: crate::fs::statx
-    #[repr(transparent)]
-    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct StatxFlags: u32 {
-        /// `STATX_TYPE`
-        const TYPE = c::STATX_TYPE;
-
-        /// `STATX_MODE`
-        const MODE = c::STATX_MODE;
-
-        /// `STATX_NLINK`
-        const NLINK = c::STATX_NLINK;
-
-        /// `STATX_UID`
-        const UID = c::STATX_UID;
-
-        /// `STATX_GID`
-        const GID = c::STATX_GID;
-
-        /// `STATX_ATIME`
-        const ATIME = c::STATX_ATIME;
-
-        /// `STATX_MTIME`
-        const MTIME = c::STATX_MTIME;
-
-        /// `STATX_CTIME`
-        const CTIME = c::STATX_CTIME;
-
-        /// `STATX_INO`
-        const INO = c::STATX_INO;
-
-        /// `STATX_SIZE`
-        const SIZE = c::STATX_SIZE;
-
-        /// `STATX_BLOCKS`
-        const BLOCKS = c::STATX_BLOCKS;
-
-        /// `STATX_BASIC_STATS`
-        const BASIC_STATS = c::STATX_BASIC_STATS;
-
-        /// `STATX_BTIME`
-        const BTIME = c::STATX_BTIME;
-
-        /// `STATX_MNT_ID` (since Linux 5.8)
-        const MNT_ID = c::STATX_MNT_ID;
-
-        /// `STATX_DIOALIGN` (since Linux 6.1)
-        const DIOALIGN = c::STATX_DIOALIGN;
-
-        /// `STATX_ALL`
-        const ALL = c::STATX_ALL;
-
-        /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
-        const _ = !0;
-    }
-}
-
-#[cfg(any(
-    target_os = "android",
-    all(target_os = "linux", not(target_env = "gnu")),
-))]
-bitflags! {
-    /// `STATX_*` constants for use with [`statx`].
-    ///
-    /// [`statx`]: crate::fs::statx
-    #[repr(transparent)]
-    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct StatxFlags: u32 {
-        /// `STATX_TYPE`
-        const TYPE = 0x0001;
-
-        /// `STATX_MODE`
-        const MODE = 0x0002;
-
-        /// `STATX_NLINK`
-        const NLINK = 0x0004;
-
-        /// `STATX_UID`
-        const UID = 0x0008;
-
-        /// `STATX_GID`
-        const GID = 0x0010;
-
-        /// `STATX_ATIME`
-        const ATIME = 0x0020;
-
-        /// `STATX_MTIME`
-        const MTIME = 0x0040;
-
-        /// `STATX_CTIME`
-        const CTIME = 0x0080;
-
-        /// `STATX_INO`
-        const INO = 0x0100;
-
-        /// `STATX_SIZE`
-        const SIZE = 0x0200;
-
-        /// `STATX_BLOCKS`
-        const BLOCKS = 0x0400;
-
-        /// `STATX_BASIC_STATS`
-        const BASIC_STATS = 0x07ff;
-
-        /// `STATX_BTIME`
-        const BTIME = 0x800;
-
-        /// `STATX_MNT_ID` (since Linux 5.8)
-        const MNT_ID = 0x1000;
-
-        /// `STATX_ALL`
-        const ALL = 0xfff;
-
-        /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
-        const _ = !0;
-    }
-}
-
 #[cfg(not(any(
     netbsdlike,
     target_os = "espidf",
@@ -1022,13 +900,12 @@ pub type Stat = c::stat64;
 // we use our own struct, populated from `statx` where possible, to avoid the
 // y2038 bug.
 #[cfg(all(linux_kernel, target_pointer_width = "32"))]
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 #[allow(missing_docs)]
 pub struct Stat {
     pub st_dev: u64,
     pub st_mode: u32,
-    pub st_nlink: u32,
+    pub st_nlink: u64,
     pub st_uid: u32,
     pub st_gid: u32,
     pub st_rdev: u64,
@@ -1069,6 +946,10 @@ pub type StatFs = c::statfs;
 #[cfg(linux_like)]
 pub type StatFs = c::statfs64;
 
+/// `fsid_t` for use with `StatFs`.
+#[cfg(not(target_os = "illumos"))]
+pub type Fsid = c::fsid_t;
+
 /// `struct statvfs` for use with [`statvfs`] and [`fstatvfs`].
 ///
 /// [`statvfs`]: crate::fs::statvfs
@@ -1087,70 +968,6 @@ pub struct StatVfs {
     pub f_fsid: u64,
     pub f_flag: StatVfsMountFlags,
     pub f_namemax: u64,
-}
-
-/// `struct statx` for use with [`statx`].
-///
-/// [`statx`]: crate::fs::statx
-#[cfg(all(target_os = "linux", target_env = "gnu"))]
-// Use the glibc `struct statx`.
-pub type Statx = c::statx;
-
-/// `struct statx_timestamp` for use with [`Statx`].
-#[cfg(all(target_os = "linux", target_env = "gnu"))]
-// Use the glibc `struct statx_timestamp`.
-pub type StatxTimestamp = c::statx;
-
-/// `struct statx` for use with [`statx`].
-///
-/// [`statx`]: crate::fs::statx
-// Non-glibc ABIs don't currently declare a `struct statx`, so we declare it
-// ourselves.
-#[cfg(any(
-    target_os = "android",
-    all(target_os = "linux", not(target_env = "gnu")),
-))]
-#[repr(C)]
-#[allow(missing_docs)]
-pub struct Statx {
-    pub stx_mask: u32,
-    pub stx_blksize: u32,
-    pub stx_attributes: u64,
-    pub stx_nlink: u32,
-    pub stx_uid: u32,
-    pub stx_gid: u32,
-    pub stx_mode: u16,
-    __statx_pad1: [u16; 1],
-    pub stx_ino: u64,
-    pub stx_size: u64,
-    pub stx_blocks: u64,
-    pub stx_attributes_mask: u64,
-    pub stx_atime: StatxTimestamp,
-    pub stx_btime: StatxTimestamp,
-    pub stx_ctime: StatxTimestamp,
-    pub stx_mtime: StatxTimestamp,
-    pub stx_rdev_major: u32,
-    pub stx_rdev_minor: u32,
-    pub stx_dev_major: u32,
-    pub stx_dev_minor: u32,
-    pub stx_mnt_id: u64,
-    __statx_pad2: u64,
-    __statx_pad3: [u64; 12],
-}
-
-/// `struct statx_timestamp` for use with [`Statx`].
-// Non-glibc ABIs don't currently declare a `struct statx_timestamp`, so we
-// declare it ourselves.
-#[cfg(any(
-    target_os = "android",
-    all(target_os = "linux", not(target_env = "gnu")),
-))]
-#[repr(C)]
-#[allow(missing_docs)]
-pub struct StatxTimestamp {
-    pub tv_sec: i64,
-    pub tv_nsec: u32,
-    pub __statx_timestamp_pad1: [i32; 1],
 }
 
 /// `mode_t`

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -947,7 +947,7 @@ pub type StatFs = c::statfs;
 pub type StatFs = c::statfs64;
 
 /// `fsid_t` for use with `StatFs`.
-#[cfg(not(any(target_os = "illumos", target_os = "redox")))]
+#[cfg(not(any(target_os = "illumos", target_os = "redox", target_os = "wasi")))]
 pub type Fsid = c::fsid_t;
 
 /// `struct statvfs` for use with [`statvfs`] and [`fstatvfs`].

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -950,6 +950,7 @@ pub type StatFs = c::statfs64;
 #[cfg(not(any(
     target_os = "haiku",
     target_os = "illumos",
+    target_os = "nto",
     target_os = "redox",
     target_os = "wasi"
 )))]

--- a/src/backend/libc/io/errno.rs
+++ b/src/backend/libc/io/errno.rs
@@ -782,7 +782,7 @@ impl Errno {
     #[cfg(not(target_os = "l4re"))]
     pub const NOTSOCK: Self = Self(c::ENOTSOCK);
     /// `ENOTSUP`
-    #[cfg(not(any(windows, target_os = "haiku", target_os = "redox")))]
+    #[cfg(not(any(windows, target_os = "redox")))]
     pub const NOTSUP: Self = Self(c::ENOTSUP);
     /// `ENOTTY`
     #[cfg(not(windows))]

--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -2,6 +2,7 @@
 
 use crate::backend::c;
 use crate::net::AddressFamily;
+use core::mem::size_of;
 #[cfg(unix)]
 use {
     crate::ffi::CStr,

--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -208,8 +208,9 @@ impl fmt::Debug for SocketAddrUnix {
     }
 }
 
-/// `struct sockaddr_storage` as a raw struct.
-pub type SocketAddrStorage = c::sockaddr_storage;
+/// `struct sockaddr_storage`.
+#[repr(transparent)]
+pub struct SocketAddrStorage(c::sockaddr_storage);
 
 /// Return the offset of the `sun_path` field of `sockaddr_un`.
 #[cfg(not(windows))]

--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -3,6 +3,7 @@
 use crate::backend::c;
 use crate::net::AddressFamily;
 use core::mem::size_of;
+use core::slice;
 #[cfg(unix)]
 use {
     crate::ffi::CStr,
@@ -11,7 +12,6 @@ use {
     core::cmp::Ordering,
     core::fmt,
     core::hash::{Hash, Hasher},
-    core::slice,
 };
 
 /// `struct sockaddr_un`

--- a/src/backend/libc/net/read_sockaddr.rs
+++ b/src/backend/libc/net/read_sockaddr.rs
@@ -51,7 +51,7 @@ struct sockaddr_header {
 ///
 /// `storage` must point to a valid socket address returned from the OS.
 #[inline]
-unsafe fn read_sa_family(storage: *const c::sockaddr_storage) -> u16 {
+pub(crate) unsafe fn read_sa_family(storage: *const c::sockaddr) -> u16 {
     // Assert that we know the layout of `sockaddr`.
     let _ = c::sockaddr {
         #[cfg(any(
@@ -107,7 +107,7 @@ unsafe fn read_sun_path0(storage: *const c::sockaddr_storage) -> u8 {
 
 /// Set the `sa_family` field of a socket address to `AF_UNSPEC`, so that we
 /// can test for `AF_UNSPEC` to test whether it was stored to.
-pub(crate) unsafe fn initialize_family_to_unspec(storage: *mut c::sockaddr_storage) {
+pub(crate) unsafe fn initialize_family_to_unspec(storage: *mut c::sockaddr) {
     (*storage.cast::<sockaddr_header>()).sa_family = c::AF_UNSPEC as _;
 }
 
@@ -117,7 +117,7 @@ pub(crate) unsafe fn initialize_family_to_unspec(storage: *mut c::sockaddr_stora
 ///
 /// `storage` must point to valid socket address storage.
 pub(crate) unsafe fn read_sockaddr(
-    storage: *const c::sockaddr_storage,
+    storage: *const c::sockaddr,
     len: usize,
 ) -> io::Result<SocketAddrAny> {
     #[cfg(unix)]
@@ -243,7 +243,7 @@ pub(crate) unsafe fn maybe_read_sockaddr_os(
     }
 
     assert!(len >= size_of::<c::sa_family_t>());
-    let family = read_sa_family(storage).into();
+    let family = read_sa_family(storage.cast::<c::sockaddr>()).into();
     if family == c::AF_UNSPEC {
         return None;
     }
@@ -268,7 +268,7 @@ pub(crate) unsafe fn read_sockaddr_os(
     len: usize,
 ) -> SocketAddrAny {
     assert!(len >= size_of::<c::sa_family_t>());
-    let family = read_sa_family(storage).into();
+    let family = read_sa_family(storage.cast::<c::sockaddr>()).into();
     inner_read_sockaddr_os(family, storage, len)
 }
 

--- a/src/backend/libc/net/read_sockaddr.rs
+++ b/src/backend/libc/net/read_sockaddr.rs
@@ -1,4 +1,4 @@
-//! The BSD sockets API requires us to read the `ss_family` field before we can
+//! The BSD sockets API requires us to read the `sa_family` field before we can
 //! interpret the rest of a `sockaddr` produced by the kernel.
 
 #[cfg(unix)]
@@ -33,7 +33,7 @@ struct sockaddr_header {
         target_os = "nto",
         target_os = "vita"
     ))]
-    ss_family: u8,
+    sa_family: u8,
     #[cfg(not(any(
         bsd,
         target_os = "aix",
@@ -42,16 +42,16 @@ struct sockaddr_header {
         target_os = "nto",
         target_os = "vita"
     )))]
-    ss_family: u16,
+    sa_family: u16,
 }
 
-/// Read the `ss_family` field from a socket address returned from the OS.
+/// Read the `sa_family` field from a socket address returned from the OS.
 ///
 /// # Safety
 ///
 /// `storage` must point to a valid socket address returned from the OS.
 #[inline]
-unsafe fn read_ss_family(storage: *const c::sockaddr_storage) -> u16 {
+unsafe fn read_sa_family(storage: *const c::sockaddr_storage) -> u16 {
     // Assert that we know the layout of `sockaddr`.
     let _ = c::sockaddr {
         #[cfg(any(
@@ -90,7 +90,7 @@ unsafe fn read_ss_family(storage: *const c::sockaddr_storage) -> u16 {
         sa_data: [0; 30],
     };
 
-    (*storage.cast::<sockaddr_header>()).ss_family.into()
+    (*storage.cast::<sockaddr_header>()).sa_family.into()
 }
 
 /// Read the first byte of the `sun_path` field, assuming we have an `AF_UNIX`
@@ -105,10 +105,10 @@ unsafe fn read_sun_path0(storage: *const c::sockaddr_storage) -> u8 {
         .read()
 }
 
-/// Set the `ss_family` field of a socket address to `AF_UNSPEC`, so that we
+/// Set the `sa_family` field of a socket address to `AF_UNSPEC`, so that we
 /// can test for `AF_UNSPEC` to test whether it was stored to.
 pub(crate) unsafe fn initialize_family_to_unspec(storage: *mut c::sockaddr_storage) {
-    (*storage.cast::<sockaddr_header>()).ss_family = c::AF_UNSPEC as _;
+    (*storage.cast::<sockaddr_header>()).sa_family = c::AF_UNSPEC as _;
 }
 
 /// Read a socket address encoded in a platform-specific format.
@@ -126,7 +126,7 @@ pub(crate) unsafe fn read_sockaddr(
     if len < size_of::<c::sa_family_t>() {
         return Err(io::Errno::INVAL);
     }
-    match read_ss_family(storage).into() {
+    match read_sa_family(storage).into() {
         c::AF_INET => {
             if len < size_of::<c::sockaddr_in>() {
                 return Err(io::Errno::INVAL);
@@ -243,7 +243,7 @@ pub(crate) unsafe fn maybe_read_sockaddr_os(
     }
 
     assert!(len >= size_of::<c::sa_family_t>());
-    let family = read_ss_family(storage).into();
+    let family = read_sa_family(storage).into();
     if family == c::AF_UNSPEC {
         return None;
     }
@@ -268,7 +268,7 @@ pub(crate) unsafe fn read_sockaddr_os(
     len: usize,
 ) -> SocketAddrAny {
     assert!(len >= size_of::<c::sa_family_t>());
-    let family = read_ss_family(storage).into();
+    let family = read_sa_family(storage).into();
     inner_read_sockaddr_os(family, storage, len)
 }
 

--- a/src/backend/libc/net/syscalls.rs
+++ b/src/backend/libc/net/syscalls.rs
@@ -76,14 +76,14 @@ pub(crate) unsafe fn recvfrom(
     // `recvfrom` does not write to the storage if the socket is
     // connection-oriented sockets, so we initialize the family field to
     // `AF_UNSPEC` so that we can detect this case.
-    initialize_family_to_unspec(storage.as_mut_ptr());
+    initialize_family_to_unspec(storage.as_mut_ptr().cast::<c::sockaddr>());
 
     ret_send_recv(c::recvfrom(
         borrowed_fd(fd),
         buf.cast(),
         send_recv_len(buf_len),
         bitflags_bits!(flags),
-        storage.as_mut_ptr().cast(),
+        storage.as_mut_ptr().cast::<c::sockaddr>(),
         &mut len,
     ))
     .map(|nread| {
@@ -485,7 +485,7 @@ pub(crate) fn acceptfrom(sockfd: BorrowedFd<'_>) -> io::Result<(OwnedFd, Option<
         let mut len = size_of::<c::sockaddr_storage>() as c::socklen_t;
         let owned_fd = ret_owned_fd(c::accept(
             borrowed_fd(sockfd),
-            storage.as_mut_ptr().cast(),
+            storage.as_mut_ptr().cast::<c::sockaddr>(),
             &mut len,
         ))?;
         Ok((
@@ -515,7 +515,7 @@ pub(crate) fn acceptfrom_with(
         let mut len = size_of::<c::sockaddr_storage>() as c::socklen_t;
         let owned_fd = ret_owned_fd(c::accept4(
             borrowed_fd(sockfd),
-            storage.as_mut_ptr().cast(),
+            storage.as_mut_ptr().cast::<c::sockaddr>(),
             &mut len,
             flags.bits() as c::c_int,
         ))?;
@@ -571,7 +571,7 @@ pub(crate) fn getsockname(sockfd: BorrowedFd<'_>) -> io::Result<SocketAddrAny> {
         let mut len = size_of::<c::sockaddr_storage>() as c::socklen_t;
         ret(c::getsockname(
             borrowed_fd(sockfd),
-            storage.as_mut_ptr().cast(),
+            storage.as_mut_ptr().cast::<c::sockaddr>(),
             &mut len,
         ))?;
         Ok(read_sockaddr_os(storage.as_ptr(), len.try_into().unwrap()))
@@ -585,7 +585,7 @@ pub(crate) fn getpeername(sockfd: BorrowedFd<'_>) -> io::Result<Option<SocketAdd
         let mut len = size_of::<c::sockaddr_storage>() as c::socklen_t;
         ret(c::getpeername(
             borrowed_fd(sockfd),
-            storage.as_mut_ptr().cast(),
+            storage.as_mut_ptr().cast::<c::sockaddr>(),
             &mut len,
         ))?;
         Ok(maybe_read_sockaddr_os(

--- a/src/backend/libc/net/write_sockaddr.rs
+++ b/src/backend/libc/net/write_sockaddr.rs
@@ -1,4 +1,4 @@
-//! The BSD sockets API requires us to read the `ss_family` field before we can
+//! The BSD sockets API requires us to read the `sa_family` field before we can
 //! interpret the rest of a `sockaddr` produced by the kernel.
 
 use super::addr::SocketAddrStorage;

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -21,6 +21,16 @@ pub(crate) use linux_raw_sys::general::{
 #[cfg(feature = "system")]
 pub(crate) use linux_raw_sys::system::sysinfo;
 
+#[cfg(feature = "fs")]
+#[cfg(target_arch = "x86")]
+#[cfg(test)]
+pub(crate) use linux_raw_sys::general::stat64;
+#[cfg(feature = "fs")]
+#[cfg(test)]
+pub(crate) use linux_raw_sys::general::{
+    __kernel_fsid_t as fsid_t, stat, statfs64, statx, statx_timestamp,
+};
+
 #[cfg(feature = "event")]
 #[cfg(test)]
 pub(crate) use linux_raw_sys::general::epoll_event;
@@ -316,3 +326,48 @@ pub(crate) const MAP_DROPPABLE: u32 = 0x8;
 
 // TODO: This is new in Linux 6.5; remove when linux-raw-sys is updated.
 pub(crate) const MOVE_MOUNT_BENEATH: u32 = 0x200;
+
+#[cfg(any(
+    feature = "fs",
+    all(
+        linux_raw,
+        not(feature = "use-libc-auxv"),
+        not(feature = "use-explicitly-provided-auxv"),
+        any(
+            feature = "param",
+            feature = "runtime",
+            feature = "thread",
+            feature = "time",
+            target_arch = "x86",
+        )
+    )
+))]
+mod statx_flags {
+    pub(crate) use linux_raw_sys::general::{
+        STATX_ALL, STATX_ATIME, STATX_BASIC_STATS, STATX_BLOCKS, STATX_BTIME, STATX_CTIME,
+        STATX_DIOALIGN, STATX_GID, STATX_INO, STATX_MNT_ID, STATX_MODE, STATX_MTIME, STATX_NLINK,
+        STATX_SIZE, STATX_TYPE, STATX_UID,
+    };
+
+    pub(crate) use linux_raw_sys::general::{
+        STATX_ATTR_APPEND, STATX_ATTR_AUTOMOUNT, STATX_ATTR_COMPRESSED, STATX_ATTR_DAX,
+        STATX_ATTR_ENCRYPTED, STATX_ATTR_IMMUTABLE, STATX_ATTR_MOUNT_ROOT, STATX_ATTR_NODUMP,
+        STATX_ATTR_VERITY,
+    };
+}
+#[cfg(any(
+    feature = "fs",
+    all(
+        linux_raw,
+        not(feature = "use-libc-auxv"),
+        not(feature = "use-explicitly-provided-auxv"),
+        any(
+            feature = "param",
+            feature = "runtime",
+            feature = "thread",
+            feature = "time",
+            target_arch = "x86",
+        )
+    )
+))]
+pub(crate) use statx_flags::*;

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -757,14 +757,15 @@ pub struct Stat {
 /// [`fstatfs`]: crate::fs::fstatfs
 #[allow(clippy::module_name_repetitions)]
 #[repr(C)]
+#[cfg_attr(target_arch = "arm", repr(packed(4)))]
 #[derive(Debug, Copy, Clone)]
 #[allow(missing_docs)]
 #[non_exhaustive]
 pub struct StatFs {
     pub f_type: FsWord,
-    #[cfg(not(target_arch = "s390x"))]
+    #[cfg(not(any(target_arch = "arm", target_arch = "s390x")))]
     pub f_bsize: ffi::c_long,
-    #[cfg(target_arch = "s390x")]
+    #[cfg(any(target_arch = "arm", target_arch = "s390x"))]
     pub f_bsize: ffi::c_uint,
     pub f_blocks: u64,
     pub f_bfree: u64,
@@ -772,17 +773,17 @@ pub struct StatFs {
     pub f_files: u64,
     pub f_ffree: u64,
     pub f_fsid: Fsid,
-    #[cfg(not(target_arch = "s390x"))]
+    #[cfg(not(any(target_arch = "arm", target_arch = "s390x")))]
     pub f_namelen: ffi::c_long,
-    #[cfg(target_arch = "s390x")]
+    #[cfg(any(target_arch = "arm", target_arch = "s390x"))]
     pub f_namelen: ffi::c_uint,
-    #[cfg(not(target_arch = "s390x"))]
+    #[cfg(not(any(target_arch = "arm", target_arch = "s390x")))]
     pub f_frsize: ffi::c_long,
-    #[cfg(target_arch = "s390x")]
+    #[cfg(any(target_arch = "arm", target_arch = "s390x"))]
     pub f_frsize: ffi::c_uint,
-    #[cfg(not(target_arch = "s390x"))]
+    #[cfg(not(any(target_arch = "arm", target_arch = "s390x")))]
     pub f_flags: ffi::c_long,
-    #[cfg(target_arch = "s390x")]
+    #[cfg(any(target_arch = "arm", target_arch = "s390x"))]
     pub f_flags: ffi::c_uint,
     #[cfg(not(target_arch = "s390x"))]
     pub(crate) f_spare: [ffi::c_long; 4],

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -496,66 +496,6 @@ bitflags! {
 }
 
 bitflags! {
-    /// `STATX_*` constants for use with [`statx`].
-    ///
-    /// [`statx`]: crate::fs::statx
-    #[repr(transparent)]
-    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct StatxFlags: u32 {
-        /// `STATX_TYPE`
-        const TYPE = linux_raw_sys::general::STATX_TYPE;
-
-        /// `STATX_MODE`
-        const MODE = linux_raw_sys::general::STATX_MODE;
-
-        /// `STATX_NLINK`
-        const NLINK = linux_raw_sys::general::STATX_NLINK;
-
-        /// `STATX_UID`
-        const UID = linux_raw_sys::general::STATX_UID;
-
-        /// `STATX_GID`
-        const GID = linux_raw_sys::general::STATX_GID;
-
-        /// `STATX_ATIME`
-        const ATIME = linux_raw_sys::general::STATX_ATIME;
-
-        /// `STATX_MTIME`
-        const MTIME = linux_raw_sys::general::STATX_MTIME;
-
-        /// `STATX_CTIME`
-        const CTIME = linux_raw_sys::general::STATX_CTIME;
-
-        /// `STATX_INO`
-        const INO = linux_raw_sys::general::STATX_INO;
-
-        /// `STATX_SIZE`
-        const SIZE = linux_raw_sys::general::STATX_SIZE;
-
-        /// `STATX_BLOCKS`
-        const BLOCKS = linux_raw_sys::general::STATX_BLOCKS;
-
-        /// `STATX_BASIC_STATS`
-        const BASIC_STATS = linux_raw_sys::general::STATX_BASIC_STATS;
-
-        /// `STATX_BTIME`
-        const BTIME = linux_raw_sys::general::STATX_BTIME;
-
-        /// `STATX_MNT_ID` (since Linux 5.8)
-        const MNT_ID = linux_raw_sys::general::STATX_MNT_ID;
-
-        /// `STATX_DIOALIGN` (since Linux 6.1)
-        const DIOALIGN = linux_raw_sys::general::STATX_DIOALIGN;
-
-        /// `STATX_ALL`
-        const ALL = linux_raw_sys::general::STATX_ALL;
-
-        /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
-        const _ = !0;
-    }
-}
-
-bitflags! {
     /// `FALLOC_FL_*` constants for use with [`fallocate`].
     ///
     /// [`fallocate`]: crate::fs::fallocate
@@ -655,6 +595,7 @@ pub enum FlockOperation {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub struct Stat {
     pub st_dev: u64,
     pub st_mode: u32,
@@ -683,14 +624,78 @@ pub struct Stat {
     not(target_arch = "mips64"),
     not(target_arch = "mips64r6")
 ))]
-pub type Stat = linux_raw_sys::general::stat;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]
+#[non_exhaustive]
+pub struct Stat {
+    pub st_dev: ffi::c_ulong,
+    pub st_ino: ffi::c_ulong,
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
+    pub st_nlink: ffi::c_ulong,
+    pub st_mode: ffi::c_uint,
+    #[cfg(not(target_arch = "x86_64"))]
+    pub st_nlink: ffi::c_uint,
+    pub st_uid: ffi::c_uint,
+    pub st_gid: ffi::c_uint,
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
+    pub(crate) __pad0: ffi::c_uint,
+    pub st_rdev: ffi::c_ulong,
+    #[cfg(not(target_arch = "x86_64"))]
+    pub(crate) __pad1: ffi::c_ulong,
+    pub st_size: ffi::c_long,
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
+    pub st_blksize: ffi::c_long,
+    #[cfg(not(target_arch = "x86_64"))]
+    pub st_blksize: ffi::c_int,
+    #[cfg(not(target_arch = "x86_64"))]
+    pub(crate) __pad2: ffi::c_int,
+    pub st_blocks: ffi::c_long,
+    pub st_atime: ffi::c_ulong,
+    pub st_atime_nsec: ffi::c_ulong,
+    pub st_mtime: ffi::c_ulong,
+    pub st_mtime_nsec: ffi::c_ulong,
+    pub st_ctime: ffi::c_ulong,
+    pub st_ctime_nsec: ffi::c_ulong,
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
+    pub(crate) __unused: [ffi::c_long; 3],
+    #[cfg(not(target_arch = "x86_64"))]
+    pub(crate) __unused4: ffi::c_uint,
+    #[cfg(not(target_arch = "x86_64"))]
+    pub(crate) __unused5: ffi::c_uint,
+}
 
 /// `struct statfs` for use with [`statfs`] and [`fstatfs`].
 ///
 /// [`statfs`]: crate::fs::statfs
 /// [`fstatfs`]: crate::fs::fstatfs
 #[allow(clippy::module_name_repetitions)]
-pub type StatFs = linux_raw_sys::general::statfs64;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]
+#[non_exhaustive]
+pub struct StatFs {
+    pub f_type: ffi::c_long,
+    pub f_bsize: ffi::c_long,
+    pub f_blocks: u64,
+    pub f_bfree: u64,
+    pub f_bavail: u64,
+    pub f_files: u64,
+    pub f_ffree: u64,
+    pub f_fsid: Fsid,
+    pub f_namelen: ffi::c_long,
+    pub f_frsize: ffi::c_long,
+    pub f_flags: ffi::c_long,
+    pub(crate) f_spare: [ffi::c_long; 4],
+}
+
+/// `fsid_t` for use with [`StatFs`].
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]
+pub struct Fsid {
+    pub(crate) val: [ffi::c_int; 2],
+}
 
 /// `struct statvfs` for use with [`statvfs`] and [`fstatvfs`].
 ///
@@ -711,31 +716,7 @@ pub struct StatVfs {
     pub f_namemax: u64,
 }
 
-/// `struct statx` for use with [`statx`].
-///
-/// [`statx`]: crate::fs::statx
-pub type Statx = linux_raw_sys::general::statx;
-
-/// `struct statx_timestamp` for use with [`Statx`].
-pub type StatxTimestamp = linux_raw_sys::general::statx_timestamp;
-
 /// `mode_t`
-#[cfg(not(any(
-    target_arch = "x86",
-    target_arch = "sparc",
-    target_arch = "avr",
-    target_arch = "arm",
-)))]
-pub type RawMode = linux_raw_sys::general::__kernel_mode_t;
-
-/// `mode_t`
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "sparc",
-    target_arch = "avr",
-    target_arch = "arm",
-))]
-// Don't use `__kernel_mode_t` since it's `u16` which differs from `st_size`.
 pub type RawMode = ffi::c_uint;
 
 /// `dev_t`
@@ -744,7 +725,7 @@ pub type Dev = u64;
 
 /// `__fsword_t`
 #[cfg(not(any(target_arch = "mips64", target_arch = "mips64r6")))]
-pub type FsWord = linux_raw_sys::general::__fsword_t;
+pub type FsWord = ffi::c_long;
 
 /// `__fsword_t`
 #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]

--- a/src/backend/linux_raw/fs/types.rs
+++ b/src/backend/linux_raw/fs/types.rs
@@ -619,37 +619,22 @@ pub struct Stat {
 ///
 /// [`statat`]: crate::fs::statat
 /// [`fstat`]: crate::fs::fstat
-#[cfg(all(
-    target_pointer_width = "64",
-    not(target_arch = "mips64"),
-    not(target_arch = "mips64r6")
-))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 #[allow(missing_docs)]
 #[non_exhaustive]
+#[cfg(target_arch = "x86_64")]
 pub struct Stat {
     pub st_dev: ffi::c_ulong,
     pub st_ino: ffi::c_ulong,
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
     pub st_nlink: ffi::c_ulong,
     pub st_mode: ffi::c_uint,
-    #[cfg(not(target_arch = "x86_64"))]
-    pub st_nlink: ffi::c_uint,
     pub st_uid: ffi::c_uint,
     pub st_gid: ffi::c_uint,
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
     pub(crate) __pad0: ffi::c_uint,
     pub st_rdev: ffi::c_ulong,
-    #[cfg(not(target_arch = "x86_64"))]
-    pub(crate) __pad1: ffi::c_ulong,
     pub st_size: ffi::c_long,
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
     pub st_blksize: ffi::c_long,
-    #[cfg(not(target_arch = "x86_64"))]
-    pub st_blksize: ffi::c_int,
-    #[cfg(not(target_arch = "x86_64"))]
-    pub(crate) __pad2: ffi::c_int,
     pub st_blocks: ffi::c_long,
     pub st_atime: ffi::c_ulong,
     pub st_atime_nsec: ffi::c_ulong,
@@ -657,12 +642,113 @@ pub struct Stat {
     pub st_mtime_nsec: ffi::c_ulong,
     pub st_ctime: ffi::c_ulong,
     pub st_ctime_nsec: ffi::c_ulong,
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
     pub(crate) __unused: [ffi::c_long; 3],
-    #[cfg(not(target_arch = "x86_64"))]
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]
+#[non_exhaustive]
+#[cfg(target_arch = "aarch64")]
+pub struct Stat {
+    pub st_dev: ffi::c_ulong,
+    pub st_ino: ffi::c_ulong,
+    pub st_mode: ffi::c_uint,
+    pub st_nlink: ffi::c_uint,
+    pub st_uid: ffi::c_uint,
+    pub st_gid: ffi::c_uint,
+    pub st_rdev: ffi::c_ulong,
+    pub(crate) __pad1: ffi::c_ulong,
+    pub st_size: ffi::c_long,
+    pub st_blksize: ffi::c_int,
+    pub(crate) __pad2: ffi::c_int,
+    pub st_blocks: ffi::c_long,
+    pub st_atime: ffi::c_long,
+    pub st_atime_nsec: ffi::c_ulong,
+    pub st_mtime: ffi::c_long,
+    pub st_mtime_nsec: ffi::c_ulong,
+    pub st_ctime: ffi::c_long,
+    pub st_ctime_nsec: ffi::c_ulong,
     pub(crate) __unused4: ffi::c_uint,
-    #[cfg(not(target_arch = "x86_64"))]
     pub(crate) __unused5: ffi::c_uint,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]
+#[non_exhaustive]
+#[cfg(target_arch = "riscv64")]
+pub struct Stat {
+    pub st_dev: ffi::c_ulong,
+    pub st_ino: ffi::c_ulong,
+    pub st_mode: ffi::c_uint,
+    pub st_nlink: ffi::c_uint,
+    pub st_uid: ffi::c_uint,
+    pub st_gid: ffi::c_uint,
+    pub st_rdev: ffi::c_ulong,
+    pub(crate) __pad1: ffi::c_ulong,
+    pub st_size: ffi::c_long,
+    pub st_blksize: ffi::c_int,
+    pub(crate) __pad2: ffi::c_int,
+    pub st_blocks: ffi::c_long,
+    pub st_atime: ffi::c_long,
+    pub st_atime_nsec: ffi::c_ulong,
+    pub st_mtime: ffi::c_long,
+    pub st_mtime_nsec: ffi::c_ulong,
+    pub st_ctime: ffi::c_long,
+    pub st_ctime_nsec: ffi::c_ulong,
+    pub(crate) __unused4: ffi::c_uint,
+    pub(crate) __unused5: ffi::c_uint,
+}
+// This follows `stat64`.
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]
+#[non_exhaustive]
+#[cfg(target_arch = "powerpc64")]
+pub struct Stat {
+    pub st_dev: ffi::c_ulong,
+    pub st_ino: ffi::c_ulong,
+    pub st_nlink: ffi::c_ulong,
+    pub st_mode: ffi::c_uint,
+    pub st_uid: ffi::c_uint,
+    pub st_gid: ffi::c_uint,
+    pub st_rdev: ffi::c_ulong,
+    pub st_size: ffi::c_long,
+    pub st_blksize: ffi::c_ulong,
+    pub st_blocks: ffi::c_ulong,
+    pub st_atime: ffi::c_ulong,
+    pub st_atime_nsec: ffi::c_ulong,
+    pub st_mtime: ffi::c_ulong,
+    pub st_mtime_nsec: ffi::c_ulong,
+    pub st_ctime: ffi::c_ulong,
+    pub st_ctime_nsec: ffi::c_ulong,
+    pub(crate) __unused4: ffi::c_ulong,
+    pub(crate) __unused5: ffi::c_ulong,
+    pub(crate) __unused6: ffi::c_ulong,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]
+#[non_exhaustive]
+#[cfg(target_arch = "s390x")]
+pub struct Stat {
+    pub st_dev: ffi::c_ulong,
+    pub st_ino: ffi::c_ulong,
+    pub st_nlink: ffi::c_ulong,
+    pub st_mode: ffi::c_uint,
+    pub st_uid: ffi::c_uint,
+    pub st_gid: ffi::c_uint,
+    pub(crate) __pad1: ffi::c_uint,
+    pub st_rdev: ffi::c_ulong,
+    pub st_size: ffi::c_ulong,
+    pub st_atime: ffi::c_ulong,
+    pub st_atime_nsec: ffi::c_ulong,
+    pub st_mtime: ffi::c_ulong,
+    pub st_mtime_nsec: ffi::c_ulong,
+    pub st_ctime: ffi::c_ulong,
+    pub st_ctime_nsec: ffi::c_ulong,
+    pub st_blksize: ffi::c_ulong,
+    pub st_blocks: ffi::c_long,
+    pub(crate) __unused: [ffi::c_ulong; 3],
 }
 
 /// `struct statfs` for use with [`statfs`] and [`fstatfs`].
@@ -675,18 +761,33 @@ pub struct Stat {
 #[allow(missing_docs)]
 #[non_exhaustive]
 pub struct StatFs {
-    pub f_type: ffi::c_long,
+    pub f_type: FsWord,
+    #[cfg(not(target_arch = "s390x"))]
     pub f_bsize: ffi::c_long,
+    #[cfg(target_arch = "s390x")]
+    pub f_bsize: ffi::c_uint,
     pub f_blocks: u64,
     pub f_bfree: u64,
     pub f_bavail: u64,
     pub f_files: u64,
     pub f_ffree: u64,
     pub f_fsid: Fsid,
+    #[cfg(not(target_arch = "s390x"))]
     pub f_namelen: ffi::c_long,
+    #[cfg(target_arch = "s390x")]
+    pub f_namelen: ffi::c_uint,
+    #[cfg(not(target_arch = "s390x"))]
     pub f_frsize: ffi::c_long,
+    #[cfg(target_arch = "s390x")]
+    pub f_frsize: ffi::c_uint,
+    #[cfg(not(target_arch = "s390x"))]
     pub f_flags: ffi::c_long,
+    #[cfg(target_arch = "s390x")]
+    pub f_flags: ffi::c_uint,
+    #[cfg(not(target_arch = "s390x"))]
     pub(crate) f_spare: [ffi::c_long; 4],
+    #[cfg(target_arch = "s390x")]
+    pub(crate) f_spare: [ffi::c_uint; 5],
 }
 
 /// `fsid_t` for use with [`StatFs`].
@@ -724,9 +825,17 @@ pub type RawMode = ffi::c_uint;
 pub type Dev = u64;
 
 /// `__fsword_t`
-#[cfg(not(any(target_arch = "mips64", target_arch = "mips64r6")))]
+#[cfg(not(any(
+    target_arch = "mips64",
+    target_arch = "mips64r6",
+    target_arch = "s390x"
+)))]
 pub type FsWord = ffi::c_long;
 
 /// `__fsword_t`
 #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
 pub type FsWord = i64;
+
+/// `__fsword_t`
+#[cfg(target_arch = "s390x")]
+pub type FsWord = u32;

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -169,6 +169,14 @@ impl fmt::Debug for SocketAddrUnix {
 pub struct SocketAddrStorage(c::sockaddr_storage);
 
 impl SocketAddrStorage {
+    /// Return a socket addr storage initialized to all zero bytes. The
+    /// `sa_family` is set to `AddressFamily::UNSPEC`.
+    pub fn zeroed() -> Self {
+        assert_eq!(c::AF_UNSPEC, 0);
+        // SAFETY: `sockaddr_storage` is meant to be zero-initializable.
+        unsafe { core::mem::zeroed() }
+    }
+
     /// Return the `sa_family` of this socket address.
     pub fn family(&self) -> AddressFamily {
         unsafe {
@@ -184,6 +192,16 @@ impl SocketAddrStorage {
         unsafe {
             crate::backend::net::read_sockaddr::initialize_family_to_unspec(
                 crate::utils::as_mut_ptr(&mut self.0).cast::<c::sockaddr>(),
+            )
+        }
+    }
+
+    /// View the storage as a byte slice.
+    pub fn as_mut_bytes(&mut self) -> &mut [u8] {
+        unsafe {
+            slice::from_raw_parts_mut(
+                crate::utils::as_mut_ptr(self).cast::<u8>(),
+                size_of::<Self>(),
             )
         }
     }

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -8,6 +8,7 @@
 
 use crate::backend::c;
 use crate::ffi::CStr;
+use crate::net::AddressFamily;
 use crate::{io, path};
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
@@ -166,6 +167,27 @@ impl fmt::Debug for SocketAddrUnix {
 /// `struct sockaddr_storage`.
 #[repr(transparent)]
 pub struct SocketAddrStorage(c::sockaddr_storage);
+
+impl SocketAddrStorage {
+    /// Return the `sa_family` of this socket address.
+    pub fn family(&self) -> AddressFamily {
+        unsafe {
+            AddressFamily::from_raw(crate::backend::net::read_sockaddr::read_sa_family(
+                crate::utils::as_ptr(&self.0).cast::<c::sockaddr>(),
+            ))
+        }
+    }
+
+    /// Clear the `sa_family` of this socket address to
+    /// `AddressFamily::UNSPEC`.
+    pub fn clear_family(&mut self) {
+        unsafe {
+            crate::backend::net::read_sockaddr::initialize_family_to_unspec(
+                crate::utils::as_mut_ptr(&mut self.0).cast::<c::sockaddr>(),
+            )
+        }
+    }
+}
 
 /// Return the offset of the `sun_path` field of `sockaddr_un`.
 #[inline]

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -6,6 +6,7 @@
 //! to be NUL-terminated.
 #![allow(unsafe_code)]
 
+use core::mem::size_of;
 use crate::backend::c;
 use crate::ffi::CStr;
 use crate::net::AddressFamily;

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -6,13 +6,13 @@
 //! to be NUL-terminated.
 #![allow(unsafe_code)]
 
-use core::mem::size_of;
 use crate::backend::c;
 use crate::ffi::CStr;
 use crate::net::AddressFamily;
 use crate::{io, path};
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
+use core::mem::size_of;
 use core::{fmt, slice};
 
 /// `struct sockaddr_un`

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -163,8 +163,9 @@ impl fmt::Debug for SocketAddrUnix {
     }
 }
 
-/// `struct sockaddr_storage` as a raw struct.
-pub type SocketAddrStorage = c::sockaddr;
+/// `struct sockaddr_storage`.
+#[repr(transparent)]
+pub struct SocketAddrStorage(c::sockaddr_storage);
 
 /// Return the offset of the `sun_path` field of `sockaddr_un`.
 #[inline]

--- a/src/backend/linux_raw/net/read_sockaddr.rs
+++ b/src/backend/linux_raw/net/read_sockaddr.rs
@@ -137,7 +137,7 @@ pub(crate) unsafe fn read_sockaddr(
 ///
 /// `storage` must point to a valid socket address returned from the OS.
 pub(crate) unsafe fn maybe_read_sockaddr_os(
-    storage: *const c::sockaddr,
+    storage: *const c::sockaddr_storage,
     len: usize,
 ) -> Option<SocketAddrAny> {
     if len == 0 {
@@ -152,11 +152,14 @@ pub(crate) unsafe fn maybe_read_sockaddr_os(
 /// # Safety
 ///
 /// `storage` must point to a valid socket address returned from the OS.
-pub(crate) unsafe fn read_sockaddr_os(storage: *const c::sockaddr, len: usize) -> SocketAddrAny {
+pub(crate) unsafe fn read_sockaddr_os(
+    storage: *const c::sockaddr_storage,
+    len: usize,
+) -> SocketAddrAny {
     let offsetof_sun_path = super::addr::offsetof_sun_path();
 
     assert!(len >= size_of::<c::sa_family_t>());
-    match read_sa_family(storage).into() {
+    match read_sa_family(storage.cast::<c::sockaddr>()).into() {
         c::AF_INET => {
             assert!(len >= size_of::<c::sockaddr_in>());
             let decode = &*storage.cast::<c::sockaddr_in>();

--- a/src/backend/linux_raw/net/write_sockaddr.rs
+++ b/src/backend/linux_raw/net/write_sockaddr.rs
@@ -1,4 +1,4 @@
-//! The BSD sockets API requires us to read the `ss_family` field before we can
+//! The BSD sockets API requires us to read the `sa_family` field before we can
 //! interpret the rest of a `sockaddr` produced by the kernel.
 #![allow(unsafe_code)]
 

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -5,3 +5,145 @@ use crate::backend;
 pub use crate::io::FdFlags;
 pub use crate::timespec::{Nsecs, Secs, Timespec};
 pub use backend::fs::types::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::c;
+    // Rust's libc crate lacks statx for Non-glibc targets.
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    use crate::fs::{Statx, StatxTimestamp};
+
+    #[test]
+    fn test_layouts() {
+        #[cfg(linux_kernel)]
+        assert_eq_size!(FsWord, linux_raw_sys::general::__fsword_t);
+
+        // Don't test against `__kernel_mode_t` on platforms where it's a `u16`.
+        #[cfg(linux_kernel)]
+        #[cfg(not(any(
+            target_arch = "x86",
+            target_arch = "sparc",
+            target_arch = "avr",
+            target_arch = "arm",
+        )))]
+        assert_eq_size!(RawMode, linux_raw_sys::general::__kernel_mode_t);
+
+        #[cfg(linux_kernel)]
+        #[cfg(any(
+            target_arch = "x86",
+            target_arch = "sparc",
+            target_arch = "avr",
+            target_arch = "arm",
+        ))]
+        assert_eq_size!(u16, linux_raw_sys::general::__kernel_mode_t);
+
+        #[cfg(all(
+            linux_raw,
+            target_pointer_width = "64",
+            not(target_arch = "mips64"),
+            not(target_arch = "mips64r6")
+        ))]
+        {
+            check_renamed_type!(Stat, stat);
+            check_renamed_struct_field!(Stat, stat, st_dev);
+            check_renamed_struct_field!(Stat, stat, st_ino);
+            check_renamed_struct_field!(Stat, stat, st_nlink);
+            check_renamed_struct_field!(Stat, stat, st_mode);
+            check_renamed_struct_field!(Stat, stat, st_uid);
+            check_renamed_struct_field!(Stat, stat, st_gid);
+            #[cfg(all(linux_raw, not(any(target_arch = "aarch64", target_arch = "riscv64"))))]
+            check_renamed_struct_field!(Stat, stat, __pad0);
+            check_renamed_struct_field!(Stat, stat, st_rdev);
+            #[cfg(all(linux_raw, not(target_arch = "x86_64")))]
+            check_renamed_struct_field!(Stat, stat, __pad1);
+            check_renamed_struct_field!(Stat, stat, st_size);
+            check_renamed_struct_field!(Stat, stat, st_blksize);
+            #[cfg(all(linux_raw, not(target_arch = "x86_64")))]
+            check_renamed_struct_field!(Stat, stat, __pad2);
+            check_renamed_struct_field!(Stat, stat, st_blocks);
+            check_renamed_struct_field!(Stat, stat, st_atime);
+            check_renamed_struct_field!(Stat, stat, st_atime_nsec);
+            check_renamed_struct_field!(Stat, stat, st_mtime);
+            check_renamed_struct_field!(Stat, stat, st_mtime_nsec);
+            check_renamed_struct_field!(Stat, stat, st_ctime);
+            check_renamed_struct_field!(Stat, stat, st_ctime_nsec);
+            #[cfg(all(linux_raw, not(any(target_arch = "aarch64", target_arch = "riscv64"))))]
+            check_renamed_struct_field!(Stat, stat, __unused);
+            #[cfg(all(linux_raw, not(target_arch = "x86_64")))]
+            check_renamed_struct_field!(Stat, stat, __unused4);
+            #[cfg(all(linux_raw, not(target_arch = "x86_64")))]
+            check_renamed_struct_field!(Stat, stat, __unused5);
+        }
+
+        check_renamed_type!(Fsid, fsid_t);
+        #[cfg(not(libc))] // libc hides the `val` field
+        check_renamed_struct_field!(Fsid, fsid_t, val);
+
+        #[cfg(linux_like)]
+        {
+            check_renamed_type!(StatFs, statfs64);
+            check_renamed_struct_field!(StatFs, statfs64, f_type);
+            check_renamed_struct_field!(StatFs, statfs64, f_bsize);
+            check_renamed_struct_field!(StatFs, statfs64, f_blocks);
+            check_renamed_struct_field!(StatFs, statfs64, f_bfree);
+            check_renamed_struct_field!(StatFs, statfs64, f_bavail);
+            check_renamed_struct_field!(StatFs, statfs64, f_files);
+            check_renamed_struct_field!(StatFs, statfs64, f_ffree);
+            check_renamed_struct_field!(StatFs, statfs64, f_fsid);
+            check_renamed_struct_field!(StatFs, statfs64, f_namelen);
+            check_renamed_struct_field!(StatFs, statfs64, f_frsize);
+            check_renamed_struct_field!(StatFs, statfs64, f_flags);
+            #[cfg(linux_raw)]
+            check_renamed_struct_field!(StatFs, statfs64, f_spare);
+        }
+
+        // Rust's libc crate lacks statx for Non-glibc targets.
+        #[cfg(all(target_os = "linux", target_env = "gnu"))]
+        {
+            check_renamed_type!(StatxTimestamp, statx_timestamp);
+            check_renamed_struct_field!(StatxTimestamp, statx_timestamp, tv_sec);
+            check_renamed_struct_field!(StatxTimestamp, statx_timestamp, tv_nsec);
+            #[cfg(linux_raw)]
+            check_renamed_struct_field!(StatxTimestamp, statx_timestamp, __reserved);
+
+            check_renamed_type!(Statx, statx);
+            check_renamed_struct_field!(Statx, statx, stx_mask);
+            check_renamed_struct_field!(Statx, statx, stx_blksize);
+            check_renamed_struct_field!(Statx, statx, stx_attributes);
+            check_renamed_struct_field!(Statx, statx, stx_nlink);
+            check_renamed_struct_field!(Statx, statx, stx_uid);
+            check_renamed_struct_field!(Statx, statx, stx_gid);
+            check_renamed_struct_field!(Statx, statx, stx_mode);
+            #[cfg(linux_raw)]
+            check_renamed_struct_field!(Statx, statx, __spare0);
+            check_renamed_struct_field!(Statx, statx, stx_ino);
+            check_renamed_struct_field!(Statx, statx, stx_size);
+            check_renamed_struct_field!(Statx, statx, stx_blocks);
+            check_renamed_struct_field!(Statx, statx, stx_attributes_mask);
+            check_renamed_struct_field!(Statx, statx, stx_atime);
+            check_renamed_struct_field!(Statx, statx, stx_btime);
+            check_renamed_struct_field!(Statx, statx, stx_ctime);
+            check_renamed_struct_field!(Statx, statx, stx_mtime);
+            check_renamed_struct_field!(Statx, statx, stx_rdev_major);
+            check_renamed_struct_field!(Statx, statx, stx_rdev_minor);
+            check_renamed_struct_field!(Statx, statx, stx_dev_major);
+            check_renamed_struct_field!(Statx, statx, stx_dev_minor);
+            check_renamed_struct_field!(Statx, statx, stx_mnt_id);
+            check_renamed_struct_field!(Statx, statx, stx_dio_mem_align);
+            check_renamed_struct_field!(Statx, statx, stx_dio_offset_align);
+            #[cfg(not(libc))] // not in libc yet
+            check_renamed_struct_field!(Statx, statx, stx_subvol);
+            #[cfg(not(libc))] // not in libc yet
+            check_renamed_struct_field!(Statx, statx, stx_atomic_write_unit_min);
+            #[cfg(not(libc))] // not in libc yet
+            check_renamed_struct_field!(Statx, statx, stx_atomic_write_unit_max);
+            #[cfg(not(libc))] // not in libc yet
+            check_renamed_struct_field!(Statx, statx, stx_atomic_write_segments_max);
+            #[cfg(linux_raw)]
+            check_renamed_struct_field!(Statx, statx, __spare1);
+            #[cfg(linux_raw)]
+            check_renamed_struct_field!(Statx, statx, __spare3);
+        }
+    }
+}

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -76,9 +76,12 @@ mod tests {
             check_renamed_struct_field!(Stat, stat, __unused5);
         }
 
-        check_renamed_type!(Fsid, fsid_t);
-        #[cfg(not(libc))] // libc hides the `val` field
-        check_renamed_struct_field!(Fsid, fsid_t, val);
+        #[cfg(not(any(target_os = "illumos", target_os = "redox")))]
+        {
+            check_renamed_type!(Fsid, fsid_t);
+            #[cfg(not(libc))] // libc hides the `val` field
+            check_renamed_struct_field!(Fsid, fsid_t, val);
+        }
 
         #[cfg(linux_like)]
         {

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -52,14 +52,29 @@ mod tests {
             check_renamed_struct_field!(Stat, stat, st_mode);
             check_renamed_struct_field!(Stat, stat, st_uid);
             check_renamed_struct_field!(Stat, stat, st_gid);
-            #[cfg(all(linux_raw, not(any(target_arch = "aarch64", target_arch = "riscv64"))))]
+            #[cfg(all(
+                linux_raw,
+                not(any(
+                    target_arch = "aarch64",
+                    target_arch = "powerpc64",
+                    target_arch = "riscv64",
+                    target_arch = "s390x"
+                ))
+            ))]
             check_renamed_struct_field!(Stat, stat, __pad0);
             check_renamed_struct_field!(Stat, stat, st_rdev);
-            #[cfg(all(linux_raw, not(target_arch = "x86_64")))]
+            #[cfg(all(linux_raw, not(any(target_arch = "powerpc64", target_arch = "x86_64"))))]
             check_renamed_struct_field!(Stat, stat, __pad1);
             check_renamed_struct_field!(Stat, stat, st_size);
             check_renamed_struct_field!(Stat, stat, st_blksize);
-            #[cfg(all(linux_raw, not(target_arch = "x86_64")))]
+            #[cfg(all(
+                linux_raw,
+                not(any(
+                    target_arch = "powerpc64",
+                    target_arch = "s390x",
+                    target_arch = "x86_64"
+                ))
+            ))]
             check_renamed_struct_field!(Stat, stat, __pad2);
             check_renamed_struct_field!(Stat, stat, st_blocks);
             check_renamed_struct_field!(Stat, stat, st_atime);
@@ -68,12 +83,29 @@ mod tests {
             check_renamed_struct_field!(Stat, stat, st_mtime_nsec);
             check_renamed_struct_field!(Stat, stat, st_ctime);
             check_renamed_struct_field!(Stat, stat, st_ctime_nsec);
-            #[cfg(all(linux_raw, not(any(target_arch = "aarch64", target_arch = "riscv64"))))]
+            #[cfg(all(
+                linux_raw,
+                not(any(
+                    target_arch = "aarch64",
+                    target_arch = "powerpc64",
+                    target_arch = "riscv64"
+                ))
+            ))]
             check_renamed_struct_field!(Stat, stat, __unused);
-            #[cfg(all(linux_raw, not(target_arch = "x86_64")))]
+            #[cfg(all(linux_raw, not(any(target_arch = "s390x", target_arch = "x86_64"))))]
             check_renamed_struct_field!(Stat, stat, __unused4);
-            #[cfg(all(linux_raw, not(target_arch = "x86_64")))]
+            #[cfg(all(linux_raw, not(any(target_arch = "s390x", target_arch = "x86_64"))))]
             check_renamed_struct_field!(Stat, stat, __unused5);
+            #[cfg(all(
+                linux_raw,
+                not(any(
+                    target_arch = "aarch64",
+                    target_arch = "riscv64",
+                    target_arch = "s390x",
+                    target_arch = "x86_64"
+                ))
+            ))]
+            check_renamed_struct_field!(Stat, stat, __unused6);
         }
 
         #[cfg(not(any(target_os = "illumos", target_os = "redox")))]

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -109,7 +109,13 @@ mod tests {
             check_renamed_struct_field!(Stat, stat, __unused6);
         }
 
-        #[cfg(not(any(target_os = "haiku", target_os = "illumos", target_os = "redox")))]
+        #[cfg(not(any(
+            solarish,
+            target_os = "haiku",
+            target_os = "nto",
+            target_os = "redox",
+            target_os = "wasi"
+        )))]
         {
             check_renamed_type!(Fsid, fsid_t);
             #[cfg(not(libc))] // libc hides the `val` field

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -108,7 +108,7 @@ mod tests {
             check_renamed_struct_field!(Stat, stat, __unused6);
         }
 
-        #[cfg(not(any(target_os = "illumos", target_os = "redox")))]
+        #[cfg(not(any(target_os = "haiku", target_os = "illumos", target_os = "redox")))]
         {
             check_renamed_type!(Fsid, fsid_t);
             #[cfg(not(libc))] // libc hides the `val` field

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -7,6 +7,7 @@ pub use crate::timespec::{Nsecs, Secs, Timespec};
 pub use backend::fs::types::*;
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
     use super::*;
     use crate::backend::c;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -115,7 +115,7 @@ pub use sendfile::sendfile;
 #[cfg(not(any(target_os = "espidf", target_os = "redox")))]
 pub use special::*;
 #[cfg(linux_kernel)]
-pub use statx::statx;
+pub use statx::*;
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "redox",

--- a/src/fs/statx.rs
+++ b/src/fs/statx.rs
@@ -56,7 +56,7 @@ pub struct Statx {
 pub struct StatxTimestamp {
     pub tv_sec: i64,
     pub tv_nsec: u32,
-    pub __reserved: i32,
+    pub(crate) __reserved: i32,
 }
 
 bitflags! {

--- a/src/fs/statx.rs
+++ b/src/fs/statx.rs
@@ -12,8 +12,6 @@ use backend::fs::syscalls::statx as _statx;
 use compat::statx as _statx;
 
 /// `struct statx` for use with [`statx`].
-///
-/// [`statx`]: crate::fs::statx
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 #[allow(missing_docs)]

--- a/src/fs/statx.rs
+++ b/src/fs/statx.rs
@@ -3,12 +3,160 @@
 use crate::fd::AsFd;
 use crate::fs::AtFlags;
 use crate::{backend, io, path};
-use backend::fs::types::{Statx, StatxFlags};
+use backend::c;
+use bitflags::bitflags;
 
 #[cfg(feature = "linux_4_11")]
 use backend::fs::syscalls::statx as _statx;
 #[cfg(not(feature = "linux_4_11"))]
 use compat::statx as _statx;
+
+/// `struct statx` for use with [`statx`].
+///
+/// [`statx`]: crate::fs::statx
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]
+#[non_exhaustive]
+pub struct Statx {
+    pub stx_mask: u32,
+    pub stx_blksize: u32,
+    pub stx_attributes: StatxAttributes,
+    pub stx_nlink: u32,
+    pub stx_uid: u32,
+    pub stx_gid: u32,
+    pub stx_mode: u16,
+    pub(crate) __spare0: [u16; 1],
+    pub stx_ino: u64,
+    pub stx_size: u64,
+    pub stx_blocks: u64,
+    pub stx_attributes_mask: StatxAttributes,
+    pub stx_atime: StatxTimestamp,
+    pub stx_btime: StatxTimestamp,
+    pub stx_ctime: StatxTimestamp,
+    pub stx_mtime: StatxTimestamp,
+    pub stx_rdev_major: u32,
+    pub stx_rdev_minor: u32,
+    pub stx_dev_major: u32,
+    pub stx_dev_minor: u32,
+    pub stx_mnt_id: u64,
+    pub stx_dio_mem_align: u32,
+    pub stx_dio_offset_align: u32,
+    pub stx_subvol: u64,
+    pub stx_atomic_write_unit_min: u32,
+    pub stx_atomic_write_unit_max: u32,
+    pub stx_atomic_write_segments_max: u32,
+    pub(crate) __spare1: [u32; 1],
+    pub(crate) __spare3: [u64; 9],
+}
+
+/// `struct statx_timestamp` for use with [`Statx`].
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]
+#[non_exhaustive]
+pub struct StatxTimestamp {
+    pub tv_sec: i64,
+    pub tv_nsec: u32,
+    pub __reserved: i32,
+}
+
+bitflags! {
+    /// `STATX_*` constants for use with [`statx`].
+    ///
+    /// [`statx`]: crate::fs::statx
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+    pub struct StatxFlags: u32 {
+        /// `STATX_TYPE`
+        const TYPE = c::STATX_TYPE;
+
+        /// `STATX_MODE`
+        const MODE = c::STATX_MODE;
+
+        /// `STATX_NLINK`
+        const NLINK = c::STATX_NLINK;
+
+        /// `STATX_UID`
+        const UID = c::STATX_UID;
+
+        /// `STATX_GID`
+        const GID = c::STATX_GID;
+
+        /// `STATX_ATIME`
+        const ATIME = c::STATX_ATIME;
+
+        /// `STATX_MTIME`
+        const MTIME = c::STATX_MTIME;
+
+        /// `STATX_CTIME`
+        const CTIME = c::STATX_CTIME;
+
+        /// `STATX_INO`
+        const INO = c::STATX_INO;
+
+        /// `STATX_SIZE`
+        const SIZE = c::STATX_SIZE;
+
+        /// `STATX_BLOCKS`
+        const BLOCKS = c::STATX_BLOCKS;
+
+        /// `STATX_BASIC_STATS`
+        const BASIC_STATS = c::STATX_BASIC_STATS;
+
+        /// `STATX_BTIME`
+        const BTIME = c::STATX_BTIME;
+
+        /// `STATX_MNT_ID` (since Linux 5.8)
+        const MNT_ID = c::STATX_MNT_ID;
+
+        /// `STATX_DIOALIGN` (since Linux 6.1)
+        const DIOALIGN = c::STATX_DIOALIGN;
+
+        /// `STATX_ALL`
+        const ALL = c::STATX_ALL;
+
+        /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
+        const _ = !0;
+    }
+}
+
+bitflags! {
+    /// `STATX_ATTR_*` flags for use with [`Statx`].
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+    pub struct StatxAttributes: u64 {
+        /// `STATX_ATTR_COMPRESSED`
+        const COMPRESSED = c::STATX_ATTR_COMPRESSED as u64;
+
+        /// `STATX_ATTR_IMMUTABLE`
+        const IMMUTABLE = c::STATX_ATTR_IMMUTABLE as u64;
+
+        /// `STATX_ATTR_APPEND`
+        const APPEND = c::STATX_ATTR_APPEND as u64;
+
+        /// `STATX_ATTR_NODUMP`
+        const NODUMP = c::STATX_ATTR_NODUMP as u64;
+
+        /// `STATX_ATTR_ENCRYPTED`
+        const ENCRYPTED = c::STATX_ATTR_ENCRYPTED as u64;
+
+        /// `STATX_ATTR_AUTOMOUNT`
+        const AUTOMOUNT = c::STATX_ATTR_AUTOMOUNT as u64;
+
+        /// `STATX_ATTR_MOUNT_ROOT`
+        const MOUNT_ROOT = c::STATX_ATTR_MOUNT_ROOT as u64;
+
+        /// `STATX_ATTR_VERITY`
+        const VERITY = c::STATX_ATTR_VERITY as u64;
+
+        /// `STATX_ATTR_DAX`
+        const DAX = c::STATX_ATTR_DAX as u64;
+
+        /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
+        const _ = !0;
+    }
+}
 
 /// `statx(dirfd, path, flags, mask, statxbuf)`
 ///
@@ -31,9 +179,8 @@ use compat::statx as _statx;
 /// /// `Ok(None)` if the kernel is not new enough to support `statx` or
 /// /// [`libc::STATX_ATTR_MOUNT_ROOT`].
 /// fn is_mountpoint(root: BorrowedFd<'_>, path: &Path) -> io::Result<Option<bool>> {
-///     use rustix::fs::{AtFlags, StatxFlags};
+///     use rustix::fs::{AtFlags, StatxAttributes, StatxFlags};
 ///
-///     let mountroot_flag = libc::STATX_ATTR_MOUNT_ROOT as u64;
 ///     match rustix::fs::statx(
 ///         root,
 ///         path,
@@ -41,8 +188,8 @@ use compat::statx as _statx;
 ///         StatxFlags::empty(),
 ///     ) {
 ///         Ok(r) => {
-///             let present = (r.stx_attributes_mask & mountroot_flag) > 0;
-///             Ok(present.then(|| r.stx_attributes & mountroot_flag > 0))
+///             let present = r.stx_attributes_mask.contains(StatxAttributes::MOUNT_ROOT);
+///             Ok(present.then(|| r.stx_attributes.contains(StatxAttributes::MOUNT_ROOT)))
 ///         }
 ///         Err(rustix::io::Errno::NOSYS) => Ok(None),
 ///         Err(e) => Err(e.into()),
@@ -65,11 +212,9 @@ pub fn statx<P: path::Arg, Fd: AsFd>(
 mod compat {
     use crate::fd::BorrowedFd;
     use crate::ffi::CStr;
-    use crate::fs::AtFlags;
+    use crate::fs::{AtFlags, Statx, StatxFlags};
     use crate::{backend, io};
     use core::sync::atomic::{AtomicU8, Ordering};
-
-    use backend::fs::types::{Statx, StatxFlags};
 
     // Linux kernel prior to 4.11 and old versions of Docker don't support
     // `statx`. We store the availability in a global to avoid unnecessary

--- a/src/fs/statx.rs
+++ b/src/fs/statx.rs
@@ -175,7 +175,7 @@ bitflags! {
 /// # use rustix::fd::BorrowedFd;
 /// /// Try to determine if the provided path is a mount root. Will return
 /// /// `Ok(None)` if the kernel is not new enough to support `statx` or
-/// /// [`libc::STATX_ATTR_MOUNT_ROOT`].
+/// /// [`StatxAttributes::MOUNT_ROOT`].
 /// fn is_mountpoint(root: BorrowedFd<'_>, path: &Path) -> io::Result<Option<bool>> {
 ///     use rustix::fs::{AtFlags, StatxAttributes, StatxFlags};
 ///

--- a/src/net/socket_addr_any.rs
+++ b/src/net/socket_addr_any.rs
@@ -103,7 +103,7 @@ impl SocketAddrAny {
     /// `storage` must point to valid memory for decoding a socket
     /// address.
     pub unsafe fn read(storage: *const SocketAddrStorage, len: usize) -> io::Result<Self> {
-        backend::net::read_sockaddr::read_sockaddr(storage, len)
+        backend::net::read_sockaddr::read_sockaddr(storage.cast(), len)
     }
 }
 

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1789,6 +1789,7 @@ fn test_sizes() {
     #[cfg(target_os = "linux")]
     use crate::backend::c;
     use crate::ffi::c_int;
+    use crate::net::SocketAddrStorage;
     use core::mem::transmute;
 
     // Backend code needs to cast these to `c_int` so make sure that cast isn't
@@ -1800,6 +1801,7 @@ fn test_sizes() {
     assert_eq_size!(RawSocketType, c_int);
     assert_eq_size!(SocketType, c_int);
     assert_eq_size!(SocketFlags, c_int);
+    assert_eq_size!(SocketAddrStorage, c::sockaddr_storage);
 
     // Rustix doesn't depend on `Option<Protocol>` matching the ABI of a raw
     // integer for correctness, but it should work nonetheless.

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -1211,34 +1211,39 @@ impl core::fmt::Debug for SpecialCodeIndex {
             Self::VKILL => write!(f, "VKILL"),
             #[cfg(not(any(
                 solarish,
+                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64")),
                 target_os = "aix",
-                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64"))
+                target_os = "haiku",
             )))]
             Self::VEOF => write!(f, "VEOF"),
             #[cfg(not(any(
                 solarish,
+                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64")),
                 target_os = "aix",
-                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64"))
+                target_os = "haiku",
             )))]
             Self::VTIME => write!(f, "VTIME"),
             #[cfg(not(any(
                 solarish,
+                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64")),
                 target_os = "aix",
-                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64"))
+                target_os = "haiku",
             )))]
             Self::VMIN => write!(f, "VMIN"),
 
-            // On Solarish platforms, Linux on SPARC, and AIX, `VMIN` and `VTIME`
-            // have the same value as `VEOF` and `VEOL`.
+            // On Solarish platforms, Linux on SPARC, AIX, and Haiku, `VMIN`
+            // and `VTIME`have the same value as `VEOF` and `VEOL`.
             #[cfg(any(
                 solarish,
+                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64")),
                 target_os = "aix",
-                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64"))
+                target_os = "haiku",
             ))]
             Self::VMIN => write!(f, "VMIN/VEOF"),
             #[cfg(any(
                 solarish,
-                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64"))
+                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64")),
+                target_os = "haiku",
             ))]
             Self::VTIME => write!(f, "VTIME/VEOL"),
 
@@ -1256,7 +1261,8 @@ impl core::fmt::Debug for SpecialCodeIndex {
             Self::VSUSP => write!(f, "VSUSP"),
             #[cfg(not(any(
                 solarish,
-                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64"))
+                all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64")),
+                target_os = "haiku",
             )))]
             Self::VEOL => write!(f, "VEOL"),
             #[cfg(not(target_os = "haiku"))]

--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -43,6 +43,7 @@ mod renameat;
 mod seals;
 mod seek;
 mod special;
+mod stat;
 #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 mod statfs;
 #[cfg(linux_kernel)]

--- a/tests/fs/stat.rs
+++ b/tests/fs/stat.rs
@@ -1,0 +1,19 @@
+#[test]
+fn test_stat() {
+    use rustix::fs::{fstat, lstat, stat, symlink};
+    use std::io::Write;
+
+    let tmp = tempfile::tempdir().unwrap();
+
+    let mut w = std::fs::File::create(tmp.path().join("file")).unwrap();
+    write!(&mut w, "Hello, File!\n").unwrap();
+
+    assert_eq!(fstat(&w).unwrap().st_size, 13);
+    assert_eq!(stat(tmp.path().join("file")).unwrap().st_size, 13);
+    assert_eq!(lstat(tmp.path().join("file")).unwrap().st_size, 13);
+
+    symlink("file", tmp.path().join("link")).unwrap();
+
+    assert_eq!(stat(tmp.path().join("link")).unwrap().st_size, 13);
+    assert_eq!(lstat(tmp.path().join("link")).unwrap().st_size, 4);
+}

--- a/tests/process/pidfd.rs
+++ b/tests/process/pidfd.rs
@@ -24,6 +24,7 @@ fn test_pidfd_waitid() {
         Ok(pidfd) => pidfd,
         Err(io::Errno::NOSYS) => {
             // The kernel does not support pidfds.
+            unsafe { kill(child.id() as _, SIGSTOP) };
             return;
         }
         Err(e) => panic!("failed to open pidfd: {}", e),


### PR DESCRIPTION
Remove linux-raw-sys types for `stat`, `statx`, and `__kernel_sockaddr_storage` from the public API. To do this, define our own `Statx` struct.

This also enables moving `stx_attributes` to a bitflags type.