### PR TITLE
Emscripten has a 64-bit `time_t` now.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -151,11 +151,9 @@ fn main() {
             || arch == "mips"
             || arch == "sparc"
             || arch == "x86"
-            || (arch == "wasm32" && os == "emscripten")
             || (arch == "aarch64" && os == "linux" && abi == Ok("ilp32".to_string())))
         && (apple
             || os == "android"
-            || os == "emscripten"
             || os == "haiku"
             || env == "gnu"
             || (env == "musl" && arch == "x86")


### PR DESCRIPTION
Emscripten has changed to have a 64-bit `time_t`, and the libc bindings have now updated, so update rustix to omit the y2038 fix.