### PR TITLE
Make `io_uring_enter` more ergonomic.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -230,6 +230,12 @@ advice applies to the end of the file. To convert an arbitrary `u64` value to
 
 [`rustix::fs::fadvise`]: https://docs.rs/rustix/1.0.0/rustix/fs/fn.fadvise.html
 
+[`rustix::io_uring::io_uring_enter`] has a new signature; instead of `arg` and
+`size` providing a raw `*mut c_void` and `usize`, it now takes any `&T` and
+infers the size.
+
+[`rustix::io_uring::io_uring_enter`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/fn.io_uring_enter.html
+
 The [`sigmask`] and [`ts`] fields of [`rustix::io_uring::getevents_arg`]
 changed from `u64` to [`rustix::io_uring::io_uring_ptr`], to better preserve
 pointer provenance.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ name = "mod"
 harness = false
 
 [package.metadata.docs.rs]
-features = ["all-apis", "use-libc-sigrt"]
+features = ["all-apis"]
 targets = [
     "x86_64-unknown-linux-gnu",
     "i686-unknown-linux-gnu",
@@ -195,9 +195,6 @@ all-apis = [
     "thread",
     "time",
 ]
-
-# Enable `Signal::rt` and related features, which depend on libc.
-use-libc-sigrt = []
 
 # When using the linux_raw backend, should we use libc for reading the aux
 # vectors, instead of reading them ourselves from /proc/self/auxv?

--- a/src/check_types.rs
+++ b/src/check_types.rs
@@ -106,3 +106,26 @@ macro_rules! check_struct {
         $(check_struct_field!($name, $field));*
     };
 }
+
+/// For the case of renaming, check all fields of a struct.
+macro_rules! check_renamed_struct {
+    ($to_struct:ident, $from_struct:ident, $($field:ident),*) => {
+        // Check the size and alignment.
+        check_renamed_type!($to_struct, $from_struct);
+
+        // Check that we have all the fields.
+        if false {
+            #[allow(unreachable_code)]
+            let _test = $to_struct {
+                $($field: panic!()),*
+            };
+            #[allow(unreachable_code)]
+            let _test = c::$from_struct {
+                $($field: panic!()),*
+            };
+        }
+
+        // Check that the fields have the right sizes and offsets.
+        $(check_renamed_struct_field!($to_struct, $from_struct, $field));*
+    };
+}

--- a/src/kernel_sigset.rs
+++ b/src/kernel_sigset.rs
@@ -1,0 +1,270 @@
+//! The [`KernelSigSet`] type.
+
+#![allow(unsafe_code)]
+#![allow(non_camel_case_types)]
+
+use crate::signal::Signal;
+use core::fmt;
+use linux_raw_sys::general::{kernel_sigset_t, _NSIG};
+
+/// `kernel_sigset_t`—A set of signal numbers, as used by some syscalls.
+///
+/// Like [`SigSet`] but with only enough space for the signals currently known
+/// to be used by the kernel. It is used in functions where Linux's
+/// documentation states that the size "is currently required to have a fixed
+/// architecture specific value (equal to `sizeof(kernel_sigset_t)`)".
+///
+/// This type is guaranteed to have a subset of the layout of `libc::sigset_t`.
+///
+/// libc implementations typically reserve some signal values for internal use.
+/// In a process that contains a libc, some unsafe functions invoke undefined
+/// behavior if passed a `KernelSigSet` that contains one of the signals that
+/// the libc reserves.
+///
+/// [`SigSet`]: crate::sigset::SigSet
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct KernelSigSet(kernel_sigset_t);
+
+impl KernelSigSet {
+    /// Create a new empty `KernelSigSet`.
+    pub const fn empty() -> Self {
+        Self(kernel_sigset_t {
+            #[cfg(target_pointer_width = "64")]
+            sig: [0; 1],
+            #[cfg(target_pointer_width = "32")]
+            sig: [0; 2],
+        })
+    }
+
+    /// Create a new `KernelSigSet` with all signals set.
+    ///
+    /// This includes signals which are typically reserved for libc.
+    pub const fn all() -> Self {
+        Self(kernel_sigset_t {
+            #[cfg(target_pointer_width = "64")]
+            sig: [!0; 1],
+            #[cfg(target_pointer_width = "32")]
+            sig: [!0; 2],
+        })
+    }
+
+    /// Remove all signals.
+    pub fn clear(&mut self) {
+        *self = Self(kernel_sigset_t {
+            sig: Default::default(),
+        });
+    }
+
+    /// Insert a signal.
+    pub fn insert(&mut self, sig: Signal) {
+        let sigs_per_elt = core::mem::size_of_val(&self.0.sig[0]) * 8;
+
+        let raw = (sig.as_raw().wrapping_sub(1)) as usize;
+        self.0.sig[raw / sigs_per_elt] |= 1 << (raw % sigs_per_elt);
+    }
+
+    /// Insert all signals.
+    pub fn insert_all(&mut self) {
+        self.0.sig.fill(!0);
+    }
+
+    /// Remove a signal.
+    pub fn remove(&mut self, sig: Signal) {
+        let sigs_per_elt = core::mem::size_of_val(&self.0.sig[0]) * 8;
+
+        let raw = (sig.as_raw().wrapping_sub(1)) as usize;
+        self.0.sig[raw / sigs_per_elt] &= !(1 << (raw % sigs_per_elt));
+    }
+
+    /// Test whether a given signal is present.
+    pub fn contains(&self, sig: Signal) -> bool {
+        let sigs_per_elt = core::mem::size_of_val(&self.0.sig[0]) * 8;
+
+        let raw = (sig.as_raw().wrapping_sub(1)) as usize;
+        (self.0.sig[raw / sigs_per_elt] & (1 << (raw % sigs_per_elt))) != 0
+    }
+}
+
+impl Default for KernelSigSet {
+    #[inline]
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl fmt::Debug for KernelSigSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_set();
+
+        // Surprisingly, `_NSIG` is inclusive.
+        for i in 1..=_NSIG {
+            // SAFETY: This value is non-zero, in range, and only used for
+            // debug output.
+            let sig = unsafe { Signal::from_raw_unchecked(i as _) };
+
+            if self.contains(sig) {
+                d.entry(&sig);
+            }
+        }
+
+        d.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::{KERNEL_SIGRTMAX, KERNEL_SIGRTMIN};
+    use crate::sigset::SigSet;
+    use core::mem::{align_of, size_of};
+
+    #[test]
+    fn test_assumptions() {
+        assert!(KERNEL_SIGRTMAX as usize - 1 < size_of::<KernelSigSet>() * 8);
+    }
+
+    #[test]
+    fn test_layouts() {
+        assert!(size_of::<KernelSigSet>() <= size_of::<libc::sigset_t>());
+        assert!(align_of::<KernelSigSet>() <= align_of::<libc::sigset_t>());
+    }
+
+    /// A bunch of signals for testing.
+    const SIGS: [Signal; 31] = [
+        Signal::HUP,
+        Signal::INT,
+        Signal::QUIT,
+        Signal::ILL,
+        Signal::TRAP,
+        Signal::ABORT,
+        Signal::BUS,
+        Signal::FPE,
+        Signal::KILL,
+        Signal::USR1,
+        Signal::SEGV,
+        Signal::USR2,
+        Signal::PIPE,
+        Signal::ALARM,
+        Signal::TERM,
+        Signal::CHILD,
+        Signal::CONT,
+        Signal::STOP,
+        Signal::TSTP,
+        Signal::TTIN,
+        Signal::TTOU,
+        Signal::URG,
+        Signal::XCPU,
+        Signal::XFSZ,
+        Signal::VTALARM,
+        Signal::PROF,
+        Signal::WINCH,
+        Signal::SYS,
+        unsafe { Signal::from_raw_unchecked(KERNEL_SIGRTMIN) },
+        unsafe { Signal::from_raw_unchecked(KERNEL_SIGRTMIN + 7) },
+        unsafe { Signal::from_raw_unchecked(KERNEL_SIGRTMAX) },
+    ];
+
+    #[test]
+    fn test_ops_plain() {
+        for sig in SIGS {
+            let mut set = KernelSigSet::empty();
+            for sig in SIGS {
+                assert!(!set.contains(sig));
+            }
+
+            set.insert(sig);
+            assert!(set.contains(sig));
+            for sig in SIGS.iter().filter(|s| **s != sig) {
+                assert!(!set.contains(*sig));
+            }
+
+            set.remove(sig);
+            for sig in SIGS {
+                assert!(!set.contains(sig));
+            }
+        }
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut set = KernelSigSet::empty();
+        for sig in SIGS {
+            set.insert(sig);
+        }
+
+        set.clear();
+
+        for sig in SIGS {
+            assert!(!set.contains(sig));
+        }
+    }
+
+    // We guarantee that `KernelSigSet` has a subset of the layout of `SigSet`.
+    // Test this.
+    #[test]
+    fn test_sigset_layout_compatibility() {
+        use crate::utils::as_ptr;
+
+        let mut s = SigSet::empty();
+        let mut k = KernelSigSet::empty();
+
+        assert_eq!(
+            unsafe {
+                libc::memcmp(
+                    as_ptr(&s).cast(),
+                    as_ptr(&k).cast(),
+                    (KERNEL_SIGRTMAX as usize + 7) / 8,
+                )
+            },
+            0
+        );
+
+        for sig in SIGS {
+            k.insert(sig);
+            assert_ne!(
+                unsafe {
+                    libc::memcmp(
+                        as_ptr(&s).cast(),
+                        as_ptr(&k).cast(),
+                        (KERNEL_SIGRTMAX as usize + 7) / 8,
+                    )
+                },
+                0
+            );
+            s.insert(sig);
+            assert_eq!(
+                unsafe {
+                    libc::memcmp(
+                        as_ptr(&s).cast(),
+                        as_ptr(&k).cast(),
+                        (KERNEL_SIGRTMAX as usize + 7) / 8,
+                    )
+                },
+                0
+            );
+            k.remove(sig);
+            assert_ne!(
+                unsafe {
+                    libc::memcmp(
+                        as_ptr(&s).cast(),
+                        as_ptr(&k).cast(),
+                        (KERNEL_SIGRTMAX as usize + 7) / 8,
+                    )
+                },
+                0
+            );
+            s.remove(sig);
+            assert_eq!(
+                unsafe {
+                    libc::memcmp(
+                        as_ptr(&s).cast(),
+                        as_ptr(&k).cast(),
+                        (KERNEL_SIGRTMAX as usize + 7) / 8,
+                    )
+                },
+                0
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,6 +343,9 @@ pub(crate) mod path;
 #[cfg(not(any(windows, target_os = "espidf")))]
 #[cfg(any(feature = "thread", feature = "time", target_arch = "x86"))]
 mod clockid;
+#[cfg(linux_raw)]
+#[cfg(feature = "runtime")]
+mod kernel_sigset;
 #[cfg(not(any(windows, target_os = "wasi")))]
 #[cfg(any(
     feature = "process",
@@ -357,8 +360,16 @@ mod pid;
 #[cfg(linux_kernel)]
 mod prctl;
 #[cfg(not(any(windows, target_os = "espidf", target_os = "wasi")))]
-#[cfg(any(feature = "process", feature = "runtime", all(bsd, feature = "event")))]
+#[cfg(any(
+    feature = "io_uring",
+    feature = "process",
+    feature = "runtime",
+    all(bsd, feature = "event")
+))]
 mod signal;
+#[cfg(linux_kernel)]
+#[cfg(any(feature = "runtime", feature = "io_uring"))]
+mod sigset;
 #[cfg(any(
     feature = "fs",
     feature = "event",

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -863,8 +863,8 @@ mod tests {
             sa_flags,
             sa_mask
         );
-        assert_eq_size!(KernelSigactionFlags, core::ffi::c_ulong);
-        assert_eq_align!(KernelSigactionFlags, core::ffi::c_ulong);
+        assert_eq_size!(KernelSigactionFlags, crate::ffi::c_ulong);
+        assert_eq_align!(KernelSigactionFlags, crate::ffi::c_ulong);
         check_renamed_type!(KernelSigrestore, __sigrestore_t);
         check_renamed_type!(KernelSighandler, __kernel_sighandler_t);
 

--- a/src/sigset.rs
+++ b/src/sigset.rs
@@ -1,0 +1,384 @@
+//! The [`SigSet`] type.
+//!
+//! # Safety
+//!
+//! This code calls libc `sigset_t` functions.
+
+#![allow(unsafe_code)]
+#![allow(non_camel_case_types)]
+
+#[cfg(all(linux_raw, feature = "runtime"))]
+use crate::kernel_sigset::KernelSigSet;
+use crate::signal::Signal;
+#[cfg(linux_raw)]
+use crate::utils::as_mut_ptr;
+use core::fmt;
+#[cfg(linux_raw)]
+use core::mem::MaybeUninit;
+
+// linux_raw backend: use a `sigset_t` that matches libc so that we support the
+// same extensibility.
+#[cfg(linux_raw)]
+#[repr(C)]
+#[derive(Clone)]
+struct sigset_t {
+    // The fields are `MaybeUninit` because this is guaranteed to match the
+    // libc representation and libc implementations don't always initialize
+    // fields beyond `_NSIG`.
+    #[cfg(target_pointer_width = "32")]
+    __val: [MaybeUninit<u32>; 32],
+    #[cfg(target_pointer_width = "64")]
+    __val: [MaybeUninit<u64>; 16],
+}
+
+// libc backend: use libc's `sigset_t`.
+#[cfg(libc)]
+use libc::sigset_t;
+
+/// `sigset_t`—A set of signal numbers.
+///
+/// This type is guaranteed to have the same layout as `libc::sigset_t`.
+///
+/// libc implementations typically reserve some signal values for internal use.
+/// In a process that contains a libc, some unsafe functions invoke undefined
+/// behavior if passed a `SigSet` that contains one of the signals that the
+/// libc reserves.
+///
+/// For additional operations such as [`SigSet::all`] and
+/// [`SigSet::insert_all`], which are wrappers around `libc::sigfillset`, see
+/// [rustix-libc-wrappers].
+///
+/// [`SigSet::all`]: https://docs.rs/rustix-libc-wrappers/*/rustix_libc_wrappers/trait.SigSetExt.html#tymethod.all
+/// [`SigSet::insert_all`]: https://docs.rs/rustix-libc-wrappers/*/rustix_libc_wrappers/trait.SigSetExt.html#tymethod.insert_all
+/// [rustix-libc-wrappers]: https://docs.rs/rustix-libc-wrappers
+// This is `repr(transparent)` so that users such as rustix-libc-wrappers and
+// c-scape can cast pointers to `libc::sigset_t` to pointers to `SigSet`.
+#[repr(transparent)]
+#[derive(Clone)]
+#[doc(alias = "sigfillset")]
+pub struct SigSet(sigset_t);
+
+impl SigSet {
+    /// Create a new empty `SigSet`.
+    #[doc(alias = "sigemptyset")]
+    pub fn empty() -> Self {
+        #[cfg(linux_raw)]
+        {
+            Self(sigset_t {
+                #[cfg(target_pointer_width = "32")]
+                __val: [MaybeUninit::zeroed(); 32],
+                #[cfg(target_pointer_width = "64")]
+                __val: [MaybeUninit::zeroed(); 16],
+            })
+        }
+
+        // SAFETY: Use `sigemptyset` from libc to initialize `new`.
+        #[cfg(libc)]
+        unsafe {
+            let mut new = core::mem::MaybeUninit::<sigset_t>::uninit();
+            let _r = libc::sigemptyset(new.as_mut_ptr());
+            debug_assert_eq!(_r, 0);
+            Self(new.assume_init())
+        }
+    }
+
+    /// Remove all signals.
+    #[doc(alias = "sigemptyset")]
+    pub fn clear(&mut self) {
+        #[cfg(linux_raw)]
+        {
+            self.0.__val.fill(MaybeUninit::zeroed());
+        }
+
+        // SAFETY: Use `sigemptyset` from libc.
+        #[cfg(libc)]
+        unsafe {
+            let _r = libc::sigemptyset(&mut self.0);
+            debug_assert_eq!(_r, 0);
+        }
+    }
+
+    /// Insert a signal.
+    #[doc(alias = "sigaddset")]
+    pub fn insert(&mut self, sig: Signal) {
+        // This assumes the `Signal` does not contain any of the values
+        // reserved by libc, which is enforced by `Signal`'s API.
+        #[cfg(linux_raw)]
+        {
+            let sigs_per_elt = core::mem::size_of_val(&self.0.__val[0]) * 8;
+
+            let raw = (sig.as_raw().wrapping_sub(1)) as usize;
+            let elt = unsafe { self.0.__val[raw / sigs_per_elt].assume_init_mut() };
+            *elt |= 1 << (raw % sigs_per_elt);
+        }
+
+        // SAFETY: Use `sigaddset` from libc.
+        #[cfg(libc)]
+        unsafe {
+            let _r = libc::sigaddset(&mut self.0, sig.as_raw());
+            debug_assert_eq!(_r, 0);
+        }
+    }
+
+    /// Remove a signal.
+    #[doc(alias = "sigdelset")]
+    pub fn remove(&mut self, sig: Signal) {
+        // This assumes the `Signal` does not contain any of the values
+        // reserved by libc, which is enforced by `Signal`'s API.
+        #[cfg(linux_raw)]
+        {
+            let sigs_per_elt = core::mem::size_of_val(&self.0.__val[0]) * 8;
+
+            let raw = (sig.as_raw().wrapping_sub(1)) as usize;
+            let elt = unsafe { self.0.__val[raw / sigs_per_elt].assume_init_mut() };
+            *elt &= !(1 << (raw % sigs_per_elt));
+        }
+
+        // SAFETY: Use `sigdelset` from libc.
+        #[cfg(libc)]
+        unsafe {
+            let _r = libc::sigdelset(&mut self.0, sig.as_raw());
+            debug_assert_eq!(_r, 0);
+        }
+    }
+
+    /// Test whether a given signal is present.
+    #[doc(alias = "sigismember")]
+    pub fn contains(&self, sig: Signal) -> bool {
+        #[cfg(linux_raw)]
+        {
+            let sigs_per_elt = core::mem::size_of_val(&self.0.__val[0]) * 8;
+
+            let raw = (sig.as_raw().wrapping_sub(1)) as usize;
+            let elt = unsafe { self.0.__val[raw / sigs_per_elt].assume_init_ref() };
+            (*elt & (1 << (raw % sigs_per_elt))) != 0
+        }
+
+        // SAFETY: Use `sigismember` from libc.
+        #[cfg(libc)]
+        unsafe {
+            // Treat `-1` as meaning the set does not contain the signal.
+            libc::sigismember(&self.0, sig.as_raw()) == 1
+        }
+    }
+}
+
+#[cfg(all(linux_raw, feature = "runtime"))]
+impl From<KernelSigSet> for SigSet {
+    fn from(kernel: KernelSigSet) -> Self {
+        let mut res = Self::empty();
+        // SAFETY: We guarantee that `KernelSigSet` is a subset of the layout
+        // of `SigSet`.
+        unsafe {
+            as_mut_ptr(&mut res).cast::<KernelSigSet>().write(kernel);
+        }
+        res
+    }
+}
+
+impl fmt::Debug for SigSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_set();
+
+        // Surprisingly, `_NSIG` is inclusive.
+        #[cfg(linux_raw)]
+        for i in 1..=linux_raw_sys::general::_NSIG {
+            // SAFETY: This value is non-zero, in range, and only used for
+            // debug output.
+            let sig = unsafe { Signal::from_raw_unchecked(i as _) };
+
+            if self.contains(sig) {
+                d.entry(&sig);
+            }
+        }
+
+        #[cfg(libc)]
+        {
+            // First check all the known signals.
+            for i in 1..=libc::SIGRTMAX() {
+                if unsafe { libc::sigismember(&self.0, i) } == 1 {
+                    d.entry(&unsafe { Signal::from_raw_unchecked(i) });
+                }
+            }
+            // Then check for any reserved signals above `libc::SIGRTMAX`.
+            let mut i = libc::SIGRTMAX();
+            loop {
+                i += 1;
+                match unsafe { libc::sigismember(&self.0, i) } {
+                    1 => {
+                        d.entry(&unsafe { Signal::from_raw_unchecked(i) });
+                    }
+                    0 => {}
+                    // libc will return an error when we pass the upper bound.
+                    _ => break,
+                }
+            }
+        }
+
+        d.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_assumptions() {
+        // POSIX guarantees at least 8 RT signals.
+        assert!(libc::SIGRTMIN() + 8 <= libc::SIGRTMAX());
+
+        assert!(libc::SIGRTMAX() as usize - 1 < core::mem::size_of::<libc::sigset_t>() * 8);
+    }
+
+    #[test]
+    fn test_layouts() {
+        assert_eq_size!(SigSet, libc::sigset_t);
+        assert_eq_align!(SigSet, libc::sigset_t);
+    }
+
+    /// A bunch of signals for testing.
+    fn sigs() -> [Signal; 31] {
+        [
+            Signal::HUP,
+            Signal::INT,
+            Signal::QUIT,
+            Signal::ILL,
+            Signal::TRAP,
+            Signal::ABORT,
+            Signal::BUS,
+            Signal::FPE,
+            Signal::KILL,
+            Signal::USR1,
+            Signal::SEGV,
+            Signal::USR2,
+            Signal::PIPE,
+            Signal::ALARM,
+            Signal::TERM,
+            Signal::CHILD,
+            Signal::CONT,
+            Signal::STOP,
+            Signal::TSTP,
+            Signal::TTIN,
+            Signal::TTOU,
+            Signal::URG,
+            Signal::XCPU,
+            Signal::XFSZ,
+            Signal::VTALARM,
+            Signal::PROF,
+            Signal::WINCH,
+            Signal::SYS,
+            unsafe { Signal::from_raw_unchecked(libc::SIGRTMIN()) },
+            unsafe { Signal::from_raw_unchecked(libc::SIGRTMIN() + 7) },
+            unsafe { Signal::from_raw_unchecked(libc::SIGRTMAX()) },
+        ]
+    }
+
+    #[test]
+    fn test_ops_plain() {
+        for sig in sigs() {
+            let mut set = SigSet::empty();
+            for sig in sigs() {
+                assert!(!set.contains(sig));
+            }
+
+            set.insert(sig);
+            assert!(set.contains(sig));
+            for sig in sigs().iter().filter(|s| **s != sig) {
+                assert!(!set.contains(*sig));
+            }
+
+            set.remove(sig);
+            for sig in sigs() {
+                assert!(!set.contains(sig));
+            }
+        }
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut set = SigSet::empty();
+        for sig in sigs() {
+            set.insert(sig);
+        }
+
+        set.clear();
+
+        for sig in sigs() {
+            assert!(!set.contains(sig));
+        }
+    }
+
+    // io_uring libraries assume that libc's `sigset_t` matches the layout
+    // of the Linux kernel's `kernel_sigset_t`. Test that rustix's layout
+    // matches as well.
+    #[test]
+    fn test_libc_layout_compatibility() {
+        use crate::utils::as_ptr;
+
+        let mut lc = unsafe { core::mem::zeroed::<libc::sigset_t>() };
+        let mut ru = SigSet::empty();
+        let r = unsafe { libc::sigemptyset(&mut lc) };
+
+        assert_eq!(r, 0);
+        assert_eq!(
+            unsafe {
+                libc::memcmp(
+                    as_ptr(&lc).cast(),
+                    as_ptr(&ru).cast(),
+                    (libc::SIGRTMAX() as usize + 7) / 8,
+                )
+            },
+            0
+        );
+
+        for sig in sigs() {
+            ru.insert(sig);
+            assert_ne!(
+                unsafe {
+                    libc::memcmp(
+                        as_ptr(&lc).cast(),
+                        as_ptr(&ru).cast(),
+                        (libc::SIGRTMAX() as usize + 7) / 8,
+                    )
+                },
+                0
+            );
+            let r = unsafe { libc::sigaddset(&mut lc, sig.as_raw()) };
+            assert_eq!(r, 0);
+            assert_eq!(
+                unsafe {
+                    libc::memcmp(
+                        as_ptr(&lc).cast(),
+                        as_ptr(&ru).cast(),
+                        (libc::SIGRTMAX() as usize + 7) / 8,
+                    )
+                },
+                0
+            );
+            ru.remove(sig);
+            assert_ne!(
+                unsafe {
+                    libc::memcmp(
+                        as_ptr(&lc).cast(),
+                        as_ptr(&ru).cast(),
+                        (libc::SIGRTMAX() as usize + 7) / 8,
+                    )
+                },
+                0
+            );
+            let r = unsafe { libc::sigdelset(&mut lc, sig.as_raw()) };
+            assert_eq!(r, 0);
+            assert_eq!(
+                unsafe {
+                    libc::memcmp(
+                        as_ptr(&lc).cast(),
+                        as_ptr(&ru).cast(),
+                        (libc::SIGRTMAX() as usize + 7) / 8,
+                    )
+                },
+                0
+            );
+        }
+    }
+}


### PR DESCRIPTION
Define a `Sigset` type which fully encapsulates the `linux_raw_sys` type, and change `io_uring_enter`'s `arg`/`size` arguments to a `&T` argument where `T` must either be `Sigset` or `io_uring_getevents_arg` (with `IoringEnterFlags::EXT_ARG` set accordingly).

Supporting this, also define a `KernelSigSet` type, and define our own versions of `KernelSigaction` and friends.