### PR TITLE
Make Ioctl::opcode a method instead of a constant

### DIFF
--- a/src/fs/ioctl.rs
+++ b/src/fs/ioctl.rs
@@ -79,7 +79,10 @@ unsafe impl ioctl::Ioctl for Ficlone<'_> {
     type Output = ();
 
     const IS_MUTATING: bool = false;
-    const OPCODE: ioctl::Opcode = ioctl::Opcode::old(c::FICLONE as ioctl::RawOpcode);
+
+    fn opcode(&self) -> ioctl::Opcode {
+        ioctl::Opcode::old(c::FICLONE as ioctl::RawOpcode)
+    }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
         self.0.as_raw_fd() as *mut c::c_void

--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -85,7 +85,7 @@ use bsd as platform;
 #[inline]
 pub unsafe fn ioctl<F: AsFd, I: Ioctl>(fd: F, mut ioctl: I) -> Result<I::Output> {
     let fd = fd.as_fd();
-    let request = I::OPCODE.raw();
+    let request = ioctl.opcode().raw();
     let arg = ioctl.as_ptr();
 
     // SAFETY: The variant of `Ioctl` asserts that this is a valid IOCTL call
@@ -138,7 +138,7 @@ unsafe fn _ioctl_readonly(
 ///   output as indicated by `output`.
 /// - That `output_from_ptr` can safely take the pointer from `as_ptr` and cast
 ///   it to the correct type, *only* after the `ioctl` call.
-/// - That `OPCODE` uniquely identifies the `ioctl` call.
+/// - That the return value of `opcode` uniquely identifies the `ioctl` call.
 /// - That, for whatever platforms you are targeting, the `ioctl` call is safe
 ///   to make.
 /// - If `IS_MUTATING` is false, that no userspace data will be modified by the
@@ -149,12 +149,6 @@ pub unsafe trait Ioctl {
     /// Given a pointer, one should be able to construct an instance of this
     /// type.
     type Output;
-
-    /// The opcode used by this `ioctl` command.
-    ///
-    /// There are different types of opcode depending on the operation. See
-    /// documentation for the [`Opcode`] struct for more information.
-    const OPCODE: Opcode;
 
     /// Does the `ioctl` mutate any data in the userspace?
     ///
@@ -168,6 +162,12 @@ pub unsafe trait Ioctl {
     /// any data in the userspace. Undefined behavior may occur if this is set
     /// to `false` when it should be `true`.
     const IS_MUTATING: bool;
+
+    /// Get the opcode used by this `ioctl` command.
+    ///
+    /// There are different types of opcode depending on the operation. See
+    /// documentation for the [`Opcode`] struct for more information.
+    fn opcode(&self) -> Opcode;
 
     /// Get a pointer to the data to be passed to the `ioctl` command.
     ///

--- a/src/ioctl/patterns.rs
+++ b/src/ioctl/patterns.rs
@@ -39,7 +39,10 @@ unsafe impl<Opcode: CompileTimeOpcode> Ioctl for NoArg<Opcode> {
     type Output = ();
 
     const IS_MUTATING: bool = false;
-    const OPCODE: self::Opcode = Opcode::OPCODE;
+
+    fn opcode(&self) -> self::Opcode {
+        Opcode::OPCODE
+    }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
         core::ptr::null_mut()
@@ -89,7 +92,10 @@ unsafe impl<Opcode: CompileTimeOpcode, Output> Ioctl for Getter<Opcode, Output> 
     type Output = Output;
 
     const IS_MUTATING: bool = true;
-    const OPCODE: self::Opcode = Opcode::OPCODE;
+
+    fn opcode(&self) -> self::Opcode {
+        Opcode::OPCODE
+    }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
         self.output.as_mut_ptr().cast()
@@ -142,7 +148,10 @@ unsafe impl<Opcode: CompileTimeOpcode, Input> Ioctl for Setter<Opcode, Input> {
     type Output = ();
 
     const IS_MUTATING: bool = false;
-    const OPCODE: self::Opcode = Opcode::OPCODE;
+
+    fn opcode(&self) -> self::Opcode {
+        Opcode::OPCODE
+    }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
         addr_of_mut!(self.input).cast::<c::c_void>()
@@ -186,7 +195,10 @@ unsafe impl<'a, Opcode: CompileTimeOpcode, T> Ioctl for Updater<'a, Opcode, T> {
     type Output = ();
 
     const IS_MUTATING: bool = true;
-    const OPCODE: self::Opcode = Opcode::OPCODE;
+
+    fn opcode(&self) -> self::Opcode {
+        Opcode::OPCODE
+    }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
         (self.value as *mut T).cast()
@@ -244,7 +256,10 @@ unsafe impl<Opcode: CompileTimeOpcode> Ioctl for IntegerSetter<Opcode> {
     type Output = ();
 
     const IS_MUTATING: bool = false;
-    const OPCODE: self::Opcode = Opcode::OPCODE;
+
+    fn opcode(&self) -> self::Opcode {
+        Opcode::OPCODE
+    }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
         self.value

--- a/src/process/ioctl.rs
+++ b/src/process/ioctl.rs
@@ -37,7 +37,10 @@ unsafe impl ioctl::Ioctl for Tiocsctty {
     type Output = ();
 
     const IS_MUTATING: bool = false;
-    const OPCODE: ioctl::Opcode = ioctl::Opcode::old(c::TIOCSCTTY as ioctl::RawOpcode);
+
+    fn opcode(&self) -> ioctl::Opcode {
+        ioctl::Opcode::old(c::TIOCSCTTY as ioctl::RawOpcode)
+    }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
         (&0_u32) as *const u32 as *mut c::c_void

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -206,7 +206,10 @@ unsafe impl ioctl::Ioctl for Tiocgptpeer {
     type Output = OwnedFd;
 
     const IS_MUTATING: bool = false;
-    const OPCODE: ioctl::Opcode = ioctl::Opcode::old(c::TIOCGPTPEER as ioctl::RawOpcode);
+
+    fn opcode(&self) -> ioctl::Opcode {
+        ioctl::Opcode::old(c::TIOCGPTPEER as ioctl::RawOpcode)
+    }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
         self.0.bits() as *mut c::c_void


### PR DESCRIPTION
This lets the `Ioctl` trait be compatible with ioctls that take a runtime length value, e.g. these evdev ioctls from `input.h`:
```h
#define EVIOCGNAME(len)		_IOC(_IOC_READ, 'E', 0x06, len)		/* get device name */
#define EVIOCGPHYS(len)		_IOC(_IOC_READ, 'E', 0x07, len)		/* get physical location */
#define EVIOCGUNIQ(len)		_IOC(_IOC_READ, 'E', 0x08, len)		/* get unique identifier */
#define EVIOCGPROP(len)		_IOC(_IOC_READ, 'E', 0x09, len)		/* get device properties */
```
These generally specify the length of the passed buffer, so that the driver can copy data into userspace (à la `read()`). `rg 'len\)\s*_IO' /usr/include` gives 26 results on my system, so they're not rare, and it'd be great to be able to use the `Ioctl` trait to wrap them.

Prior art: [`nix::ioctl_read_buf!()`](https://docs.rs/nix/latest/nix/macro.ioctl_read_buf.html)