### PR TITLE
Use `io_uring_ptr` for pointers in `io_uring_getevents_arg`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -230,5 +230,14 @@ advice applies to the end of the file. To convert an arbitrary `u64` value to
 
 [`rustix::fs::fadvise`]: https://docs.rs/rustix/1.0.0/rustix/fs/fn.fadvise.html
 
+The [`sigmask`] and [`ts`] fields of [`rustix::io_uring::getevents_arg`]
+changed from `u64` to [`rustix::io_uring::io_uring_ptr`], to better preserve
+pointer provenance.
+
+[`sigmask`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/struct.io_uring_getevents_arg.html#structfield.sigmask
+[`ts`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/struct.io_uring_getevents_arg.html#structfield.ts
+[`rustix::io_uring::getevents_arg`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/struct.io_uring_getevents_arg.html
+[`rustix::io_uring::io_uring_ptr`]: https://docs.rs/rustix/1.0.0-prerelease.0/rustix/io_uring/struct.io_uring_ptr.html
+
 All explicitly deprecated functions and types have been removed. Their
 deprecation messages will have identified alternatives.

--- a/src/io_uring/mod.rs
+++ b/src/io_uring/mod.rs
@@ -1568,8 +1568,8 @@ mod tests {
         // io_uring stores them in a `u64`.
         unsafe {
             const MAGIC: u64 = !0x0123456789abcdef;
-            let ptr = io_uring_ptr::from(core::ptr::without_provenance_mut(MAGIC as usize));
-            assert_eq!(ptr.ptr, core::ptr::without_provenance_mut(MAGIC as usize));
+            let ptr = io_uring_ptr::from(MAGIC as usize as *mut c_void);
+            assert_eq!(ptr.ptr, MAGIC as usize as *mut c_void);
             #[cfg(target_pointer_width = "16")]
             assert_eq!(ptr.__pad16, 0);
             #[cfg(any(target_pointer_width = "16", target_pointer_width = "32"))]

--- a/src/io_uring/mod.rs
+++ b/src/io_uring/mod.rs
@@ -958,7 +958,8 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: i32 = sys::IORING_NOTIF_USAGE_ZC_COPIED 
 /// `io_uring`'s native API represents pointers as `u64` values. In order to
 /// preserve strict-provenance, use a `*mut c_void`. On platforms where
 /// pointers are narrower than 64 bits, this requires additional padding.
-#[repr(C, align(8))]
+#[repr(C)]
+#[cfg_attr(target_arch = "arm", repr(align(8)))]
 #[derive(Copy, Clone)]
 #[non_exhaustive]
 pub struct io_uring_ptr {

--- a/src/io_uring/mod.rs
+++ b/src/io_uring/mod.rs
@@ -1395,10 +1395,10 @@ pub struct io_uring_rsrc_update2 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Default)]
 pub struct io_uring_getevents_arg {
-    pub sigmask: u64,
+    pub sigmask: io_uring_ptr,
     pub sigmask_sz: u32,
     pub min_wait_usec: u32,
-    pub ts: u64,
+    pub ts: io_uring_ptr,
 }
 
 #[allow(missing_docs)]

--- a/src/io_uring/mod.rs
+++ b/src/io_uring/mod.rs
@@ -958,7 +958,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: i32 = sys::IORING_NOTIF_USAGE_ZC_COPIED 
 /// `io_uring`'s native API represents pointers as `u64` values. In order to
 /// preserve strict-provenance, use a `*mut c_void`. On platforms where
 /// pointers are narrower than 64 bits, this requires additional padding.
-#[repr(C)]
+#[repr(C, align(8))]
 #[derive(Copy, Clone)]
 #[non_exhaustive]
 pub struct io_uring_ptr {
@@ -1560,6 +1560,7 @@ mod tests {
         use sys as c;
 
         assert_eq_size!(io_uring_ptr, u64);
+        assert_eq_align!(io_uring_ptr, u64);
 
         check_renamed_type!(off_or_addr2_union, io_uring_sqe__bindgen_ty_1);
         check_renamed_type!(addr_or_splice_off_in_union, io_uring_sqe__bindgen_ty_2);


### PR DESCRIPTION
io_uring represents pointers as `u64`. Rustix uses an `io_uring_ptr` struct which is layout-compatible with `u64` but preserves pointer provenance.