### PR TITLE
Add an `epoll::wait_uninit`.

### DIFF
--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -4,7 +4,6 @@ use crate::backend::c;
 #[cfg(any(linux_kernel, solarish, target_os = "redox"))]
 use crate::backend::conv::ret;
 use crate::backend::conv::ret_c_int;
-#[cfg(feature = "alloc")]
 #[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 use crate::backend::conv::ret_u32;
 #[cfg(solarish)]
@@ -27,7 +26,7 @@ use crate::utils::as_ptr;
 #[cfg(any(
     all(feature = "alloc", bsd),
     solarish,
-    all(feature = "alloc", any(linux_kernel, target_os = "redox")),
+    all(any(linux_kernel, target_os = "redox")),
 ))]
 use core::mem::MaybeUninit;
 #[cfg(any(
@@ -512,7 +511,6 @@ pub(crate) fn epoll_del(epoll: BorrowedFd<'_>, source: BorrowedFd<'_>) -> io::Re
 }
 
 #[inline]
-#[cfg(feature = "alloc")]
 #[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 pub(crate) fn epoll_wait(
     epoll: BorrowedFd<'_>,

--- a/src/backend/linux_raw/event/syscalls.rs
+++ b/src/backend/linux_raw/event/syscalls.rs
@@ -15,7 +15,6 @@ use crate::io;
 use crate::utils::as_mut_ptr;
 #[cfg(feature = "linux_5_11")]
 use crate::utils::option_as_ptr;
-#[cfg(feature = "alloc")]
 use core::mem::MaybeUninit;
 use core::ptr::null_mut;
 use linux_raw_sys::general::{kernel_sigset_t, EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD};
@@ -174,7 +173,6 @@ pub(crate) fn epoll_del(epfd: BorrowedFd<'_>, fd: BorrowedFd<'_>) -> io::Result<
     }
 }
 
-#[cfg(feature = "alloc")]
 #[inline]
 pub(crate) fn epoll_wait(
     epfd: BorrowedFd<'_>,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -5,21 +5,21 @@
 use core::mem::MaybeUninit;
 use core::slice;
 
-/// Split an uninitialized byte slice into initialized and uninitialized parts.
+/// Split an uninitialized slice into initialized and uninitialized parts.
 ///
 /// # Safety
 ///
 /// `init_len` must not be greater than `buf.len()`, and at least `init_len`
-/// bytes must be initialized.
+/// elements must be initialized.
 #[inline]
-pub(super) unsafe fn split_init(
-    buf: &mut [MaybeUninit<u8>],
+pub(super) unsafe fn split_init<T>(
+    buf: &mut [MaybeUninit<T>],
     init_len: usize,
-) -> (&mut [u8], &mut [MaybeUninit<u8>]) {
+) -> (&mut [T], &mut [MaybeUninit<T>]) {
     debug_assert!(init_len <= buf.len());
     let buf_ptr = buf.as_mut_ptr();
     let uninit_len = buf.len() - init_len;
-    let init = slice::from_raw_parts_mut(buf_ptr.cast::<u8>(), init_len);
+    let init = slice::from_raw_parts_mut(buf_ptr.cast::<T>(), init_len);
     let uninit = slice::from_raw_parts_mut(buf_ptr.add(init_len), uninit_len);
     (init, uninit)
 }
@@ -66,7 +66,7 @@ mod tests {
     #[test]
     fn test_split_init_empty() {
         unsafe {
-            let (init, uninit) = split_init(&mut [], 0);
+            let (init, uninit) = split_init::<u8>(&mut [], 0);
             assert!(init.is_empty());
             assert!(uninit.is_empty());
         }

--- a/src/event/epoll.rs
+++ b/src/event/epoll.rs
@@ -235,11 +235,11 @@ pub fn wait<EpollFd: AsFd>(
 /// function and the slice that remains uninitialized.
 #[doc(alias = "epoll_wait")]
 #[inline]
-pub fn wait_uninit<EpollFd: AsFd>(
+pub fn wait_uninit<'a, EpollFd: AsFd>(
     epoll: EpollFd,
-    event_list: &mut [MaybeUninit<Event>],
+    event_list: &'a mut [MaybeUninit<Event>],
     timeout: Option<&Timespec>,
-) -> io::Result<(&mut [Event], &mut [MaybeUninit<Event>])> {
+) -> io::Result<(&'a mut [Event], &'a mut [MaybeUninit<Event>])> {
     // SAFETY: We're calling `epoll_wait` via FFI and we know how it
     // behaves.
     unsafe {

--- a/src/event/epoll.rs
+++ b/src/event/epoll.rs
@@ -78,7 +78,6 @@ use crate::backend::event::syscalls;
 use crate::buffer::split_init;
 use crate::fd::{AsFd, OwnedFd};
 use crate::io;
-#[cfg(feature = "alloc")]
 use crate::timespec::Timespec;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -239,7 +238,7 @@ pub fn wait<EpollFd: AsFd>(
 pub fn wait_uninit<EpollFd: AsFd>(
     epoll: EpollFd,
     event_list: &mut [MaybeUninit<Event>],
-    timeout: crate::ffi::c_int,
+    timeout: Option<&Timespec>,
 ) -> io::Result<(&mut [Event], &mut [MaybeUninit<Event>])> {
     // SAFETY: We're calling `epoll_wait` via FFI and we know how it
     // behaves.

--- a/tests/event/epoll.rs
+++ b/tests/event/epoll.rs
@@ -97,7 +97,7 @@ fn server_uninit(ready: Arc<(Mutex<u16>, Condvar)>) {
 
     let mut event_list = [MaybeUninit::uninit(); 4];
     loop {
-        let (init, _) = epoll::wait_uninit(&epoll, &mut event_list, -1).unwrap();
+        let (init, _) = epoll::wait_uninit(&epoll, &mut event_list, None).unwrap();
         for event in init {
             let target = event.data;
             if target.u64() == 1 {

--- a/tests/event/epoll.rs
+++ b/tests/event/epoll.rs
@@ -67,13 +67,10 @@ fn server(ready: Arc<(Mutex<u16>, Condvar)>) {
 
 fn server_uninit(ready: Arc<(Mutex<u16>, Condvar)>) {
     let listen_sock = socket(AddressFamily::INET, SocketType::STREAM, None).unwrap();
-    bind_v4(&listen_sock, &SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)).unwrap();
+    bind(&listen_sock, &SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)).unwrap();
     listen(&listen_sock, 1).unwrap();
 
-    let who = match getsockname(&listen_sock).unwrap() {
-        SocketAddrAny::V4(addr) => addr,
-        _ => panic!(),
-    };
+    let who = SocketAddrV4::try_from(getsockname(&listen_sock).unwrap()).unwrap();
 
     {
         let (lock, cvar) = &*ready;


### PR DESCRIPTION
This is like `epoll::wait`, except that it can read into an uninitialized buffer, and it returns a pair of slices, similar to `read_uninit`. This also means it doesn't require "alloc".

This is a possible alternative direction to #1290. I'm on the fence still. I like some things about the `Buffer` trait magic, including how it can encapsulate the unsafety of the `set_len` to resize a `Vec` to the number of initialized bytes. However, I don't like how it seems to feel more magical than it is. In `read(fd, extend(&mut v))`, you still have to think about end-of-stream, `EINTR`, short reads, and spare capacity.