### PR TITLE
Derive Ord for Timespec

### DIFF
--- a/src/timespec.rs
+++ b/src/timespec.rs
@@ -11,7 +11,7 @@ use crate::ffi;
 use core::ptr::null;
 
 /// `struct timespec`
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(C)]
 pub struct Timespec {
     /// Seconds.


### PR DESCRIPTION
Meaningless if `Timespec`s were from different kind (duration and timestamp).

Maybe add conversion to/from `core::time::Duration` and some arithmetic?