### PR TITLE
Rename `SocketAddrAny::len` to `SocketAddrAny::addr_len`.

### DIFF
--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -93,7 +93,7 @@ impl SocketAddrUnix {
         Self {
             unix: Self::init(),
             #[cfg(not(any(bsd, target_os = "haiku")))]
-            len: offsetof_sun_path() as SocketAddrLen,
+            len: offsetof_sun_path() as c::socklen_t,
         }
     }
 

--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -93,7 +93,7 @@ impl SocketAddrUnix {
         Self {
             unix: Self::init(),
             #[cfg(not(any(bsd, target_os = "haiku")))]
-            len: offsetof_sun_path() as _,
+            len: offsetof_sun_path() as SocketAddrLen,
         }
     }
 
@@ -155,11 +155,11 @@ impl SocketAddrUnix {
     pub(crate) fn addr_len(&self) -> SocketAddrLen {
         #[cfg(not(any(bsd, target_os = "haiku")))]
         {
-            self.len as _
+            bitcast!(self.len)
         }
         #[cfg(any(bsd, target_os = "haiku"))]
         {
-            c::socklen_t::from(self.unix.sun_len) as _
+            bitcast!(c::socklen_t::from(self.unix.sun_len))
         }
     }
 

--- a/src/backend/libc/net/msghdr.rs
+++ b/src/backend/libc/net/msghdr.rs
@@ -164,7 +164,7 @@ pub(crate) unsafe fn with_msghdr<R>(
     addr.with_sockaddr(|addr_ptr, addr_len| {
         let mut h = zero_msghdr();
         h.msg_name = addr_ptr as *mut _;
-        h.msg_namelen = addr_len as _;
+        h.msg_namelen = bitcast!(addr_len);
         h.msg_iov = iov.as_ptr() as _;
         h.msg_iovlen = msg_iov_len(iov.len());
         h.msg_control = control.as_control_ptr().cast();

--- a/src/backend/libc/net/read_sockaddr.rs
+++ b/src/backend/libc/net/read_sockaddr.rs
@@ -150,7 +150,7 @@ pub(crate) fn read_sockaddr_v4(addr: &SocketAddrAny) -> Result<SocketAddrV4, Err
     if addr.address_family() != AddressFamily::INET {
         return Err(Errno::AFNOSUPPORT);
     }
-    assert!(addr.len() as usize >= size_of::<c::sockaddr_in>());
+    assert!(addr.addr_len() as usize >= size_of::<c::sockaddr_in>());
     let decode = unsafe { &*addr.as_ptr().cast::<c::sockaddr_in>() };
     Ok(SocketAddrV4::new(
         Ipv4Addr::from(u32::from_be(in_addr_s_addr(decode.sin_addr))),
@@ -163,7 +163,7 @@ pub(crate) fn read_sockaddr_v6(addr: &SocketAddrAny) -> Result<SocketAddrV6, Err
     if addr.address_family() != AddressFamily::INET6 {
         return Err(Errno::AFNOSUPPORT);
     }
-    assert!(addr.len() as usize >= size_of::<c::sockaddr_in6>());
+    assert!(addr.addr_len() as usize >= size_of::<c::sockaddr_in6>());
     let decode = unsafe { &*addr.as_ptr().cast::<c::sockaddr_in6>() };
     Ok(SocketAddrV6::new(
         Ipv6Addr::from(in6_addr_s6_addr(decode.sin6_addr)),
@@ -181,7 +181,7 @@ pub(crate) fn read_sockaddr_unix(addr: &SocketAddrAny) -> Result<SocketAddrUnix,
     }
 
     let offsetof_sun_path = super::addr::offsetof_sun_path();
-    let len = addr.len() as usize;
+    let len = addr.addr_len() as usize;
 
     assert!(len >= offsetof_sun_path);
 
@@ -237,7 +237,7 @@ pub(crate) fn read_sockaddr_xdp(addr: &SocketAddrAny) -> Result<SocketAddrXdp, E
     if addr.address_family() != AddressFamily::XDP {
         return Err(Errno::AFNOSUPPORT);
     }
-    assert!(addr.len() as usize >= size_of::<c::sockaddr_xdp>());
+    assert!(addr.addr_len() as usize >= size_of::<c::sockaddr_xdp>());
     let decode = unsafe { &*addr.as_ptr().cast::<c::sockaddr_xdp>() };
     Ok(SocketAddrXdp::new(
         SockaddrXdpFlags::from_bits_retain(decode.sxdp_flags),
@@ -253,7 +253,7 @@ pub(crate) fn read_sockaddr_netlink(addr: &SocketAddrAny) -> Result<SocketAddrNe
     if addr.address_family() != AddressFamily::NETLINK {
         return Err(Errno::AFNOSUPPORT);
     }
-    assert!(addr.len() as usize >= size_of::<c::sockaddr_nl>());
+    assert!(addr.addr_len() as usize >= size_of::<c::sockaddr_nl>());
     let decode = unsafe { &*addr.as_ptr().cast::<c::sockaddr_nl>() };
     Ok(SocketAddrNetlink::new(decode.nl_pid, decode.nl_groups))
 }

--- a/src/backend/libc/net/syscalls.rs
+++ b/src/backend/libc/net/syscalls.rs
@@ -89,7 +89,7 @@ pub(crate) fn sendto(
                 send_recv_len(buf.len()),
                 bitflags_bits!(flags),
                 addr_ptr.cast(),
-                addr_len as _,
+                bitcast!(addr_len),
             ))
         })
     }
@@ -135,7 +135,11 @@ pub(crate) fn socket_with(
 pub(crate) fn bind(sockfd: BorrowedFd<'_>, addr: &impl SocketAddrArg) -> io::Result<()> {
     unsafe {
         addr.with_sockaddr(|addr_ptr, addr_len| {
-            ret(c::bind(borrowed_fd(sockfd), addr_ptr.cast(), addr_len as _))
+            ret(c::bind(
+                borrowed_fd(sockfd),
+                addr_ptr.cast(),
+                bitcast!(addr_len),
+            ))
         })
     }
 }
@@ -146,7 +150,7 @@ pub(crate) fn connect(sockfd: BorrowedFd<'_>, addr: &impl SocketAddrArg) -> io::
             ret(c::connect(
                 borrowed_fd(sockfd),
                 addr_ptr.cast(),
-                addr_len as _,
+                bitcast!(addr_len),
             ))
         })
     }

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -39,7 +39,7 @@ impl SocketAddrUnix {
             return Err(io::Errno::NAMETOOLONG);
         }
         for (i, b) in bytes.iter().enumerate() {
-            unix.sun_path[i] = *b as _;
+            unix.sun_path[i] = bitcast!(*b);
         }
         let len = offsetof_sun_path() + bytes.len();
         let len = len.try_into().unwrap();
@@ -81,7 +81,7 @@ impl SocketAddrUnix {
         Self {
             unix: Self::init(),
             #[cfg(not(any(bsd, target_os = "haiku")))]
-            len: offsetof_sun_path() as _,
+            len: offsetof_sun_path() as SocketAddrLen,
         }
     }
 
@@ -123,7 +123,7 @@ impl SocketAddrUnix {
 
     #[inline]
     pub(crate) fn addr_len(&self) -> SocketAddrLen {
-        self.len as _
+        bitcast!(self.len)
     }
 
     #[inline]

--- a/src/backend/linux_raw/net/msghdr.rs
+++ b/src/backend/linux_raw/net/msghdr.rs
@@ -59,7 +59,7 @@ pub(crate) unsafe fn with_recv_msghdr<R>(
         control.set_control_len(msghdr.msg_controllen as usize);
     }
 
-    name.len = msghdr.msg_namelen as _;
+    name.len = bitcast!(msghdr.msg_namelen);
 
     res
 }
@@ -105,7 +105,7 @@ pub(crate) unsafe fn with_msghdr<R>(
         // beyond the call to `with_sockaddr`.
         let mut msghdr = noaddr_msghdr(iov, control);
         msghdr.msg_name = addr_ptr as _;
-        msghdr.msg_namelen = addr_len as _;
+        msghdr.msg_namelen = bitcast!(addr_len);
 
         f(&msghdr)
     })

--- a/src/backend/linux_raw/net/read_sockaddr.rs
+++ b/src/backend/linux_raw/net/read_sockaddr.rs
@@ -64,7 +64,7 @@ pub(crate) fn read_sockaddr_v4(addr: &SocketAddrAny) -> Result<SocketAddrV4, Err
     if addr.address_family() != AddressFamily::INET {
         return Err(Errno::AFNOSUPPORT);
     }
-    assert!(addr.len() as usize >= size_of::<c::sockaddr_in>());
+    assert!(addr.addr_len() as usize >= size_of::<c::sockaddr_in>());
     let decode = unsafe { &*addr.as_ptr().cast::<c::sockaddr_in>() };
     Ok(SocketAddrV4::new(
         Ipv4Addr::from(u32::from_be(decode.sin_addr.s_addr)),
@@ -77,7 +77,7 @@ pub(crate) fn read_sockaddr_v6(addr: &SocketAddrAny) -> Result<SocketAddrV6, Err
     if addr.address_family() != AddressFamily::INET6 {
         return Err(Errno::AFNOSUPPORT);
     }
-    assert!(addr.len() as usize >= size_of::<c::sockaddr_in6>());
+    assert!(addr.addr_len() as usize >= size_of::<c::sockaddr_in6>());
     let decode = unsafe { &*addr.as_ptr().cast::<c::sockaddr_in6>() };
     Ok(SocketAddrV6::new(
         Ipv6Addr::from(unsafe { decode.sin6_addr.in6_u.u6_addr8 }),
@@ -93,7 +93,7 @@ pub(crate) fn read_sockaddr_unix(addr: &SocketAddrAny) -> Result<SocketAddrUnix,
         return Err(Errno::AFNOSUPPORT);
     }
     let offsetof_sun_path = super::addr::offsetof_sun_path();
-    let len = addr.len() as usize;
+    let len = addr.addr_len() as usize;
 
     assert!(len >= offsetof_sun_path);
 
@@ -130,7 +130,7 @@ pub(crate) fn read_sockaddr_xdp(addr: &SocketAddrAny) -> Result<SocketAddrXdp, E
     if addr.address_family() != AddressFamily::XDP {
         return Err(Errno::AFNOSUPPORT);
     }
-    assert!(addr.len() as usize >= size_of::<c::sockaddr_xdp>());
+    assert!(addr.addr_len() as usize >= size_of::<c::sockaddr_xdp>());
     let decode = unsafe { &*addr.as_ptr().cast::<c::sockaddr_xdp>() };
     Ok(SocketAddrXdp::new(
         SockaddrXdpFlags::from_bits_retain(decode.sxdp_flags),
@@ -145,7 +145,7 @@ pub(crate) fn read_sockaddr_netlink(addr: &SocketAddrAny) -> Result<SocketAddrNe
     if addr.address_family() != AddressFamily::NETLINK {
         return Err(Errno::AFNOSUPPORT);
     }
-    assert!(addr.len() as usize >= size_of::<c::sockaddr_nl>());
+    assert!(addr.addr_len() as usize >= size_of::<c::sockaddr_nl>());
     let decode = unsafe { &*addr.as_ptr().cast::<c::sockaddr_nl>() };
     Ok(SocketAddrNetlink::new(decode.nl_pid, decode.nl_groups))
 }

--- a/src/net/send_recv/msg.rs
+++ b/src/net/send_recv/msg.rs
@@ -319,7 +319,7 @@ impl<'buf, 'slice, 'fd> SendAncillaryBuffer<'buf, 'slice, 'fd> {
         // Get the pointer to the payload and copy the data.
         unsafe {
             let payload = c::CMSG_DATA(last_header);
-            ptr::copy_nonoverlapping(source.as_ptr(), payload, source_len as _);
+            ptr::copy_nonoverlapping(source.as_ptr(), payload, source_len as usize);
         }
 
         true
@@ -626,7 +626,7 @@ impl<'a> MMsgHdr<'a> {
         // give us a pointer directly, so we use that.
         let mut msghdr = noaddr_msghdr(iov, control);
         msghdr.msg_name = addr.as_ptr() as _;
-        msghdr.msg_namelen = addr.len() as _;
+        msghdr.msg_namelen = bitcast!(addr.addr_len());
 
         Self::wrap(msghdr)
     }
@@ -644,7 +644,7 @@ impl<'a> MMsgHdr<'a> {
     /// Returns the number of bytes sent. This will return 0 until after a
     /// successful call to [sendmmsg].
     pub fn bytes_sent(&self) -> usize {
-        self.raw.msg_len as _
+        self.raw.msg_len as usize
     }
 }
 

--- a/src/net/socket_addr_any.rs
+++ b/src/net/socket_addr_any.rs
@@ -138,7 +138,7 @@ impl SocketAddrAny {
 
     /// Returns the length of the encoded sockaddr.
     #[inline]
-    pub fn len(&self) -> SocketAddrLen {
+    pub fn addr_len(&self) -> SocketAddrLen {
         self.len.get()
     }
 }
@@ -206,7 +206,7 @@ impl fmt::Debug for SocketAddrAny {
 
         f.debug_struct("SocketAddrAny")
             .field("address_family", &self.address_family())
-            .field("namelen", &self.len())
+            .field("namelen", &self.addr_len())
             .finish()
     }
 }
@@ -217,7 +217,7 @@ unsafe impl SocketAddrArg for SocketAddrAny {
         &self,
         f: impl FnOnce(*const SocketAddrOpaque, SocketAddrLen) -> R,
     ) -> R {
-        f(self.as_ptr().cast(), self.len())
+        f(self.as_ptr().cast(), self.addr_len())
     }
 }
 


### PR DESCRIPTION
This better reflects how it returns `SocketAddrLen` instead of `usize`. And rewrite several `as _` casts to make them more explicit.