### PR TITLE
Make `fadvise`'s `len` parameter an `Option<NonZeroU64>`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -223,5 +223,12 @@ specific socket types using `From`/`Into`/`TryFrom`/`TryInto` conversions.
 
 [`SocketAddrAny`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.SocketAddrAny.html
 
+The `len` parameter to [`rustix::fs::fadvise`] has changed from `u64` to
+`Option<NonZeroU64>`, to reflect that zero is a special case meaning the
+advice applies to the end of the file. To convert an arbitrary `u64` value to
+`Option<NonZeroU64>`, use `NonZeroU64::new`.
+
+[`rustix::fs::fadvise`]: https://docs.rs/rustix/1.0.0/rustix/fs/fn.fadvise.html
+
 All explicitly deprecated functions and types have been removed. Their
 deprecation messages will have identified alternatives.

--- a/src/fs/fadvise.rs
+++ b/src/fs/fadvise.rs
@@ -1,9 +1,12 @@
 use crate::{backend, io};
 use backend::fd::AsFd;
 use backend::fs::types::Advice;
+use core::num::NonZeroU64;
 
 /// `posix_fadvise(fd, offset, len, advice)`—Declares an expected access
 /// pattern for a file.
+///
+/// If `len` is `None`, the advice extends to the end of the file.
 ///
 /// # References
 ///  - [POSIX]
@@ -15,6 +18,11 @@ use backend::fs::types::Advice;
 /// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=posix_fadvise&sektion=2
 #[inline]
 #[doc(alias = "posix_fadvise")]
-pub fn fadvise<Fd: AsFd>(fd: Fd, offset: u64, len: u64, advice: Advice) -> io::Result<()> {
+pub fn fadvise<Fd: AsFd>(
+    fd: Fd,
+    offset: u64,
+    len: Option<NonZeroU64>,
+    advice: Advice,
+) -> io::Result<()> {
     backend::fs::syscalls::fadvise(fd.as_fd(), offset, len, advice)
 }

--- a/src/net/addr.rs
+++ b/src/net/addr.rs
@@ -155,7 +155,7 @@ mod tests {
     fn test_layouts() {
         assert_eq_size!(SocketAddrLen, c::socklen_t);
 
-        #[cfg(not(windows))]
+        #[cfg(not(any(windows, target_os = "redox")))]
         assert_eq!(
             memoffset::span_of!(c::msghdr, msg_namelen).len(),
             size_of::<SocketAddrLen>()

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -1,3 +1,15 @@
+
+#[cfg(not(any(
+    apple,
+    netbsdlike,
+    target_os = "solaris",
+    target_os = "dragonfly",
+    target_os = "espidf",
+    target_os = "haiku",
+    target_os = "redox",
+)))]
+use core::num::NonZeroU64;
+
 #[cfg(not(target_os = "redox"))]
 #[test]
 fn test_file() {
@@ -88,9 +100,8 @@ fn test_file() {
         target_os = "dragonfly",
         target_os = "espidf",
         target_os = "haiku",
-        target_os = "redox",
     )))]
-    rustix::fs::fadvise(&file, 0, 10, rustix::fs::Advice::Normal).unwrap();
+    rustix::fs::fadvise(&file, 0, NonZeroU64::new(10), rustix::fs::Advice::Normal).unwrap();
 
     rustix::fs::fsync(&file).unwrap();
 
@@ -99,7 +110,6 @@ fn test_file() {
         target_os = "dragonfly",
         target_os = "espidf",
         target_os = "haiku",
-        target_os = "redox",
     )))]
     rustix::fs::fdatasync(&file).unwrap();
 
@@ -134,7 +144,6 @@ fn test_file() {
         solarish,
         target_os = "haiku",
         target_os = "netbsd",
-        target_os = "redox",
         target_os = "wasi",
     )))]
     {

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -1,4 +1,3 @@
-
 #[cfg(not(any(
     apple,
     netbsdlike,

--- a/tests/fs/invalid_offset.rs
+++ b/tests/fs/invalid_offset.rs
@@ -67,6 +67,7 @@ fn invalid_offset_fallocate() {
 )))]
 #[test]
 fn invalid_offset_fadvise() {
+    use core::num::NonZeroU64;
     use rustix::fs::{fadvise, openat, Advice, Mode, OFlags, CWD};
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(CWD, tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
@@ -79,21 +80,63 @@ fn invalid_offset_fadvise() {
     .unwrap();
 
     // `fadvise` never fails on invalid offsets.
-    fadvise(&file, i64::MAX as u64, i64::MAX as u64, Advice::Normal).unwrap();
-    fadvise(&file, u64::MAX, 0, Advice::Normal).unwrap();
-    fadvise(&file, i64::MAX as u64, 1, Advice::Normal).unwrap();
-    fadvise(&file, 1, i64::MAX as u64, Advice::Normal).unwrap();
-    fadvise(&file, i64::MAX as u64 + 1, 0, Advice::Normal).unwrap();
-    fadvise(&file, u64::MAX, i64::MAX as u64, Advice::Normal).unwrap();
+    fadvise(
+        &file,
+        i64::MAX as u64,
+        NonZeroU64::new(i64::MAX as u64),
+        Advice::Normal,
+    )
+    .unwrap();
+    fadvise(&file, u64::MAX, None, Advice::Normal).unwrap();
+    fadvise(&file, i64::MAX as u64, NonZeroU64::new(1), Advice::Normal).unwrap();
+    fadvise(&file, 1, NonZeroU64::new(i64::MAX as u64), Advice::Normal).unwrap();
+    fadvise(&file, i64::MAX as u64 + 1, None, Advice::Normal).unwrap();
+    fadvise(
+        &file,
+        u64::MAX,
+        NonZeroU64::new(i64::MAX as u64),
+        Advice::Normal,
+    )
+    .unwrap();
 
     // `fadvise` fails on invalid lengths.
-    fadvise(&file, u64::MAX, u64::MAX, Advice::Normal).unwrap_err();
-    fadvise(&file, i64::MAX as u64, u64::MAX, Advice::Normal).unwrap_err();
-    fadvise(&file, 0, u64::MAX, Advice::Normal).unwrap_err();
-    fadvise(&file, u64::MAX, i64::MAX as u64 + 1, Advice::Normal).unwrap_err();
-    fadvise(&file, i64::MAX as u64 + 1, u64::MAX, Advice::Normal).unwrap_err();
-    fadvise(&file, i64::MAX as u64, i64::MAX as u64 + 1, Advice::Normal).unwrap_err();
-    fadvise(&file, 0, i64::MAX as u64 + 1, Advice::Normal).unwrap_err();
+    fadvise(&file, u64::MAX, NonZeroU64::new(u64::MAX), Advice::Normal).unwrap_err();
+    fadvise(
+        &file,
+        i64::MAX as u64,
+        NonZeroU64::new(u64::MAX),
+        Advice::Normal,
+    )
+    .unwrap_err();
+    fadvise(&file, 0, NonZeroU64::new(u64::MAX), Advice::Normal).unwrap_err();
+    fadvise(
+        &file,
+        u64::MAX,
+        NonZeroU64::new(i64::MAX as u64 + 1),
+        Advice::Normal,
+    )
+    .unwrap_err();
+    fadvise(
+        &file,
+        i64::MAX as u64 + 1,
+        NonZeroU64::new(u64::MAX),
+        Advice::Normal,
+    )
+    .unwrap_err();
+    fadvise(
+        &file,
+        i64::MAX as u64,
+        NonZeroU64::new(i64::MAX as u64 + 1),
+        Advice::Normal,
+    )
+    .unwrap_err();
+    fadvise(
+        &file,
+        0,
+        NonZeroU64::new(i64::MAX as u64 + 1),
+        Advice::Normal,
+    )
+    .unwrap_err();
 }
 
 #[test]

--- a/tests/fs/negative_timestamp.rs
+++ b/tests/fs/negative_timestamp.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_os = "redox"))]
 #[test]
 fn negative_file_timetamp() {
     use rustix::fs::{


### PR DESCRIPTION
This reflects how zero is special-cased to mean the length to the end of the file.

Fixes #1333.