### PR TITLE
Replace epoll's `EventVec` with just `Vec`.

### DIFF
--- a/tests/event/epoll.rs
+++ b/tests/event/epoll.rs
@@ -41,7 +41,7 @@ fn server(ready: Arc<(Mutex<u16>, Condvar)>) {
     let mut next_data = epoll::EventData::new_u64(2);
     let mut targets = HashMap::new();
 
-    let mut event_list = epoll::EventVec::with_capacity(4);
+    let mut event_list = Vec::with_capacity(4);
     loop {
         epoll::wait(&epoll, &mut event_list, -1).unwrap();
         for event in &event_list {


### PR DESCRIPTION
`EventVec` was an artifact of an older API. At this point, it was just a trivial wrapper around a `Vec`, so we can drop it and just use `Vec` now.