### PR TITLE
Document experimental runtime API on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ targets = [
     "wasm32-unknown-emscripten",
     "wasm32-wasip1",
 ]
+rustdoc-args = ["--cfg", "document_experimental_runtime_api"]
 
 [features]
 


### PR DESCRIPTION
One can also use `cargo docs-rs` locally for viewing docs.

Closes #1180