### PR TITLE
Change `epoll`'s timeout to `Option<&Timespec>`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,11 +208,14 @@ use-explicitly-provided-auxv = []
 
 # OS compatibility features
 
-# Optimize for Linux 4.11 or later
+# Specialize for Linux 4.11 or later
 linux_4_11 = []
 
-# Enable all optimizations for the latest Linux versions.
-linux_latest = ["linux_4_11"]
+# Specialize for Linux 5.11 or later
+linux_5_11 = ["linux_4_11"]
+
+# Enable all specializations for the latest Linux versions.
+linux_latest = ["linux_5_11"]
 
 # Enable features which depend on the Rust global allocator, such as functions
 # that return owned strings or `Vec`s.

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -2009,7 +2009,7 @@ pub(crate) fn statx(
     }
 }
 
-#[cfg(linux_kernel)]
+#[cfg(all(linux_kernel, not(feature = "linux_4_11")))]
 #[inline]
 pub(crate) fn is_statx_available() -> bool {
     unsafe {

--- a/tests/event/epoll.rs
+++ b/tests/event/epoll.rs
@@ -40,7 +40,7 @@ fn server(ready: Arc<(Mutex<u16>, Condvar)>) {
 
     let mut event_list = Vec::with_capacity(4);
     loop {
-        epoll::wait(&epoll, &mut event_list, -1).unwrap();
+        epoll::wait(&epoll, &mut event_list, None).unwrap();
         for event in &event_list {
             let target = event.data;
             if target.u64() == 1 {

--- a/tests/event/epoll_timeout.rs
+++ b/tests/event/epoll_timeout.rs
@@ -1,0 +1,25 @@
+use rustix::event::{epoll, Timespec};
+use std::time::Instant;
+
+#[test]
+fn epoll_timeout() {
+    let epoll_fd = epoll::create(epoll::CreateFlags::CLOEXEC).unwrap();
+
+    let start = Instant::now();
+    let mut events = Vec::with_capacity(1);
+    epoll::wait(
+        &epoll_fd,
+        &mut events,
+        Some(&Timespec {
+            tv_sec: 0,
+            tv_nsec: 1_000_000,
+        }),
+    )
+    .unwrap();
+
+    let duration = start.elapsed();
+
+    assert!(
+        duration.as_secs() > 0 || (duration.as_secs() == 0 && duration.subsec_nanos() >= 1_000_000)
+    );
+}

--- a/tests/event/main.rs
+++ b/tests/event/main.rs
@@ -6,6 +6,10 @@
 #[cfg(feature = "net")]
 #[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 mod epoll;
+#[cfg(not(feature = "rustc-dep-of-std"))] // TODO
+#[cfg(feature = "net")]
+#[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
+mod epoll_timeout;
 #[cfg(not(windows))]
 #[cfg(not(target_os = "wasi"))]
 mod eventfd;


### PR DESCRIPTION
This eliminates the last place in rustix's public API that exposed a time value as a `c_int` milliseconds.

On Linux, the syscall needed to pass a full timespec is only available on Linux >= 5.11, so add a "linux_5_11" cargo feature to enable it.