### PR TITLE
Use `c::` instead of `libc::` and `linux_raw_sys::` in more places.

### DIFF
--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -84,7 +84,7 @@ pub(crate) const IUCLC: tcflag_t = linux_raw_sys::general::IUCLC as _;
 pub(crate) const XCASE: tcflag_t = linux_raw_sys::general::XCASE as _;
 
 #[cfg(target_os = "aix")]
-pub(crate) const MSG_DONTWAIT: c_int = libc::MSG_NONBLOCK;
+pub(crate) const MSG_DONTWAIT: c_int = MSG_NONBLOCK;
 
 // `O_LARGEFILE` can be automatically set by the kernel on Linux:
 // <https://github.com/torvalds/linux/blob/v6.7/fs/open.c#L1458-L1459>
@@ -104,7 +104,7 @@ pub(crate) const O_LARGEFILE: c_int = 0x2000;
     feature = "termios",
     any(target_arch = "powerpc", target_arch = "powerpc64")
 ))]
-pub(crate) use libc::{
+pub(crate) use {
     termios as termios2, TCGETS as TCGETS2, TCSETS as TCSETS2, TCSETSF as TCSETSF2,
     TCSETSW as TCSETSW2,
 };
@@ -116,30 +116,30 @@ pub(crate) use libc::{
     feature = "termios",
     any(target_arch = "powerpc", target_arch = "powerpc64")
 ))]
-pub(crate) const CIBAUD: u32 = libc::CBAUD << libc::IBSHIFT;
+pub(crate) const CIBAUD: u32 = CBAUD << IBSHIFT;
 
 // Automatically enable “large file” support (LFS) features.
 
 #[cfg(target_os = "vxworks")]
-pub(super) use libc::_Vx_ticks64_t as _Vx_ticks_t;
+pub(super) use _Vx_ticks64_t as _Vx_ticks_t;
 #[cfg(linux_kernel)]
-pub(super) use libc::fallocate64 as fallocate;
+pub(super) use fallocate64 as fallocate;
 #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
 #[cfg(any(linux_like, target_os = "aix"))]
-pub(super) use libc::open64 as open;
+pub(super) use open64 as open;
 #[cfg(any(
     linux_kernel,
     target_os = "aix",
     target_os = "hurd",
     target_os = "l4re"
 ))]
-pub(super) use libc::posix_fallocate64 as posix_fallocate;
+pub(super) use posix_fallocate64 as posix_fallocate;
 #[cfg(any(all(linux_like, not(target_os = "android")), target_os = "aix"))]
-pub(super) use libc::{blkcnt64_t as blkcnt_t, rlim64_t as rlim_t};
+pub(super) use {blkcnt64_t as blkcnt_t, rlim64_t as rlim_t};
 // TODO: AIX has `stat64x`, `fstat64x`, `lstat64x`, and `stat64xat`; add them
 // to the upstream libc crate and implement rustix's `statat` etc. with them.
 #[cfg(target_os = "aix")]
-pub(super) use libc::{
+pub(super) use {
     blksize64_t as blksize_t, fstat64 as fstat, fstatfs64 as fstatfs, fstatvfs64 as fstatvfs,
     ftruncate64 as ftruncate, getrlimit64 as getrlimit, ino_t, lseek64 as lseek, mmap,
     off64_t as off_t, openat, posix_fadvise64 as posix_fadvise, preadv, pwritev,
@@ -147,7 +147,7 @@ pub(super) use libc::{
     statvfs64 as statvfs, RLIM_INFINITY,
 };
 #[cfg(any(linux_like, target_os = "hurd"))]
-pub(super) use libc::{
+pub(super) use {
     fstat64 as fstat, fstatat64 as fstatat, fstatfs64 as fstatfs, fstatvfs64 as fstatvfs,
     ftruncate64 as ftruncate, getrlimit64 as getrlimit, ino64_t as ino_t, lseek64 as lseek,
     mmap64 as mmap, off64_t as off_t, openat64 as openat, posix_fadvise64 as posix_fadvise,
@@ -155,7 +155,7 @@ pub(super) use libc::{
     RLIM64_INFINITY as RLIM_INFINITY,
 };
 #[cfg(apple)]
-pub(super) use libc::{
+pub(super) use {
     host_info64_t as host_info_t, host_statistics64 as host_statistics,
     vm_statistics64_t as vm_statistics_t,
 };
@@ -168,32 +168,32 @@ pub(super) use libc::{
     )
 )))]
 #[cfg(any(linux_like, target_os = "aix", target_os = "hurd"))]
-pub(super) use libc::{lstat64 as lstat, stat64 as stat};
+pub(super) use {lstat64 as lstat, stat64 as stat};
 #[cfg(any(
     linux_kernel,
     target_os = "aix",
     target_os = "hurd",
     target_os = "emscripten"
 ))]
-pub(super) use libc::{pread64 as pread, pwrite64 as pwrite};
+pub(super) use {pread64 as pread, pwrite64 as pwrite};
 #[cfg(any(target_os = "linux", target_os = "hurd", target_os = "emscripten"))]
-pub(super) use libc::{preadv64 as preadv, pwritev64 as pwritev};
+pub(super) use {preadv64 as preadv, pwritev64 as pwritev};
 
 #[cfg(all(target_os = "linux", any(target_env = "gnu", target_env = "uclibc")))]
 pub(super) unsafe fn prlimit(
-    pid: libc::pid_t,
-    resource: libc::__rlimit_resource_t,
-    new_limit: *const libc::rlimit64,
-    old_limit: *mut libc::rlimit64,
-) -> libc::c_int {
+    pid: pid_t,
+    resource: __rlimit_resource_t,
+    new_limit: *const rlimit64,
+    old_limit: *mut rlimit64,
+) -> c_int {
     // `prlimit64` wasn't supported in glibc until 2.13.
     weak_or_syscall! {
         fn prlimit64(
-            pid: libc::pid_t,
-            resource: libc::__rlimit_resource_t,
-            new_limit: *const libc::rlimit64,
-            old_limit: *mut libc::rlimit64
-        ) via SYS_prlimit64 -> libc::c_int
+            pid: pid_t,
+            resource: __rlimit_resource_t,
+            new_limit: *const rlimit64,
+            old_limit: *mut rlimit64
+        ) via SYS_prlimit64 -> c_int
     }
 
     prlimit64(pid, resource, new_limit, old_limit)
@@ -201,18 +201,18 @@ pub(super) unsafe fn prlimit(
 
 #[cfg(all(target_os = "linux", target_env = "musl"))]
 pub(super) unsafe fn prlimit(
-    pid: libc::pid_t,
-    resource: libc::c_int,
-    new_limit: *const libc::rlimit64,
-    old_limit: *mut libc::rlimit64,
-) -> libc::c_int {
+    pid: pid_t,
+    resource: c_int,
+    new_limit: *const rlimit64,
+    old_limit: *mut rlimit64,
+) -> c_int {
     weak_or_syscall! {
         fn prlimit64(
-            pid: libc::pid_t,
-            resource: libc::c_int,
-            new_limit: *const libc::rlimit64,
-            old_limit: *mut libc::rlimit64
-        ) via SYS_prlimit64 -> libc::c_int
+            pid: pid_t,
+            resource: c_int,
+            new_limit: *const rlimit64,
+            old_limit: *mut rlimit64
+        ) via SYS_prlimit64 -> c_int
     }
 
     prlimit64(pid, resource, new_limit, old_limit)
@@ -220,18 +220,18 @@ pub(super) unsafe fn prlimit(
 
 #[cfg(target_os = "android")]
 pub(super) unsafe fn prlimit(
-    pid: libc::pid_t,
-    resource: libc::c_int,
-    new_limit: *const libc::rlimit64,
-    old_limit: *mut libc::rlimit64,
-) -> libc::c_int {
+    pid: pid_t,
+    resource: c_int,
+    new_limit: *const rlimit64,
+    old_limit: *mut rlimit64,
+) -> c_int {
     weak_or_syscall! {
         fn prlimit64(
-            pid: libc::pid_t,
-            resource: libc::c_int,
-            new_limit: *const libc::rlimit64,
-            old_limit: *mut libc::rlimit64
-        ) via SYS_prlimit64 -> libc::c_int
+            pid: pid_t,
+            resource: c_int,
+            new_limit: *const rlimit64,
+            old_limit: *mut rlimit64
+        ) via SYS_prlimit64 -> c_int
     }
 
     prlimit64(pid, resource, new_limit, old_limit)
@@ -242,17 +242,17 @@ mod readwrite_pv64 {
     use super::*;
 
     pub(in super::super) unsafe fn preadv64(
-        fd: libc::c_int,
-        iov: *const libc::iovec,
-        iovcnt: libc::c_int,
-        offset: libc::off64_t,
-    ) -> libc::ssize_t {
+        fd: c_int,
+        iov: *const iovec,
+        iovcnt: c_int,
+        offset: off64_t,
+    ) -> ssize_t {
         // Older Android libc lacks `preadv64`, so use the `weak!` mechanism to
-        // test for it, and call back to `libc::syscall`. We don't use
+        // test for it, and call back to `syscall`. We don't use
         // `weak_or_syscall` here because we need to pass the 64-bit offset
         // specially.
         weak! {
-            fn preadv64(libc::c_int, *const libc::iovec, libc::c_int, libc::off64_t) -> libc::ssize_t
+            fn preadv64(c_int, *const iovec, c_int, off64_t) -> ssize_t
         }
         if let Some(fun) = preadv64.get() {
             fun(fd, iov, iovcnt, offset)
@@ -261,25 +261,25 @@ mod readwrite_pv64 {
             // offset in an endian-independent way, and always in two registers.
             syscall! {
                 fn preadv(
-                    fd: libc::c_int,
-                    iov: *const libc::iovec,
-                    iovcnt: libc::c_int,
+                    fd: c_int,
+                    iov: *const iovec,
+                    iovcnt: c_int,
                     offset_lo: usize,
                     offset_hi: usize
-                ) via SYS_preadv -> libc::ssize_t
+                ) via SYS_preadv -> ssize_t
             }
             preadv(fd, iov, iovcnt, offset as usize, (offset >> 32) as usize)
         }
     }
     pub(in super::super) unsafe fn pwritev64(
-        fd: libc::c_int,
-        iov: *const libc::iovec,
-        iovcnt: libc::c_int,
-        offset: libc::off64_t,
-    ) -> libc::ssize_t {
+        fd: c_int,
+        iov: *const iovec,
+        iovcnt: c_int,
+        offset: off64_t,
+    ) -> ssize_t {
         // See the comments in `preadv64`.
         weak! {
-            fn pwritev64(libc::c_int, *const libc::iovec, libc::c_int, libc::off64_t) -> libc::ssize_t
+            fn pwritev64(c_int, *const iovec, c_int, off64_t) -> ssize_t
         }
         if let Some(fun) = pwritev64.get() {
             fun(fd, iov, iovcnt, offset)
@@ -288,12 +288,12 @@ mod readwrite_pv64 {
             // offset in an endian-independent way, and always in two registers.
             syscall! {
                 fn pwritev(
-                    fd: libc::c_int,
-                    iov: *const libc::iovec,
-                    iovcnt: libc::c_int,
+                    fd: c_int,
+                    iov: *const iovec,
+                    iovcnt: c_int,
                     offset_lo: usize,
                     offset_hi: usize
-                ) via SYS_pwritev -> libc::ssize_t
+                ) via SYS_pwritev -> ssize_t
             }
             pwritev(fd, iov, iovcnt, offset as usize, (offset >> 32) as usize)
         }
@@ -305,20 +305,21 @@ pub(super) use readwrite_pv64::{preadv64 as preadv, pwritev64 as pwritev};
 // macOS added `preadv` and `pwritev` in version 11.0.
 #[cfg(apple)]
 mod readwrite_pv {
+    use super::*;
     weakcall! {
         pub(in super::super) fn preadv(
-            fd: libc::c_int,
-            iov: *const libc::iovec,
-            iovcnt: libc::c_int,
-            offset: libc::off_t
-        ) -> libc::ssize_t
+            fd: c_int,
+            iov: *const iovec,
+            iovcnt: c_int,
+            offset: off_t
+        ) -> ssize_t
     }
     weakcall! {
         pub(in super::super) fn pwritev(
-            fd: libc::c_int,
-            iov: *const libc::iovec,
-            iovcnt: libc::c_int, offset: libc::off_t
-        ) -> libc::ssize_t
+            fd: c_int,
+            iov: *const iovec,
+            iovcnt: c_int, offset: off_t
+        ) -> ssize_t
     }
 }
 #[cfg(apple)]
@@ -330,18 +331,18 @@ mod readwrite_pv64v2 {
     use super::*;
 
     pub(in super::super) unsafe fn preadv64v2(
-        fd: libc::c_int,
-        iov: *const libc::iovec,
-        iovcnt: libc::c_int,
-        offset: libc::off64_t,
-        flags: libc::c_int,
-    ) -> libc::ssize_t {
+        fd: c_int,
+        iov: *const iovec,
+        iovcnt: c_int,
+        offset: off64_t,
+        flags: c_int,
+    ) -> ssize_t {
         // Older glibc lacks `preadv64v2`, so use the `weak!` mechanism to
-        // test for it, and call back to `libc::syscall`. We don't use
+        // test for it, and call back to `syscall`. We don't use
         // `weak_or_syscall` here because we need to pass the 64-bit offset
         // specially.
         weak! {
-            fn preadv64v2(libc::c_int, *const libc::iovec, libc::c_int, libc::off64_t, libc::c_int) -> libc::ssize_t
+            fn preadv64v2(c_int, *const iovec, c_int, off64_t, c_int) -> ssize_t
         }
         if let Some(fun) = preadv64v2.get() {
             fun(fd, iov, iovcnt, offset, flags)
@@ -350,13 +351,13 @@ mod readwrite_pv64v2 {
             // offset in an endian-independent way, and always in two registers.
             syscall! {
                 fn preadv2(
-                    fd: libc::c_int,
-                    iov: *const libc::iovec,
-                    iovcnt: libc::c_int,
+                    fd: c_int,
+                    iov: *const iovec,
+                    iovcnt: c_int,
                     offset_lo: usize,
                     offset_hi: usize,
-                    flags: libc::c_int
-                ) via SYS_preadv2 -> libc::ssize_t
+                    flags: c_int
+                ) via SYS_preadv2 -> ssize_t
             }
             preadv2(
                 fd,
@@ -369,15 +370,15 @@ mod readwrite_pv64v2 {
         }
     }
     pub(in super::super) unsafe fn pwritev64v2(
-        fd: libc::c_int,
-        iov: *const libc::iovec,
-        iovcnt: libc::c_int,
-        offset: libc::off64_t,
-        flags: libc::c_int,
-    ) -> libc::ssize_t {
+        fd: c_int,
+        iov: *const iovec,
+        iovcnt: c_int,
+        offset: off64_t,
+        flags: c_int,
+    ) -> ssize_t {
         // See the comments in `preadv64v2`.
         weak! {
-            fn pwritev64v2(libc::c_int, *const libc::iovec, libc::c_int, libc::off64_t, libc::c_int) -> libc::ssize_t
+            fn pwritev64v2(c_int, *const iovec, c_int, off64_t, c_int) -> ssize_t
         }
         if let Some(fun) = pwritev64v2.get() {
             fun(fd, iov, iovcnt, offset, flags)
@@ -386,13 +387,13 @@ mod readwrite_pv64v2 {
             // offset in an endian-independent way, and always in two registers.
             syscall! {
                 fn pwritev2(
-                    fd: libc::c_int,
-                    iov: *const libc::iovec,
-                    iovec: libc::c_int,
+                    fd: c_int,
+                    iov: *const iovec,
+                    iovec: c_int,
                     offset_lo: usize,
                     offset_hi: usize,
-                    flags: libc::c_int
-                ) via SYS_pwritev2 -> libc::ssize_t
+                    flags: c_int
+                ) via SYS_pwritev2 -> ssize_t
             }
             pwritev2(
                 fd,
@@ -418,23 +419,23 @@ mod readwrite_pv64v2 {
     use super::*;
 
     pub(in super::super) unsafe fn preadv64v2(
-        fd: libc::c_int,
-        iov: *const libc::iovec,
-        iovcnt: libc::c_int,
-        offset: libc::off64_t,
-        flags: libc::c_int,
-    ) -> libc::ssize_t {
+        fd: c_int,
+        iov: *const iovec,
+        iovcnt: c_int,
+        offset: off64_t,
+        flags: c_int,
+    ) -> ssize_t {
         // Unlike the plain "p" functions, the "pv" functions pass their offset
         // in an endian-independent way, and always in two registers.
         syscall! {
             fn preadv2(
-                fd: libc::c_int,
-                iov: *const libc::iovec,
-                iovcnt: libc::c_int,
+                fd: c_int,
+                iov: *const iovec,
+                iovcnt: c_int,
                 offset_lo: usize,
                 offset_hi: usize,
-                flags: libc::c_int
-            ) via SYS_preadv2 -> libc::ssize_t
+                flags: c_int
+            ) via SYS_preadv2 -> ssize_t
         }
         preadv2(
             fd,
@@ -446,23 +447,23 @@ mod readwrite_pv64v2 {
         )
     }
     pub(in super::super) unsafe fn pwritev64v2(
-        fd: libc::c_int,
-        iov: *const libc::iovec,
-        iovcnt: libc::c_int,
-        offset: libc::off64_t,
-        flags: libc::c_int,
-    ) -> libc::ssize_t {
+        fd: c_int,
+        iov: *const iovec,
+        iovcnt: c_int,
+        offset: off64_t,
+        flags: c_int,
+    ) -> ssize_t {
         // Unlike the plain "p" functions, the "pv" functions pass their offset
         // in an endian-independent way, and always in two registers.
         syscall! {
             fn pwritev2(
-                fd: libc::c_int,
-                iov: *const libc::iovec,
-                iovcnt: libc::c_int,
+                fd: c_int,
+                iov: *const iovec,
+                iovcnt: c_int,
                 offset_lo: usize,
                 offset_hi: usize,
-                flags: libc::c_int
-            ) via SYS_pwritev2 -> libc::ssize_t
+                flags: c_int
+            ) via SYS_pwritev2 -> ssize_t
         }
         pwritev2(
             fd,
@@ -508,7 +509,7 @@ pub(crate) use statx_flags::*;
 
 #[cfg(feature = "fs")]
 #[cfg(target_os = "android")]
-pub(crate) use libc::__fsid_t as fsid_t;
+pub(crate) use __fsid_t as fsid_t;
 
 #[cfg(feature = "mm")]
 #[cfg(target_os = "android")]

--- a/src/backend/libc/mm/types.rs
+++ b/src/backend/libc/mm/types.rs
@@ -479,15 +479,15 @@ bitflags! {
         /// created. `MCL_ONFAULT` must be used with either `MCL_CURRENT` or
         /// `MCL_FUTURE` or both.
         #[cfg(linux_kernel)]
-        const ONFAULT = bitcast!(libc::MCL_ONFAULT);
+        const ONFAULT = bitcast!(c::MCL_ONFAULT);
         /// Lock all pages which will become mapped into the address space of
         /// the process in the future. These could be, for instance, new pages
         /// required by a growing heap and stack as well as new memory-mapped
         /// files or shared memory regions.
-        const FUTURE = bitcast!(libc::MCL_FUTURE);
+        const FUTURE = bitcast!(c::MCL_FUTURE);
         /// Lock all pages which are currently mapped into the address space of
         /// the process.
-        const CURRENT = bitcast!(libc::MCL_CURRENT);
+        const CURRENT = bitcast!(c::MCL_CURRENT);
 
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
         const _ = !0;

--- a/src/backend/libc/net/netdevice.rs
+++ b/src/backend/libc/net/netdevice.rs
@@ -4,12 +4,13 @@
 
 #[cfg(feature = "alloc")]
 use crate::alloc::string::String;
+use crate::backend::c;
 use crate::backend::io::syscalls::ioctl;
 use crate::fd::AsFd;
 use crate::io;
 #[cfg(feature = "alloc")]
-use libc::SIOCGIFNAME;
-use libc::{__c_anonymous_ifr_ifru, c_char, ifreq, IFNAMSIZ, SIOCGIFINDEX};
+use c::SIOCGIFNAME;
+use c::{__c_anonymous_ifr_ifru, c_char, ifreq, IFNAMSIZ, SIOCGIFINDEX};
 
 pub(crate) fn name_to_index(fd: impl AsFd, if_name: &str) -> io::Result<u32> {
     let if_name_bytes = if_name.as_bytes();

--- a/src/backend/libc/pty/syscalls.rs
+++ b/src/backend/libc/pty/syscalls.rs
@@ -66,7 +66,7 @@ pub(crate) fn ptsname(fd: BorrowedFd<'_>, mut buffer: Vec<u8>) -> io::Result<CSt
             if let Some(func) = ptsname_r.get() {
                 func(borrowed_fd(fd), buffer.as_mut_ptr().cast(), buffer.len())
             } else {
-                libc::ENOSYS
+                c::ENOSYS
             }
         };
 

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -102,7 +102,7 @@ pub(crate) fn tcgetattr(fd: BorrowedFd<'_>) -> io::Result<Termios> {
         let mut result = MaybeUninit::<Termios>::uninit();
 
         // `result` is a `Termios` which starts with the same layout as
-        // `libc::termios`, so we can cast the pointer.
+        // `c::termios`, so we can cast the pointer.
         ret(c::tcgetattr(borrowed_fd(fd), result.as_mut_ptr().cast()))?;
 
         Ok(result.assume_init())

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -665,7 +665,7 @@ pub(crate) fn setgroups_thread(groups: &[crate::ugid::Gid]) -> io::Result<()> {
 #[cfg(any(linux_kernel, target_os = "dragonfly"))]
 #[inline]
 pub(crate) fn sched_getcpu() -> usize {
-    let r = unsafe { libc::sched_getcpu() };
+    let r = unsafe { c::sched_getcpu() };
     debug_assert!(r >= 0);
     r as usize
 }

--- a/src/backend/libc/time/types.rs
+++ b/src/backend/libc/time/types.rs
@@ -50,24 +50,24 @@ impl From<Itimerspec> for LibcItimerspec {
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(not(fix_y2038))]
-pub(crate) fn as_libc_itimerspec_ptr(itimerspec: &Itimerspec) -> *const libc::itimerspec {
+pub(crate) fn as_libc_itimerspec_ptr(itimerspec: &Itimerspec) -> *const c::itimerspec {
     #[cfg(test)]
     {
-        assert_eq_size!(Itimerspec, libc::itimerspec);
+        assert_eq_size!(Itimerspec, c::itimerspec);
     }
-    crate::utils::as_ptr(itimerspec).cast::<libc::itimerspec>()
+    crate::utils::as_ptr(itimerspec).cast::<c::itimerspec>()
 }
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(not(fix_y2038))]
 pub(crate) fn as_libc_itimerspec_mut_ptr(
     itimerspec: &mut core::mem::MaybeUninit<Itimerspec>,
-) -> *mut libc::itimerspec {
+) -> *mut c::itimerspec {
     #[cfg(test)]
     {
-        assert_eq_size!(Itimerspec, libc::itimerspec);
+        assert_eq_size!(Itimerspec, c::itimerspec);
     }
-    itimerspec.as_mut_ptr().cast::<libc::itimerspec>()
+    itimerspec.as_mut_ptr().cast::<c::itimerspec>()
 }
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -35,6 +35,13 @@ pub(crate) use linux_raw_sys::general::{
 #[cfg(test)]
 pub(crate) use linux_raw_sys::general::epoll_event;
 
+#[cfg(feature = "mm")]
+mod mm {
+    pub(crate) use linux_raw_sys::general::{MAP_HUGETLB, MAP_HUGE_SHIFT};
+}
+#[cfg(feature = "mm")]
+pub(crate) use mm::*;
+
 #[cfg(any(
     feature = "fs",
     all(

--- a/src/fs/special.rs
+++ b/src/fs/special.rs
@@ -58,7 +58,7 @@ mod tests {
         assert!(CWD.as_raw_fd() != -1);
         #[cfg(linux_kernel)]
         #[cfg(feature = "io_uring")]
-        assert!(CWD.as_raw_fd() != linux_raw_sys::io_uring::IORING_REGISTER_FILES_SKIP);
+        assert!(CWD.as_raw_fd() != crate::io_uring::IORING_REGISTER_FILES_SKIP.as_raw_fd());
     }
 
     #[test]
@@ -68,6 +68,6 @@ mod tests {
         assert!(ABS.as_raw_fd() != c::AT_FDCWD);
         #[cfg(linux_kernel)]
         #[cfg(feature = "io_uring")]
-        assert!(ABS.as_raw_fd() != linux_raw_sys::io_uring::IORING_REGISTER_FILES_SKIP);
+        assert!(ABS.as_raw_fd() != crate::io_uring::IORING_REGISTER_FILES_SKIP.as_raw_fd());
     }
 }

--- a/src/mm/mmap.rs
+++ b/src/mm/mmap.rs
@@ -34,9 +34,9 @@ impl MapFlags {
     /// ```
     #[cfg(linux_kernel)]
     pub const fn hugetlb_with_size_log2(huge_page_size_log2: u32) -> Option<Self> {
-        use linux_raw_sys::general::{MAP_HUGETLB, MAP_HUGE_SHIFT};
+        use crate::backend::c;
         if 16 <= huge_page_size_log2 && huge_page_size_log2 <= 63 {
-            let bits = MAP_HUGETLB | (huge_page_size_log2 << MAP_HUGE_SHIFT);
+            let bits = bitcast!(c::MAP_HUGETLB) | (huge_page_size_log2 << c::MAP_HUGE_SHIFT);
             Self::from_bits(bits)
         } else {
             None


### PR DESCRIPTION
This helps unify some code between the two backends.