### PR TITLE
Update the io_uring module for Linux changes

### DIFF
--- a/tests/io_uring/register.rs
+++ b/tests/io_uring/register.rs
@@ -158,7 +158,7 @@ fn io_uring_buf_ring_can_be_registered() {
     let br = unsafe { br_ptr.as_mut() }.expect("A valid io_uring_buf_ring struct");
 
     let reg = io_uring_buf_reg {
-        ring_addr: br_ptr as u64,
+        ring_addr: br_ptr.cast::<c_void>().into(),
         ring_entries: ENTRIES as u32,
         bgid: BGID,
         flags: 0,


### PR DESCRIPTION
Add new opcodes `ReadMultishot`, `Waitid`, `FixedFdInstall`, `Ftruncate`, `Bind`, and `Listen`, and add support for `IoringFeatureFlags::RECVSEND_BUNDLE`.

Also, use `io_uring_ptr` and `io_uring_user_data` instead of `u64` in more fields, to better preserve pointer provenance, and add more utility functions for working with `io_uring_ptr` and `io_uring_user_data`.