### PR TITLE
Remove the `port_` and `Inotify` prefixes.

### DIFF
--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -164,12 +164,9 @@ pub(super) unsafe fn raw_fd<'a, Num: ArgNumber>(fd: RawFd) -> ArgReg<'a, Num> {
     #[cfg(feature = "fs")]
     debug_assert!(fd == crate::fs::CWD.as_raw_fd() || fd == crate::fs::ABS.as_raw_fd() || fd >= 0);
 
-    // Don't pass the `IO_URING_REGISTER_FILES_SKIP` sentry value this way.
+    // Don't pass the `IORING_REGISTER_FILES_SKIP` sentry value this way.
     #[cfg(feature = "io_uring")]
-    debug_assert_ne!(
-        fd,
-        crate::io_uring::IO_URING_REGISTER_FILES_SKIP.as_raw_fd()
-    );
+    debug_assert_ne!(fd, crate::io_uring::IORING_REGISTER_FILES_SKIP.as_raw_fd());
 
     // Linux doesn't look at the high bits beyond the `c_int`, so use
     // zero-extension rather than sign-extension because it's a smaller

--- a/src/event/port.rs
+++ b/src/event/port.rs
@@ -39,7 +39,7 @@ impl Event {
 ///
 /// [OpenSolaris]: https://www.unix.com/man-page/opensolaris/3C/port_create/
 /// [illumos]: https://illumos.org/man/3C/port_create
-pub fn port_create() -> io::Result<OwnedFd> {
+pub fn create() -> io::Result<OwnedFd> {
     syscalls::port_create()
 }
 
@@ -50,7 +50,7 @@ pub fn port_create() -> io::Result<OwnedFd> {
 ///
 /// Any `object`s passed into the `port` must be valid for the lifetime of the
 /// `port`. Logically, `port` keeps a borrowed reference to the `object` until
-/// it is removed via `port_dissociate_fd`.
+/// it is removed via [`dissociate_fd`].
 ///
 /// # References
 ///  - [OpenSolaris]
@@ -58,7 +58,7 @@ pub fn port_create() -> io::Result<OwnedFd> {
 ///
 /// [OpenSolaris]: https://www.unix.com/man-page/opensolaris/3C/port_associate/
 /// [illumos]: https://illumos.org/man/3C/port_associate
-pub unsafe fn port_associate_fd<Fd: AsFd, RawFd: AsRawFd>(
+pub unsafe fn associate_fd<Fd: AsFd, RawFd: AsRawFd>(
     port: Fd,
     object: RawFd,
     events: PollFlags,
@@ -79,7 +79,7 @@ pub unsafe fn port_associate_fd<Fd: AsFd, RawFd: AsRawFd>(
 /// # Safety
 ///
 /// The file descriptor passed into this function must have been previously
-/// associated with the port via [`port_associate_fd`].
+/// associated with the port via [`associate_fd`].
 ///
 /// # References
 ///  - [OpenSolaris]
@@ -87,10 +87,7 @@ pub unsafe fn port_associate_fd<Fd: AsFd, RawFd: AsRawFd>(
 ///
 /// [OpenSolaris]: https://www.unix.com/man-page/opensolaris/3C/port_dissociate
 /// [illumos]: https://illumos.org/man/3C/port_dissociate
-pub unsafe fn port_dissociate_fd<Fd: AsFd, RawFd: AsRawFd>(
-    port: Fd,
-    object: RawFd,
-) -> io::Result<()> {
+pub unsafe fn dissociate_fd<Fd: AsFd, RawFd: AsRawFd>(port: Fd, object: RawFd) -> io::Result<()> {
     syscalls::port_dissociate(port.as_fd(), c::PORT_SOURCE_FD, object.as_raw_fd() as _)
 }
 
@@ -102,7 +99,7 @@ pub unsafe fn port_dissociate_fd<Fd: AsFd, RawFd: AsRawFd>(
 ///
 /// [OpenSolaris]: https://www.unix.com/man-page/opensolaris/3C/port_get/
 /// [illumos]: https://illumos.org/man/3C/port_get
-pub fn port_get<Fd: AsFd>(port: Fd, timeout: Option<Duration>) -> io::Result<Event> {
+pub fn get<Fd: AsFd>(port: Fd, timeout: Option<Duration>) -> io::Result<Event> {
     let mut timeout = timeout.map(|timeout| c::timespec {
         tv_sec: timeout.as_secs().try_into().unwrap(),
         tv_nsec: timeout.subsec_nanos() as _,
@@ -119,7 +116,7 @@ pub fn port_get<Fd: AsFd>(port: Fd, timeout: Option<Duration>) -> io::Result<Eve
 /// this does nothing and returns immediately.
 ///
 /// To query the number of events without retrieving any, use
-/// [`port_getn_query`].
+/// [`getn_query`].
 ///
 /// # References
 ///  - [OpenSolaris]
@@ -128,7 +125,7 @@ pub fn port_get<Fd: AsFd>(port: Fd, timeout: Option<Duration>) -> io::Result<Eve
 /// [OpenSolaris]: https://www.unix.com/man-page/opensolaris/3C/port_getn/
 /// [illumos]: https://illumos.org/man/3C/port_getn
 #[cfg(feature = "alloc")]
-pub fn port_getn<Fd: AsFd>(
+pub fn getn<Fd: AsFd>(
     port: Fd,
     events: &mut Vec<Event>,
     min_events: usize,
@@ -152,7 +149,7 @@ pub fn port_getn<Fd: AsFd>(
 /// `port_getn(port, NULL, 0, NULL)`—Queries the number of events
 /// available from a port.
 ///
-/// To retrieve the events, use [`port_getn`].
+/// To retrieve the events, use [`getn`].
 ///
 /// # References
 ///  - [OpenSolaris]
@@ -160,7 +157,7 @@ pub fn port_getn<Fd: AsFd>(
 ///
 /// [OpenSolaris]: https://www.unix.com/man-page/opensolaris/3C/port_getn/
 /// [illumos]: https://illumos.org/man/3C/port_getn
-pub fn port_getn_query<Fd: AsFd>(port: Fd) -> io::Result<u32> {
+pub fn getn_query<Fd: AsFd>(port: Fd) -> io::Result<u32> {
     syscalls::port_getn_query(port.as_fd())
 }
 
@@ -172,6 +169,6 @@ pub fn port_getn_query<Fd: AsFd>(port: Fd) -> io::Result<u32> {
 ///
 /// [OpenSolaris]: https://www.unix.com/man-page/opensolaris/3C/port_send/
 /// [illumos]: https://illumos.org/man/3C/port_send
-pub fn port_send<Fd: AsFd>(port: Fd, events: i32, userdata: *mut ffi::c_void) -> io::Result<()> {
+pub fn send<Fd: AsFd>(port: Fd, events: i32, userdata: *mut ffi::c_void) -> io::Result<()> {
     syscalls::port_send(port.as_fd(), events, userdata.cast())
 }

--- a/src/event/port.rs
+++ b/src/event/port.rs
@@ -40,6 +40,7 @@ pub use super::PollFlags;
 
 /// The structure representing a port event.
 #[repr(transparent)]
+#[doc(alias = "port_event")]
 pub struct Event(pub(crate) c::port_event);
 
 impl Event {
@@ -67,6 +68,7 @@ impl Event {
 ///
 /// [OpenSolaris]: https://www.unix.com/man-page/opensolaris/3C/port_create/
 /// [illumos]: https://illumos.org/man/3C/port_create
+#[doc(alias = "port_create")]
 pub fn create() -> io::Result<OwnedFd> {
     syscalls::port_create()
 }
@@ -86,6 +88,7 @@ pub fn create() -> io::Result<OwnedFd> {
 ///
 /// [OpenSolaris]: https://www.unix.com/man-page/opensolaris/3C/port_associate/
 /// [illumos]: https://illumos.org/man/3C/port_associate
+#[doc(alias = "port_associate")]
 pub unsafe fn associate_fd<Fd: AsFd, RawFd: AsRawFd>(
     port: Fd,
     object: RawFd,
@@ -115,6 +118,7 @@ pub unsafe fn associate_fd<Fd: AsFd, RawFd: AsRawFd>(
 ///
 /// [OpenSolaris]: https://www.unix.com/man-page/opensolaris/3C/port_dissociate
 /// [illumos]: https://illumos.org/man/3C/port_dissociate
+#[doc(alias = "port_dissociate")]
 pub unsafe fn dissociate_fd<Fd: AsFd, RawFd: AsRawFd>(port: Fd, object: RawFd) -> io::Result<()> {
     syscalls::port_dissociate(port.as_fd(), c::PORT_SOURCE_FD, object.as_raw_fd() as _)
 }
@@ -127,6 +131,7 @@ pub unsafe fn dissociate_fd<Fd: AsFd, RawFd: AsRawFd>(port: Fd, object: RawFd) -
 ///
 /// [OpenSolaris]: https://www.unix.com/man-page/opensolaris/3C/port_get/
 /// [illumos]: https://illumos.org/man/3C/port_get
+#[doc(alias = "port_get")]
 pub fn get<Fd: AsFd>(port: Fd, timeout: Option<Duration>) -> io::Result<Event> {
     let mut timeout = timeout.map(|timeout| c::timespec {
         tv_sec: timeout.as_secs().try_into().unwrap(),
@@ -153,6 +158,7 @@ pub fn get<Fd: AsFd>(port: Fd, timeout: Option<Duration>) -> io::Result<Event> {
 /// [OpenSolaris]: https://www.unix.com/man-page/opensolaris/3C/port_getn/
 /// [illumos]: https://illumos.org/man/3C/port_getn
 #[cfg(feature = "alloc")]
+#[doc(alias = "port_getn")]
 pub fn getn<Fd: AsFd>(
     port: Fd,
     events: &mut Vec<Event>,
@@ -185,6 +191,7 @@ pub fn getn<Fd: AsFd>(
 ///
 /// [OpenSolaris]: https://www.unix.com/man-page/opensolaris/3C/port_getn/
 /// [illumos]: https://illumos.org/man/3C/port_getn
+#[doc(alias = "port_getn")]
 pub fn getn_query<Fd: AsFd>(port: Fd) -> io::Result<u32> {
     syscalls::port_getn_query(port.as_fd())
 }
@@ -197,6 +204,7 @@ pub fn getn_query<Fd: AsFd>(port: Fd) -> io::Result<u32> {
 ///
 /// [OpenSolaris]: https://www.unix.com/man-page/opensolaris/3C/port_send/
 /// [illumos]: https://illumos.org/man/3C/port_send
+#[doc(alias = "port_send")]
 pub fn send<Fd: AsFd>(port: Fd, events: i32, userdata: *mut ffi::c_void) -> io::Result<()> {
     syscalls::port_send(port.as_fd(), events, userdata.cast())
 }

--- a/src/event/port.rs
+++ b/src/event/port.rs
@@ -3,14 +3,13 @@
 //! # Examples
 //!
 //! ```
-//! # fn test() -> io::Result<()> {
+//! # fn test() -> std::io::Result<()> {
 //! use rustix::event::port;
 //! use rustix::stdio::stdout;
 //! use std::io;
-//! use std::ptr::without_provenance_mut;
 //!
 //! let some_fd = stdout();
-//! let some_userdata = without_provenance_mut(7);
+//! let some_userdata = 7 as *mut _;
 //!
 //! // Create a port.
 //! let port = port::create()?;
@@ -21,7 +20,7 @@
 //! }
 //!
 //! // Get a single event.
-//! let event = port::get(&port, None);
+//! let event = port::get(&port, None)?;
 //!
 //! assert_eq!(event.userdata(), some_userdata);
 //! # Ok(())

--- a/src/event/port.rs
+++ b/src/event/port.rs
@@ -1,4 +1,32 @@
 //! Solaris/illumos event ports.
+//!
+//! # Examples
+//!
+//! ```
+//! # fn test() -> io::Result<()> {
+//! use rustix::event::port;
+//! use rustix::stdio::stdout;
+//! use std::io;
+//! use std::ptr::without_provenance_mut;
+//!
+//! let some_fd = stdout();
+//! let some_userdata = without_provenance_mut(7);
+//!
+//! // Create a port.
+//! let port = port::create()?;
+//!
+//! // Associate `some_fd` with the port.
+//! unsafe {
+//!     port::associate_fd(&port, some_fd, port::PollFlags::IN, some_userdata)?;
+//! }
+//!
+//! // Get a single event.
+//! let event = port::get(&port, None);
+//!
+//! assert_eq!(event.userdata(), some_userdata);
+//! # Ok(())
+//! # }
+//! ```
 
 use crate::backend::c;
 use crate::backend::event::syscalls;
@@ -6,9 +34,9 @@ use crate::fd::{AsFd, AsRawFd, OwnedFd};
 use crate::ffi;
 use crate::io;
 
-use super::PollFlags;
-
 use core::time::Duration;
+
+pub use super::PollFlags;
 
 /// The structure representing a port event.
 #[repr(transparent)]

--- a/src/fs/inotify.rs
+++ b/src/fs/inotify.rs
@@ -123,14 +123,14 @@ impl<'buf, Fd: AsFd> Reader<'buf, Fd> {
 
 /// An inotify event.
 #[derive(Debug)]
-pub struct InotifyEvent<'a> {
+pub struct Event<'a> {
     wd: i32,
     events: ReadFlags,
     cookie: u32,
     file_name: Option<&'a CStr>,
 }
 
-impl<'a> InotifyEvent<'a> {
+impl<'a> Event<'a> {
     /// Returns the watch for which this event occurs.
     #[inline]
     pub fn wd(&self) -> i32 {
@@ -172,7 +172,7 @@ impl<'buf, Fd: AsFd> Reader<'buf, Fd> {
     ///    error occurs.
     #[allow(unsafe_code)]
     #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> io::Result<InotifyEvent<'_>> {
+    pub fn next(&mut self) -> io::Result<Event<'_>> {
         if self.is_buffer_empty() {
             match read_uninit(self.fd.as_fd(), self.buf).map(|(init, _)| init.len()) {
                 Ok(0) => return Err(Errno::INVAL),
@@ -195,7 +195,7 @@ impl<'buf, Fd: AsFd> Reader<'buf, Fd> {
 
         self.offset += size_of::<inotify_event>() + usize::try_from(event.len).unwrap();
 
-        Ok(InotifyEvent {
+        Ok(Event {
             wd: event.wd,
             events: ReadFlags::from_bits_retain(event.mask),
             cookie: event.cookie,

--- a/src/io_uring/mod.rs
+++ b/src/io_uring/mod.rs
@@ -912,11 +912,10 @@ pub const IORING_OFF_CQ_RING: u64 = sys::IORING_OFF_CQ_RING as _;
 pub const IORING_OFF_SQES: u64 = sys::IORING_OFF_SQES as _;
 
 /// `IORING_REGISTER_FILES_SKIP`
-#[doc(alias = "IORING_REGISTER_FILES_SKIP")]
 // SAFETY: `IORING_REGISTER_FILES_SKIP` is a reserved value that is never
 // dynamically allocated, so it'll remain valid for the duration of
 // `'static`.
-pub const IO_URING_REGISTER_FILES_SKIP: BorrowedFd<'static> =
+pub const IORING_REGISTER_FILES_SKIP: BorrowedFd<'static> =
     unsafe { BorrowedFd::<'static>::borrow_raw(sys::IORING_REGISTER_FILES_SKIP as RawFd) };
 
 /// `IORING_NOTIF_USAGE_ZC_COPIED` (since Linux 6.2)

--- a/src/shm.rs
+++ b/src/shm.rs
@@ -1,6 +1,6 @@
 //! POSIX shared memory
 //!
-//! # Example
+//! # Examples
 //!
 //! ```
 //! use rustix::fs::{ftruncate, Mode};

--- a/tests/fs/inotify.rs
+++ b/tests/fs/inotify.rs
@@ -41,7 +41,7 @@ fn test_inotify_iter() {
     }
 
     let expected = format!(
-        r#"inotify::Event {{
+        r#"Event {{
     wd: 1,
     events: ReadFlags(
         CREATE,
@@ -51,7 +51,7 @@ fn test_inotify_iter() {
         "foo",
     ),
 }}
-inotify::Event {{
+Event {{
     wd: 1,
     events: ReadFlags(
         OPEN,
@@ -61,7 +61,7 @@ inotify::Event {{
         "foo",
     ),
 }}
-inotify::Event {{
+Event {{
     wd: 1,
     events: ReadFlags(
         CLOSE_WRITE,
@@ -71,7 +71,7 @@ inotify::Event {{
         "foo",
     ),
 }}
-inotify::Event {{
+Event {{
     wd: 1,
     events: ReadFlags(
         MOVED_FROM,
@@ -81,7 +81,7 @@ inotify::Event {{
         "foo",
     ),
 }}
-inotify::Event {{
+Event {{
     wd: 1,
     events: ReadFlags(
         MOVED_TO,
@@ -91,7 +91,7 @@ inotify::Event {{
         "bar",
     ),
 }}
-inotify::Event {{
+Event {{
     wd: 1,
     events: ReadFlags(
         DELETE,

--- a/tests/fs/inotify.rs
+++ b/tests/fs/inotify.rs
@@ -41,7 +41,7 @@ fn test_inotify_iter() {
     }
 
     let expected = format!(
-        r#"InotifyEvent {{
+        r#"inotify::Event {{
     wd: 1,
     events: ReadFlags(
         CREATE,
@@ -51,7 +51,7 @@ fn test_inotify_iter() {
         "foo",
     ),
 }}
-InotifyEvent {{
+inotify::Event {{
     wd: 1,
     events: ReadFlags(
         OPEN,
@@ -61,7 +61,7 @@ InotifyEvent {{
         "foo",
     ),
 }}
-InotifyEvent {{
+inotify::Event {{
     wd: 1,
     events: ReadFlags(
         CLOSE_WRITE,
@@ -71,7 +71,7 @@ InotifyEvent {{
         "foo",
     ),
 }}
-InotifyEvent {{
+inotify::Event {{
     wd: 1,
     events: ReadFlags(
         MOVED_FROM,
@@ -81,7 +81,7 @@ InotifyEvent {{
         "foo",
     ),
 }}
-InotifyEvent {{
+inotify::Event {{
     wd: 1,
     events: ReadFlags(
         MOVED_TO,
@@ -91,7 +91,7 @@ InotifyEvent {{
         "bar",
     ),
 }}
-InotifyEvent {{
+inotify::Event {{
     wd: 1,
     events: ReadFlags(
         DELETE,


### PR DESCRIPTION
`port_*` and `Inotify*` are in public modules named `port` and `inotify` so remove their prefixes to make them less redundant.