### PR TITLE
Change `listxattr`'s `list` argument to `[u8]`.

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -2441,17 +2441,21 @@ pub(crate) fn fsetxattr(
 }
 
 #[cfg(any(apple, linux_kernel, target_os = "hurd"))]
-pub(crate) fn listxattr(path: &CStr, list: &mut [ffi::c_char]) -> io::Result<usize> {
+pub(crate) fn listxattr(path: &CStr, list: &mut [u8]) -> io::Result<usize> {
     #[cfg(not(apple))]
     unsafe {
-        ret_usize(c::listxattr(path.as_ptr(), list.as_mut_ptr(), list.len()))
+        ret_usize(c::listxattr(
+            path.as_ptr(),
+            list.as_mut_ptr().cast::<ffi::c_char>(),
+            list.len(),
+        ))
     }
 
     #[cfg(apple)]
     unsafe {
         ret_usize(c::listxattr(
             path.as_ptr(),
-            list.as_mut_ptr(),
+            list.as_mut_ptr().cast::<ffi::c_char>(),
             list.len(),
             0,
         ))
@@ -2459,17 +2463,21 @@ pub(crate) fn listxattr(path: &CStr, list: &mut [ffi::c_char]) -> io::Result<usi
 }
 
 #[cfg(any(apple, linux_kernel, target_os = "hurd"))]
-pub(crate) fn llistxattr(path: &CStr, list: &mut [ffi::c_char]) -> io::Result<usize> {
+pub(crate) fn llistxattr(path: &CStr, list: &mut [u8]) -> io::Result<usize> {
     #[cfg(not(apple))]
     unsafe {
-        ret_usize(c::llistxattr(path.as_ptr(), list.as_mut_ptr(), list.len()))
+        ret_usize(c::llistxattr(
+            path.as_ptr(),
+            list.as_mut_ptr().cast::<ffi::c_char>(),
+            list.len(),
+        ))
     }
 
     #[cfg(apple)]
     unsafe {
         ret_usize(c::listxattr(
             path.as_ptr(),
-            list.as_mut_ptr(),
+            list.as_mut_ptr().cast::<ffi::c_char>(),
             list.len(),
             c::XATTR_NOFOLLOW,
         ))
@@ -2477,17 +2485,26 @@ pub(crate) fn llistxattr(path: &CStr, list: &mut [ffi::c_char]) -> io::Result<us
 }
 
 #[cfg(any(apple, linux_kernel, target_os = "hurd"))]
-pub(crate) fn flistxattr(fd: BorrowedFd<'_>, list: &mut [ffi::c_char]) -> io::Result<usize> {
+pub(crate) fn flistxattr(fd: BorrowedFd<'_>, list: &mut [u8]) -> io::Result<usize> {
     let fd = borrowed_fd(fd);
 
     #[cfg(not(apple))]
     unsafe {
-        ret_usize(c::flistxattr(fd, list.as_mut_ptr(), list.len()))
+        ret_usize(c::flistxattr(
+            fd,
+            list.as_mut_ptr().cast::<ffi::c_char>(),
+            list.len(),
+        ))
     }
 
     #[cfg(apple)]
     unsafe {
-        ret_usize(c::flistxattr(fd, list.as_mut_ptr(), list.len(), 0))
+        ret_usize(c::flistxattr(
+            fd,
+            list.as_mut_ptr().cast::<ffi::c_char>(),
+            list.len(),
+            0,
+        ))
     }
 }
 

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -31,7 +31,7 @@ use crate::backend::conv::{loff_t, loff_t_from_u64, ret_u64};
 ))]
 use crate::fd::AsFd;
 use crate::fd::{BorrowedFd, OwnedFd};
-use crate::ffi::{self, CStr};
+use crate::ffi::CStr;
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use crate::fs::CWD;
 use crate::fs::{
@@ -1628,19 +1628,19 @@ pub(crate) fn fsetxattr(
 }
 
 #[inline]
-pub(crate) fn listxattr(path: &CStr, list: &mut [ffi::c_char]) -> io::Result<usize> {
+pub(crate) fn listxattr(path: &CStr, list: &mut [u8]) -> io::Result<usize> {
     let (list_addr_mut, list_len) = slice_mut(list);
     unsafe { ret_usize(syscall!(__NR_listxattr, path, list_addr_mut, list_len)) }
 }
 
 #[inline]
-pub(crate) fn llistxattr(path: &CStr, list: &mut [ffi::c_char]) -> io::Result<usize> {
+pub(crate) fn llistxattr(path: &CStr, list: &mut [u8]) -> io::Result<usize> {
     let (list_addr_mut, list_len) = slice_mut(list);
     unsafe { ret_usize(syscall!(__NR_llistxattr, path, list_addr_mut, list_len)) }
 }
 
 #[inline]
-pub(crate) fn flistxattr(fd: BorrowedFd<'_>, list: &mut [ffi::c_char]) -> io::Result<usize> {
+pub(crate) fn flistxattr(fd: BorrowedFd<'_>, list: &mut [u8]) -> io::Result<usize> {
     let (list_addr_mut, list_len) = slice_mut(list);
     unsafe { ret_usize(syscall!(__NR_flistxattr, fd, list_addr_mut, list_len)) }
 }

--- a/src/fs/xattr.rs
+++ b/src/fs/xattr.rs
@@ -137,7 +137,7 @@ pub fn fsetxattr<Fd: AsFd, Name: path::Arg>(
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/listxattr.2.html
 #[inline]
-pub fn listxattr<P: path::Arg>(path: P, list: &mut [ffi::c_char]) -> io::Result<usize> {
+pub fn listxattr<P: path::Arg>(path: P, list: &mut [u8]) -> io::Result<usize> {
     path.into_with_c_str(|path| backend::fs::syscalls::listxattr(path, list))
 }
 
@@ -149,7 +149,7 @@ pub fn listxattr<P: path::Arg>(path: P, list: &mut [ffi::c_char]) -> io::Result<
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/llistxattr.2.html
 #[inline]
-pub fn llistxattr<P: path::Arg>(path: P, list: &mut [ffi::c_char]) -> io::Result<usize> {
+pub fn llistxattr<P: path::Arg>(path: P, list: &mut [u8]) -> io::Result<usize> {
     path.into_with_c_str(|path| backend::fs::syscalls::llistxattr(path, list))
 }
 
@@ -161,7 +161,7 @@ pub fn llistxattr<P: path::Arg>(path: P, list: &mut [ffi::c_char]) -> io::Result
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/flistxattr.2.html
 #[inline]
-pub fn flistxattr<Fd: AsFd>(fd: Fd, list: &mut [ffi::c_char]) -> io::Result<usize> {
+pub fn flistxattr<Fd: AsFd>(fd: Fd, list: &mut [u8]) -> io::Result<usize> {
     backend::fs::syscalls::flistxattr(fd.as_fd(), list)
 }
 


### PR DESCRIPTION
Change `listxattr`'s `list` argument from [`c_char`] to `[u8]`, since it's more ergonomic to use with APIs like `CStr::from_bytes_with_nul`.

Fixes #1218.