### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/backend/libc/fs/dir.rs
+++ b/src/backend/libc/fs/dir.rs
@@ -1,4 +1,10 @@
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "nto", target_os = "vita")))]
+#[cfg(not(any(
+    solarish,
+    target_os = "aix",
+    target_os = "haiku",
+    target_os = "nto",
+    target_os = "vita"
+)))]
 use super::types::FileType;
 use crate::backend::c;
 use crate::backend::conv::owned_fd;

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -194,6 +194,14 @@ impl fmt::Debug for SocketAddrUnix {
 #[repr(transparent)]
 pub struct SocketAddrStorage(c::sockaddr_storage);
 
+// SAFETY: Bindgen adds a union with a raw pointer for alignment but it's never
+// used. `sockaddr_storage` is just a bunch of bytes and it doesn't hold
+// pointers.
+unsafe impl Send for SocketAddrStorage {}
+
+// SAFETY: Same as with `Send`.
+unsafe impl Sync for SocketAddrStorage {}
+
 impl SocketAddrStorage {
     /// Return a socket addr storage initialized to all zero bytes. The
     /// `sa_family` is set to `AddressFamily::UNSPEC`.

--- a/src/fs/ioctl.rs
+++ b/src/fs/ioctl.rs
@@ -101,6 +101,8 @@ bitflags! {
     /// `FS_*` constants for use with [`ioctl_getflags`].
     ///
     /// [`ioctl_getflags`]: crate::fs::ioctl::ioctl_getflags
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct IFlags: ffi::c_uint {
         /// `FS_APPEND_FL`
         const APPEND = linux_raw_sys::general::FS_APPEND_FL;

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -1,3 +1,11 @@
+//! Wait for processes to change state.
+//!
+//! # Safety
+//!
+//! This code needs to implement `Send` and `Sync` for `WaitIdStatus` because
+//! the linux-raw-sys bindings generate a type that doesn't do so
+//! automatically.
+#![allow(unsafe_code)]
 use crate::process::Pid;
 use crate::{backend, io};
 use bitflags::bitflags;

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -137,6 +137,15 @@ impl WaitStatus {
 #[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "wasi")))]
 pub struct WaitIdStatus(pub(crate) backend::c::siginfo_t);
 
+// SAFTEY: `siginfo_t` does contain some raw pointers, such as the `si_ptr`
+// and the `si_addr` fields, however it's up to users to use those correctly.
+#[cfg(linux_raw)]
+unsafe impl Send for WaitIdStatus {}
+
+// SAFETY: Same as with `Send`.
+#[cfg(linux_raw)]
+unsafe impl Sync for WaitIdStatus {}
+
 #[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "wasi")))]
 impl WaitIdStatus {
     /// Returns whether the process is currently stopped.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -586,7 +586,7 @@ pub unsafe fn brk(addr: *mut c_void) -> io::Result<*mut c_void> {
 ///
 /// See [`sigrt`] for a convenient way to construct `SIGRTMIN + n` values.
 #[cfg(linux_raw)]
-pub const SIGRTMIN: u32 = linux_raw_sys::general::SIGRTMIN;
+pub const SIGRTMIN: i32 = linux_raw_sys::general::SIGRTMIN as i32;
 
 /// `SIGRTMAX`—The last of the raw OS “real-time” signal range.
 ///
@@ -595,7 +595,7 @@ pub const SIGRTMIN: u32 = linux_raw_sys::general::SIGRTMIN;
 /// won't share a process with a libc (perhaps because you yourself are
 /// implementing a libc).
 #[cfg(linux_raw)]
-pub const SIGRTMAX: u32 = {
+pub const SIGRTMAX: i32 = {
     // Use the actual `SIGRTMAX` value on platforms which define it.
     #[cfg(not(any(
         target_arch = "arm",
@@ -604,7 +604,7 @@ pub const SIGRTMAX: u32 = {
         target_arch = "x86_64",
     )))]
     {
-        linux_raw_sys::general::SIGRTMAX
+        linux_raw_sys::general::SIGRTMAX as i32
     }
 
     // On platforms that don't, derive it from `_NSIG`.
@@ -615,7 +615,7 @@ pub const SIGRTMAX: u32 = {
         target_arch = "x86_64",
     ))]
     {
-        linux_raw_sys::general::_NSIG - 1
+        linux_raw_sys::general::_NSIG as i32 - 1
     }
 };
 
@@ -627,14 +627,14 @@ pub const SIGRTMAX: u32 = {
 /// implementing a libc).
 #[cfg(linux_raw)]
 #[doc(alias = "SIGRTMIN")]
-pub fn sigrt(n: u32) -> Option<Signal> {
+pub fn sigrt(n: i32) -> Option<Signal> {
     let sig = SIGRTMIN.wrapping_add(n);
     if (SIGRTMIN..=SIGRTMAX).contains(&sig) {
         // SAFETY: We've checked that `sig` is in the expected range. It could
         // still conflict with libc's reserved values, however users of the
         // `runtime` module here must already know that there's no other libc
         // to conflict with.
-        Some(unsafe { Signal::from_raw_unchecked(sig as i32) })
+        Some(unsafe { Signal::from_raw_unchecked(sig) })
     } else {
         None
     }

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -1243,6 +1243,7 @@ impl core::fmt::Debug for SpecialCodeIndex {
             #[cfg(any(
                 solarish,
                 all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64")),
+                target_os = "aix",
                 target_os = "haiku",
             ))]
             Self::VTIME => write!(f, "VTIME/VEOL"),
@@ -1262,6 +1263,7 @@ impl core::fmt::Debug for SpecialCodeIndex {
             #[cfg(not(any(
                 solarish,
                 all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64")),
+                target_os = "aix",
                 target_os = "haiku",
             )))]
             Self::VEOL => write!(f, "VEOL"),

--- a/tests/fs/special.rs
+++ b/tests/fs/special.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "process")]
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[test]
 fn test_special_fds() {
     use rustix::fs::{fstat, open, openat, Mode, OFlags, Stat, ABS, CWD};

--- a/tests/termios/termios.rs
+++ b/tests/termios/termios.rs
@@ -105,12 +105,12 @@ fn test_termios_modes() {
     assert!(!tio.local_modes.contains(LocalModes::TOSTOP));
     assert!(!tio.output_modes.contains(OutputModes::ONOCR));
     assert!(!tio.input_modes.contains(InputModes::IGNBRK));
-    assert!(!tio.control_modes.contains(ControlModes::CRTSCTS));
+    assert!(!tio.control_modes.contains(ControlModes::CLOCAL));
 
     tio.local_modes.insert(LocalModes::TOSTOP);
     tio.output_modes.insert(OutputModes::ONOCR);
     tio.input_modes.insert(InputModes::IGNBRK);
-    tio.control_modes.insert(ControlModes::CRTSCTS);
+    tio.control_modes.insert(ControlModes::CLOCAL);
 
     tcsetattr(&pty, OptionalActions::Now, &tio).unwrap();
 
@@ -119,7 +119,7 @@ fn test_termios_modes() {
     assert!(new_tio.local_modes.contains(LocalModes::TOSTOP));
     assert!(new_tio.output_modes.contains(OutputModes::ONOCR));
     assert!(new_tio.input_modes.contains(InputModes::IGNBRK));
-    assert!(new_tio.control_modes.contains(ControlModes::CRTSCTS));
+    assert!(new_tio.control_modes.contains(ControlModes::CLOCAL));
 }
 
 // Disable on illumos where `tcgetattr` doesn't appear to support


### PR DESCRIPTION
 - Fix compilation on AIX
 - Fix attributes for `ioctl::IFlags` bitflags.
 - Fix test compilation on Redox.
 - Make all raw signal numbers signed.
 - Make `SocketAddrStorage` and `WaitIdStatus` impl `Sync` and `Sync`, to match libc.