### PR TITLE
Enable `rustix::net` on Redox.

### DIFF
--- a/src/backend/libc/conv.rs
+++ b/src/backend/libc/conv.rs
@@ -151,7 +151,7 @@ pub(super) fn ret_discarded_char_ptr(raw: *mut c::c_char) -> io::Result<()> {
 }
 
 /// Convert the buffer-length argument value of a `send` or `recv` call.
-#[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(windows, target_os = "wasi")))]
 #[inline]
 pub(super) fn send_recv_len(len: usize) -> usize {
     len
@@ -168,7 +168,7 @@ pub(super) fn send_recv_len(len: usize) -> i32 {
 }
 
 /// Convert the return value of a `send` or `recv` call.
-#[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(windows, target_os = "wasi")))]
 #[inline]
 pub(super) fn ret_send_recv(len: isize) -> io::Result<usize> {
     ret_usize(len)
@@ -183,7 +183,7 @@ pub(super) fn ret_send_recv(len: i32) -> io::Result<usize> {
 
 /// Convert the value to the `msg_iovlen` field of a `msghdr` struct.
 #[cfg(all(
-    not(any(windows, target_os = "espidf", target_os = "redox", target_os = "wasi")),
+    not(any(windows, target_os = "espidf", target_os = "wasi")),
     any(
         target_os = "android",
         all(

--- a/src/backend/libc/mod.rs
+++ b/src/backend/libc/mod.rs
@@ -117,7 +117,7 @@ pub(crate) mod mm;
 #[cfg(linux_kernel)]
 #[cfg(feature = "mount")]
 pub(crate) mod mount;
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(target_os = "wasi"))]
 #[cfg(feature = "net")]
 pub(crate) mod net;
 #[cfg(not(any(windows, target_os = "espidf")))]

--- a/src/backend/libc/net/mod.rs
+++ b/src/backend/libc/net/mod.rs
@@ -1,18 +1,11 @@
 pub(crate) mod addr;
 pub(crate) mod ext;
-#[cfg(not(any(
-    windows,
-    target_os = "espidf",
-    target_os = "redox",
-    target_os = "vita",
-    target_os = "wasi"
-)))]
+#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "vita")))]
 pub(crate) mod msghdr;
 #[cfg(linux_kernel)]
 pub(crate) mod netdevice;
 pub(crate) mod read_sockaddr;
 pub(crate) mod send_recv;
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) mod sockopt;
 pub(crate) mod syscalls;
 pub(crate) mod write_sockaddr;

--- a/src/backend/libc/net/send_recv.rs
+++ b/src/backend/libc/net/send_recv.rs
@@ -20,6 +20,7 @@ bitflags! {
             target_os = "nto",
             target_os = "haiku",
             target_os = "hurd",
+            target_os = "redox",
             target_os = "vita",
         )))]
         const CONFIRM = bitcast!(c::MSG_CONFIRM);
@@ -40,10 +41,11 @@ bitflags! {
             target_os = "haiku",
             target_os = "hurd",
             target_os = "nto",
+            target_os = "redox",
             target_os = "vita",
         )))]
         const MORE = bitcast!(c::MSG_MORE);
-        #[cfg(not(any(apple, windows, target_os = "vita")))]
+        #[cfg(not(any(apple, windows, target_os = "redox", target_os = "vita")))]
         /// `MSG_NOSIGNAL`
         const NOSIGNAL = bitcast!(c::MSG_NOSIGNAL);
         /// `MSG_OOB`
@@ -72,6 +74,7 @@ bitflags! {
             target_os = "espidf",
             target_os = "haiku",
             target_os = "nto",
+            target_os = "redox",
             target_os = "vita",
         )))]
         const CMSG_CLOEXEC = bitcast!(c::MSG_CMSG_CLOEXEC);
@@ -88,6 +91,7 @@ bitflags! {
             target_os = "haiku",
             target_os = "hurd",
             target_os = "nto",
+            target_os = "redox",
             target_os = "vita",
         )))]
         const ERRQUEUE = bitcast!(c::MSG_ERRQUEUE);

--- a/src/backend/libc/net/sockopt.rs
+++ b/src/backend/libc/net/sockopt.rs
@@ -806,6 +806,7 @@ pub(crate) fn ipv6_original_dst(fd: BorrowedFd<'_>) -> io::Result<SocketAddrV6> 
     windows,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "redox",
     target_os = "vita"
 )))]
 #[inline]
@@ -818,6 +819,7 @@ pub(crate) fn set_ipv6_tclass(fd: BorrowedFd<'_>, value: u32) -> io::Result<()> 
     windows,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "redox",
     target_os = "vita"
 )))]
 #[inline]
@@ -836,13 +838,23 @@ pub(crate) fn tcp_nodelay(fd: BorrowedFd<'_>) -> io::Result<bool> {
 }
 
 #[inline]
-#[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "haiku",
+    target_os = "nto",
+    target_os = "redox"
+)))]
 pub(crate) fn set_tcp_keepcnt(fd: BorrowedFd<'_>, count: u32) -> io::Result<()> {
     setsockopt(fd, c::IPPROTO_TCP, c::TCP_KEEPCNT, count)
 }
 
 #[inline]
-#[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "haiku",
+    target_os = "nto",
+    target_os = "redox"
+)))]
 pub(crate) fn tcp_keepcnt(fd: BorrowedFd<'_>) -> io::Result<u32> {
     getsockopt(fd, c::IPPROTO_TCP, c::TCP_KEEPCNT)
 }
@@ -862,14 +874,24 @@ pub(crate) fn tcp_keepidle(fd: BorrowedFd<'_>) -> io::Result<Duration> {
 }
 
 #[inline]
-#[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "haiku",
+    target_os = "nto",
+    target_os = "redox"
+)))]
 pub(crate) fn set_tcp_keepintvl(fd: BorrowedFd<'_>, duration: Duration) -> io::Result<()> {
     let secs: c::c_uint = duration_to_secs(duration)?;
     setsockopt(fd, c::IPPROTO_TCP, c::TCP_KEEPINTVL, secs)
 }
 
 #[inline]
-#[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "haiku",
+    target_os = "nto",
+    target_os = "redox"
+)))]
 pub(crate) fn tcp_keepintvl(fd: BorrowedFd<'_>) -> io::Result<Duration> {
     let secs: c::c_uint = getsockopt(fd, c::IPPROTO_TCP, c::TCP_KEEPINTVL)?;
     Ok(Duration::from_secs(secs as u64))

--- a/src/backend/libc/net/syscalls.rs
+++ b/src/backend/libc/net/syscalls.rs
@@ -4,39 +4,33 @@
 use super::addr::SocketAddrUnix;
 #[cfg(target_os = "linux")]
 use super::msghdr::with_xdp_msghdr;
+use super::read_sockaddr::{initialize_family_to_unspec, maybe_read_sockaddr_os, read_sockaddr_os};
+#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "vita")))]
+use super::send_recv::ReturnFlags;
+use super::send_recv::{RecvFlags, SendFlags};
 #[cfg(target_os = "linux")]
 use super::write_sockaddr::encode_sockaddr_xdp;
+use super::write_sockaddr::{encode_sockaddr_v4, encode_sockaddr_v6};
 use crate::backend::c;
 use crate::backend::conv::{borrowed_fd, ret, ret_owned_fd, ret_send_recv, send_recv_len};
 use crate::fd::{BorrowedFd, OwnedFd};
 use crate::io;
 #[cfg(target_os = "linux")]
 use crate::net::xdp::SocketAddrXdp;
-use crate::net::{SocketAddrAny, SocketAddrV4, SocketAddrV6};
+use crate::net::{
+    AddressFamily, Protocol, Shutdown, SocketAddrAny, SocketAddrV4, SocketAddrV6, SocketFlags,
+    SocketType,
+};
 use crate::utils::as_ptr;
 use core::mem::{size_of, MaybeUninit};
-#[cfg(not(any(
-    windows,
-    target_os = "espidf",
-    target_os = "redox",
-    target_os = "vita",
-    target_os = "wasi"
-)))]
+use core::ptr::null_mut;
+#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "vita")))]
 use {
     super::msghdr::{with_noaddr_msghdr, with_recv_msghdr, with_v4_msghdr, with_v6_msghdr},
     crate::io::{IoSlice, IoSliceMut},
     crate::net::{RecvAncillaryBuffer, RecvMsgReturn, SendAncillaryBuffer},
 };
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
-use {
-    super::read_sockaddr::{initialize_family_to_unspec, maybe_read_sockaddr_os, read_sockaddr_os},
-    super::send_recv::{RecvFlags, ReturnFlags, SendFlags},
-    super::write_sockaddr::{encode_sockaddr_v4, encode_sockaddr_v6},
-    crate::net::{AddressFamily, Protocol, Shutdown, SocketFlags, SocketType},
-    core::ptr::null_mut,
-};
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) unsafe fn recv(
     fd: BorrowedFd<'_>,
     buf: *mut u8,
@@ -51,7 +45,6 @@ pub(crate) unsafe fn recv(
     ))
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn send(fd: BorrowedFd<'_>, buf: &[u8], flags: SendFlags) -> io::Result<usize> {
     unsafe {
         ret_send_recv(c::send(
@@ -63,7 +56,6 @@ pub(crate) fn send(fd: BorrowedFd<'_>, buf: &[u8], flags: SendFlags) -> io::Resu
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) unsafe fn recvfrom(
     fd: BorrowedFd<'_>,
     buf: *mut u8,
@@ -94,7 +86,6 @@ pub(crate) unsafe fn recvfrom(
     })
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn sendto_v4(
     fd: BorrowedFd<'_>,
     buf: &[u8],
@@ -113,7 +104,6 @@ pub(crate) fn sendto_v4(
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn sendto_v6(
     fd: BorrowedFd<'_>,
     buf: &[u8],
@@ -132,7 +122,7 @@ pub(crate) fn sendto_v6(
     }
 }
 
-#[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
+#[cfg(not(windows))]
 pub(crate) fn sendto_unix(
     fd: BorrowedFd<'_>,
     buf: &[u8],
@@ -170,7 +160,6 @@ pub(crate) fn sendto_xdp(
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn socket(
     domain: AddressFamily,
     type_: SocketType,
@@ -189,7 +178,6 @@ pub(crate) fn socket(
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn socket_with(
     domain: AddressFamily,
     type_: SocketType,
@@ -209,7 +197,6 @@ pub(crate) fn socket_with(
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn bind_v4(sockfd: BorrowedFd<'_>, addr: &SocketAddrV4) -> io::Result<()> {
     unsafe {
         ret(c::bind(
@@ -220,7 +207,6 @@ pub(crate) fn bind_v4(sockfd: BorrowedFd<'_>, addr: &SocketAddrV4) -> io::Result
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn bind_v6(sockfd: BorrowedFd<'_>, addr: &SocketAddrV6) -> io::Result<()> {
     unsafe {
         ret(c::bind(
@@ -231,7 +217,7 @@ pub(crate) fn bind_v6(sockfd: BorrowedFd<'_>, addr: &SocketAddrV6) -> io::Result
     }
 }
 
-#[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
+#[cfg(not(windows))]
 pub(crate) fn bind_unix(sockfd: BorrowedFd<'_>, addr: &SocketAddrUnix) -> io::Result<()> {
     unsafe {
         ret(c::bind(
@@ -253,7 +239,6 @@ pub(crate) fn bind_xdp(sockfd: BorrowedFd<'_>, addr: &SocketAddrXdp) -> io::Resu
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn connect_v4(sockfd: BorrowedFd<'_>, addr: &SocketAddrV4) -> io::Result<()> {
     unsafe {
         ret(c::connect(
@@ -264,7 +249,6 @@ pub(crate) fn connect_v4(sockfd: BorrowedFd<'_>, addr: &SocketAddrV4) -> io::Res
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn connect_v6(sockfd: BorrowedFd<'_>, addr: &SocketAddrV6) -> io::Result<()> {
     unsafe {
         ret(c::connect(
@@ -275,7 +259,7 @@ pub(crate) fn connect_v6(sockfd: BorrowedFd<'_>, addr: &SocketAddrV6) -> io::Res
     }
 }
 
-#[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
+#[cfg(not(windows))]
 pub(crate) fn connect_unix(sockfd: BorrowedFd<'_>, addr: &SocketAddrUnix) -> io::Result<()> {
     unsafe {
         ret(c::connect(
@@ -286,7 +270,6 @@ pub(crate) fn connect_unix(sockfd: BorrowedFd<'_>, addr: &SocketAddrUnix) -> io:
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn connect_unspec(sockfd: BorrowedFd<'_>) -> io::Result<()> {
     debug_assert_eq!(c::AF_UNSPEC, 0);
     let addr = MaybeUninit::<c::sockaddr_storage>::zeroed();
@@ -299,12 +282,10 @@ pub(crate) fn connect_unspec(sockfd: BorrowedFd<'_>) -> io::Result<()> {
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn listen(sockfd: BorrowedFd<'_>, backlog: c::c_int) -> io::Result<()> {
     unsafe { ret(c::listen(borrowed_fd(sockfd), backlog)) }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn accept(sockfd: BorrowedFd<'_>) -> io::Result<OwnedFd> {
     unsafe {
         let owned_fd = ret_owned_fd(c::accept(borrowed_fd(sockfd), null_mut(), null_mut()))?;
@@ -312,13 +293,7 @@ pub(crate) fn accept(sockfd: BorrowedFd<'_>) -> io::Result<OwnedFd> {
     }
 }
 
-#[cfg(not(any(
-    windows,
-    target_os = "espidf",
-    target_os = "redox",
-    target_os = "vita",
-    target_os = "wasi"
-)))]
+#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "vita")))]
 pub(crate) fn recvmsg(
     sockfd: BorrowedFd<'_>,
     iov: &mut [IoSliceMut<'_>],
@@ -350,13 +325,7 @@ pub(crate) fn recvmsg(
     })
 }
 
-#[cfg(not(any(
-    windows,
-    target_os = "espidf",
-    target_os = "redox",
-    target_os = "vita",
-    target_os = "wasi"
-)))]
+#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "vita")))]
 pub(crate) fn sendmsg(
     sockfd: BorrowedFd<'_>,
     iov: &[IoSlice<'_>],
@@ -372,13 +341,7 @@ pub(crate) fn sendmsg(
     })
 }
 
-#[cfg(not(any(
-    windows,
-    target_os = "espidf",
-    target_os = "redox",
-    target_os = "vita",
-    target_os = "wasi"
-)))]
+#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "vita")))]
 pub(crate) fn sendmsg_v4(
     sockfd: BorrowedFd<'_>,
     addr: &SocketAddrV4,
@@ -395,13 +358,7 @@ pub(crate) fn sendmsg_v4(
     })
 }
 
-#[cfg(not(any(
-    windows,
-    target_os = "espidf",
-    target_os = "redox",
-    target_os = "vita",
-    target_os = "wasi"
-)))]
+#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "vita")))]
 pub(crate) fn sendmsg_v6(
     sockfd: BorrowedFd<'_>,
     addr: &SocketAddrV6,
@@ -461,10 +418,9 @@ pub(crate) fn sendmsg_xdp(
     target_os = "aix",
     target_os = "espidf",
     target_os = "haiku",
-    target_os = "redox",
     target_os = "nto",
+    target_os = "redox",
     target_os = "vita",
-    target_os = "wasi",
 )))]
 pub(crate) fn accept_with(sockfd: BorrowedFd<'_>, flags: SocketFlags) -> io::Result<OwnedFd> {
     unsafe {
@@ -478,7 +434,6 @@ pub(crate) fn accept_with(sockfd: BorrowedFd<'_>, flags: SocketFlags) -> io::Res
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn acceptfrom(sockfd: BorrowedFd<'_>) -> io::Result<(OwnedFd, Option<SocketAddrAny>)> {
     unsafe {
         let mut storage = MaybeUninit::<c::sockaddr_storage>::uninit();
@@ -504,7 +459,6 @@ pub(crate) fn acceptfrom(sockfd: BorrowedFd<'_>) -> io::Result<(OwnedFd, Option<
     target_os = "nto",
     target_os = "redox",
     target_os = "vita",
-    target_os = "wasi",
 )))]
 pub(crate) fn acceptfrom_with(
     sockfd: BorrowedFd<'_>,
@@ -535,6 +489,7 @@ pub(crate) fn acceptfrom_with(
     target_os = "espidf",
     target_os = "haiku",
     target_os = "nto",
+    target_os = "redox",
     target_os = "vita",
 ))]
 pub(crate) fn accept_with(sockfd: BorrowedFd<'_>, _flags: SocketFlags) -> io::Result<OwnedFd> {
@@ -550,6 +505,7 @@ pub(crate) fn accept_with(sockfd: BorrowedFd<'_>, _flags: SocketFlags) -> io::Re
     target_os = "espidf",
     target_os = "haiku",
     target_os = "nto",
+    target_os = "redox",
     target_os = "vita",
 ))]
 pub(crate) fn acceptfrom_with(
@@ -559,12 +515,10 @@ pub(crate) fn acceptfrom_with(
     acceptfrom(sockfd)
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn shutdown(sockfd: BorrowedFd<'_>, how: Shutdown) -> io::Result<()> {
     unsafe { ret(c::shutdown(borrowed_fd(sockfd), how as c::c_int)) }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn getsockname(sockfd: BorrowedFd<'_>) -> io::Result<SocketAddrAny> {
     unsafe {
         let mut storage = MaybeUninit::<c::sockaddr_storage>::uninit();
@@ -578,7 +532,6 @@ pub(crate) fn getsockname(sockfd: BorrowedFd<'_>) -> io::Result<SocketAddrAny> {
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn getpeername(sockfd: BorrowedFd<'_>) -> io::Result<Option<SocketAddrAny>> {
     unsafe {
         let mut storage = MaybeUninit::<c::sockaddr_storage>::uninit();
@@ -595,7 +548,7 @@ pub(crate) fn getpeername(sockfd: BorrowedFd<'_>) -> io::Result<Option<SocketAdd
     }
 }
 
-#[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
+#[cfg(not(windows))]
 pub(crate) fn socketpair(
     domain: AddressFamily,
     type_: SocketType,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ pub mod mm;
 #[cfg(feature = "mount")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mount")))]
 pub mod mount;
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(target_os = "wasi"))]
 #[cfg(feature = "net")]
 #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
 pub mod net;

--- a/src/maybe_polyfill/no_std/mod.rs
+++ b/src/maybe_polyfill/no_std/mod.rs
@@ -10,7 +10,7 @@
 
 #[cfg(not(windows))]
 pub mod io;
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(target_os = "wasi"))]
 #[cfg(feature = "net")]
 pub mod net;
 pub mod os;

--- a/src/maybe_polyfill/std/mod.rs
+++ b/src/maybe_polyfill/std/mod.rs
@@ -11,7 +11,7 @@ pub mod io {
     pub use std::io::{IoSlice, IoSliceMut};
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(target_os = "wasi"))]
 #[cfg(feature = "net")]
 pub mod net {
     pub use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};

--- a/src/net/send_recv/mod.rs
+++ b/src/net/send_recv/mod.rs
@@ -15,22 +15,10 @@ use core::mem::MaybeUninit;
 
 pub use backend::net::send_recv::{RecvFlags, ReturnFlags, SendFlags};
 
-#[cfg(not(any(
-    windows,
-    target_os = "espidf",
-    target_os = "redox",
-    target_os = "vita",
-    target_os = "wasi"
-)))]
+#[cfg(not(any(windows, target_os = "espidf", target_os = "vita", target_os = "redox")))]
 mod msg;
 
-#[cfg(not(any(
-    windows,
-    target_os = "espidf",
-    target_os = "redox",
-    target_os = "vita",
-    target_os = "wasi"
-)))]
+#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "vita")))]
 pub use msg::*;
 
 /// `recv(fd, buf, flags)`—Reads data from a socket.

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -1121,6 +1121,7 @@ pub fn ipv6_original_dst<Fd: AsFd>(fd: Fd) -> io::Result<SocketAddrV6> {
     windows,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "redox",
     target_os = "vita"
 )))]
 #[inline]
@@ -1139,6 +1140,7 @@ pub fn set_ipv6_tclass<Fd: AsFd>(fd: Fd, value: u32) -> io::Result<()> {
     windows,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "redox",
     target_os = "vita"
 )))]
 #[inline]
@@ -1174,7 +1176,12 @@ pub fn tcp_nodelay<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
 /// See the [module-level documentation] for more.
 ///
 /// [module-level documentation]: self#references-for-get_tcp_-and-set_tcp_-functions
-#[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "haiku",
+    target_os = "nto",
+    target_os = "redox"
+)))]
 #[inline]
 #[doc(alias = "TCP_KEEPCNT")]
 pub fn set_tcp_keepcnt<Fd: AsFd>(fd: Fd, value: u32) -> io::Result<()> {
@@ -1186,7 +1193,12 @@ pub fn set_tcp_keepcnt<Fd: AsFd>(fd: Fd, value: u32) -> io::Result<()> {
 /// See the [module-level documentation] for more.
 ///
 /// [module-level documentation]: self#references-for-get_tcp_-and-set_tcp_-functions
-#[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "haiku",
+    target_os = "nto",
+    target_os = "redox"
+)))]
 #[inline]
 #[doc(alias = "TCP_KEEPCNT")]
 pub fn tcp_keepcnt<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
@@ -1226,7 +1238,12 @@ pub fn tcp_keepidle<Fd: AsFd>(fd: Fd) -> io::Result<Duration> {
 /// See the [module-level documentation] for more.
 ///
 /// [module-level documentation]: self#references-for-get_tcp_-and-set_tcp_-functions
-#[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "haiku",
+    target_os = "nto",
+    target_os = "redox"
+)))]
 #[inline]
 #[doc(alias = "TCP_KEEPINTVL")]
 pub fn set_tcp_keepintvl<Fd: AsFd>(fd: Fd, value: Duration) -> io::Result<()> {
@@ -1238,7 +1255,12 @@ pub fn set_tcp_keepintvl<Fd: AsFd>(fd: Fd, value: Duration) -> io::Result<()> {
 /// See the [module-level documentation] for more.
 ///
 /// [module-level documentation]: self#references-for-get_tcp_-and-set_tcp_-functions
-#[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "haiku",
+    target_os = "nto",
+    target_os = "redox"
+)))]
 #[inline]
 #[doc(alias = "TCP_KEEPINTVL")]
 pub fn tcp_keepintvl<Fd: AsFd>(fd: Fd) -> io::Result<Duration> {

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -31,7 +31,7 @@ impl SocketType {
     pub const RAW: Self = Self(c::SOCK_RAW as _);
 
     /// `SOCK_RDM`
-    #[cfg(not(any(target_os = "espidf", target_os = "haiku")))]
+    #[cfg(not(any(target_os = "espidf", target_os = "haiku", target_os = "redox")))]
     pub const RDM: Self = Self(c::SOCK_RDM as _);
 
     /// Constructs a `SocketType` from a raw integer.
@@ -94,6 +94,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const NETLINK: Self = Self(c::AF_NETLINK as _);
@@ -110,6 +111,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const AX25: Self = Self(c::AF_AX25 as _);
@@ -117,11 +119,12 @@ impl AddressFamily {
     #[cfg(not(any(
         target_os = "aix",
         target_os = "espidf",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const IPX: Self = Self(c::AF_IPX as _);
     /// `AF_APPLETALK`
-    #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+    #[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "vita")))]
     pub const APPLETALK: Self = Self(c::AF_APPLETALK as _);
     /// `AF_NETROM`
     #[cfg(not(any(
@@ -133,6 +136,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const NETROM: Self = Self(c::AF_NETROM as _);
@@ -146,6 +150,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const BRIDGE: Self = Self(c::AF_BRIDGE as _);
@@ -159,6 +164,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const ATMPVC: Self = Self(c::AF_ATMPVC as _);
@@ -171,6 +177,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const X25: Self = Self(c::AF_X25 as _);
@@ -184,11 +191,17 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const ROSE: Self = Self(c::AF_ROSE as _);
     /// `AF_DECnet`
-    #[cfg(not(any(target_os = "espidf", target_os = "haiku", target_os = "vita")))]
+    #[cfg(not(any(
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "redox",
+        target_os = "vita"
+    )))]
     pub const DECnet: Self = Self(c::AF_DECnet as _);
     /// `AF_NETBEUI`
     #[cfg(not(any(
@@ -200,6 +213,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const NETBEUI: Self = Self(c::AF_NETBEUI as _);
@@ -213,6 +227,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const SECURITY: Self = Self(c::AF_SECURITY as _);
@@ -225,6 +240,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const KEY: Self = Self(c::AF_KEY as _);
@@ -242,6 +258,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const PACKET: Self = Self(c::AF_PACKET as _);
@@ -255,6 +272,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const ASH: Self = Self(c::AF_ASH as _);
@@ -268,6 +286,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const ECONET: Self = Self(c::AF_ECONET as _);
@@ -281,6 +300,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const ATMSVC: Self = Self(c::AF_ATMSVC as _);
@@ -294,11 +314,17 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const RDS: Self = Self(c::AF_RDS as _);
     /// `AF_SNA`
-    #[cfg(not(any(target_os = "espidf", target_os = "haiku", target_os = "vita")))]
+    #[cfg(not(any(
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "redox",
+        target_os = "vita"
+    )))]
     pub const SNA: Self = Self(c::AF_SNA as _);
     /// `AF_IRDA`
     #[cfg(not(any(
@@ -309,6 +335,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const IRDA: Self = Self(c::AF_IRDA as _);
@@ -322,6 +349,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const PPPOX: Self = Self(c::AF_PPPOX as _);
@@ -335,6 +363,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const WANPIPE: Self = Self(c::AF_WANPIPE as _);
@@ -348,6 +377,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const LLC: Self = Self(c::AF_LLC as _);
@@ -361,6 +391,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const CAN: Self = Self(c::AF_CAN as _);
@@ -374,6 +405,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const TIPC: Self = Self(c::AF_TIPC as _);
@@ -385,6 +417,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "hurd",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const BLUETOOTH: Self = Self(c::AF_BLUETOOTH as _);
@@ -398,6 +431,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const IUCV: Self = Self(c::AF_IUCV as _);
@@ -411,6 +445,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const RXRPC: Self = Self(c::AF_RXRPC as _);
@@ -422,6 +457,7 @@ impl AddressFamily {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "hurd",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const ISDN: Self = Self(c::AF_ISDN as _);
@@ -435,6 +471,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const PHONET: Self = Self(c::AF_PHONET as _);
@@ -448,6 +485,7 @@ impl AddressFamily {
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const IEEE802154: Self = Self(c::AF_IEEE802154 as _);
@@ -684,6 +722,7 @@ pub mod ipproto {
         windows,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "redox",
         target_os = "vita"
     )))]
     pub const IPIP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_IPIP as _));
@@ -694,6 +733,7 @@ pub mod ipproto {
         solarish,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "redox",
         target_os = "vita"
     )))]
     pub const EGP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_EGP as _));
@@ -721,6 +761,7 @@ pub mod ipproto {
         windows,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "redox",
         target_os = "vita"
     )))]
     pub const TP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_TP as _));
@@ -735,6 +776,7 @@ pub mod ipproto {
         target_os = "haiku",
         target_os = "nto",
         target_os = "openbsd",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const DCCP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_DCCP as _));
@@ -746,6 +788,7 @@ pub mod ipproto {
         windows,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "redox",
         target_os = "vita"
     )))]
     pub const RSVP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_RSVP as _));
@@ -755,6 +798,7 @@ pub mod ipproto {
         windows,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "redox",
         target_os = "vita"
     )))]
     pub const GRE: Protocol = Protocol(new_raw_protocol(c::IPPROTO_GRE as _));
@@ -763,6 +807,7 @@ pub mod ipproto {
         solarish,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "redox",
         target_os = "vita"
     )))]
     pub const ESP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_ESP as _));
@@ -771,6 +816,7 @@ pub mod ipproto {
         solarish,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "redox",
         target_os = "vita"
     )))]
     pub const AH: Protocol = Protocol(new_raw_protocol(c::IPPROTO_AH as _));
@@ -783,6 +829,7 @@ pub mod ipproto {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const MTP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_MTP as _));
@@ -795,6 +842,7 @@ pub mod ipproto {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const BEETPH: Protocol = Protocol(new_raw_protocol(c::IPPROTO_BEETPH as _));
@@ -805,6 +853,7 @@ pub mod ipproto {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const ENCAP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_ENCAP as _));
@@ -814,6 +863,7 @@ pub mod ipproto {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "redox",
         target_os = "vita"
     )))]
     pub const PIM: Protocol = Protocol(new_raw_protocol(c::IPPROTO_PIM as _));
@@ -826,6 +876,7 @@ pub mod ipproto {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const COMP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_COMP as _));
@@ -836,6 +887,7 @@ pub mod ipproto {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "openbsd",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const SCTP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_SCTP as _));
@@ -850,6 +902,7 @@ pub mod ipproto {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const UDPLITE: Protocol = Protocol(new_raw_protocol(c::IPPROTO_UDPLITE as _));
@@ -864,6 +917,7 @@ pub mod ipproto {
         target_os = "haiku",
         target_os = "netbsd",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const MPLS: Protocol = Protocol(new_raw_protocol(c::IPPROTO_MPLS as _));
@@ -884,6 +938,7 @@ pub mod ipproto {
         target_os = "fuchsia",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const MPTCP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_MPTCP as _));
@@ -892,6 +947,7 @@ pub mod ipproto {
         solarish,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "redox",
         target_os = "vita"
     )))]
     pub const FRAGMENT: Protocol = Protocol(new_raw_protocol(c::IPPROTO_FRAGMENT as _));
@@ -907,6 +963,7 @@ pub mod ipproto {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "redox",
         target_os = "vita",
     )))]
     pub const MH: Protocol = Protocol(new_raw_protocol(c::IPPROTO_MH as _));
@@ -915,6 +972,7 @@ pub mod ipproto {
         solarish,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "redox",
         target_os = "vita"
     )))]
     pub const ROUTING: Protocol = Protocol(new_raw_protocol(c::IPPROTO_ROUTING as _));

--- a/tests/event/main.rs
+++ b/tests/event/main.rs
@@ -21,6 +21,7 @@ mod windows {
 
     impl Thing {
         pub fn new() -> Self {
+            #[cfg(feature = "net")]
             let _ = rustix::net::wsa_startup().unwrap();
             Self
         }
@@ -28,6 +29,7 @@ mod windows {
 
     impl Drop for Thing {
         fn drop(&mut self) {
+            #[cfg(feature = "net")]
             rustix::net::wsa_cleanup().unwrap();
         }
     }

--- a/tests/net/main.rs
+++ b/tests/net/main.rs
@@ -2,11 +2,11 @@
 
 #![cfg(feature = "net")]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
-#![cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#![cfg(not(target_os = "wasi"))]
 #![cfg_attr(core_c_str, feature(core_c_str))]
 
 mod addr;
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "redox")))]
 mod cmsg;
 mod connect_bind_send;
 mod dgram;

--- a/tests/net/poll.rs
+++ b/tests/net/poll.rs
@@ -1,6 +1,6 @@
 //! The same as v6.rs, but with `poll` calls.
 
-#![cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#![cfg(not(target_os = "wasi"))]
 
 use rustix::event::{poll, PollFd, PollFlags};
 use rustix::net::{

--- a/tests/net/recv_trunc.rs
+++ b/tests/net/recv_trunc.rs
@@ -1,5 +1,8 @@
+#[cfg(not(target_os = "redox"))]
 use rustix::io::IoSliceMut;
-use rustix::net::{AddressFamily, RecvFlags, ReturnFlags, SendFlags, SocketAddrUnix, SocketType};
+#[cfg(not(target_os = "redox"))]
+use rustix::net::ReturnFlags;
+use rustix::net::{AddressFamily, RecvFlags, SendFlags, SocketAddrUnix, SocketType};
 use std::mem::MaybeUninit;
 
 /// Test `recv_uninit` with the `RecvFlags::Trunc` flag.
@@ -55,6 +58,7 @@ fn net_recv_uninit_trunc() {
 }
 
 /// Test `recvmsg` with the `RecvFlags::Trunc` flag.
+#[cfg(not(target_os = "redox"))]
 #[test]
 fn net_recvmsg_trunc() {
     crate::init();

--- a/tests/net/v4.rs
+++ b/tests/net/v4.rs
@@ -2,11 +2,13 @@
 //!
 //! The client send a message and the server sends one back.
 
-#![cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#![cfg(not(target_os = "wasi"))]
 
+#[cfg(not(target_os = "redox"))]
+use rustix::net::ReturnFlags;
 use rustix::net::{
     accept, bind_v4, connect_v4, getsockname, listen, recv, send, socket, AddressFamily, Ipv4Addr,
-    RecvFlags, ReturnFlags, SendFlags, SocketAddrAny, SocketAddrV4, SocketType,
+    RecvFlags, SendFlags, SocketAddrAny, SocketAddrV4, SocketType,
 };
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;

--- a/tests/net/v6.rs
+++ b/tests/net/v6.rs
@@ -2,11 +2,13 @@
 //!
 //! The client send a message and the server sends one back.
 
-#![cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#![cfg(not(target_os = "wasi"))]
 
+#[cfg(not(target_os = "redox"))]
+use rustix::net::ReturnFlags;
 use rustix::net::{
     accept, bind_v6, connect_v6, getsockname, listen, recv, send, socket, AddressFamily, Ipv6Addr,
-    RecvFlags, ReturnFlags, SendFlags, SocketAddrAny, SocketAddrV6, SocketType,
+    RecvFlags, SendFlags, SocketAddrAny, SocketAddrV6, SocketType,
 };
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;


### PR DESCRIPTION
Redox supports most of the socket APIs, so enable `rustix::net` on Redox.