### PR TITLE
Split the UMEM fd out of `SocketAddrXdp`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -245,5 +245,14 @@ pointer provenance.
 [`rustix::io_uring::getevents_arg`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/struct.io_uring_getevents_arg.html
 [`rustix::io_uring::io_uring_ptr`]: https://docs.rs/rustix/1.0.0-prerelease.0/rustix/io_uring/struct.io_uring_ptr.html
 
+[`SocketAddrXdp`] no longer has a shared umem field. A new
+[`SocketAddrXdpWithSharedUmem`] is added for the purpose of calling `bind` and
+passing it an XDP address with a shared UMEM fd. And `SockaddrXdpFlags` is
+renamed to [`SocketAddrXdpFlags`].
+
+[`SocketAddrXdp`]: https://docs.rs/rustix/1.0.0/rustix/net/xdp/struct.SocketAddrXdp.html
+[`SocketAddrXdpWithSharedUmem`]: https://docs.rs/rustix/1.0.0/rustix/net/xdp/struct.SocketAddrXdpWithSharedUmem.html
+[`SocketAddrXdpFlags`]: https://docs.rs/rustix/1.0.0/rustix/net/xdp/struct.SocketAddrXdpFlags.html
+
 All explicitly deprecated functions and types have been removed. Their
 deprecation messages will have identified alternatives.

--- a/src/backend/libc/net/read_sockaddr.rs
+++ b/src/backend/libc/net/read_sockaddr.rs
@@ -12,7 +12,7 @@ use crate::net::addr::SocketAddrLen;
 #[cfg(linux_kernel)]
 use crate::net::netlink::SocketAddrNetlink;
 #[cfg(target_os = "linux")]
-use crate::net::xdp::{SockaddrXdpFlags, SocketAddrXdp};
+use crate::net::xdp::{SocketAddrXdp, SocketAddrXdpFlags};
 use crate::net::{AddressFamily, Ipv4Addr, Ipv6Addr, SocketAddrAny, SocketAddrV4, SocketAddrV6};
 use core::mem::size_of;
 
@@ -239,11 +239,14 @@ pub(crate) fn read_sockaddr_xdp(addr: &SocketAddrAny) -> Result<SocketAddrXdp, E
     }
     assert!(addr.addr_len() as usize >= size_of::<c::sockaddr_xdp>());
     let decode = unsafe { &*addr.as_ptr().cast::<c::sockaddr_xdp>() };
+
+    // This ignores the `sxdp_shared_umem_fd` field, which is only expected to
+    // be significant in `bind` calls, and not returned from `acceptfrom` or
+    // `recvmsg` or similar.
     Ok(SocketAddrXdp::new(
-        SockaddrXdpFlags::from_bits_retain(decode.sxdp_flags),
+        SocketAddrXdpFlags::from_bits_retain(decode.sxdp_flags),
         u32::from_be(decode.sxdp_ifindex),
         u32::from_be(decode.sxdp_queue_id),
-        u32::from_be(decode.sxdp_shared_umem_fd),
     ))
 }
 


### PR DESCRIPTION
Remove `SocketAddrXdp`'s shared umem field. Add a new `SocketAddrXdpWithSharedUmem` which pairs a `SocketAddrXdp` with a `BorrowedFd` for passing to `bind`.

While here, rename `SockaddrXdpFlags` to `SocketAddrXdpFlags` for consistency with the other `SocketAddr*` types.

This fixes the `SocketAddrXdp` side of #1001.