### PR TITLE
Simplify the `ioctl` API.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -304,11 +304,10 @@ vector before calling `epoll::wait` or `kqueue`, or consuming it using
 [`spare_capacity`]: https://docs.rs/rustix/1.0.0/rustix/buffer/fn.spare_capacity.html
 
 The `Opcode` type has changed from a struct to a raw integer value, and the
-associated utilities are change to `const` functions. In place of `BadOpcode`,
-use the opcode value directly. In place of `ReadOpcode`, `WriteOpcode`,
-`ReadWriteOpcode`, and `NoneOpcode`, use the `read`, `write`, `read_write`, and
-`none` const functions in the [`ioctl::opcode`] module. For example, in place
-of this:
+associated utilities are change to `const` functions. In place of `ReadOpcode`,
+`WriteOpcode`, `ReadWriteOpcode`, and `NoneOpcode`, use the `read`, `write`,
+`read_write`, and `none` const functions in the [`ioctl::opcode`] module. For
+example, in place of this:
 ```rust
 ioctl::Setter::<ioctl::ReadOpcode<b'U', 15, c_uint>, c_uint>::new(interface)
 ```
@@ -317,6 +316,8 @@ use this:
 + ioctl::Setter::<{ ioctl::opcode::read::<c_uint>(b'U', 15) }, c_uint>::new(interface)
 ```
 .
+
+In place of `BadOpcode`, use the opcode value directly.
 
 [`ioctl::opcode`]: https://docs.rs/rustix/1.0.0/rustix/ioctl/opcode/index.html
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -303,5 +303,22 @@ vector before calling `epoll::wait` or `kqueue`, or consuming it using
 [`Buffer` trait]: https://docs.rs/rustix/1.0.0/rustix/buffer/trait.Buffer.html
 [`spare_capacity`]: https://docs.rs/rustix/1.0.0/rustix/buffer/fn.spare_capacity.html
 
+The `Opcode` type has changed from a struct to a raw integer value, and the
+associated utilities are change to `const` functions. In place of `BadOpcode`,
+use the opcode value directly. In place of `ReadOpcode`, `WriteOpcode`,
+`ReadWriteOpcode`, and `NoneOpcode`, use the `read`, `write`, `read_write`, and
+`none` const functions in the [`ioctl::opcode`] module. For example, in place
+of this:
+```rust
+ioctl::Setter::<ioctl::ReadOpcode<b'U', 15, c_uint>, c_uint>::new(interface)
+```
+use this:
+```rust
++ ioctl::Setter::<{ ioctl::opcode::read::<c_uint>(b'U', 15) }, c_uint>::new(interface)
+```
+.
+
+[`ioctl::opcode`]: https://docs.rs/rustix/1.0.0/rustix/ioctl/opcode/index.html
+
 All explicitly deprecated functions and types have been removed. Their
 deprecation messages will have identified alternatives.

--- a/src/backend/libc/fs/mod.rs
+++ b/src/backend/libc/fs/mod.rs
@@ -16,8 +16,8 @@ pub(crate) mod types;
 
 // TODO: Fix linux-raw-sys to define ioctl codes for sparc.
 #[cfg(all(linux_kernel, any(target_arch = "sparc", target_arch = "sparc64")))]
-pub(crate) const EXT4_IOC_RESIZE_FS: crate::ioctl::RawOpcode = 0x8008_6610;
+pub(crate) const EXT4_IOC_RESIZE_FS: crate::ioctl::Opcode = 0x8008_6610;
 
 #[cfg(all(linux_kernel, not(any(target_arch = "sparc", target_arch = "sparc64"))))]
-pub(crate) const EXT4_IOC_RESIZE_FS: crate::ioctl::RawOpcode =
-    linux_raw_sys::ioctl::EXT4_IOC_RESIZE_FS as crate::ioctl::RawOpcode;
+pub(crate) const EXT4_IOC_RESIZE_FS: crate::ioctl::Opcode =
+    linux_raw_sys::ioctl::EXT4_IOC_RESIZE_FS as crate::ioctl::Opcode;

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -16,7 +16,7 @@ use crate::io::DupFlags;
 #[cfg(linux_kernel)]
 use crate::io::ReadWriteFlags;
 use crate::io::{self, FdFlags};
-use crate::ioctl::{IoctlOutput, RawOpcode};
+use crate::ioctl::{IoctlOutput, Opcode};
 use core::cmp::min;
 #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
 use {
@@ -210,7 +210,7 @@ pub(crate) unsafe fn try_close(raw_fd: RawFd) -> io::Result<()> {
 #[inline]
 pub(crate) unsafe fn ioctl(
     fd: BorrowedFd<'_>,
-    request: RawOpcode,
+    request: Opcode,
     arg: *mut c::c_void,
 ) -> io::Result<IoctlOutput> {
     ret_c_int(c::ioctl(borrowed_fd(fd), request, arg))
@@ -219,7 +219,7 @@ pub(crate) unsafe fn ioctl(
 #[inline]
 pub(crate) unsafe fn ioctl_readonly(
     fd: BorrowedFd<'_>,
-    request: RawOpcode,
+    request: Opcode,
     arg: *mut c::c_void,
 ) -> io::Result<IoctlOutput> {
     ioctl(fd, request, arg)

--- a/src/backend/libc/io/windows_syscalls.rs
+++ b/src/backend/libc/io/windows_syscalls.rs
@@ -7,7 +7,7 @@ use crate::backend::conv::{borrowed_fd, ret_c_int, ret_send_recv, send_recv_len}
 use crate::backend::fd::LibcFd;
 use crate::fd::{BorrowedFd, RawFd};
 use crate::io;
-use crate::ioctl::{IoctlOutput, RawOpcode};
+use crate::ioctl::{IoctlOutput, Opcode};
 
 pub(crate) unsafe fn read(fd: BorrowedFd<'_>, buf: (*mut u8, usize)) -> io::Result<usize> {
     // `read` on a socket is equivalent to `recv` with no flags.
@@ -43,7 +43,7 @@ pub(crate) unsafe fn try_close(raw_fd: RawFd) -> io::Result<()> {
 #[inline]
 pub(crate) unsafe fn ioctl(
     fd: BorrowedFd<'_>,
-    request: RawOpcode,
+    request: Opcode,
     arg: *mut c::c_void,
 ) -> io::Result<IoctlOutput> {
     ret_c_int(c::ioctl(borrowed_fd(fd), request, arg.cast()))
@@ -52,7 +52,7 @@ pub(crate) unsafe fn ioctl(
 #[inline]
 pub(crate) unsafe fn ioctl_readonly(
     fd: BorrowedFd<'_>,
-    request: RawOpcode,
+    request: Opcode,
     arg: *mut c::c_void,
 ) -> io::Result<IoctlOutput> {
     ioctl(fd, request, arg)

--- a/src/backend/linux_raw/io/syscalls.rs
+++ b/src/backend/linux_raw/io/syscalls.rs
@@ -27,7 +27,7 @@ use crate::backend::conv::{hi, lo};
 use crate::backend::{c, MAX_IOV};
 use crate::fd::{AsFd as _, BorrowedFd, OwnedFd, RawFd};
 use crate::io::{self, DupFlags, FdFlags, IoSlice, IoSliceMut, ReadWriteFlags};
-use crate::ioctl::{IoctlOutput, RawOpcode};
+use crate::ioctl::{IoctlOutput, Opcode};
 use core::cmp;
 use linux_raw_sys::general::{F_DUPFD_CLOEXEC, F_GETFD, F_SETFD};
 
@@ -272,7 +272,7 @@ pub(crate) unsafe fn try_close(fd: RawFd) -> io::Result<()> {
 #[inline]
 pub(crate) unsafe fn ioctl(
     fd: BorrowedFd<'_>,
-    request: RawOpcode,
+    request: Opcode,
     arg: *mut c::c_void,
 ) -> io::Result<IoctlOutput> {
     ret_c_int(syscall!(__NR_ioctl, fd, c_uint(request), arg))
@@ -281,7 +281,7 @@ pub(crate) unsafe fn ioctl(
 #[inline]
 pub(crate) unsafe fn ioctl_readonly(
     fd: BorrowedFd<'_>,
-    request: RawOpcode,
+    request: Opcode,
     arg: *mut c::c_void,
 ) -> io::Result<IoctlOutput> {
     ret_c_int(syscall_readonly!(__NR_ioctl, fd, c_uint(request), arg))

--- a/src/fs/ioctl.rs
+++ b/src/fs/ioctl.rs
@@ -25,7 +25,7 @@ use crate::fd::{AsRawFd as _, BorrowedFd};
 pub fn ioctl_blksszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
     // SAFETY: `BLZSSZGET` is a getter opcode that gets a u32.
     unsafe {
-        let ctl = ioctl::Getter::<ioctl::BadOpcode<{ c::BLKSSZGET }>, c::c_uint>::new();
+        let ctl = ioctl::Getter::<{ c::BLKSSZGET }, c::c_uint>::new();
         ioctl::ioctl(fd, ctl)
     }
 }
@@ -37,7 +37,7 @@ pub fn ioctl_blksszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
 pub fn ioctl_blkpbszget<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
     // SAFETY: `BLKPBSZGET` is a getter opcode that gets a u32.
     unsafe {
-        let ctl = ioctl::Getter::<ioctl::BadOpcode<{ c::BLKPBSZGET }>, c::c_uint>::new();
+        let ctl = ioctl::Getter::<{ c::BLKPBSZGET }, c::c_uint>::new();
         ioctl::ioctl(fd, ctl)
     }
 }
@@ -64,9 +64,7 @@ pub fn ioctl_ficlone<Fd: AsFd, SrcFd: AsFd>(fd: Fd, src_fd: SrcFd) -> io::Result
 pub fn ext4_ioc_resize_fs<Fd: AsFd>(fd: Fd, blocks: u64) -> io::Result<()> {
     // SAFETY: `EXT4_IOC_RESIZE_FS` is a pointer setter opcode.
     unsafe {
-        let ctl = ioctl::Setter::<ioctl::BadOpcode<{ backend::fs::EXT4_IOC_RESIZE_FS }>, u64>::new(
-            blocks,
-        );
+        let ctl = ioctl::Setter::<{ backend::fs::EXT4_IOC_RESIZE_FS }, u64>::new(blocks);
         ioctl::ioctl(fd, ctl)
     }
 }
@@ -81,7 +79,7 @@ unsafe impl ioctl::Ioctl for Ficlone<'_> {
     const IS_MUTATING: bool = false;
 
     fn opcode(&self) -> ioctl::Opcode {
-        ioctl::Opcode::old(c::FICLONE as ioctl::RawOpcode)
+        c::FICLONE as ioctl::Opcode
     }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
@@ -144,9 +142,9 @@ bitflags! {
 pub fn ioctl_getflags<Fd: AsFd>(fd: Fd) -> io::Result<IFlags> {
     unsafe {
         #[cfg(target_pointer_width = "32")]
-        let ctl = ioctl::Getter::<ioctl::BadOpcode<{ c::FS_IOC32_GETFLAGS }>, u32>::new();
+        let ctl = ioctl::Getter::<{ c::FS_IOC32_GETFLAGS }, u32>::new();
         #[cfg(target_pointer_width = "64")]
-        let ctl = ioctl::Getter::<ioctl::BadOpcode<{ c::FS_IOC_GETFLAGS }>, u32>::new();
+        let ctl = ioctl::Getter::<{ c::FS_IOC_GETFLAGS }, u32>::new();
 
         ioctl::ioctl(fd, ctl).map(IFlags::from_bits_retain)
     }
@@ -161,11 +159,10 @@ pub fn ioctl_getflags<Fd: AsFd>(fd: Fd) -> io::Result<IFlags> {
 pub fn ioctl_setflags<Fd: AsFd>(fd: Fd, flags: IFlags) -> io::Result<()> {
     unsafe {
         #[cfg(target_pointer_width = "32")]
-        let ctl =
-            ioctl::Setter::<ioctl::BadOpcode<{ c::FS_IOC32_SETFLAGS }>, u32>::new(flags.bits());
+        let ctl = ioctl::Setter::<{ c::FS_IOC32_SETFLAGS }, u32>::new(flags.bits());
 
         #[cfg(target_pointer_width = "64")]
-        let ctl = ioctl::Setter::<ioctl::BadOpcode<{ c::FS_IOC_SETFLAGS }>, u32>::new(flags.bits());
+        let ctl = ioctl::Setter::<{ c::FS_IOC_SETFLAGS }, u32>::new(flags.bits());
 
         ioctl::ioctl(fd, ctl)
     }

--- a/src/io/ioctl.rs
+++ b/src/io/ioctl.rs
@@ -23,7 +23,7 @@ use backend::fd::AsFd;
 pub fn ioctl_fioclex<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     // SAFETY: `FIOCLEX` is a no-argument setter opcode.
     unsafe {
-        let ctl = ioctl::NoArg::<ioctl::BadOpcode<{ c::FIOCLEX }>>::new();
+        let ctl = ioctl::NoArg::<{ c::FIOCLEX }>::new();
         ioctl::ioctl(fd, ctl)
     }
 }
@@ -43,7 +43,7 @@ pub fn ioctl_fioclex<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 pub fn ioctl_fionbio<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
     // SAFETY: `FIONBIO` is a pointer setter opcode.
     unsafe {
-        let ctl = ioctl::Setter::<ioctl::BadOpcode<{ c::FIONBIO }>, c::c_int>::new(value.into());
+        let ctl = ioctl::Setter::<{ c::FIONBIO }, c::c_int>::new(value.into());
         ioctl::ioctl(fd, ctl)
     }
 }
@@ -71,7 +71,7 @@ pub fn ioctl_fionbio<Fd: AsFd>(fd: Fd, value: bool) -> io::Result<()> {
 pub fn ioctl_fionread<Fd: AsFd>(fd: Fd) -> io::Result<u64> {
     // SAFETY: `FIONREAD` is a getter opcode that gets a `c_int`.
     unsafe {
-        let ctl = ioctl::Getter::<ioctl::BadOpcode<{ c::FIONREAD }>, c::c_int>::new();
+        let ctl = ioctl::Getter::<{ c::FIONREAD }, c::c_int>::new();
         ioctl::ioctl(fd, ctl).map(|n| n as u64)
     }
 }

--- a/src/ioctl/bsd.rs
+++ b/src/ioctl/bsd.rs
@@ -1,13 +1,13 @@
 //! `ioctl` opcode behavior for BSD platforms.
 
-use super::{Direction, RawOpcode};
+use super::{Direction, Opcode};
 
 pub(super) const fn compose_opcode(
     dir: Direction,
-    group: RawOpcode,
-    num: RawOpcode,
-    size: RawOpcode,
-) -> RawOpcode {
+    group: Opcode,
+    num: Opcode,
+    size: Opcode,
+) -> Opcode {
     let dir = match dir {
         Direction::None => NONE,
         Direction::Read => READ,
@@ -19,9 +19,9 @@ pub(super) const fn compose_opcode(
 }
 
 // `IOC_VOID`
-pub const NONE: RawOpcode = 0x2000_0000;
+pub const NONE: Opcode = 0x2000_0000;
 // `IOC_OUT` (“out” is from the perspective of the kernel)
-pub const READ: RawOpcode = 0x4000_0000;
+pub const READ: Opcode = 0x4000_0000;
 // `IOC_IN` (“in” is from the perspective of the kernel)
-pub const WRITE: RawOpcode = 0x8000_0000;
-pub const IOCPARAM_MASK: RawOpcode = 0x1FFF;
+pub const WRITE: Opcode = 0x8000_0000;
+pub const IOCPARAM_MASK: Opcode = 0x1FFF;

--- a/src/ioctl/linux.rs
+++ b/src/ioctl/linux.rs
@@ -1,15 +1,15 @@
 //! `ioctl` opcode behavior for Linux platforms.
 
-use super::{Direction, RawOpcode};
+use super::{Direction, Opcode};
 use consts::*;
 
 /// Compose an opcode from its component parts.
 pub(super) const fn compose_opcode(
     dir: Direction,
-    group: RawOpcode,
-    num: RawOpcode,
-    size: RawOpcode,
-) -> RawOpcode {
+    group: Opcode,
+    num: Opcode,
+    size: Opcode,
+) -> Opcode {
     macro_rules! mask_and_shift {
         ($val:expr, $shift:expr, $mask:expr) => {{
             ($val & $mask) << $shift
@@ -29,18 +29,18 @@ pub(super) const fn compose_opcode(
         | mask_and_shift!(dir, DIR_SHIFT, DIR_MASK)
 }
 
-const NUM_BITS: RawOpcode = 8;
-const GROUP_BITS: RawOpcode = 8;
+const NUM_BITS: Opcode = 8;
+const GROUP_BITS: Opcode = 8;
 
-const NUM_SHIFT: RawOpcode = 0;
-const GROUP_SHIFT: RawOpcode = NUM_SHIFT + NUM_BITS;
-const SIZE_SHIFT: RawOpcode = GROUP_SHIFT + GROUP_BITS;
-const DIR_SHIFT: RawOpcode = SIZE_SHIFT + SIZE_BITS;
+const NUM_SHIFT: Opcode = 0;
+const GROUP_SHIFT: Opcode = NUM_SHIFT + NUM_BITS;
+const SIZE_SHIFT: Opcode = GROUP_SHIFT + GROUP_BITS;
+const DIR_SHIFT: Opcode = SIZE_SHIFT + SIZE_BITS;
 
-const NUM_MASK: RawOpcode = (1 << NUM_BITS) - 1;
-const GROUP_MASK: RawOpcode = (1 << GROUP_BITS) - 1;
-const SIZE_MASK: RawOpcode = (1 << SIZE_BITS) - 1;
-const DIR_MASK: RawOpcode = (1 << DIR_BITS) - 1;
+const NUM_MASK: Opcode = (1 << NUM_BITS) - 1;
+const GROUP_MASK: Opcode = (1 << GROUP_BITS) - 1;
+const SIZE_MASK: Opcode = (1 << SIZE_BITS) - 1;
+const DIR_MASK: Opcode = (1 << DIR_BITS) - 1;
 
 #[cfg(any(
     target_arch = "x86",
@@ -54,13 +54,13 @@ const DIR_MASK: RawOpcode = (1 << DIR_BITS) - 1;
     target_arch = "csky"
 ))]
 mod consts {
-    use super::RawOpcode;
+    use super::Opcode;
 
-    pub(super) const NONE: RawOpcode = 0;
-    pub(super) const READ: RawOpcode = 2;
-    pub(super) const WRITE: RawOpcode = 1;
-    pub(super) const SIZE_BITS: RawOpcode = 14;
-    pub(super) const DIR_BITS: RawOpcode = 2;
+    pub(super) const NONE: Opcode = 0;
+    pub(super) const READ: Opcode = 2;
+    pub(super) const WRITE: Opcode = 1;
+    pub(super) const SIZE_BITS: Opcode = 14;
+    pub(super) const DIR_BITS: Opcode = 2;
 }
 
 #[cfg(any(
@@ -74,13 +74,13 @@ mod consts {
     target_arch = "sparc64"
 ))]
 mod consts {
-    use super::RawOpcode;
+    use super::Opcode;
 
-    pub(super) const NONE: RawOpcode = 1;
-    pub(super) const READ: RawOpcode = 2;
-    pub(super) const WRITE: RawOpcode = 4;
-    pub(super) const SIZE_BITS: RawOpcode = 13;
-    pub(super) const DIR_BITS: RawOpcode = 3;
+    pub(super) const NONE: Opcode = 1;
+    pub(super) const READ: Opcode = 2;
+    pub(super) const WRITE: Opcode = 4;
+    pub(super) const SIZE_BITS: Opcode = 13;
+    pub(super) const DIR_BITS: Opcode = 3;
 }
 
 #[cfg(not(any(
@@ -98,11 +98,11 @@ fn check_known_opcodes() {
     assert_eq!(
         compose_opcode(
             Direction::Read,
-            b'U' as RawOpcode,
+            b'U' as Opcode,
             15,
-            size_of::<c_uint>() as RawOpcode
+            size_of::<c_uint>() as Opcode
         ),
-        linux_raw_sys::ioctl::USBDEVFS_CLAIMINTERFACE as RawOpcode
+        linux_raw_sys::ioctl::USBDEVFS_CLAIMINTERFACE as Opcode
     );
 
     // _IOW('v', 2, long)
@@ -111,10 +111,10 @@ fn check_known_opcodes() {
     assert_eq!(
         compose_opcode(
             Direction::Write,
-            b'v' as RawOpcode,
+            b'v' as Opcode,
             2,
-            size_of::<c_long>() as RawOpcode
+            size_of::<c_long>() as Opcode
         ),
-        linux_raw_sys::ioctl::FS_IOC_SETVERSION as RawOpcode
+        linux_raw_sys::ioctl::FS_IOC_SETVERSION as Opcode
     );
 }

--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -185,6 +185,14 @@ pub unsafe trait Ioctl {
 }
 
 /// Const functions for computing opcode values.
+///
+/// Linux's headers define macros such as `_IO`, `_IOR`, `_IOW`, and `_IORW`
+/// for defining ioctl values in a structured way that encode whether they
+/// are reading and/or writing, and other information about the ioctl. The
+/// functions in this module correspond to those macros.
+///
+/// If you're writing a driver and defining your own ioctl numbers, it's
+/// recommended to use these functions to compute them.
 #[cfg(any(linux_kernel, bsd))]
 pub mod opcode {
     use super::*;
@@ -192,6 +200,7 @@ pub mod opcode {
     /// Create a new opcode from a direction, group, number, and size.
     ///
     /// This corresponds to the C macro `_IOC(direction, group, number, size)`
+    #[doc(alias = "_IOC")]
     #[inline]
     pub const fn from_components(
         direction: Direction,
@@ -212,6 +221,7 @@ pub mod opcode {
     /// Create a new opcode from a group, a number, that uses no data.
     ///
     /// This corresponds to the C macro `_IO(group, number)`.
+    #[doc(alias = "_IO")]
     #[inline]
     pub const fn none(group: u8, number: u8) -> Opcode {
         from_components(Direction::None, group, number, 0)
@@ -221,6 +231,7 @@ pub mod opcode {
     /// data.
     ///
     /// This corresponds to the C macro `_IOR(group, number, T)`.
+    #[doc(alias = "_IOR")]
     #[inline]
     pub const fn read<T>(group: u8, number: u8) -> Opcode {
         from_components(Direction::Read, group, number, mem::size_of::<T>())
@@ -230,6 +241,7 @@ pub mod opcode {
     /// data.
     ///
     /// This corresponds to the C macro `_IOW(group, number, T)`.
+    #[doc(alias = "_IOW")]
     #[inline]
     pub const fn write<T>(group: u8, number: u8) -> Opcode {
         from_components(Direction::Write, group, number, mem::size_of::<T>())
@@ -239,6 +251,7 @@ pub mod opcode {
     /// type of data.
     ///
     /// This corresponds to the C macro `_IOWR(group, number, T)`.
+    #[doc(alias = "_IORW")]
     #[inline]
     pub const fn read_write<T>(group: u8, number: u8) -> Opcode {
         from_components(Direction::ReadWrite, group, number, mem::size_of::<T>())

--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -209,14 +209,12 @@ pub mod opcode {
         )
     }
 
-    /// Create a new non-mutating opcode from a group, a number, and the type
-    /// of data.
+    /// Create a new opcode from a group, a number, that uses no data.
     ///
-    /// This corresponds to the C macro `_IO(group, number)` when `T` is zero
-    /// sized.
+    /// This corresponds to the C macro `_IO(group, number)`.
     #[inline]
-    pub const fn none<T>(group: u8, number: u8) -> Opcode {
-        from_components(Direction::None, group, number, mem::size_of::<T>())
+    pub const fn none(group: u8, number: u8) -> Opcode {
+        from_components(Direction::None, group, number, 0)
     }
 
     /// Create a new reading opcode from a group, a number and the type of

--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -58,11 +58,12 @@ use bsd as platform;
 ///
 /// # Safety
 ///
-/// While [`Ioctl`] takes much of the unsafety out of `ioctl` calls, it is
-/// still unsafe to call this code with arbitrary device drivers, as it is up
-/// to the device driver to implement the `ioctl` call correctly. It is on the
-/// onus of the protocol between the user and the driver to ensure that the
-/// `ioctl` call is safe to make.
+/// While [`Ioctl`] takes much of the unsafety out of `ioctl` calls, callers
+/// must still ensure that the opcode value, operand type, and data access
+/// correctly reflect what's in the device driver servicing the call. `ioctl`
+/// calls form a protocol between the userspace `ioctl` callers and the device
+/// drivers in the kernel, and safety depends on both sides agreeing and
+/// upholding the expectations of the other.
 ///
 /// # References
 ///  - [Linux]

--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -85,7 +85,7 @@ use bsd as platform;
 #[inline]
 pub unsafe fn ioctl<F: AsFd, I: Ioctl>(fd: F, mut ioctl: I) -> Result<I::Output> {
     let fd = fd.as_fd();
-    let request = ioctl.opcode().raw();
+    let request = ioctl.opcode();
     let arg = ioctl.as_ptr();
 
     // SAFETY: The variant of `Ioctl` asserts that this is a valid IOCTL call
@@ -101,17 +101,13 @@ pub unsafe fn ioctl<F: AsFd, I: Ioctl>(fd: F, mut ioctl: I) -> Result<I::Output>
     I::output_from_ptr(output, arg)
 }
 
-unsafe fn _ioctl(
-    fd: BorrowedFd<'_>,
-    request: RawOpcode,
-    arg: *mut c::c_void,
-) -> Result<IoctlOutput> {
+unsafe fn _ioctl(fd: BorrowedFd<'_>, request: Opcode, arg: *mut c::c_void) -> Result<IoctlOutput> {
     crate::backend::io::syscalls::ioctl(fd, request, arg)
 }
 
 unsafe fn _ioctl_readonly(
     fd: BorrowedFd<'_>,
-    request: RawOpcode,
+    request: Opcode,
     arg: *mut c::c_void,
 ) -> Result<IoctlOutput> {
     crate::backend::io::syscalls::ioctl_readonly(fd, request, arg)
@@ -166,7 +162,7 @@ pub unsafe trait Ioctl {
     /// Get the opcode used by this `ioctl` command.
     ///
     /// There are different types of opcode depending on the operation. See
-    /// documentation for the [`Opcode`] struct for more information.
+    /// documentation for [`opcode`] for more information.
     fn opcode(&self) -> Opcode;
 
     /// Get a pointer to the data to be passed to the `ioctl` command.
@@ -188,46 +184,29 @@ pub unsafe trait Ioctl {
     ) -> Result<Self::Output>;
 }
 
-/// The opcode used by an `Ioctl`.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Opcode {
-    /// The raw opcode.
-    raw: RawOpcode,
-}
-
-impl Opcode {
-    /// Create a new old `Opcode` from a raw opcode.
-    ///
-    /// Rather than being a composition of several attributes, old opcodes are
-    /// just numbers. In general most drivers follow stricter conventions, but
-    /// older drivers may still use this strategy.
-    #[inline]
-    pub const fn old(raw: RawOpcode) -> Self {
-        Self { raw }
-    }
+/// Const functions for computing opcode values.
+#[cfg(any(linux_kernel, bsd))]
+pub mod opcode {
+    use super::*;
 
     /// Create a new opcode from a direction, group, number, and size.
     ///
     /// This corresponds to the C macro `_IOC(direction, group, number, size)`
-    #[cfg(any(linux_kernel, bsd))]
     #[inline]
     pub const fn from_components(
         direction: Direction,
         group: u8,
         number: u8,
         data_size: usize,
-    ) -> Self {
-        assert!(
-            data_size <= RawOpcode::MAX as usize,
-            "data size is too large"
-        );
+    ) -> Opcode {
+        assert!(data_size <= Opcode::MAX as usize, "data size is too large");
 
-        Self::old(platform::compose_opcode(
+        platform::compose_opcode(
             direction,
-            group as RawOpcode,
-            number as RawOpcode,
-            data_size as RawOpcode,
-        ))
+            group as Opcode,
+            number as Opcode,
+            data_size as Opcode,
+        )
     }
 
     /// Create a new non-mutating opcode from a group, a number, and the type
@@ -235,46 +214,36 @@ impl Opcode {
     ///
     /// This corresponds to the C macro `_IO(group, number)` when `T` is zero
     /// sized.
-    #[cfg(any(linux_kernel, bsd))]
     #[inline]
-    pub const fn none<T>(group: u8, number: u8) -> Self {
-        Self::from_components(Direction::None, group, number, mem::size_of::<T>())
+    pub const fn none<T>(group: u8, number: u8) -> Opcode {
+        from_components(Direction::None, group, number, mem::size_of::<T>())
     }
 
     /// Create a new reading opcode from a group, a number and the type of
     /// data.
     ///
     /// This corresponds to the C macro `_IOR(group, number, T)`.
-    #[cfg(any(linux_kernel, bsd))]
     #[inline]
-    pub const fn read<T>(group: u8, number: u8) -> Self {
-        Self::from_components(Direction::Read, group, number, mem::size_of::<T>())
+    pub const fn read<T>(group: u8, number: u8) -> Opcode {
+        from_components(Direction::Read, group, number, mem::size_of::<T>())
     }
 
     /// Create a new writing opcode from a group, a number and the type of
     /// data.
     ///
     /// This corresponds to the C macro `_IOW(group, number, T)`.
-    #[cfg(any(linux_kernel, bsd))]
     #[inline]
-    pub const fn write<T>(group: u8, number: u8) -> Self {
-        Self::from_components(Direction::Write, group, number, mem::size_of::<T>())
+    pub const fn write<T>(group: u8, number: u8) -> Opcode {
+        from_components(Direction::Write, group, number, mem::size_of::<T>())
     }
 
     /// Create a new reading and writing opcode from a group, a number and the
     /// type of data.
     ///
     /// This corresponds to the C macro `_IOWR(group, number, T)`.
-    #[cfg(any(linux_kernel, bsd))]
     #[inline]
-    pub const fn read_write<T>(group: u8, number: u8) -> Self {
-        Self::from_components(Direction::ReadWrite, group, number, mem::size_of::<T>())
-    }
-
-    /// Get the raw opcode.
-    #[inline]
-    pub fn raw(self) -> RawOpcode {
-        self.raw
+    pub const fn read_write<T>(group: u8, number: u8) -> Opcode {
+        from_components(Direction::ReadWrite, group, number, mem::size_of::<T>())
     }
 }
 
@@ -301,11 +270,11 @@ pub enum Direction {
 pub type IoctlOutput = c::c_int;
 
 /// The type used by the `ioctl` to signify the command.
-pub type RawOpcode = _RawOpcode;
+pub type Opcode = _Opcode;
 
 // Under raw Linux, this is an `unsigned int`.
 #[cfg(linux_raw)]
-type _RawOpcode = c::c_uint;
+type _Opcode = c::c_uint;
 
 // On libc Linux with GNU libc or uclibc, this is an `unsigned long`.
 #[cfg(all(
@@ -313,7 +282,7 @@ type _RawOpcode = c::c_uint;
     target_os = "linux",
     any(target_env = "gnu", target_env = "uclibc")
 ))]
-type _RawOpcode = c::c_ulong;
+type _Opcode = c::c_ulong;
 
 // Musl uses `c_int`.
 #[cfg(all(
@@ -322,11 +291,11 @@ type _RawOpcode = c::c_ulong;
     not(target_env = "gnu"),
     not(target_env = "uclibc")
 ))]
-type _RawOpcode = c::c_int;
+type _Opcode = c::c_int;
 
 // Android uses `c_int`.
 #[cfg(all(not(linux_raw), target_os = "android"))]
-type _RawOpcode = c::c_int;
+type _Opcode = c::c_int;
 
 // BSD, Haiku, Hurd, Redox, and Vita use `unsigned long`.
 #[cfg(any(
@@ -337,7 +306,7 @@ type _RawOpcode = c::c_int;
     target_os = "hurd",
     target_os = "vita"
 ))]
-type _RawOpcode = c::c_ulong;
+type _Opcode = c::c_ulong;
 
 // AIX, Emscripten, Fuchsia, Solaris, and WASI use a `int`.
 #[cfg(any(
@@ -348,12 +317,12 @@ type _RawOpcode = c::c_ulong;
     target_os = "wasi",
     target_os = "nto"
 ))]
-type _RawOpcode = c::c_int;
+type _Opcode = c::c_int;
 
 // ESP-IDF uses a `c_uint`.
 #[cfg(target_os = "espidf")]
-type _RawOpcode = c::c_uint;
+type _Opcode = c::c_uint;
 
 // Windows has `ioctlsocket`, which uses `i32`.
 #[cfg(windows)]
-type _RawOpcode = i32;
+type _Opcode = i32;

--- a/src/ioctl/patterns.rs
+++ b/src/ioctl/patterns.rs
@@ -55,7 +55,7 @@ unsafe impl<const OPCODE: Opcode> Ioctl for NoArg<OPCODE> {
 /// Implements the traditional “getter” pattern for `ioctl`s.
 ///
 /// Some `ioctl`s just read data into the userspace. As this is a popular
-/// pattern this structure implements it.
+/// pattern, this structure implements it.
 ///
 /// To compute a value for the `OPCODE` argument, see the functions in the
 /// [`opcode`] module.

--- a/src/ioctl/patterns.rs
+++ b/src/ioctl/patterns.rs
@@ -1,47 +1,41 @@
 //! Implements typical patterns for `ioctl` usage.
 
-use super::{Ioctl, IoctlOutput, Opcode, RawOpcode};
+use super::{Ioctl, IoctlOutput, Opcode};
 
 use crate::backend::c;
 use crate::io::Result;
 
-use core::marker::PhantomData;
 use core::ptr::addr_of_mut;
 use core::{fmt, mem};
 
 /// Implements an `ioctl` with no real arguments.
-pub struct NoArg<Opcode> {
-    /// The opcode.
-    _opcode: PhantomData<Opcode>,
-}
+pub struct NoArg<const OPCODE: Opcode> {}
 
-impl<Opcode: CompileTimeOpcode> fmt::Debug for NoArg<Opcode> {
+impl<const OPCODE: Opcode> fmt::Debug for NoArg<OPCODE> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("NoArg").field(&Opcode::OPCODE).finish()
+        f.debug_tuple("NoArg").field(&OPCODE).finish()
     }
 }
 
-impl<Opcode: CompileTimeOpcode> NoArg<Opcode> {
+impl<const OPCODE: Opcode> NoArg<OPCODE> {
     /// Create a new no-argument `ioctl` object.
     ///
     /// # Safety
     ///
-    /// - `Opcode` must provide a valid opcode.
+    /// - `OPCODE` must provide a valid opcode.
     #[inline]
     pub unsafe fn new() -> Self {
-        Self {
-            _opcode: PhantomData,
-        }
+        Self {}
     }
 }
 
-unsafe impl<Opcode: CompileTimeOpcode> Ioctl for NoArg<Opcode> {
+unsafe impl<const OPCODE: Opcode> Ioctl for NoArg<OPCODE> {
     type Output = ();
 
     const IS_MUTATING: bool = false;
 
     fn opcode(&self) -> self::Opcode {
-        Opcode::OPCODE
+        OPCODE
     }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
@@ -57,44 +51,40 @@ unsafe impl<Opcode: CompileTimeOpcode> Ioctl for NoArg<Opcode> {
 ///
 /// Some `ioctl`s just read data into the userspace. As this is a popular
 /// pattern this structure implements it.
-pub struct Getter<Opcode, Output> {
+pub struct Getter<const OPCODE: Opcode, Output> {
     /// The output data.
     output: mem::MaybeUninit<Output>,
-
-    /// The opcode.
-    _opcode: PhantomData<Opcode>,
 }
 
-impl<Opcode: CompileTimeOpcode, Output> fmt::Debug for Getter<Opcode, Output> {
+impl<const OPCODE: Opcode, Output> fmt::Debug for Getter<OPCODE, Output> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Getter").field(&Opcode::OPCODE).finish()
+        f.debug_tuple("Getter").field(&OPCODE).finish()
     }
 }
 
-impl<Opcode: CompileTimeOpcode, Output> Getter<Opcode, Output> {
+impl<const OPCODE: Opcode, Output> Getter<OPCODE, Output> {
     /// Create a new getter-style `ioctl` object.
     ///
     /// # Safety
     ///
-    /// - `Opcode` must provide a valid opcode.
+    /// - `OPCODE` must provide a valid opcode.
     /// - For this opcode, `Output` must be the type that the kernel expects to
     ///   write into.
     #[inline]
     pub unsafe fn new() -> Self {
         Self {
             output: mem::MaybeUninit::uninit(),
-            _opcode: PhantomData,
         }
     }
 }
 
-unsafe impl<Opcode: CompileTimeOpcode, Output> Ioctl for Getter<Opcode, Output> {
+unsafe impl<const OPCODE: Opcode, Output> Ioctl for Getter<OPCODE, Output> {
     type Output = Output;
 
     const IS_MUTATING: bool = true;
 
     fn opcode(&self) -> self::Opcode {
-        Opcode::OPCODE
+        OPCODE
     }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
@@ -110,47 +100,41 @@ unsafe impl<Opcode: CompileTimeOpcode, Output> Ioctl for Getter<Opcode, Output> 
 /// the `ioctl`.
 ///
 /// The opcode must be read-only.
-pub struct Setter<Opcode, Input> {
+pub struct Setter<const OPCODE: Opcode, Input> {
     /// The input data.
     input: Input,
-
-    /// The opcode.
-    _opcode: PhantomData<Opcode>,
 }
 
-impl<Opcode: CompileTimeOpcode, Input: fmt::Debug> fmt::Debug for Setter<Opcode, Input> {
+impl<const OPCODE: Opcode, Input: fmt::Debug> fmt::Debug for Setter<OPCODE, Input> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Setter")
-            .field(&Opcode::OPCODE)
+            .field(&OPCODE)
             .field(&self.input)
             .finish()
     }
 }
 
-impl<Opcode: CompileTimeOpcode, Input> Setter<Opcode, Input> {
+impl<const OPCODE: Opcode, Input> Setter<OPCODE, Input> {
     /// Create a new pointer setter-style `ioctl` object.
     ///
     /// # Safety
     ///
-    /// - `Opcode` must provide a valid opcode.
+    /// - `OPCODE` must provide a valid opcode.
     /// - For this opcode, `Input` must be the type that the kernel expects to
     ///   get.
     #[inline]
     pub unsafe fn new(input: Input) -> Self {
-        Self {
-            input,
-            _opcode: PhantomData,
-        }
+        Self { input }
     }
 }
 
-unsafe impl<Opcode: CompileTimeOpcode, Input> Ioctl for Setter<Opcode, Input> {
+unsafe impl<const OPCODE: Opcode, Input> Ioctl for Setter<OPCODE, Input> {
     type Output = ();
 
     const IS_MUTATING: bool = false;
 
     fn opcode(&self) -> self::Opcode {
-        Opcode::OPCODE
+        OPCODE
     }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
@@ -166,38 +150,32 @@ unsafe impl<Opcode: CompileTimeOpcode, Input> Ioctl for Setter<Opcode, Input> {
 ///
 /// The ioctl takes a reference to a struct that it reads its input from,
 /// then writes output to the same struct.
-pub struct Updater<'a, Opcode, Value> {
+pub struct Updater<'a, const OPCODE: Opcode, Value> {
     /// Reference to input/output data.
     value: &'a mut Value,
-
-    /// The opcode.
-    _opcode: PhantomData<Opcode>,
 }
 
-impl<'a, Opcode: CompileTimeOpcode, Value> Updater<'a, Opcode, Value> {
+impl<'a, const OPCODE: Opcode, Value> Updater<'a, OPCODE, Value> {
     /// Create a new pointer updater-style `ioctl` object.
     ///
     /// # Safety
     ///
-    /// - `Opcode` must provide a valid opcode.
+    /// - `OPCODE` must provide a valid opcode.
     /// - For this opcode, `Value` must be the type that the kernel expects to
     ///   get.
     #[inline]
     pub unsafe fn new(value: &'a mut Value) -> Self {
-        Self {
-            value,
-            _opcode: PhantomData,
-        }
+        Self { value }
     }
 }
 
-unsafe impl<'a, Opcode: CompileTimeOpcode, T> Ioctl for Updater<'a, Opcode, T> {
+unsafe impl<'a, const OPCODE: Opcode, T> Ioctl for Updater<'a, OPCODE, T> {
     type Output = ();
 
     const IS_MUTATING: bool = true;
 
     fn opcode(&self) -> self::Opcode {
-        Opcode::OPCODE
+        OPCODE
     }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
@@ -210,55 +188,46 @@ unsafe impl<'a, Opcode: CompileTimeOpcode, T> Ioctl for Updater<'a, Opcode, T> {
 }
 
 /// Implements an `ioctl` that passes an integer into the `ioctl`.
-pub struct IntegerSetter<Opcode> {
+pub struct IntegerSetter<const OPCODE: Opcode> {
     /// The value to pass in.
     ///
     /// For strict provenance preservation, this is a pointer.
     value: *mut c::c_void,
-
-    /// The opcode.
-    _opcode: PhantomData<Opcode>,
 }
 
-impl<Opcode: CompileTimeOpcode> IntegerSetter<Opcode> {
+impl<const OPCODE: Opcode> IntegerSetter<OPCODE> {
     /// Create a new integer `Ioctl` helper containing a `usize`.
     ///
     /// # Safety
     ///
-    /// - `Opcode` must provide a valid opcode.
+    /// - `OPCODE` must provide a valid opcode.
     /// - For this opcode, it must expect an integer.
     /// - The integer is in the valid range for this opcode.
     #[inline]
     pub unsafe fn new_usize(value: usize) -> Self {
-        Self {
-            value: value as _,
-            _opcode: PhantomData,
-        }
+        Self { value: value as _ }
     }
 
     /// Create a new integer `Ioctl` helper containing a `*mut c_void`.
     ///
     /// # Safety
     ///
-    /// - `Opcode` must provide a valid opcode.
+    /// - `OPCODE` must provide a valid opcode.
     /// - For this opcode, it must expect an integer.
     /// - The integer is in the valid range for this opcode.
     #[inline]
     pub unsafe fn new_pointer(value: &mut c::c_void) -> Self {
-        Self {
-            value,
-            _opcode: PhantomData,
-        }
+        Self { value }
     }
 }
 
-unsafe impl<Opcode: CompileTimeOpcode> Ioctl for IntegerSetter<Opcode> {
+unsafe impl<const OPCODE: Opcode> Ioctl for IntegerSetter<OPCODE> {
     type Output = ();
 
     const IS_MUTATING: bool = false;
 
     fn opcode(&self) -> self::Opcode {
-        Opcode::OPCODE
+        OPCODE
     }
 
     fn as_ptr(&mut self) -> *mut c::c_void {
@@ -271,68 +240,4 @@ unsafe impl<Opcode: CompileTimeOpcode> Ioctl for IntegerSetter<Opcode> {
     ) -> Result<Self::Output> {
         Ok(())
     }
-}
-
-/// Trait for something that provides an `ioctl` opcode at compile time.
-pub trait CompileTimeOpcode {
-    /// The opcode.
-    const OPCODE: Opcode;
-}
-
-/// Provides a “bad” opcode at compile time.
-///
-/// Linux [calls them “bad”] because they use an older style of opcode
-/// numbering; it doesn't mean there's anything bad about them from the
-/// perspective of a user of these opcodes.
-///
-/// [calls them “bad”]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/asm-generic/ioctl.h?id=6d89ead19946181df1e41d38917fddc951dbd95b#n89
-pub struct BadOpcode<const OPCODE: RawOpcode>;
-
-impl<const OPCODE: RawOpcode> CompileTimeOpcode for BadOpcode<OPCODE> {
-    const OPCODE: Opcode = Opcode::old(OPCODE);
-}
-
-/// Provides a read code at compile time.
-///
-/// This corresponds to the C macro `_IOR(GROUP, NUM, Data)`.
-#[cfg(any(linux_kernel, bsd))]
-pub struct ReadOpcode<const GROUP: u8, const NUM: u8, Data>(Data);
-
-#[cfg(any(linux_kernel, bsd))]
-impl<const GROUP: u8, const NUM: u8, Data> CompileTimeOpcode for ReadOpcode<GROUP, NUM, Data> {
-    const OPCODE: Opcode = Opcode::read::<Data>(GROUP, NUM);
-}
-
-/// Provides a write code at compile time.
-///
-/// This corresponds to the C macro `_IOW(GROUP, NUM, Data)`.
-#[cfg(any(linux_kernel, bsd))]
-pub struct WriteOpcode<const GROUP: u8, const NUM: u8, Data>(Data);
-
-#[cfg(any(linux_kernel, bsd))]
-impl<const GROUP: u8, const NUM: u8, Data> CompileTimeOpcode for WriteOpcode<GROUP, NUM, Data> {
-    const OPCODE: Opcode = Opcode::write::<Data>(GROUP, NUM);
-}
-
-/// Provides a read/write code at compile time.
-///
-/// This corresponds to the C macro `_IOWR(GROUP, NUM, Data)`.
-#[cfg(any(linux_kernel, bsd))]
-pub struct ReadWriteOpcode<const GROUP: u8, const NUM: u8, Data>(Data);
-
-#[cfg(any(linux_kernel, bsd))]
-impl<const GROUP: u8, const NUM: u8, Data> CompileTimeOpcode for ReadWriteOpcode<GROUP, NUM, Data> {
-    const OPCODE: Opcode = Opcode::read_write::<Data>(GROUP, NUM);
-}
-
-/// Provides a `None` code at compile time.
-///
-/// This corresponds to the C macro `_IO(GROUP, NUM)` when `Data` is zero
-/// sized.
-#[cfg(any(linux_kernel, bsd))]
-pub struct NoneOpcode<const GROUP: u8, const NUM: u8, Data>(Data);
-
-#[cfg(any(linux_kernel, bsd))]
-impl<const GROUP: u8, const NUM: u8, Data> CompileTimeOpcode for NoneOpcode<GROUP, NUM, Data> {
-    const OPCODE: Opcode = Opcode::none::<Data>(GROUP, NUM);
 }

--- a/src/ioctl/patterns.rs
+++ b/src/ioctl/patterns.rs
@@ -9,6 +9,11 @@ use core::ptr::addr_of_mut;
 use core::{fmt, mem};
 
 /// Implements an `ioctl` with no real arguments.
+///
+/// To compute a value for the `OPCODE` argument, see the functions in the
+/// [`opcode`] module.
+///
+/// [`opcode`]: crate::ioctl::opcode
 pub struct NoArg<const OPCODE: Opcode> {}
 
 impl<const OPCODE: Opcode> fmt::Debug for NoArg<OPCODE> {
@@ -51,6 +56,11 @@ unsafe impl<const OPCODE: Opcode> Ioctl for NoArg<OPCODE> {
 ///
 /// Some `ioctl`s just read data into the userspace. As this is a popular
 /// pattern this structure implements it.
+///
+/// To compute a value for the `OPCODE` argument, see the functions in the
+/// [`opcode`] module.
+///
+/// [`opcode`]: crate::ioctl::opcode
 pub struct Getter<const OPCODE: Opcode, Output> {
     /// The output data.
     output: mem::MaybeUninit<Output>,
@@ -100,6 +110,11 @@ unsafe impl<const OPCODE: Opcode, Output> Ioctl for Getter<OPCODE, Output> {
 /// the `ioctl`.
 ///
 /// The opcode must be read-only.
+///
+/// To compute a value for the `OPCODE` argument, see the functions in the
+/// [`opcode`] module.
+///
+/// [`opcode`]: crate::ioctl::opcode
 pub struct Setter<const OPCODE: Opcode, Input> {
     /// The input data.
     input: Input,
@@ -150,6 +165,11 @@ unsafe impl<const OPCODE: Opcode, Input> Ioctl for Setter<OPCODE, Input> {
 ///
 /// The ioctl takes a reference to a struct that it reads its input from,
 /// then writes output to the same struct.
+///
+/// To compute a value for the `OPCODE` argument, see the functions in the
+/// [`opcode`] module.
+///
+/// [`opcode`]: crate::ioctl::opcode
 pub struct Updater<'a, const OPCODE: Opcode, Value> {
     /// Reference to input/output data.
     value: &'a mut Value,
@@ -188,6 +208,11 @@ unsafe impl<'a, const OPCODE: Opcode, T> Ioctl for Updater<'a, OPCODE, T> {
 }
 
 /// Implements an `ioctl` that passes an integer into the `ioctl`.
+///
+/// To compute a value for the `OPCODE` argument, see the functions in the
+/// [`opcode`] module.
+///
+/// [`opcode`]: crate::ioctl::opcode
 pub struct IntegerSetter<const OPCODE: Opcode> {
     /// The value to pass in.
     ///

--- a/src/process/ioctl.rs
+++ b/src/process/ioctl.rs
@@ -39,7 +39,7 @@ unsafe impl ioctl::Ioctl for Tiocsctty {
     const IS_MUTATING: bool = false;
 
     fn opcode(&self) -> ioctl::Opcode {
-        ioctl::Opcode::old(c::TIOCSCTTY as ioctl::RawOpcode)
+        c::TIOCSCTTY as ioctl::Opcode
     }
 
     fn as_ptr(&mut self) -> *mut c::c_void {

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -208,7 +208,7 @@ unsafe impl ioctl::Ioctl for Tiocgptpeer {
     const IS_MUTATING: bool = false;
 
     fn opcode(&self) -> ioctl::Opcode {
-        ioctl::Opcode::old(c::TIOCGPTPEER as ioctl::RawOpcode)
+        c::TIOCGPTPEER as ioctl::Opcode
     }
 
     fn as_ptr(&mut self) -> *mut c::c_void {

--- a/src/termios/ioctl.rs
+++ b/src/termios/ioctl.rs
@@ -27,7 +27,7 @@ use backend::c;
 pub fn ioctl_tiocexcl<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     // SAFETY: `TIOCEXCL` is a no-argument setter opcode.
     unsafe {
-        let ctl = ioctl::NoArg::<ioctl::BadOpcode<{ c::TIOCEXCL as _ }>>::new();
+        let ctl = ioctl::NoArg::<{ c::TIOCEXCL as _ }>::new();
         ioctl::ioctl(fd, ctl)
     }
 }
@@ -50,7 +50,7 @@ pub fn ioctl_tiocexcl<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 pub fn ioctl_tiocnxcl<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     // SAFETY: `TIOCNXCL` is a no-argument setter opcode.
     unsafe {
-        let ctl = ioctl::NoArg::<ioctl::BadOpcode<{ c::TIOCNXCL as _ }>>::new();
+        let ctl = ioctl::NoArg::<{ c::TIOCNXCL as _ }>::new();
         ioctl::ioctl(fd, ctl)
     }
 }

--- a/tests/io/ioctl.rs
+++ b/tests/io/ioctl.rs
@@ -14,15 +14,15 @@ fn test_ioctls() {
 #[test]
 fn test_int_setter() {
     use rustix::fs::{open, Mode, OFlags};
-    use rustix::ioctl::{ioctl, BadOpcode, IntegerSetter, RawOpcode};
+    use rustix::ioctl::{ioctl, IntegerSetter, Opcode};
 
-    const TUNSETOFFLOAD: RawOpcode = 0x4004_54D0;
+    const TUNSETOFFLOAD: Opcode = 0x4004_54D0;
 
     let tun = open("/dev/net/tun", OFlags::RDWR, Mode::empty()).unwrap();
 
     // SAFETY: `TUNSETOFFLOAD` is defined for TUN.
     unsafe {
-        let code = IntegerSetter::<BadOpcode<{ TUNSETOFFLOAD }>>::new_usize(0);
+        let code = IntegerSetter::<TUNSETOFFLOAD>::new_usize(0);
         assert!(ioctl(&tun, code).is_err());
     }
 }


### PR DESCRIPTION
As suggested [here], simplify the ioctl API by renaming `RawOpcode` to `Opcode` and using const generics.

[here]: https://github.com/bytecodealliance/rustix/issues/1022#issuecomment-2661284241