### PR TITLE
Change `poll`'s timeout from `c_int` to `Option<&Timespec>`.

### DIFF
--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -187,7 +187,9 @@ pub(crate) fn poll(fds: &mut [PollFd<'_>], timeout: Option<&Timespec>) -> io::Re
                     return Err(io::Errno::INVAL);
                 }
                 secs.checked_mul(1000)
-                    .and_then(|millis| millis.checked_add((timeout.tv_nsec + 999_999) / 1_000_000))
+                    .and_then(|millis| {
+                        millis.checked_add((i64::from(timeout.tv_nsec) + 999_999) / 1_000_000)
+                    })
                     .and_then(|millis| c::c_int::try_from(millis).ok())
                     .ok_or(io::Errno::OVERFLOW)?
             }

--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -191,7 +191,7 @@ pub(crate) fn poll(fds: &mut [PollFd<'_>], timeout: Option<&Timespec>) -> io::Re
                         millis.checked_add((i64::from(timeout.tv_nsec) + 999_999) / 1_000_000)
                     })
                     .and_then(|millis| c::c_int::try_from(millis).ok())
-                    .ok_or(io::Errno::OVERFLOW)?
+                    .ok_or(io::Errno::INVAL)?
             }
         };
         ret_c_int(unsafe { c::poll(fds.as_mut_ptr().cast(), nfds, timeout) })

--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -208,6 +208,8 @@ pub(crate) fn poll(fds: &mut [PollFd<'_>], timeout: Option<&Timespec>) -> io::Re
                 }
                 secs.checked_mul(1000)
                     .and_then(|millis| {
+                        // Add the nanoseconds, converted to millis, rounding
+                        // up. With Rust 1.73.0 this can use `div_ceil`.
                         millis.checked_add((i64::from(timeout.tv_nsec) + 999_999) / 1_000_000)
                     })
                     .and_then(|millis| c::c_int::try_from(millis).ok())

--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -183,10 +183,8 @@ pub(crate) fn poll(fds: &mut [PollFd<'_>], timeout: Option<&Timespec>) -> io::Re
                 ) -> c::c_int
             }
             if let Some(func) = ppoll.get() {
-                return ret_c_int(unsafe {
-                    func(fds.as_mut_ptr().cast(), nfds, timeout, null())
-                })
-                .map(|nready| nready as usize);
+                return ret_c_int(unsafe { func(fds.as_mut_ptr().cast(), nfds, timeout, null()) })
+                    .map(|nready| nready as usize);
             }
         }
     }

--- a/src/backend/libc/event/windows_syscalls.rs
+++ b/src/backend/libc/event/windows_syscalls.rs
@@ -2,14 +2,31 @@
 
 use crate::backend::c;
 use crate::backend::conv::ret_c_int;
-use crate::event::{FdSetElement, PollFd};
+use crate::event::{FdSetElement, PollFd, Timespec};
 use crate::io;
 
-pub(crate) fn poll(fds: &mut [PollFd<'_>], timeout: c::c_int) -> io::Result<usize> {
+pub(crate) fn poll(fds: &mut [PollFd<'_>], timeout: Option<&Timespec>) -> io::Result<usize> {
     let nfds = fds
         .len()
         .try_into()
         .map_err(|_convert_err| io::Errno::INVAL)?;
+
+    let timeout = match timeout {
+        None => -1,
+        Some(timeout) => {
+            // Convert from `Timespec` to `c_int` milliseconds.
+            let secs = timeout.tv_sec;
+            if secs < 0 {
+                return Err(io::Errno::INVAL);
+            }
+            secs.checked_mul(1000)
+                .and_then(|millis| {
+                    millis.checked_add((i64::from(timeout.tv_nsec) + 999_999) / 1_000_000)
+                })
+                .and_then(|millis| c::c_int::try_from(millis).ok())
+                .ok_or(io::Errno::INVAL)?
+        }
+    };
 
     ret_c_int(unsafe { c::poll(fds.as_mut_ptr().cast(), nfds, timeout) })
         .map(|nready| nready as usize)

--- a/src/backend/libc/event/windows_syscalls.rs
+++ b/src/backend/libc/event/windows_syscalls.rs
@@ -21,6 +21,8 @@ pub(crate) fn poll(fds: &mut [PollFd<'_>], timeout: Option<&Timespec>) -> io::Re
             }
             secs.checked_mul(1000)
                 .and_then(|millis| {
+                    // Add the nanoseconds, converted to millis, rounding up.
+                    // With Rust 1.73.0 this can use `div_ceil`.
                     millis.checked_add((i64::from(timeout.tv_nsec) + 999_999) / 1_000_000)
                 })
                 .and_then(|millis| c::c_int::try_from(millis).ok())

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -235,7 +235,6 @@ pub(super) fn opt_mut<T: Sized, Num: ArgNumber>(t: Option<&mut T>) -> ArgReg<'_,
 
 /// Convert an optional immutable reference into a `usize` for passing to a
 /// syscall.
-#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 #[inline]
 pub(super) fn opt_ref<T: Sized, Num: ArgNumber>(t: Option<&T>) -> ArgReg<'_, Num> {
     // This optimizes into the equivalent of `transmute(t)`, and has the

--- a/src/backend/linux_raw/event/syscalls.rs
+++ b/src/backend/linux_raw/event/syscalls.rs
@@ -9,34 +9,26 @@ use crate::backend::c;
 use crate::backend::conv::{
     by_ref, c_int, c_uint, ret, ret_c_int, ret_error, ret_owned_fd, ret_usize, slice_mut, zero,
 };
-use crate::event::{epoll, EventfdFlags, FdSetElement, PollFd};
+use crate::event::{epoll, EventfdFlags, FdSetElement, PollFd, Timespec};
 use crate::fd::{BorrowedFd, OwnedFd};
 use crate::io;
-use crate::utils::as_mut_ptr;
+use crate::utils::{as_mut_ptr, option_as_ptr};
 #[cfg(feature = "alloc")]
 use core::mem::MaybeUninit;
 use core::ptr::null_mut;
 use linux_raw_sys::general::{EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD};
-#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use {
     crate::backend::conv::{opt_ref, size_of},
-    linux_raw_sys::general::{__kernel_timespec, kernel_sigset_t},
+    linux_raw_sys::general::kernel_sigset_t,
 };
 
 #[inline]
-pub(crate) fn poll(fds: &mut [PollFd<'_>], timeout: c::c_int) -> io::Result<usize> {
+pub(crate) fn poll(fds: &mut [PollFd<'_>], timeout: Option<&Timespec>) -> io::Result<usize> {
     let (fds_addr_mut, fds_len) = slice_mut(fds);
 
-    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+    let timeout = option_as_ptr(timeout);
+
     unsafe {
-        let timeout = if timeout >= 0 {
-            Some(__kernel_timespec {
-                tv_sec: (timeout as i64) / 1000,
-                tv_nsec: (timeout as i64) % 1000 * 1_000_000,
-            })
-        } else {
-            None
-        };
         ret_usize(syscall!(
             __NR_ppoll,
             fds_addr_mut,
@@ -45,10 +37,6 @@ pub(crate) fn poll(fds: &mut [PollFd<'_>], timeout: c::c_int) -> io::Result<usiz
             zero(),
             size_of::<kernel_sigset_t, _>()
         ))
-    }
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
-    unsafe {
-        ret_usize(syscall!(__NR_poll, fds_addr_mut, fds_len, c_int(timeout)))
     }
 }
 

--- a/src/backend/linux_raw/event/syscalls.rs
+++ b/src/backend/linux_raw/event/syscalls.rs
@@ -8,7 +8,8 @@
 #[cfg(feature = "alloc")]
 use crate::backend::c;
 use crate::backend::conv::{
-    by_ref, c_int, c_uint, ret, ret_c_int, ret_error, ret_owned_fd, ret_usize, slice_mut, zero,
+    by_ref, c_int, c_uint, opt_ref, ret, ret_c_int, ret_error, ret_owned_fd, ret_usize, size_of,
+    slice_mut, zero,
 };
 use crate::event::{epoll, EventfdFlags, FdSetElement, PollFd, Timespec};
 use crate::fd::{BorrowedFd, OwnedFd};
@@ -17,11 +18,7 @@ use crate::utils::{as_mut_ptr, option_as_ptr};
 #[cfg(feature = "alloc")]
 use core::mem::MaybeUninit;
 use core::ptr::null_mut;
-use linux_raw_sys::general::{EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD};
-use {
-    crate::backend::conv::{opt_ref, size_of},
-    linux_raw_sys::general::kernel_sigset_t,
-};
+use linux_raw_sys::general::{kernel_sigset_t, EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD};
 
 #[inline]
 pub(crate) fn poll(fds: &mut [PollFd<'_>], timeout: Option<&Timespec>) -> io::Result<usize> {

--- a/src/backend/linux_raw/event/syscalls.rs
+++ b/src/backend/linux_raw/event/syscalls.rs
@@ -5,6 +5,7 @@
 //! See the `rustix::backend` module documentation for details.
 #![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
+#[cfg(feature = "alloc")]
 use crate::backend::c;
 use crate::backend::conv::{
     by_ref, c_int, c_uint, ret, ret_c_int, ret_error, ret_owned_fd, ret_usize, slice_mut, zero,

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -19,6 +19,7 @@ pub mod port;
 #[cfg(any(bsd, linux_kernel, windows, target_os = "wasi"))]
 mod select;
 
+pub use crate::timespec::{Nsecs, Secs, Timespec};
 #[cfg(any(
     linux_kernel,
     target_os = "freebsd",

--- a/src/event/poll.rs
+++ b/src/event/poll.rs
@@ -1,8 +1,15 @@
+use crate::event::Timespec;
 use crate::{backend, io};
 
 pub use backend::event::poll_fd::{PollFd, PollFlags};
 
 /// `poll(self.fds, timeout)`—Wait for events on lists of file descriptors.
+///
+/// Some platforms (those that don't support `ppoll`) don't support timeouts
+/// greater than `c_int::MAX` milliseconds, and some (those that aren't fully
+/// y2038-ready) don't support timeouts with a seconds value greater than
+/// `i32::MAX`; if an unsupported timeout is passed, this function fails with
+/// [`io::Errno::OVERFLOW`].
 ///
 /// On macOS, `poll` doesn't work on fds for /dev/tty or /dev/null, however
 /// [`select`] is available and does work on these fds.
@@ -32,6 +39,6 @@ pub use backend::event::poll_fd::{PollFd, PollFlags};
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=poll&section=2
 /// [illumos]: https://illumos.org/man/2/poll
 #[inline]
-pub fn poll(fds: &mut [PollFd<'_>], timeout: i32) -> io::Result<usize> {
+pub fn poll(fds: &mut [PollFd<'_>], timeout: Option<&Timespec>) -> io::Result<usize> {
     backend::event::syscalls::poll(fds, timeout)
 }

--- a/src/event/poll.rs
+++ b/src/event/poll.rs
@@ -6,10 +6,8 @@ pub use backend::event::poll_fd::{PollFd, PollFlags};
 /// `poll(self.fds, timeout)`—Wait for events on lists of file descriptors.
 ///
 /// Some platforms (those that don't support `ppoll`) don't support timeouts
-/// greater than `c_int::MAX` milliseconds, and some (those that aren't fully
-/// y2038-ready) don't support timeouts with a seconds value greater than
-/// `i32::MAX`; if an unsupported timeout is passed, this function fails with
-/// [`io::Errno::OVERFLOW`].
+/// greater than `c_int::MAX` milliseconds; if an unsupported timeout is
+/// passed, this function fails with [`io::Errno::INVAL`].
 ///
 /// On macOS, `poll` doesn't work on fds for /dev/tty or /dev/null, however
 /// [`select`] is available and does work on these fds.

--- a/src/event/select.rs
+++ b/src/event/select.rs
@@ -7,14 +7,13 @@
 
 #[cfg(any(linux_like, target_os = "wasi"))]
 use crate::backend::c;
+use crate::event::Timespec;
 use crate::fd::RawFd;
 use crate::{backend, io};
 #[cfg(any(windows, target_os = "wasi"))]
 use core::mem::{align_of, size_of};
 #[cfg(any(windows, target_os = "wasi"))]
 use core::slice;
-
-pub use crate::timespec::{Nsecs, Secs, Timespec};
 
 /// wasi-libc's `fd_set` type. The libc bindings for it have private fields,
 /// so we redeclare it for ourselves so that we can access the fields. They're

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,6 +358,7 @@ mod prctl;
 mod signal;
 #[cfg(any(
     feature = "fs",
+    feature = "event",
     feature = "process",
     feature = "runtime",
     feature = "thread",

--- a/src/timespec.rs
+++ b/src/timespec.rs
@@ -7,9 +7,11 @@
 use crate::backend::c;
 #[allow(unused)]
 use crate::ffi;
+#[cfg(not(fix_y2038))]
+use core::ptr::null;
 
 /// `struct timespec`
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 #[repr(C)]
 pub struct Timespec {
     /// Seconds.
@@ -97,6 +99,14 @@ pub(crate) fn as_libc_timespec_mut_ptr(
         assert_eq_size!(Timespec, c::timespec);
     }
     timespec.as_mut_ptr().cast::<c::timespec>()
+}
+
+#[cfg(not(fix_y2038))]
+pub(crate) fn option_as_libc_timespec_ptr(timespec: Option<&Timespec>) -> *const c::timespec {
+    match timespec {
+        None => null(),
+        Some(timespec) => as_libc_timespec_ptr(timespec),
+    }
 }
 
 #[test]

--- a/tests/net/poll.rs
+++ b/tests/net/poll.rs
@@ -36,7 +36,7 @@ fn server(ready: Arc<(Mutex<u16>, Condvar)>) {
     let data_socket = accept(&connection_socket).unwrap();
 
     let mut fds = [PollFd::new(&data_socket, PollFlags::IN)];
-    assert_eq!(poll(&mut fds, -1).unwrap(), 1);
+    assert_eq!(poll(&mut fds, None).unwrap(), 1);
     assert!(fds[0].revents().intersects(PollFlags::IN));
     assert!(!fds[0].revents().intersects(PollFlags::OUT));
 
@@ -49,7 +49,7 @@ fn server(ready: Arc<(Mutex<u16>, Condvar)>) {
     }
 
     let mut fds = [PollFd::new(&data_socket, PollFlags::OUT)];
-    assert_eq!(poll(&mut fds, -1).unwrap(), 1);
+    assert_eq!(poll(&mut fds, None).unwrap(), 1);
     assert!(!fds[0].revents().intersects(PollFlags::IN));
     assert!(fds[0].revents().intersects(PollFlags::OUT));
 
@@ -73,14 +73,14 @@ fn client(ready: Arc<(Mutex<u16>, Condvar)>) {
     connect_v6(&data_socket, &addr).unwrap();
 
     let mut fds = [PollFd::new(&data_socket, PollFlags::OUT)];
-    assert_eq!(poll(&mut fds, -1).unwrap(), 1);
+    assert_eq!(poll(&mut fds, None).unwrap(), 1);
     assert!(!fds[0].revents().intersects(PollFlags::IN));
     assert!(fds[0].revents().intersects(PollFlags::OUT));
 
     send(&data_socket, b"hello, world", SendFlags::empty()).unwrap();
 
     let mut fds = [PollFd::new(&data_socket, PollFlags::IN)];
-    assert_eq!(poll(&mut fds, -1).unwrap(), 1);
+    assert_eq!(poll(&mut fds, None).unwrap(), 1);
     assert!(fds[0].revents().intersects(PollFlags::IN));
     assert!(!fds[0].revents().intersects(PollFlags::OUT));
 

--- a/tests/process/pidfd.rs
+++ b/tests/process/pidfd.rs
@@ -78,7 +78,7 @@ fn test_pidfd_poll() {
 
     // Wait for the child process to exit.
     let pfd = event::PollFd::new(&pidfd, event::PollFlags::IN);
-    event::poll(&mut [pfd], -1).unwrap();
+    event::poll(&mut [pfd], None).unwrap();
 
     // The child process should have exited.
     let status = process::waitid(


### PR DESCRIPTION
This harmonizes the timeout with the rest of rustix, which uses `Timespec` for all time values. And, it eliminates the awkwardness of using `-1` as a sentinel value.

On platforms with `ppoll`, the `Timespec` can be passed straight to the OS. On platforms without `ppoll`, we have to do a fallible conversion into `c_int`.