### PR TITLE
Disable OsStrExt ettc. on WASIp2 on stable Rust.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,7 @@ jobs:
       run: >
         rustup target add
         wasm32-wasip1
+        wasm32-wasip2
         x86_64-unknown-fuchsia
     - if: matrix.rust == '1.63'
       run: rustup target add x86_64-fuchsia
@@ -102,6 +103,8 @@ jobs:
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-netbsd --features=all-apis --all-targets
     - if: matrix.rust != '1.63'
       run: cargo check --workspace --release -vv --target=wasm32-wasip1 --features=all-apis
+    - if: matrix.rust != '1.63'
+      run: cargo check --workspace --release -vv --target=wasm32-wasip2 --features=all-apis
     - if: matrix.rust != '1.63'
       run: cargo check --workspace --release -vv --target=x86_64-unknown-fuchsia --features=all-apis --all-targets
     - if: matrix.rust == '1.63'
@@ -179,10 +182,8 @@ jobs:
     - run: >
         rustup target add
         x86_64-unknown-redox
-        wasm32-wasip1
         thumbv7neon-unknown-linux-gnueabihf
     - run: cargo check --workspace --release -vv --target=x86_64-unknown-redox --features=all-apis
-    - run: cargo check --workspace --release -vv --target=wasm32-wasip1 --features=all-apis
     - run: cargo check --workspace --release -vv --target=thumbv7neon-unknown-linux-gnueabihf --features=all-apis
 
   check_tier3:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,5 +261,6 @@ check-cfg = [
     'cfg(thumb_mode)',
     'cfg(wasi)',
     'cfg(wasi_ext)',
+    'cfg(wasip2)',
     'cfg(target_arch, values("xtensa"))',
 ]

--- a/build.rs
+++ b/build.rs
@@ -82,6 +82,7 @@ fn main() {
     // WASI support can utilize wasi_ext if present.
     if os == "wasi" {
         use_feature_or_nothing("wasi_ext");
+        use_feature_or_nothing("wasip2");
     }
 
     // If the libc backend is requested, or if we're not on a platform for

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
         target_os = "wasi",
         target_env = "p2",
         any(feature = "fs", feature = "mount", feature = "net")
+        wasip2,
     ),
     feature(wasip2)
 )]

--- a/src/path/arg.rs
+++ b/src/path/arg.rs
@@ -21,7 +21,11 @@ use std::os::hermit::ext::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 #[cfg(all(feature = "std", target_os = "vxworks"))]
 use std::os::vxworks::ext::ffi::{OsStrExt, OsStringExt};
-#[cfg(all(feature = "std", target_os = "wasi"))]
+#[cfg(all(
+    feature = "std",
+    target_os = "wasi",
+    any(not(target_env = "p2"), wasip2)
+))]
 use std::os::wasi::ffi::{OsStrExt, OsStringExt};
 #[cfg(feature = "std")]
 use std::path::{Component, Components, Iter, Path, PathBuf};
@@ -225,6 +229,7 @@ impl Arg for String {
 }
 
 #[cfg(feature = "std")]
+#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl Arg for &OsStr {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
@@ -267,6 +272,7 @@ impl Arg for &OsStr {
 }
 
 #[cfg(feature = "std")]
+#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl Arg for &OsString {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
@@ -308,6 +314,7 @@ impl Arg for &OsString {
 }
 
 #[cfg(feature = "std")]
+#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl Arg for OsString {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
@@ -350,6 +357,7 @@ impl Arg for OsString {
 }
 
 #[cfg(feature = "std")]
+#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl Arg for &Path {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
@@ -392,6 +400,7 @@ impl Arg for &Path {
 }
 
 #[cfg(feature = "std")]
+#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl Arg for &PathBuf {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
@@ -436,6 +445,7 @@ impl Arg for &PathBuf {
 }
 
 #[cfg(feature = "std")]
+#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl Arg for PathBuf {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
@@ -639,8 +649,8 @@ impl<'a> Arg for Cow<'a, str> {
     }
 }
 
-#[cfg(feature = "std")]
 #[cfg(feature = "alloc")]
+#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl<'a> Arg for Cow<'a, OsStr> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
@@ -726,6 +736,7 @@ impl<'a> Arg for Cow<'a, CStr> {
 }
 
 #[cfg(feature = "std")]
+#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl<'a> Arg for Component<'a> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
@@ -768,6 +779,7 @@ impl<'a> Arg for Component<'a> {
 }
 
 #[cfg(feature = "std")]
+#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl<'a> Arg for Components<'a> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
@@ -812,6 +824,7 @@ impl<'a> Arg for Components<'a> {
 }
 
 #[cfg(feature = "std")]
+#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl<'a> Arg for Iter<'a> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
@@ -939,6 +952,7 @@ impl Arg for &Vec<u8> {
 }
 
 #[cfg(feature = "alloc")]
+#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl Arg for Vec<u8> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {

--- a/src/path/dec_int.rs
+++ b/src/path/dec_int.rs
@@ -13,7 +13,11 @@ use core::mem::{self, MaybeUninit};
 use core::num::NonZeroU8;
 #[cfg(all(feature = "std", unix))]
 use std::os::unix::ffi::OsStrExt;
-#[cfg(all(feature = "std", target_os = "wasi"))]
+#[cfg(all(
+    feature = "std",
+    target_os = "wasi",
+    any(not(target_env = "p2"), wasip2)
+))]
 use std::os::wasi::ffi::OsStrExt;
 #[cfg(feature = "std")]
 use {core::fmt, std::ffi::OsStr, std::path::Path};
@@ -236,6 +240,7 @@ impl DecInt {
 }
 
 #[cfg(feature = "std")]
+#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl AsRef<Path> for DecInt {
     #[inline]
     fn as_ref(&self) -> &Path {


### PR DESCRIPTION
`OsStrExt` and friends aren't stable on the wasm32-wasip2 target yet, so disable features that depend on them when they aren't available.

Fixes #1060.