### PR TITLE
Dependency updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ compiler_builtins = { version = '0.1.49', optional = true }
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_endian = "little", target_arch = "s390x"), any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "s390x"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
 linux-raw-sys = { version = "0.7.0", default-features = false, features = ["general", "errno", "ioctl", "no_std", "elf"] }
 libc_errno = { package = "errno", version = "0.3.10", default-features = false, optional = true }
-libc = { version = "0.2.161", default-features = false, optional = true }
+libc = { version = "0.2.168", default-features = false, optional = true }
 
 # Dependencies for platforms where only libc is supported:
 #
@@ -40,7 +40,7 @@ libc = { version = "0.2.161", default-features = false, optional = true }
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_endian = "little", target_arch = "s390x"), any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "s390x"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.10", default-features = false }
-libc = { version = "0.2.161", default-features = false }
+libc = { version = "0.2.168", default-features = false }
 
 # Additional dependencies for Linux with the libc backend:
 #
@@ -51,12 +51,10 @@ linux-raw-sys = { version = "0.7", default-features = false, features = ["genera
 
 # For the libc backend on Windows, use the Winsock API in windows-sys.
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = ">=0.52, <=0.59"
+version = ">=0.52, <0.60"
 features = [
     "Win32_Foundation",
     "Win32_Networking_WinSock",
-    "Win32_NetworkManagement_IpHelper",
-    "Win32_System_Threading"
 ]
 
 # For the libc backend on Windows, also use the errno crate, which has Windows
@@ -68,7 +66,7 @@ default-features = false
 
 [dev-dependencies]
 tempfile = "3.5.0"
-libc = "0.2.161"
+libc = "0.2.168"
 libc_errno = { package = "errno", version = "0.3.10", default-features = false }
 serial_test = "2.0.0"
 memoffset = "0.9.0"


### PR DESCRIPTION
Allow windows-sys 0.59.x, and trim unused features.

Also update to libc 0.2.168 for `MAP_DROPPABLE`.