### PR TITLE
Add `fcntl_getlk` for fetching information of a lock held by another process

### DIFF
--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -666,12 +666,6 @@ pub(crate) fn getgroups(buf: &mut [Gid]) -> io::Result<usize> {
 )))]
 #[inline]
 pub(crate) fn fcntl_getlk(fd: BorrowedFd<'_>, lock: &Flock) -> io::Result<Option<Flock>> {
-    // In order to guarantee consistent behavior across all POSIX platforms, return `EINVAL` when
-    // `flock.l_type` is `F_UNLCK`
-    if lock.typ == crate::process::FlockType::Unlocked {
-        return Err(io::Errno::INVAL);
-    }
-
     let mut curr_lock: c::flock = lock.as_raw();
     unsafe { ret(c::fcntl(borrowed_fd(fd), c::F_GETLK, &mut curr_lock))? };
 

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -29,6 +29,15 @@ use crate::ffi::CStr;
 #[cfg(feature = "fs")]
 use crate::fs::Mode;
 use crate::io;
+#[cfg(not(any(
+    target_os = "emscripten",
+    target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
+use crate::process::Flock;
 #[cfg(all(feature = "alloc", not(target_os = "wasi")))]
 use crate::process::Gid;
 #[cfg(not(target_os = "wasi"))]
@@ -43,7 +52,7 @@ use crate::process::Signal;
 )))]
 use crate::process::Uid;
 #[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
-use crate::process::{Flock, RawPid, WaitOptions, WaitStatus};
+use crate::process::{RawPid, WaitOptions, WaitStatus};
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
@@ -647,6 +656,14 @@ pub(crate) fn getgroups(buf: &mut [Gid]) -> io::Result<usize> {
     unsafe { ret_usize(c::getgroups(len, buf.as_mut_ptr().cast()) as isize) }
 }
 
+#[cfg(not(any(
+    target_os = "emscripten",
+    target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 #[inline]
 pub(crate) fn fcntl_getlk(fd: BorrowedFd<'_>, lock: &Flock) -> io::Result<Option<Flock>> {
     let mut curr_lock: c::flock = lock.as_raw();

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -666,6 +666,8 @@ pub(crate) fn getgroups(buf: &mut [Gid]) -> io::Result<usize> {
 )))]
 #[inline]
 pub(crate) fn fcntl_getlk(fd: BorrowedFd<'_>, lock: &Flock) -> io::Result<Option<Flock>> {
+    // In order to guarantee consistent behavior across all POSIX platforms, return `EINVAL` when
+    // `flock.l_type` is `F_UNLCK`
     if lock.typ == crate::process::FlockType::Unlocked {
         return Err(io::Errno::INVAL);
     }

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -673,7 +673,8 @@ pub(crate) fn fcntl_getlk(fd: BorrowedFd<'_>, lock: &Flock) -> io::Result<Option
     let mut curr_lock: c::flock = lock.as_raw();
     unsafe { ret(c::fcntl(borrowed_fd(fd), c::F_GETLK, &mut curr_lock))? };
 
-    if curr_lock.l_pid == Pid::as_raw(lock.pid) {
+    // If no blocking lock is found, `fcntl(GETLK, ..)` sets `l_type` to `F_UNLCK`
+    if curr_lock.l_type == c::F_UNLCK as _ {
         Ok(None)
     } else {
         Ok(Some(unsafe { Flock::from_raw_unchecked(curr_lock) }))

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -666,7 +666,6 @@ pub(crate) fn getgroups(buf: &mut [Gid]) -> io::Result<usize> {
 )))]
 #[inline]
 pub(crate) fn fcntl_getlk(fd: BorrowedFd<'_>, lock: &Flock) -> io::Result<Option<Flock>> {
-    #[cfg(target_os = "macos")]
     if lock.typ == crate::process::FlockType::Unlocked {
         return Err(io::Errno::INVAL);
     }

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -666,6 +666,11 @@ pub(crate) fn getgroups(buf: &mut [Gid]) -> io::Result<usize> {
 )))]
 #[inline]
 pub(crate) fn fcntl_getlk(fd: BorrowedFd<'_>, lock: &Flock) -> io::Result<Option<Flock>> {
+    #[cfg(target_os = "macos")]
+    if lock.typ == crate::process::FlockType::Unlocked {
+        return Err(io::Errno::INVAL);
+    }
+
     let mut curr_lock: c::flock = lock.as_raw();
     unsafe { ret(c::fcntl(borrowed_fd(fd), c::F_GETLK, &mut curr_lock))? };
 

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -184,11 +184,20 @@ pub(crate) const CLONE_CHILD_SETTID: c_int = linux_raw_sys::general::CLONE_CHILD
 #[cfg(feature = "process")]
 pub(crate) use linux_raw_sys::{
     general::{
-        CLD_CONTINUED, CLD_DUMPED, CLD_EXITED, CLD_KILLED, CLD_STOPPED, CLD_TRAPPED,
-        O_NONBLOCK as PIDFD_NONBLOCK, P_ALL, P_PGID, P_PID, P_PIDFD,
+        CLD_CONTINUED, CLD_DUMPED, CLD_EXITED, CLD_KILLED, CLD_STOPPED, CLD_TRAPPED, F_RDLCK,
+        F_UNLCK, F_WRLCK, O_NONBLOCK as PIDFD_NONBLOCK, P_ALL, P_PGID, P_PID, P_PIDFD, SEEK_CUR,
+        SEEK_END, SEEK_SET,
     },
     ioctl::TIOCSCTTY,
 };
+
+#[cfg(feature = "process")]
+#[cfg(target_pointer_width = "32")]
+pub(crate) use linux_raw_sys::general::{flock64 as flock, F_GETLK64 as F_GETLK};
+
+#[cfg(feature = "process")]
+#[cfg(target_pointer_width = "64")]
+pub(crate) use linux_raw_sys::general::{flock, F_GETLK};
 
 #[cfg(feature = "pty")]
 pub(crate) use linux_raw_sys::ioctl::TIOCGPTPEER;

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -193,7 +193,7 @@ pub(crate) use linux_raw_sys::{
 
 #[cfg(feature = "process")]
 #[cfg(target_pointer_width = "32")]
-pub(crate) use linux_raw_sys::general::{flock64 as flock, F_GETLK64 as F_GETLK};
+pub(crate) use linux_raw_sys::general::{flock64 as flock, F_GETLK64};
 
 #[cfg(feature = "process")]
 #[cfg(target_pointer_width = "64")]

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -528,7 +528,7 @@ pub(crate) fn fcntl_getlk(fd: BorrowedFd<'_>, lock: &Flock) -> io::Result<Option
         ret(syscall_readonly!(
             __NR_fcntl64,
             fd,
-            c_uint(c::F_GETLK),
+            c_uint(c::F_GETLK64),
             by_ref(&mut curr_lock)
         ))?
     }
@@ -542,7 +542,8 @@ pub(crate) fn fcntl_getlk(fd: BorrowedFd<'_>, lock: &Flock) -> io::Result<Option
         ))?
     }
 
-    if curr_lock.l_pid == Pid::as_raw(lock.pid) {
+    // If no blocking lock is found, `fcntl(GETLK, ..)` sets `l_type` to `F_UNLCK`
+    if curr_lock.l_type == c::F_UNLCK as _ {
         Ok(None)
     } else {
         Ok(Some(unsafe { Flock::from_raw_unchecked(curr_lock) }))

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -525,7 +525,7 @@ pub(crate) fn fcntl_getlk(fd: BorrowedFd<'_>, lock: &Flock) -> io::Result<Option
     let mut curr_lock: c::flock = lock.as_raw();
     #[cfg(target_pointer_width = "32")]
     unsafe {
-        ret(syscall_readonly!(
+        ret(syscall!(
             __NR_fcntl64,
             fd,
             c_uint(c::F_GETLK64),
@@ -534,7 +534,7 @@ pub(crate) fn fcntl_getlk(fd: BorrowedFd<'_>, lock: &Flock) -> io::Result<Option
     }
     #[cfg(target_pointer_width = "64")]
     unsafe {
-        ret(syscall_readonly!(
+        ret(syscall!(
             __NR_fcntl,
             fd,
             c_uint(c::F_GETLK),

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -18,8 +18,8 @@ use crate::ffi::CStr;
 use crate::io;
 use crate::pid::RawPid;
 use crate::process::{
-    Pid, PidfdFlags, PidfdGetfdFlags, Resource, Rlimit, Uid, WaitId, WaitIdOptions, WaitIdStatus,
-    WaitOptions, WaitStatus,
+    Flock, Pid, PidfdFlags, PidfdGetfdFlags, Resource, Rlimit, Uid, WaitId, WaitIdOptions,
+    WaitIdStatus, WaitOptions, WaitStatus,
 };
 use crate::signal::Signal;
 use core::mem::MaybeUninit;
@@ -517,5 +517,34 @@ pub(crate) fn getgroups(buf: &mut [Gid]) -> io::Result<usize> {
             c_int(len),
             slice_just_addr_mut(buf)
         ))
+    }
+}
+
+#[inline]
+pub(crate) fn fcntl_getlk(fd: BorrowedFd<'_>, lock: &Flock) -> io::Result<Option<Flock>> {
+    let mut curr_lock: c::flock = lock.as_raw();
+    #[cfg(target_pointer_width = "32")]
+    unsafe {
+        ret(syscall_readonly!(
+            __NR_fcntl64,
+            fd,
+            c_uint(c::F_GETLK),
+            by_ref(&mut curr_lock)
+        ))?
+    }
+    #[cfg(target_pointer_width = "64")]
+    unsafe {
+        ret(syscall_readonly!(
+            __NR_fcntl,
+            fd,
+            c_uint(c::F_GETLK),
+            by_ref(&mut curr_lock)
+        ))?
+    }
+
+    if curr_lock.l_pid == Pid::as_raw(lock.pid) {
+        Ok(None)
+    } else {
+        Ok(Some(unsafe { Flock::from_raw_unchecked(curr_lock) }))
     }
 }

--- a/src/process/fcntl_getlk.rs
+++ b/src/process/fcntl_getlk.rs
@@ -2,7 +2,10 @@ use super::Flock;
 use crate::fd::AsFd;
 use crate::{backend, io};
 
-/// `fcntl(fd, F_GETLK)`—Get the first lock that blocks the lock description pointed to by the argument `lock`. If no such lock is found, then `None` is returned
+/// `fcntl(fd, F_GETLK)`—Get the first lock that blocks the lock description pointed to by the
+/// argument `lock`. If no such lock is found, then `None` is returned
+///
+/// If `lock.typ` is `FlockType::Unlocked`, then `Err(io::Errno::INVAL)` is returned
 ///
 /// # References
 ///  - [POSIX]

--- a/src/process/fcntl_getlk.rs
+++ b/src/process/fcntl_getlk.rs
@@ -1,0 +1,25 @@
+use super::Flock;
+use crate::fd::AsFd;
+use crate::{backend, io};
+
+/// `fcntl(fd, F_GETLK)`—Get the first lock that blocks the lock description pointed to by the argument `lock`.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/fcntl.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/fcntl.2.html
+#[cfg(not(any(
+    target_os = "emscripten",
+    target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
+#[inline]
+#[doc(alias = "F_GETLK")]
+pub fn fcntl_getlk<Fd: AsFd>(fd: Fd, lock: &Flock) -> io::Result<Option<Flock>> {
+    backend::process::syscalls::fcntl_getlk(fd.as_fd(), lock)
+}

--- a/src/process/fcntl_getlk.rs
+++ b/src/process/fcntl_getlk.rs
@@ -2,7 +2,7 @@ use super::Flock;
 use crate::fd::AsFd;
 use crate::{backend, io};
 
-/// `fcntl(fd, F_GETLK)`—Get the first lock that blocks the lock description pointed to by the argument `lock`.
+/// `fcntl(fd, F_GETLK)`—Get the first lock that blocks the lock description pointed to by the argument `lock`. If no such lock is found, then `None` is returned
 ///
 /// # References
 ///  - [POSIX]

--- a/src/process/fcntl_getlk.rs
+++ b/src/process/fcntl_getlk.rs
@@ -10,14 +10,6 @@ use crate::{backend, io};
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/fcntl.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/fcntl.2.html
-#[cfg(not(any(
-    target_os = "emscripten",
-    target_os = "espidf",
-    target_os = "fuchsia",
-    target_os = "redox",
-    target_os = "vita",
-    target_os = "wasi"
-)))]
 #[inline]
 #[doc(alias = "F_GETLK")]
 pub fn fcntl_getlk<Fd: AsFd>(fd: Fd, lock: &Flock) -> io::Result<Option<Flock>> {

--- a/src/process/fcntl_getlk.rs
+++ b/src/process/fcntl_getlk.rs
@@ -3,9 +3,10 @@ use crate::fd::AsFd;
 use crate::{backend, io};
 
 /// `fcntl(fd, F_GETLK)`—Get the first lock that blocks the lock description pointed to by the
-/// argument `lock`. If no such lock is found, then `None` is returned
+/// argument `lock`. If no such lock is found, then `None` is returned.
 ///
-/// If `lock.typ` is `FlockType::Unlocked`, then `Err(io::Errno::INVAL)` is returned
+/// If `lock.typ` is set to `FlockType::Unlocked`, the returned value/error is not explicitly
+/// defined, as per POSIX, and will depend on the underlying platform implementation.
 ///
 /// # References
 ///  - [POSIX]

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -5,7 +5,14 @@ mod chdir;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 mod chroot;
 mod exit;
-#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "emscripten",
+    target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 mod fcntl_getlk;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have get[gpu]id.
 mod id;
@@ -34,7 +41,14 @@ mod procctl;
     target_os = "wasi"
 )))]
 mod rlimit;
-#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "emscripten",
+    target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 mod types;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have umask.
 mod umask;
@@ -46,7 +60,14 @@ pub use chdir::*;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 pub use chroot::*;
 pub use exit::*;
-#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "emscripten",
+    target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 pub use fcntl_getlk::*;
 #[cfg(not(target_os = "wasi"))]
 pub use id::*;
@@ -74,7 +95,14 @@ pub use procctl::*;
     target_os = "wasi"
 )))]
 pub use rlimit::*;
-#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "emscripten",
+    target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 pub use types::*;
 #[cfg(not(target_os = "wasi"))]
 pub use umask::*;

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -5,6 +5,8 @@ mod chdir;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 mod chroot;
 mod exit;
+#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+mod fcntl_getlk;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have get[gpu]id.
 mod id;
 #[cfg(not(any(target_os = "aix", target_os = "espidf", target_os = "vita")))]
@@ -32,6 +34,8 @@ mod procctl;
     target_os = "wasi"
 )))]
 mod rlimit;
+#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+mod types;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have umask.
 mod umask;
 #[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
@@ -42,6 +46,8 @@ pub use chdir::*;
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 pub use chroot::*;
 pub use exit::*;
+#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+pub use fcntl_getlk::*;
 #[cfg(not(target_os = "wasi"))]
 pub use id::*;
 #[cfg(not(any(target_os = "aix", target_os = "espidf", target_os = "vita")))]
@@ -68,6 +74,8 @@ pub use procctl::*;
     target_os = "wasi"
 )))]
 pub use rlimit::*;
+#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+pub use types::*;
 #[cfg(not(target_os = "wasi"))]
 pub use umask::*;
 #[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]

--- a/src/process/types.rs
+++ b/src/process/types.rs
@@ -50,7 +50,7 @@ impl From<FlockType> for Flock {
             length: 0,
             pid: None,
             typ: value,
-            offset_type: FlockOffsetType::Seek,
+            offset_type: FlockOffsetType::Set,
         }
     }
 }
@@ -76,7 +76,7 @@ pub enum FlockType {
 #[repr(i16)]
 pub enum FlockOffsetType {
     /// `F_SEEK_SET`
-    Seek = c::SEEK_SET as _,
+    Set = c::SEEK_SET as _,
     /// `F_SEEK_CUR`
     Current = c::SEEK_CUR as _,
     /// `F_SEEK_END`

--- a/src/process/types.rs
+++ b/src/process/types.rs
@@ -32,14 +32,14 @@ impl Flock {
         }
     }
 
-    pub(crate) const fn as_raw(&self) -> c::flock {
-        c::flock {
-            l_start: self.start as _,
-            l_len: self.length as _,
-            l_pid: unsafe { transmute(self.pid) },
-            l_type: self.typ as _,
-            l_whence: self.offset_type as _,
-        }
+    pub(crate) fn as_raw(&self) -> c::flock {
+        let mut f: c::flock = unsafe { core::mem::zeroed() };
+        f.l_start = self.start as _;
+        f.l_len = self.length as _;
+        f.l_pid = unsafe { transmute(self.pid) };
+        f.l_type = self.typ as _;
+        f.l_whence = self.offset_type as _;
+        f
     }
 }
 

--- a/src/process/types.rs
+++ b/src/process/types.rs
@@ -1,0 +1,84 @@
+#![allow(unsafe_code)]
+
+use crate::backend::c;
+use crate::pid::Pid;
+use core::mem::transmute;
+
+/// File lock data structure used in [`fcntl_getlk`].
+///
+/// [`fcntl_getlk`]: crate::fs::fcntl_getlk
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Flock {
+    /// Starting offset for lock
+    pub start: isize,
+    /// Number of bytes to lock
+    pub length: isize,
+    /// PID of process blocking our lock. If set to `None`, it refers to the current process
+    pub pid: Option<Pid>,
+    /// Type of lock
+    pub typ: FlockType,
+    /// Offset type of lock
+    pub offset_type: FlockOffsetType,
+}
+
+impl Flock {
+    pub(crate) const unsafe fn from_raw_unchecked(raw_fl: c::flock) -> Flock {
+        Flock {
+            start: raw_fl.l_start as _,
+            length: raw_fl.l_len as _,
+            pid: transmute(raw_fl.l_pid),
+            typ: transmute(raw_fl.l_type),
+            offset_type: transmute(raw_fl.l_whence),
+        }
+    }
+
+    pub(crate) const fn as_raw(&self) -> c::flock {
+        c::flock {
+            l_start: self.start as _,
+            l_len: self.length as _,
+            l_pid: unsafe { transmute(self.pid) },
+            l_type: self.typ as _,
+            l_whence: self.offset_type as _,
+        }
+    }
+}
+
+impl From<FlockType> for Flock {
+    fn from(value: FlockType) -> Self {
+        Flock {
+            start: 0,
+            length: 0,
+            pid: None,
+            typ: value,
+            offset_type: FlockOffsetType::Seek,
+        }
+    }
+}
+
+/// `F_*LCK` constants for use with [`fcntl_getlk`].
+///
+/// [`fcntl_getlk`]: crate::fs::fcntl_getlk
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i16)]
+pub enum FlockType {
+    /// `F_RDLCK`
+    ReadLock = c::F_RDLCK as _,
+    /// `F_WRLCK`
+    WriteLock = c::F_WRLCK as _,
+    /// `F_UNLCK`
+    Unlocked = c::F_UNLCK as _,
+}
+
+/// `F_SEEK*` constants for use with [`fcntl_getlk`].
+///
+/// [`fcntl_getlk`]: crate::fs::fcntl_getlk
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i16)]
+pub enum FlockOffsetType {
+    /// `F_SEEK_SET`
+    Seek = c::SEEK_SET as _,
+    /// `F_SEEK_CUR`
+    Current = c::SEEK_CUR as _,
+    /// `F_SEEK_END`
+    End = c::SEEK_END as _,
+}

--- a/src/process/types.rs
+++ b/src/process/types.rs
@@ -10,9 +10,9 @@ use core::mem::transmute;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Flock {
     /// Starting offset for lock
-    pub start: isize,
+    pub start: u64,
     /// Number of bytes to lock
-    pub length: isize,
+    pub length: u64,
     /// PID of process blocking our lock. If set to `None`, it refers to the current process
     pub pid: Option<Pid>,
     /// Type of lock

--- a/tests/process/fcntl_getlk.rs
+++ b/tests/process/fcntl_getlk.rs
@@ -2,7 +2,6 @@ use rustix::fd::{AsRawFd, BorrowedFd};
 use rustix::fs::{fcntl_lock, FlockOperation};
 use rustix::process::{fcntl_getlk, getppid, Flock, FlockType};
 use std::fs::File;
-use std::io::ErrorKind;
 use std::os::unix::process::CommandExt;
 use std::process::Command;
 

--- a/tests/process/fcntl_getlk.rs
+++ b/tests/process/fcntl_getlk.rs
@@ -14,9 +14,6 @@ fn test_fcntl_getlk() {
     fcntl_lock(&f, FlockOperation::Unlock).unwrap();
     unsafe {
         child_process(&f, |fd| {
-            let err = fcntl_getlk(&fd, &Flock::from(FlockType::Unlocked)).unwrap_err();
-            assert_eq!(err.kind(), ErrorKind::InvalidInput);
-
             let lock = fcntl_getlk(&fd, &Flock::from(FlockType::ReadLock)).unwrap();
             assert_eq!(lock, None);
 
@@ -28,9 +25,6 @@ fn test_fcntl_getlk() {
     fcntl_lock(&f, FlockOperation::LockShared).unwrap();
     unsafe {
         child_process(&f, |fd| {
-            let err = fcntl_getlk(&fd, &Flock::from(FlockType::Unlocked)).unwrap_err();
-            assert_eq!(err.kind(), ErrorKind::InvalidInput);
-
             let lock = fcntl_getlk(&fd, &Flock::from(FlockType::ReadLock)).unwrap();
             assert_eq!(lock, None);
 
@@ -42,9 +36,6 @@ fn test_fcntl_getlk() {
     fcntl_lock(&f, FlockOperation::LockExclusive).unwrap();
     unsafe {
         child_process(&f, |fd| {
-            let err = fcntl_getlk(&fd, &Flock::from(FlockType::Unlocked)).unwrap_err();
-            assert_eq!(err.kind(), ErrorKind::InvalidInput);
-
             let lock = fcntl_getlk(&fd, &Flock::from(FlockType::ReadLock)).unwrap();
             assert_eq!(lock.and_then(|l| l.pid), getppid());
 

--- a/tests/process/fcntl_getlk.rs
+++ b/tests/process/fcntl_getlk.rs
@@ -1,0 +1,73 @@
+use rustix::fd::BorrowedFd;
+use rustix::fs::{fcntl_lock, FlockOperation};
+use rustix::process::{fcntl_getlk, getppid, Flock, FlockType};
+use std::fs::File;
+use std::io::ErrorKind;
+use std::os::fd::AsRawFd;
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+
+#[cfg(feature = "fs")]
+#[test]
+fn test_fcntl_getlk() {
+    let f = tempfile::tempfile().unwrap();
+
+    fcntl_lock(&f, FlockOperation::Unlock).unwrap();
+    unsafe {
+        child_process(&f, |fd| {
+            let err = fcntl_getlk(&fd, &Flock::from(FlockType::Unlocked)).unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::InvalidInput);
+
+            let lock = fcntl_getlk(&fd, &Flock::from(FlockType::ReadLock)).unwrap();
+            assert_eq!(lock, None);
+
+            let lock = fcntl_getlk(&fd, &Flock::from(FlockType::WriteLock)).unwrap();
+            assert_eq!(lock, None);
+        })
+    };
+
+    fcntl_lock(&f, FlockOperation::LockShared).unwrap();
+    unsafe {
+        child_process(&f, |fd| {
+            let err = fcntl_getlk(&fd, &Flock::from(FlockType::Unlocked)).unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::InvalidInput);
+
+            let lock = fcntl_getlk(&fd, &Flock::from(FlockType::ReadLock)).unwrap();
+            assert_eq!(lock, None);
+
+            let lock = fcntl_getlk(&fd, &Flock::from(FlockType::WriteLock)).unwrap();
+            assert_eq!(lock.and_then(|l| l.pid), getppid());
+        })
+    };
+
+    fcntl_lock(&f, FlockOperation::LockExclusive).unwrap();
+    unsafe {
+        child_process(&f, |fd| {
+            let err = fcntl_getlk(&fd, &Flock::from(FlockType::Unlocked)).unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::InvalidInput);
+
+            let lock = fcntl_getlk(&fd, &Flock::from(FlockType::ReadLock)).unwrap();
+            assert_eq!(lock.and_then(|l| l.pid), getppid());
+
+            let lock = fcntl_getlk(&fd, &Flock::from(FlockType::WriteLock)).unwrap();
+            assert_eq!(lock.and_then(|l| l.pid), getppid());
+        })
+    };
+}
+
+unsafe fn child_process<F>(file: &File, f: F)
+where
+    F: Fn(BorrowedFd<'static>) -> () + Send + Sync + 'static,
+{
+    let fd = BorrowedFd::borrow_raw(file.as_raw_fd());
+    let output = Command::new("true")
+        .pre_exec(move || {
+            f(fd);
+            Ok(())
+        })
+        .output()
+        .unwrap();
+    if !output.status.success() {
+        panic!("{}", std::str::from_utf8(&output.stderr).unwrap());
+    }
+}

--- a/tests/process/fcntl_getlk.rs
+++ b/tests/process/fcntl_getlk.rs
@@ -1,9 +1,8 @@
-use rustix::fd::BorrowedFd;
+use rustix::fd::{AsRawFd, BorrowedFd};
 use rustix::fs::{fcntl_lock, FlockOperation};
 use rustix::process::{fcntl_getlk, getppid, Flock, FlockType};
 use std::fs::File;
 use std::io::ErrorKind;
-use std::os::fd::AsRawFd;
 use std::os::unix::process::CommandExt;
 use std::process::Command;
 

--- a/tests/process/main.rs
+++ b/tests/process/main.rs
@@ -4,6 +4,15 @@
 #![cfg(not(windows))]
 #![cfg_attr(core_c_str, feature(core_c_str))]
 
+#[cfg(not(any(
+    target_os = "emscripten",
+    target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "redox",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
+mod fcntl_getlk;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have get[gpu]id.
 mod id;
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Fixes #1076.

I added this inside the `process` module as `Pid` was inaccessible in the `fs` module, and it makes more sense to include it inside `process` as we can use it to access the pid, and lock data which is held by another process. I read the code for `rustix::fs::fcntl_lock`, and added this functionality in a similar manner, but let me know if the APIs/code organization need work.

I still need to add a test for this though, but I'm not sure what would be the best way to do that. As a process will always be able to acquire it's own lock, we'll probably need to spawn another process and read the advisory lock set by the parent process over there. We may use `std::os::unix::process::CommandExt::before_exec` for forking but it might not be the best way, given that it's unsafe and we'll have to handle race conditions, so I need some guidance here.

EDIT: Used `std::os::unix::process::CommandExt::pre_exec` for spawning child processes in tests for now.

EDIT 2: After running the tests, I found that MacOS and FreeBSD are the only platform which don't return `EINVAL` when `l_type` is set to `F_UNLCK`. For ensuring consistent behavior, I've added a check [here](https://github.com/bytecodealliance/rustix/pull/1310/files#diff-3f3e90e7733855d35135272bb9f04f01aef49e024cbcb90afe5da63a86ee5b53R669-R671). Let me know if I should respect platform-specific behavior or keep the status quo.