### PR TITLE
Rename `RecvMsgReturn` to `RecvMsg`.

### DIFF
--- a/src/backend/libc/net/send_recv.rs
+++ b/src/backend/libc/net/send_recv.rs
@@ -111,10 +111,10 @@ bitflags! {
 
 bitflags! {
     /// `MSG_*` flags returned from [`recvmsg`], in the `flags` field of
-    /// [`RecvMsgReturn`]
+    /// [`RecvMsg`]
     ///
     /// [`recvmsg`]: crate::net::recvmsg
-    /// [`RecvMsgReturn`]: crate::net::RecvMsgReturn
+    /// [`RecvMsg`]: crate::net::RecvMsg
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct ReturnFlags: u32 {

--- a/src/backend/libc/net/syscalls.rs
+++ b/src/backend/libc/net/syscalls.rs
@@ -25,7 +25,7 @@ use core::mem::{size_of, MaybeUninit};
 use {
     super::msghdr::{with_noaddr_msghdr, with_recv_msghdr, with_v4_msghdr, with_v6_msghdr},
     crate::io::{IoSlice, IoSliceMut},
-    crate::net::{RecvAncillaryBuffer, RecvMsgReturn, SendAncillaryBuffer},
+    crate::net::{RecvAncillaryBuffer, RecvMsg, SendAncillaryBuffer},
 };
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 use {
@@ -324,7 +324,7 @@ pub(crate) fn recvmsg(
     iov: &mut [IoSliceMut<'_>],
     control: &mut RecvAncillaryBuffer<'_>,
     msg_flags: RecvFlags,
-) -> io::Result<RecvMsgReturn> {
+) -> io::Result<RecvMsg> {
     let mut storage = MaybeUninit::<c::sockaddr_storage>::uninit();
 
     with_recv_msghdr(&mut storage, iov, control, |msghdr| {
@@ -341,7 +341,7 @@ pub(crate) fn recvmsg(
             let addr =
                 unsafe { maybe_read_sockaddr_os(msghdr.msg_name as _, msghdr.msg_namelen as _) };
 
-            RecvMsgReturn {
+            RecvMsg {
                 bytes,
                 address: addr,
                 flags: ReturnFlags::from_bits_retain(bitcast!(msghdr.msg_flags)),

--- a/src/backend/linux_raw/net/send_recv.rs
+++ b/src/backend/linux_raw/net/send_recv.rs
@@ -61,10 +61,10 @@ bitflags! {
 
 bitflags! {
     /// `MSG_*` flags returned from [`recvmsg`], in the `flags` field of
-    /// [`RecvMsgReturn`]
+    /// [`RecvMsg`]
     ///
     /// [`recvmsg`]: crate::net::recvmsg
-    /// [`RecvMsgReturn`]: crate::net::RecvMsgReturn
+    /// [`RecvMsg`]: crate::net::RecvMsg
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct ReturnFlags: u32 {

--- a/src/backend/linux_raw/net/syscalls.rs
+++ b/src/backend/linux_raw/net/syscalls.rs
@@ -25,7 +25,7 @@ use crate::io::{self, IoSlice, IoSliceMut};
 #[cfg(target_os = "linux")]
 use crate::net::xdp::SocketAddrXdp;
 use crate::net::{
-    AddressFamily, Protocol, RecvAncillaryBuffer, RecvMsgReturn, SendAncillaryBuffer, Shutdown,
+    AddressFamily, Protocol, RecvAncillaryBuffer, RecvMsg, SendAncillaryBuffer, Shutdown,
     SocketAddrAny, SocketAddrUnix, SocketAddrV4, SocketAddrV6, SocketFlags, SocketType,
 };
 use c::{sockaddr_in, sockaddr_in6, sockaddr_storage, socklen_t};
@@ -264,7 +264,7 @@ pub(crate) fn recvmsg(
     iov: &mut [IoSliceMut<'_>],
     control: &mut RecvAncillaryBuffer<'_>,
     msg_flags: RecvFlags,
-) -> io::Result<RecvMsgReturn> {
+) -> io::Result<RecvMsg> {
     let mut storage = MaybeUninit::<c::sockaddr_storage>::uninit();
 
     with_recv_msghdr(&mut storage, iov, control, |msghdr| {
@@ -290,7 +290,7 @@ pub(crate) fn recvmsg(
             let addr =
                 unsafe { maybe_read_sockaddr_os(msghdr.msg_name as _, msghdr.msg_namelen as _) };
 
-            RecvMsgReturn {
+            RecvMsg {
                 bytes,
                 address: addr,
                 flags: ReturnFlags::from_bits_retain(msghdr.msg_flags),

--- a/src/net/send_recv/msg.rs
+++ b/src/net/send_recv/msg.rs
@@ -813,12 +813,12 @@ pub fn recvmsg<Fd: AsFd>(
     iov: &mut [IoSliceMut<'_>],
     control: &mut RecvAncillaryBuffer<'_>,
     flags: RecvFlags,
-) -> io::Result<RecvMsgReturn> {
+) -> io::Result<RecvMsg> {
     backend::net::syscalls::recvmsg(socket.as_fd(), iov, control, flags)
 }
 
 /// The result of a successful [`recvmsg`] call.
-pub struct RecvMsgReturn {
+pub struct RecvMsg {
     /// The number of bytes received.
     ///
     /// When `RecvFlags::TRUNC` is in use, this may be greater than the
@@ -834,9 +834,9 @@ pub struct RecvMsgReturn {
 }
 
 #[cfg(feature = "std")]
-impl fmt::Debug for RecvMsgReturn {
+impl fmt::Debug for RecvMsg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RecvMsgReturn")
+        f.debug_struct("RecvMsg")
             .field("bytes", &self.bytes)
             .field("flags", &self.flags)
             .field("address", &self.address)


### PR DESCRIPTION
It's shorter, and the `Return` doesn't add much.