### PR TITLE
Add `ip_mtu` and `ipv6_mtu` on linux platform

### DIFF
--- a/src/backend/libc/net/sockopt.rs
+++ b/src/backend/libc/net/sockopt.rs
@@ -480,6 +480,18 @@ pub(crate) fn ipv6_v6only(fd: BorrowedFd<'_>) -> io::Result<bool> {
     getsockopt(fd, c::IPPROTO_IPV6, c::IPV6_V6ONLY).map(to_bool)
 }
 
+#[cfg(linux_kernel)]
+#[inline]
+pub(crate) fn ip_mtu(fd: BorrowedFd<'_>) -> io::Result<u32> {
+    getsockopt(fd, c::IPPROTO_IP, c::IP_MTU)
+}
+
+#[cfg(linux_kernel)]
+#[inline]
+pub(crate) fn ipv6_mtu(fd: BorrowedFd<'_>) -> io::Result<u32> {
+    getsockopt(fd, c::IPPROTO_IPV6, c::IPV6_MTU)
+}
+
 #[inline]
 pub(crate) fn set_ip_multicast_if(fd: BorrowedFd<'_>, value: &Ipv4Addr) -> io::Result<()> {
     setsockopt(fd, c::IPPROTO_IP, c::IP_MULTICAST_IF, to_imr_addr(value))

--- a/src/backend/linux_raw/net/sockopt.rs
+++ b/src/backend/linux_raw/net/sockopt.rs
@@ -28,7 +28,7 @@ use core::time::Duration;
 use linux_raw_sys::xdp::{xdp_mmap_offsets, xdp_statistics, xdp_statistics_v1};
 use linux_raw_sys::{
     general::{__kernel_old_timeval, __kernel_sock_timeval},
-    net::{IPV6_MULTICAST_IF, IP_MULTICAST_IF},
+    net::{IPV6_MTU, IPV6_MULTICAST_IF, IP_MTU, IP_MULTICAST_IF},
 };
 #[cfg(target_arch = "x86")]
 use {
@@ -450,12 +450,12 @@ pub(crate) fn ipv6_v6only(fd: BorrowedFd<'_>) -> io::Result<bool> {
 
 #[inline]
 pub(crate) fn ip_mtu(fd: BorrowedFd<'_>) -> io::Result<u32> {
-    getsockopt(fd, c::IPPROTO_IP, c::IP_MTU)
+    getsockopt(fd, c::IPPROTO_IP, IP_MTU)
 }
 
 #[inline]
 pub(crate) fn ipv6_mtu(fd: BorrowedFd<'_>) -> io::Result<u32> {
-    getsockopt(fd, c::IPPROTO_IPV6, c::IPV6_MTU)
+    getsockopt(fd, c::IPPROTO_IPV6, IPV6_MTU)
 }
 
 #[inline]

--- a/src/backend/linux_raw/net/sockopt.rs
+++ b/src/backend/linux_raw/net/sockopt.rs
@@ -449,6 +449,16 @@ pub(crate) fn ipv6_v6only(fd: BorrowedFd<'_>) -> io::Result<bool> {
 }
 
 #[inline]
+pub(crate) fn ip_mtu(fd: BorrowedFd<'_>) -> io::Result<u32> {
+    getsockopt(fd, c::IPPROTO_IP, c::IP_MTU)
+}
+
+#[inline]
+pub(crate) fn ipv6_mtu(fd: BorrowedFd<'_>) -> io::Result<u32> {
+    getsockopt(fd, c::IPPROTO_IPV6, c::IPV6_MTU)
+}
+
+#[inline]
 pub(crate) fn set_ip_multicast_if_with_ifindex(
     fd: BorrowedFd<'_>,
     multiaddr: &Ipv4Addr,

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -647,6 +647,30 @@ pub fn ipv6_v6only<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
     backend::net::sockopt::ipv6_v6only(fd.as_fd())
 }
 
+/// `getsockopt(fd, IPPROTO_IP, IP_MTU)`
+///
+/// See the [module-level documentation] for more.
+///
+/// [module-level documentation]: self#references-for-get_ip_-and-set_ip_-functions
+#[inline]
+#[cfg(linux_kernel)]
+#[doc(alias = "IP_MTU")]
+pub fn ip_mtu<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
+    backend::net::sockopt::ip_mtu(fd.as_fd())
+}
+
+/// `getsockopt(fd, IPPROTO_IPV6, IPV6_MTU)`
+///
+/// See the [module-level documentation] for more.
+///
+/// [module-level documentation]: self#references-for-get_ip_-and-set_ip_-functions
+#[inline]
+#[cfg(linux_kernel)]
+#[doc(alias = "IPV6_MTU")]
+pub fn ipv6_mtu<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
+    backend::net::sockopt::ipv6_mtu(fd.as_fd())
+}
+
 /// `setsockopt(fd, IPPROTO_IP, IP_MULTICAST_IF, value)`
 ///
 /// See the [module-level documentation] for more.

--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -518,7 +518,15 @@ fn test_socketopts_ip_mtu() {
     let s = rustix::net::socket(AddressFamily::INET, SocketType::DGRAM, None).unwrap();
     rustix::net::bind(&s, &"127.0.0.1:0".parse().unwrap()).unwrap();
     rustix::net::connect(&s, &"127.0.0.1:0".parse().unwrap()).unwrap();
-    assert!(rustix::net::sockopt::ip_mtu(&s).unwrap() > 0);
+    match sockopt::ip_mtu(&s) {
+        Ok(mtu) => {
+            assert!(mtu > 0);
+        }
+        Err(e) if e.to_string().contains("Protocol not available") => {
+            // Skip test on unsupported platforms
+        }
+        Err(e) => panic!("{e}"),
+    }
 }
 
 #[cfg(linux_kernel)]
@@ -529,7 +537,16 @@ fn test_socketopts_ipv6_mtu() {
     let s = rustix::net::socket(AddressFamily::INET6, SocketType::DGRAM, None).unwrap();
     rustix::net::bind(&s, &"[::1]:0".parse().unwrap()).unwrap();
     rustix::net::connect(&s, &"[::1]:0".parse().unwrap()).unwrap();
-    assert!(rustix::net::sockopt::ipv6_mtu(&s).unwrap() > 0);
+
+    match sockopt::ipv6_mtu(&s) {
+        Ok(mtu) => {
+            assert!(mtu > 0);
+        }
+        Err(e) if e.to_string().contains("Protocol not available") => {
+            // Skip test on unsupported platforms
+        }
+        Err(e) => panic!("{e}"),
+    }
 }
 
 #[test]

--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -510,6 +510,28 @@ fn test_sockopts_ipv6() {
     test_sockopts_tcp(&s);
 }
 
+#[cfg(linux_kernel)]
+#[test]
+fn test_socketopts_ip_mtu() {
+    crate::init();
+
+    let s = rustix::net::socket(AddressFamily::INET, SocketType::DGRAM, None).unwrap();
+    rustix::net::bind(&s, &"127.0.0.1:0".parse().unwrap()).unwrap();
+    rustix::net::connect(&s, &"127.0.0.1:0".parse().unwrap()).unwrap();
+    assert!(rustix::net::sockopt::ip_mtu(&s).unwrap() > 0);
+}
+
+#[cfg(linux_kernel)]
+#[test]
+fn test_socketopts_ipv6_mtu() {
+    crate::init();
+
+    let s = rustix::net::socket(AddressFamily::INET, SocketType::DGRAM, None).unwrap();
+    rustix::net::bind(&s, &"[::1]:0".parse().unwrap()).unwrap();
+    rustix::net::connect(&s, &"[::1]:0".parse().unwrap()).unwrap();
+    assert!(rustix::net::sockopt::ipv6_mtu(&s).unwrap() > 0);
+}
+
 #[test]
 fn test_sockopts_multicast_ifv4() {
     crate::init();

--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -526,7 +526,7 @@ fn test_socketopts_ip_mtu() {
 fn test_socketopts_ipv6_mtu() {
     crate::init();
 
-    let s = rustix::net::socket(AddressFamily::INET, SocketType::DGRAM, None).unwrap();
+    let s = rustix::net::socket(AddressFamily::INET6, SocketType::DGRAM, None).unwrap();
     rustix::net::bind(&s, &"[::1]:0".parse().unwrap()).unwrap();
     rustix::net::connect(&s, &"[::1]:0".parse().unwrap()).unwrap();
     assert!(rustix::net::sockopt::ipv6_mtu(&s).unwrap() > 0);


### PR DESCRIPTION
Hi, add `ip_mtu` and `ipv6_mtu` for fetching MTU on connected sockets.