### PR TITLE
Tidy up the public re-exports.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -243,7 +243,15 @@ pointer provenance.
 [`sigmask`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/struct.io_uring_getevents_arg.html#structfield.sigmask
 [`ts`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/struct.io_uring_getevents_arg.html#structfield.ts
 [`rustix::io_uring::getevents_arg`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/struct.io_uring_getevents_arg.html
-[`rustix::io_uring::io_uring_ptr`]: https://docs.rs/rustix/1.0.0-prerelease.0/rustix/io_uring/struct.io_uring_ptr.html
+[`rustix::io_uring::io_uring_ptr`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/struct.io_uring_ptr.html
+
+The aliases for [`fcntl_dupfd_cloexec`], [`fcntl_getfd`], and [`fcntl_setfd`]
+in `rustix::fs` are removed; these functions are just available in
+`rustix::io` now.
+
+[`fcntl_dupfd_cloexec`]: https://docs.rs/rustix/1.0.0/rustix/io/fn.fcntl_dupfd_cloexec.html
+[`fcntl_getfd`]: https://docs.rs/rustix/1.0.0/rustix/io/fn.fcntl_getfd.html
+[`fcntl_setfd`]: https://docs.rs/rustix/1.0.0/rustix/io/fn.fcntl_setfd.html
 
 [`SocketAddrXdp`] no longer has a shared umem field. A new
 [`SocketAddrXdpWithSharedUmem`] is added for the purpose of calling `bind` and

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -590,8 +590,9 @@ pub(crate) fn renameat2(
                 flags.bits(),
             ));
         }
-        // Otherwise, see if we can use rename. There's no point in trying `renamex_np`
-        // because it was added in the same macOS release as `renameatx_np`.
+        // Otherwise, see if we can use `rename`. There's no point in trying
+        // `renamex_np` because it was added in the same macOS release as
+        // `renameatx_np`.
         if !flags.is_empty()
             || borrowed_fd(old_dirfd) != c::AT_FDCWD
             || borrowed_fd(new_dirfd) != c::AT_FDCWD

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -562,8 +562,7 @@ pub(crate) unsafe fn futex_timeout(
             val3,
         ))
         .or_else(|err| {
-            // See the comments in `rustix_clock_gettime_via_syscall` about
-            // emulation.
+            // See the comments in `clock_gettime_via_syscall` about emulation.
             if err == io::Errno::NOSYS {
                 futex_old_timespec(uaddr, op, flags, val, timeout, uaddr2, val3)
             } else {

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -1349,8 +1349,7 @@ unsafe fn _utimensat_old(
     times: &Timestamps,
     flags: AtFlags,
 ) -> io::Result<()> {
-    // See the comments in `rustix_clock_gettime_via_syscall` about
-    // emulation.
+    // See the comments in `clock_gettime_via_syscall` about emulation.
     let old_times = [
         __kernel_old_timespec {
             tv_sec: times

--- a/src/backend/linux_raw/process/wait.rs
+++ b/src/backend/linux_raw/process/wait.rs
@@ -85,3 +85,37 @@ impl SiginfoExt for siginfo_t {
             ._status
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_libc_correspondence() {
+        for status in [
+            0,
+            1,
+            63,
+            64,
+            65,
+            127,
+            128,
+            129,
+            255,
+            256,
+            257,
+            4095,
+            4096,
+            4097,
+            u32::MAX,
+        ] {
+            assert_eq!(WIFSTOPPED(status), libc::WIFSTOPPED(status as i32));
+            assert_eq!(WSTOPSIG(status), libc::WSTOPSIG(status as i32) as u32);
+            assert_eq!(WIFCONTINUED(status), libc::WIFCONTINUED(status as i32));
+            assert_eq!(WIFSIGNALED(status), libc::WIFSIGNALED(status as i32));
+            assert_eq!(WTERMSIG(status), libc::WTERMSIG(status as i32) as u32);
+            assert_eq!(WIFEXITED(status), libc::WIFEXITED(status as i32));
+            assert_eq!(WEXITSTATUS(status), libc::WEXITSTATUS(status as i32) as u32);
+        }
+    }
+}

--- a/src/backend/linux_raw/thread/syscalls.rs
+++ b/src/backend/linux_raw/thread/syscalls.rs
@@ -37,8 +37,7 @@ pub(crate) fn clock_nanosleep_relative(id: ClockId, req: &Timespec) -> Nanosleep
             &mut rem
         ))
         .or_else(|err| {
-            // See the comments in `rustix_clock_gettime_via_syscall` about
-            // emulation.
+            // See the comments in `clock_gettime_via_syscall` about emulation.
             if err == io::Errno::NOSYS {
                 clock_nanosleep_relative_old(id, req, &mut rem)
             } else {
@@ -105,8 +104,7 @@ pub(crate) fn clock_nanosleep_absolute(id: ClockId, req: &Timespec) -> io::Resul
             zero()
         ))
         .or_else(|err| {
-            // See the comments in `rustix_clock_gettime_via_syscall` about
-            // emulation.
+            // See the comments in `clock_gettime_via_syscall` about emulation.
             if err == io::Errno::NOSYS {
                 clock_nanosleep_absolute_old(id, req)
             } else {
@@ -154,8 +152,7 @@ pub(crate) fn nanosleep(req: &Timespec) -> NanosleepRelativeResult {
             &mut rem
         ))
         .or_else(|err| {
-            // See the comments in `rustix_clock_gettime_via_syscall` about
-            // emulation.
+            // See the comments in `clock_gettime_via_syscall` about emulation.
             if err == io::Errno::NOSYS {
                 nanosleep_old(req, &mut rem)
             } else {
@@ -272,8 +269,7 @@ pub(crate) unsafe fn futex_timeout(
             c_uint(val3)
         ))
         .or_else(|err| {
-            // See the comments in `rustix_clock_gettime_via_syscall` about
-            // emulation.
+            // See the comments in `clock_gettime_via_syscall` about emulation.
             if err == io::Errno::NOSYS {
                 futex_old_timespec(uaddr, op, flags, val, timeout, uaddr2, val3)
             } else {

--- a/src/backend/linux_raw/time/syscalls.rs
+++ b/src/backend/linux_raw/time/syscalls.rs
@@ -32,8 +32,7 @@ pub(crate) fn clock_getres(which_clock: ClockId) -> Timespec {
     unsafe {
         let mut result = MaybeUninit::<Timespec>::uninit();
         if let Err(err) = ret(syscall!(__NR_clock_getres_time64, which_clock, &mut result)) {
-            // See the comments in `rustix_clock_gettime_via_syscall` about
-            // emulation.
+            // See the comments in `clock_gettime_via_syscall` about emulation.
             debug_assert_eq!(err, io::Errno::NOSYS);
             clock_getres_old(which_clock, &mut result);
         }
@@ -138,8 +137,7 @@ pub(crate) fn timerfd_settime(
             &mut result
         ))
         .or_else(|err| {
-            // See the comments in `rustix_clock_gettime_via_syscall` about
-            // emulation.
+            // See the comments in `clock_gettime_via_syscall` about emulation.
             if err == io::Errno::NOSYS {
                 timerfd_settime_old(fd, flags, new_value, &mut result)
             } else {
@@ -222,8 +220,7 @@ pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
     #[cfg(target_pointer_width = "32")]
     unsafe {
         ret(syscall!(__NR_timerfd_gettime64, fd, &mut result)).or_else(|err| {
-            // See the comments in `rustix_clock_gettime_via_syscall` about
-            // emulation.
+            // See the comments in `clock_gettime_via_syscall` about emulation.
             if err == io::Errno::NOSYS {
                 timerfd_gettime_old(fd, &mut result)
             } else {

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -2,7 +2,6 @@
 
 use crate::backend;
 
-pub use crate::io::FdFlags;
 pub use crate::timespec::{Nsecs, Secs, Timespec};
 pub use backend::fs::types::*;
 

--- a/src/fs/fcntl.rs
+++ b/src/fs/fcntl.rs
@@ -16,13 +16,6 @@ use crate::{backend, io};
 use backend::fd::AsFd;
 use backend::fs::types::OFlags;
 
-// These `fcntl` functions live in the `io` module because they're not specific
-// to files, directories, or memfd objects. We re-export them here in the `fs`
-// module because the other the `fcntl` functions are here.
-#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
-pub use crate::io::fcntl_dupfd_cloexec;
-pub use crate::io::{fcntl_getfd, fcntl_setfd};
-
 /// `fcntl(fd, F_GETFL)`—Returns a file descriptor's access mode and status.
 ///
 /// # References

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,8 @@
 //!  - Provide y2038 compatibility, on platforms which support this.
 //!  - Correct selected platform bugs, such as behavioral differences when
 //!    running under seccomp.
-//!  - Use `timespec` for timestamps instead of `timeval`.
+//!  - Use `timespec` for timestamps and timeouts instead of `timeval` and
+//!    `c_int` milliseconds.
 //!
 //! Things they don't do include:
 //!  - Detecting whether functions are supported at runtime, except in specific

--- a/src/net/addr.rs
+++ b/src/net/addr.rs
@@ -99,7 +99,7 @@ pub unsafe trait SocketAddrArg {
     }
 }
 
-/// Helper for implementing SocketAddrArg::with_sockaddr
+/// Helper for implementing `SocketAddrArg::with_sockaddr`.
 ///
 /// # Safety
 ///

--- a/src/net/send_recv/msg.rs
+++ b/src/net/send_recv/msg.rs
@@ -613,9 +613,7 @@ impl<'a> MMsgHdr<'a> {
     /// Constructs a new message to a specific address.
     ///
     /// This requires a `SocketAddrAny` instead of using `impl SocketAddrArg`;
-    /// to obtain a `SocketAddrAny`, use [SocketAddrArg::as_any].
-    ///
-    /// [SocketAddrArg::as_any]: crate::net::addr::SocketAddrArg::as_any
+    /// to obtain a `SocketAddrAny`, use [`SocketAddrArg::as_any`].
     pub fn new_with_addr(
         addr: &'a SocketAddrAny,
         iov: &'a [IoSlice<'_>],

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1638,8 +1638,8 @@ pub mod xdp {
         }
     }
 
-    // Constant needs to be cast because bindgen does generate a u32 but the struct
-    // expects a u16.
+    // Constant needs to be cast because bindgen does generate a `u32` but the
+    // struct expects a `u16`.
     // <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/if_xdp.h?h=v6.13#n15>
     bitflags! {
         /// `XDP_*` constants for use in [`SocketAddrXdp`].
@@ -1686,7 +1686,8 @@ pub mod xdp {
     ///
     /// Not ABI compatible with `struct sockaddr_xdp`.
     ///
-    /// To add a shared UMEM file descriptor, use [`SocketAddrXdpWithSharedUmem`].
+    /// To add a shared UMEM file descriptor, use
+    /// [`SocketAddrXdpWithSharedUmem`].
     // <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/if_xdp.h?h=v6.13#n48>
     #[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Debug)]
     pub struct SocketAddrXdp {

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -18,10 +18,6 @@ mod sched_yield;
 #[cfg(linux_kernel)]
 mod setns;
 
-#[cfg(linux_kernel)]
-pub use crate::thread::futex::{
-    Flags as FutexFlags, OWNER_DIED as FUTEX_OWNER_DIED, WAITERS as FUTEX_WAITERS,
-};
 #[cfg(not(target_os = "redox"))]
 pub use clock::*;
 #[cfg(linux_kernel)]

--- a/src/timespec.rs
+++ b/src/timespec.rs
@@ -27,7 +27,7 @@ pub struct Timespec {
 /// A type for the `tv_sec` field of [`Timespec`].
 pub type Secs = i64;
 
-/// A type for the `tv_sec` field of [`Timespec`].
+/// A type for the `tv_nsec` field of [`Timespec`].
 #[cfg(any(
     fix_y2038,
     linux_raw,

--- a/tests/fs/fcntl.rs
+++ b/tests/fs/fcntl.rs
@@ -12,7 +12,7 @@ fn test_fcntl_dupfd_cloexec() {
     )
     .unwrap();
 
-    let new = rustix::fs::fcntl_dupfd_cloexec(&file, 700).unwrap();
+    let new = rustix::io::fcntl_dupfd_cloexec(&file, 700).unwrap();
     assert_eq!(new.as_fd().as_raw_fd(), 700);
 }
 

--- a/tests/fs/renameat.rs
+++ b/tests/fs/renameat.rs
@@ -1,15 +1,12 @@
-use rustix::fs::Stat;
+use rustix::fs::{OFlags, Stat};
 
 fn same(a: &Stat, b: &Stat) -> bool {
     a.st_ino == b.st_ino && a.st_dev == b.st_dev
 }
 
-#[cfg(test)]
-use rustix::fs::OFlags;
-
-#[cfg(all(test, linux_kernel))]
+#[cfg(linux_kernel)]
 const DIR_OPEN_FLAGS: OFlags = OFlags::RDONLY.union(OFlags::PATH);
-#[cfg(all(test, apple))]
+#[cfg(apple)]
 const DIR_OPEN_FLAGS: OFlags = OFlags::RDONLY;
 
 #[test]

--- a/tests/io/ioctl.rs
+++ b/tests/io/ioctl.rs
@@ -20,7 +20,7 @@ fn test_int_setter() {
 
     let tun = open("/dev/net/tun", OFlags::RDWR, Mode::empty()).unwrap();
 
-    // SAFETY: TUNSETOFFLOAD is defined for TUN.
+    // SAFETY: `TUNSETOFFLOAD` is defined for TUN.
     unsafe {
         let code = IntegerSetter::<BadOpcode<{ TUNSETOFFLOAD }>>::new_usize(0);
         assert!(ioctl(&tun, code).is_err());


### PR DESCRIPTION
Remove the re-exports of `fcntl_getfd`, `fcntl_setfd`, and `fcntl_dupfd_cloexec` from `rustix::fs`. They're now in `rustix::io` only.

And remove the re-exports of the futex `Flags`, `OWNER_DIED`, and `WAITERS` in the top-level `rustix::thread` module. They're now in `rustix::thread::futex` only.

Also, tidy up more comments, add a wait test, and remove the `rustix_` prefix on functions that don't need to be prefixed.