### PR TITLE
Implement `futex_waitv`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ event = []
 fs = []
 
 # Enable `rustix::io_uring::*` (on platforms that support it).
-io_uring = ["event", "fs", "net", "linux-raw-sys/io_uring"]
+io_uring = ["event", "fs", "net", "thread", "linux-raw-sys/io_uring"]
 
 # Enable `rustix::mount::*`.
 mount = []

--- a/src/backend/libc/thread/futex.rs
+++ b/src/backend/libc/thread/futex.rs
@@ -11,6 +11,42 @@ bitflags::bitflags! {
         const PRIVATE = bitcast!(c::FUTEX_PRIVATE_FLAG);
         /// `FUTEX_CLOCK_REALTIME`
         const CLOCK_REALTIME = bitcast!(c::FUTEX_CLOCK_REALTIME);
+
+        /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
+        const _ = !0;
+    }
+}
+
+bitflags::bitflags! {
+    /// `FUTEX2_*` flags for use with the functions in [`Waitv`].
+    ///
+    /// Not to be confused with [`WaitvFlags`], which is passed as an argument
+    /// to the `waitv` function.
+    ///
+    /// [`Waitv`]: crate::thread::futex::Waitv
+    /// [`WaitvFlags`]: crate::thread::futex::WaitvFlags
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+    pub struct WaitFlags: u32 {
+        /// `FUTEX_U8`
+        const SIZE_U8 = linux_raw_sys::general::FUTEX2_SIZE_U8;
+        /// `FUTEX_U16`
+        const SIZE_U16 = linux_raw_sys::general::FUTEX2_SIZE_U16;
+        /// `FUTEX_U32`
+        const SIZE_U32 = linux_raw_sys::general::FUTEX2_SIZE_U32;
+        /// `FUTEX_U64`
+        const SIZE_U64 = linux_raw_sys::general::FUTEX2_SIZE_U64;
+        /// `FUTEX_SIZE_MASK`
+        const SIZE_MASK = linux_raw_sys::general::FUTEX2_SIZE_MASK;
+
+        /// `FUTEX2_NUMA`
+        const NUMA = linux_raw_sys::general::FUTEX2_NUMA;
+
+        /// `FUTEX2_PRIVATE`
+        const PRIVATE = linux_raw_sys::general::FUTEX2_PRIVATE;
+
+        /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -12,6 +12,8 @@ pub(crate) use linux_raw_sys::errno::{EBADF, EINVAL};
 pub(crate) use linux_raw_sys::general::{__kernel_fd_set as fd_set, __FD_SETSIZE as FD_SETSIZE};
 pub(crate) use linux_raw_sys::ioctl::{FIONBIO, FIONREAD};
 // Import the kernel's `uid_t` and `gid_t` if they're 32-bit.
+#[cfg(feature = "thread")]
+pub(crate) use linux_raw_sys::general::futex_waitv;
 #[cfg(not(any(target_arch = "arm", target_arch = "sparc", target_arch = "x86")))]
 pub(crate) use linux_raw_sys::general::{__kernel_gid_t as gid_t, __kernel_uid_t as uid_t};
 pub(crate) use linux_raw_sys::general::{

--- a/src/backend/linux_raw/thread/futex.rs
+++ b/src/backend/linux_raw/thread/futex.rs
@@ -10,9 +10,41 @@ bitflags::bitflags! {
         /// `FUTEX_CLOCK_REALTIME`
         const CLOCK_REALTIME = linux_raw_sys::general::FUTEX_CLOCK_REALTIME;
 
-        // This deliberately lacks a `const _ = !0`, so that users can use
-        // `from_bits_truncate` to extract the `SocketFlags` from a flags
-        // value that also includes a `SocketType`.
+        /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
+        const _ = !0;
+    }
+}
+
+bitflags::bitflags! {
+    /// `FUTEX2_*` flags for use with the functions in [`Waitv`].
+    ///
+    /// Not to be confused with [`WaitvFlags`], which is passed as an argument
+    /// to the `waitv` function.
+    ///
+    /// [`Waitv`]: crate::thread::futex::Waitv
+    /// [`WaitvFlags`]: crate::thread::futex::WaitvFlags
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+    pub struct WaitFlags: u32 {
+        /// `FUTEX_U8`
+        const SIZE_U8 = linux_raw_sys::general::FUTEX2_SIZE_U8;
+        /// `FUTEX_U16`
+        const SIZE_U16 = linux_raw_sys::general::FUTEX2_SIZE_U16;
+        /// `FUTEX_U32`
+        const SIZE_U32 = linux_raw_sys::general::FUTEX2_SIZE_U32;
+        /// `FUTEX_U64`
+        const SIZE_U64 = linux_raw_sys::general::FUTEX2_SIZE_U64;
+        /// `FUTEX_SIZE_MASK`
+        const SIZE_MASK = linux_raw_sys::general::FUTEX2_SIZE_MASK;
+
+        /// `FUTEX2_NUMA`
+        const NUMA = linux_raw_sys::general::FUTEX2_NUMA;
+
+        /// `FUTEX2_PRIVATE`
+        const PRIVATE = linux_raw_sys::general::FUTEX2_PRIVATE;
+
+        /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
+        const _ = !0;
     }
 }
 

--- a/src/thread/futex.rs
+++ b/src/thread/futex.rs
@@ -525,6 +525,13 @@ impl WaitPtr {
     }
 }
 
+impl Default for WaitPtr {
+    #[inline]
+    fn default() -> Self {
+        Self::new(ptr::null_mut())
+    }
+}
+
 impl From<*mut c_void> for WaitPtr {
     #[inline]
     fn from(ptr: *mut c_void) -> Self {

--- a/src/thread/futex.rs
+++ b/src/thread/futex.rs
@@ -567,9 +567,7 @@ impl Wait {
     pub const fn new() -> Self {
         Self {
             val: 0,
-            uaddr: WaitPtr {
-                ptr: ptr::null_mut(),
-            },
+            uaddr: WaitPtr::new(ptr::null_mut()),
             flags: WaitFlags::empty(),
             __reserved: 0,
         }

--- a/tests/thread/futex.rs
+++ b/tests/thread/futex.rs
@@ -70,7 +70,10 @@ fn test_waitv_wake() {
     let lock = std::sync::Arc::new(AtomicU32::new(0));
 
     let mut wait = futex::Wait::new();
-    wait.uaddr = (*lock).as_ptr().cast::<c_void>().into();
+    // In Rust 1.70, use `AtomicU32::as_ptr`.
+    wait.uaddr = (&*lock as *const AtomicU32 as *mut u32)
+        .cast::<c_void>()
+        .into();
     wait.flags = futex::WaitFlags::SIZE_U32;
     wait.val = 1;
     match futex::waitv(
@@ -97,7 +100,10 @@ fn test_waitv_wake() {
 
             std::thread::sleep(std::time::Duration::from_millis(50));
             let mut wait = futex::Wait::new();
-            wait.uaddr = (*lock).as_ptr().cast::<c_void>().into();
+            // In Rust 1.70, use `AtomicU32::as_ptr`.
+            wait.uaddr = (&*lock as *const AtomicU32 as *mut u32)
+                .cast::<c_void>()
+                .into();
             wait.flags = futex::WaitFlags::SIZE_U32;
             wait.val = 1;
             match futex::waitv(
@@ -116,7 +122,10 @@ fn test_waitv_wake() {
     });
 
     let mut wait = futex::Wait::new();
-    wait.uaddr = (*lock).as_ptr().cast::<c_void>().into();
+    // In Rust 1.70, use `AtomicU32::as_ptr`.
+    wait.uaddr = (&*lock as *const AtomicU32 as *mut u32)
+        .cast::<c_void>()
+        .into();
     wait.flags = futex::WaitFlags::SIZE_U32;
     wait.val = 0;
     match futex::waitv(
@@ -190,7 +199,10 @@ fn test_waitv_timeout() {
     let lock = AtomicU32::new(0);
 
     let mut wait = futex::Wait::new();
-    wait.uaddr = lock.as_ptr().cast::<c_void>().into();
+    // In Rust 1.70, use `AtomicU32::as_ptr`.
+    wait.uaddr = (&lock as *const AtomicU32 as *mut u32)
+        .cast::<c_void>()
+        .into();
     wait.flags = futex::WaitFlags::SIZE_U32;
     wait.val = 0;
 

--- a/tests/thread/futex.rs
+++ b/tests/thread/futex.rs
@@ -83,6 +83,8 @@ fn test_waitv_wake() {
         Err(Errno::AGAIN) => {
             assert_eq!(lock.load(Ordering::SeqCst), 0, "the lock should still be 0")
         }
+        // Skip this test if the kernel doesn't support futex_waitv.
+        Err(Errno::NOSYS) => return,
         Err(err) => panic!("{err}"),
     }
 
@@ -202,6 +204,10 @@ fn test_waitv_timeout() {
         futex::ClockId::Monotonic,
     )
     .unwrap_err();
+    if err == Errno::NOSYS {
+        // Skip this test if the kernel doesn't support futex_waitv.
+        return;
+    }
     assert_eq!(err, Errno::TIMEDOUT);
 
     let err = futex::waitv(

--- a/tests/thread/futex.rs
+++ b/tests/thread/futex.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "std")]
+use core::ffi::c_void;
 use core::sync::atomic::{AtomicU32, Ordering};
 use rustix::io::Errno;
 use rustix::thread::futex;
@@ -40,7 +42,7 @@ fn test_wait_wake() {
 
             std::thread::sleep(std::time::Duration::from_millis(50));
             match futex::wait(&lock, futex::Flags::empty(), 1, None) {
-                Ok(()) => (),
+                Ok(()) => panic!("Nobody should be waking us now!"),
                 Err(Errno::AGAIN) => {
                     assert_eq!(lock.load(Ordering::SeqCst), 2, "the lock should now be 2")
                 }
@@ -61,9 +63,81 @@ fn test_wait_wake() {
     other.join().unwrap();
 }
 
+// Same as `test_wait_wake` but using `waitv`.
 #[cfg(feature = "std")]
 #[test]
-fn test_timeout() {
+fn test_waitv_wake() {
+    let lock = std::sync::Arc::new(AtomicU32::new(0));
+
+    let mut wait = futex::Wait::new();
+    wait.uaddr = (*lock).as_ptr().cast::<c_void>().into();
+    wait.flags = futex::WaitFlags::SIZE_U32;
+    wait.val = 1;
+    match futex::waitv(
+        &[wait],
+        futex::WaitvFlags::empty(),
+        None,
+        futex::ClockId::Monotonic,
+    ) {
+        Ok(_) => panic!("Nobody should be waking us!"),
+        Err(Errno::AGAIN) => {
+            assert_eq!(lock.load(Ordering::SeqCst), 0, "the lock should still be 0")
+        }
+        Err(err) => panic!("{err}"),
+    }
+
+    let other = std::thread::spawn({
+        let lock = lock.clone();
+        move || {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+            lock.store(1, Ordering::SeqCst);
+            futex::wake(&lock, futex::Flags::empty(), 1).unwrap();
+
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            let mut wait = futex::Wait::new();
+            wait.uaddr = (*lock).as_ptr().cast::<c_void>().into();
+            wait.flags = futex::WaitFlags::SIZE_U32;
+            wait.val = 1;
+            match futex::waitv(
+                &[wait],
+                futex::WaitvFlags::empty(),
+                None,
+                futex::ClockId::Monotonic,
+            ) {
+                Ok(_) => panic!("Nobody should be waking us now!"),
+                Err(Errno::AGAIN) => {
+                    assert_eq!(lock.load(Ordering::SeqCst), 2, "the lock should now be 2")
+                }
+                Err(err) => panic!("{err}"),
+            }
+        }
+    });
+
+    let mut wait = futex::Wait::new();
+    wait.uaddr = (*lock).as_ptr().cast::<c_void>().into();
+    wait.flags = futex::WaitFlags::SIZE_U32;
+    wait.val = 0;
+    match futex::waitv(
+        &[wait],
+        futex::WaitvFlags::empty(),
+        None,
+        futex::ClockId::Monotonic,
+    ) {
+        Ok(0) => {}
+        Ok(n) => panic!("Somehow we woke up waiter {}!", n),
+        Err(Errno::AGAIN) => assert_eq!(lock.load(Ordering::SeqCst), 1, "the lock should now be 1"),
+        Err(err) => panic!("{err}"),
+    }
+
+    lock.store(2, Ordering::SeqCst);
+    futex::wake(&lock, futex::Flags::empty(), 1).unwrap();
+
+    other.join().unwrap();
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn test_wait_timeout() {
     use rustix::thread::futex::Timespec;
 
     let lock = AtomicU32::new(0);
@@ -100,6 +174,56 @@ fn test_timeout() {
             tv_sec: -1,
             tv_nsec: 0,
         }),
+    )
+    .unwrap_err();
+    assert_eq!(err, Errno::INVAL);
+}
+
+// Same as `test_wait_timeout` but using `waitv`.
+#[cfg(feature = "std")]
+#[test]
+fn test_waitv_timeout() {
+    use rustix::thread::futex::Timespec;
+
+    let lock = AtomicU32::new(0);
+
+    let mut wait = futex::Wait::new();
+    wait.uaddr = lock.as_ptr().cast::<c_void>().into();
+    wait.flags = futex::WaitFlags::SIZE_U32;
+    wait.val = 0;
+
+    let err = futex::waitv(
+        &[wait],
+        futex::WaitvFlags::empty(),
+        Some(&Timespec {
+            tv_sec: 1,
+            tv_nsec: 13,
+        }),
+        futex::ClockId::Monotonic,
+    )
+    .unwrap_err();
+    assert_eq!(err, Errno::TIMEDOUT);
+
+    let err = futex::waitv(
+        &[wait],
+        futex::WaitvFlags::empty(),
+        Some(&Timespec {
+            tv_sec: 0,
+            tv_nsec: 1_000_000_000,
+        }),
+        futex::ClockId::Monotonic,
+    )
+    .unwrap_err();
+    assert_eq!(err, Errno::INVAL);
+
+    let err = futex::waitv(
+        &[wait],
+        futex::WaitvFlags::empty(),
+        Some(&Timespec {
+            tv_sec: -1,
+            tv_nsec: 0,
+        }),
+        futex::ClockId::Monotonic,
     )
     .unwrap_err();
     assert_eq!(err, Errno::INVAL);


### PR DESCRIPTION
Implement the new `futex_waitv` syscall, as well as the corresponding io_uring support.