### PR TITLE
Add support for `renameat_with` on Apple platforms

### DIFF
--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -475,6 +475,25 @@ bitflags! {
     }
 }
 
+#[cfg(apple)]
+bitflags! {
+    /// `RENAME_*` constants for use with [`renameat_with`].
+    ///
+    /// [`renameat_with`]: crate::fs::renameat_with
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+    pub struct RenameFlags: ffi::c_uint {
+        /// `RENAME_SWAP`
+        const EXCHANGE = bitcast!(c::RENAME_SWAP);
+
+        /// `RENAME_EXCL`
+        const NOREPLACE = bitcast!(c::RENAME_EXCL);
+
+        /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
+        const _ = !0;
+    }
+}
+
 /// `S_IF*` constants for use with [`mknodat`] and [`Stat`]'s `st_mode` field.
 ///
 /// [`mknodat`]: crate::fs::mknodat

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -14,7 +14,7 @@ use crate::fs::Access;
 use crate::fs::AtFlags;
 #[cfg(apple)]
 use crate::fs::CloneFlags;
-#[cfg(linux_kernel)]
+#[cfg(any(linux_kernel, apple))]
 use crate::fs::RenameFlags;
 #[cfg(not(target_os = "espidf"))]
 use crate::fs::Stat;
@@ -277,9 +277,10 @@ pub fn renameat<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/renameat2.2.html
-#[cfg(linux_kernel)]
+#[cfg(any(apple, linux_kernel))]
 #[inline]
 #[doc(alias = "renameat2")]
+#[doc(alias = "renameatx_np")]
 pub fn renameat_with<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(
     old_dirfd: PFd,
     old_path: P,


### PR DESCRIPTION
Apple platforms (both iOS and macOS) added a `renameat2` equivalent in 10.12 (and the iOS equivalent). This patch uses that syscall to implement `renameat2`, and subsequently `renameat_with`.

Unlike Linux, the `RenameFlags::WHITEOUT` flag isn't supported. At the moment, any programs trying to use that flag will fail to compile on Apple operating systems.