### PR TITLE
Remove netlink protocol constants that are actually socket options

### DIFF
--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1110,46 +1110,6 @@ pub mod netlink {
     /// `NETLINK_INET_DIAG`
     #[cfg(linux_kernel)]
     pub const INET_DIAG: Protocol = Protocol(new_raw_protocol(c::NETLINK_INET_DIAG as _));
-    /// `NETLINK_ADD_MEMBERSHIP`
-    #[cfg(linux_kernel)]
-    pub const ADD_MEMBERSHIP: Protocol = Protocol(new_raw_protocol(c::NETLINK_ADD_MEMBERSHIP as _));
-    /// `NETLINK_DROP_MEMBERSHIP`
-    #[cfg(linux_kernel)]
-    pub const DROP_MEMBERSHIP: Protocol =
-        Protocol(new_raw_protocol(c::NETLINK_DROP_MEMBERSHIP as _));
-    /// `NETLINK_PKTINFO`
-    #[cfg(linux_kernel)]
-    pub const PKTINFO: Protocol = Protocol(new_raw_protocol(c::NETLINK_PKTINFO as _));
-    /// `NETLINK_BROADCAST_ERROR`
-    #[cfg(linux_kernel)]
-    pub const BROADCAST_ERROR: Protocol =
-        Protocol(new_raw_protocol(c::NETLINK_BROADCAST_ERROR as _));
-    /// `NETLINK_NO_ENOBUFS`
-    #[cfg(linux_kernel)]
-    pub const NO_ENOBUFS: Protocol = Protocol(new_raw_protocol(c::NETLINK_NO_ENOBUFS as _));
-    /// `NETLINK_RX_RING`
-    #[cfg(linux_kernel)]
-    pub const RX_RING: Protocol = Protocol(new_raw_protocol(c::NETLINK_RX_RING as _));
-    /// `NETLINK_TX_RING`
-    #[cfg(linux_kernel)]
-    pub const TX_RING: Protocol = Protocol(new_raw_protocol(c::NETLINK_TX_RING as _));
-    /// `NETLINK_LISTEN_ALL_NSID`
-    #[cfg(linux_kernel)]
-    pub const LISTEN_ALL_NSID: Protocol =
-        Protocol(new_raw_protocol(c::NETLINK_LISTEN_ALL_NSID as _));
-    /// `NETLINK_LIST_MEMBERSHIPS`
-    #[cfg(linux_kernel)]
-    pub const LIST_MEMBERSHIPS: Protocol =
-        Protocol(new_raw_protocol(c::NETLINK_LIST_MEMBERSHIPS as _));
-    /// `NETLINK_CAP_ACK`
-    #[cfg(linux_kernel)]
-    pub const CAP_ACK: Protocol = Protocol(new_raw_protocol(c::NETLINK_CAP_ACK as _));
-    /// `NETLINK_EXT_ACK`
-    #[cfg(linux_kernel)]
-    pub const EXT_ACK: Protocol = Protocol(new_raw_protocol(c::NETLINK_EXT_ACK as _));
-    /// `NETLINK_GET_STRICT_CHK`
-    #[cfg(linux_kernel)]
-    pub const GET_STRICT_CHK: Protocol = Protocol(new_raw_protocol(c::NETLINK_GET_STRICT_CHK as _));
 
     /// A Netlink socket address.
     ///


### PR DESCRIPTION
From https://github.com/bytecodealliance/rustix/issues/1252: these are not protocols but rather socket options. Most of these are listed under `Socket Options` in the [netlink man page](https://man7.org/linux/man-pages/man7/netlink.7.html). The remaining two (`RX_RING` and `TX_RING`) are in the [same block of `#defines` in the kernel source](https://github.com/torvalds/linux/blob/496659003dac5d08ea292c44fce9dfb36fa34691/tools/include/uapi/linux/netlink.h#L145-L158) and all the code I can find using these passes them to `setsockopt`.

As discussed in https://github.com/bytecodealliance/rustix/issues/1252 these socket options could be exposed in various ways, but for the sake of 1.0, remove the `Protocol` constants that don't belong.