### PR TITLE
Factor out a `SocketAddrArg::write_sockaddr` function.

### DIFF
--- a/src/net/addr.rs
+++ b/src/net/addr.rs
@@ -90,13 +90,11 @@ pub unsafe trait SocketAddrArg {
     /// `storage` must be valid to write up to `size_of<SocketAddrStorage>()`
     /// bytes to.
     unsafe fn write_sockaddr(&self, storage: *mut SocketAddrStorage) -> SocketAddrLen {
-        // SAFETY: The closure dereferences exactly `len` bytes at `ptr`.
-        unsafe {
-            self.with_sockaddr(|ptr, len| {
-                ptr::copy_nonoverlapping(ptr.cast::<u8>(), storage.cast::<u8>(), len as usize);
-                len
-            })
-        }
+        // The closure dereferences exactly `len` bytes at `ptr`.
+        self.with_sockaddr(|ptr, len| {
+            ptr::copy_nonoverlapping(ptr.cast::<u8>(), storage.cast::<u8>(), len as usize);
+            len
+        })
     }
 }
 

--- a/src/process/types.rs
+++ b/src/process/types.rs
@@ -1,4 +1,6 @@
 //! Types for use with [`rustix::process`] functions.
+//!
+//! [`rustix::process`]: crate::process
 
 #![allow(unsafe_code)]
 

--- a/tests/net/unix.rs
+++ b/tests/net/unix.rs
@@ -418,7 +418,6 @@ fn test_abstract_unix_msg_unconnected() {
     do_test_unix_msg_unconnected(name);
 }
 
-#[cfg(feature = "pipe")]
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[cfg(feature = "pipe")]
 #[test]
@@ -715,7 +714,6 @@ fn test_unix_peercred_implicit() {
 
 /// Like `test_unix_msg_with_scm_rights`, but with multiple file descriptors
 /// over multiple control messages.
-#[cfg(feature = "pipe")]
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[cfg(feature = "pipe")]
 #[test]

--- a/tests/net/unix_alloc.rs
+++ b/tests/net/unix_alloc.rs
@@ -416,7 +416,6 @@ fn test_abstract_unix_msg_unconnected() {
     do_test_unix_msg_unconnected(name);
 }
 
-#[cfg(feature = "pipe")]
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[cfg(feature = "pipe")]
 #[test]
@@ -656,7 +655,6 @@ fn test_unix_peercred() {
 
 /// Like `test_unix_msg_with_scm_rights`, but with multiple file descriptors
 /// over multiple control messages.
-#[cfg(feature = "pipe")]
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[cfg(feature = "pipe")]
 #[test]

--- a/tests/termios/termios.rs
+++ b/tests/termios/termios.rs
@@ -120,6 +120,20 @@ fn test_termios_modes() {
     assert!(new_tio.output_modes.contains(OutputModes::ONOCR));
     assert!(new_tio.input_modes.contains(InputModes::IGNBRK));
     assert!(new_tio.control_modes.contains(ControlModes::CLOCAL));
+
+    tio.local_modes.remove(LocalModes::TOSTOP);
+    tio.output_modes.remove(OutputModes::ONOCR);
+    tio.input_modes.remove(InputModes::IGNBRK);
+    tio.control_modes.remove(ControlModes::CLOCAL);
+
+    tcsetattr(&pty, OptionalActions::Now, &tio).unwrap();
+
+    let new_tio = tcgetattr(&pty).unwrap();
+
+    assert!(!new_tio.local_modes.contains(LocalModes::TOSTOP));
+    assert!(!new_tio.output_modes.contains(OutputModes::ONOCR));
+    assert!(!new_tio.input_modes.contains(InputModes::IGNBRK));
+    assert!(!new_tio.control_modes.contains(ControlModes::CLOCAL));
 }
 
 // Disable on illumos where `tcgetattr` doesn't appear to support


### PR DESCRIPTION
This is needed by c-scape in order to encode socket addresses into libc-compatible form.

And a few other minor cleanups.