### PR TITLE
Add support for armv6k-nintendo-3ds.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,8 +223,7 @@ jobs:
     # - run: cargo check -Z build-std --target=riscv32imc-esp-espidf --features=all-apis
     - run: cargo check -Z build-std --target=aarch64-unknown-nto-qnx710 --features=all-apis
     - run: cargo check -Z build-std --target=x86_64-pc-nto-qnx710 --features=all-apis
-    # Temporarily disable --features=all-apis, which doesn't build yet.
-    - run: cargo check -Z build-std --target=armv6k-nintendo-3ds
+    - run: cargo check -Z build-std --target=armv6k-nintendo-3ds --all-features
     - run: cargo check -Z build-std --target=armv7-sony-vita-newlibeabihf --features=all-apis
     - run: cargo check -Z build-std --target=powerpc64-ibm-aix --features=all-apis
     - run: cargo check -Z build-std --target=mipsel-unknown-linux-gnu --features=all-apis

--- a/src/backend/libc/fs/dir.rs
+++ b/src/backend/libc/fs/dir.rs
@@ -16,6 +16,7 @@ use crate::fs::{fstat, Stat};
 #[cfg(not(any(
     solarish,
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "netbsd",
     target_os = "nto",
     target_os = "redox",
@@ -217,7 +218,7 @@ impl Dir {
     }
 
     /// `fstat(self)`
-    #[cfg(not(target_os = "vita"))]
+    #[cfg(not(any(target_os = "horizon", target_os = "vita")))]
     #[inline]
     pub fn stat(&self) -> io::Result<Stat> {
         fstat(unsafe { BorrowedFd::borrow_raw(c::dirfd(self.libc_dir.as_ptr())) })
@@ -227,6 +228,7 @@ impl Dir {
     #[cfg(not(any(
         solarish,
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "netbsd",
         target_os = "nto",
         target_os = "redox",
@@ -242,6 +244,7 @@ impl Dir {
     #[cfg(not(any(
         solarish,
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "redox",
         target_os = "vita",
         target_os = "wasi"
@@ -253,7 +256,12 @@ impl Dir {
 
     /// `fchdir(self)`
     #[cfg(feature = "process")]
-    #[cfg(not(any(target_os = "fuchsia", target_os = "vita", target_os = "wasi")))]
+    #[cfg(not(any(
+        target_os = "fuchsia",
+        target_os = "horizon",
+        target_os = "vita",
+        target_os = "wasi"
+    )))]
     #[cfg_attr(docsrs, doc(cfg(feature = "process")))]
     #[inline]
     pub fn chdir(&self) -> io::Result<()> {
@@ -287,7 +295,7 @@ impl Iterator for Dir {
 impl fmt::Debug for Dir {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut s = f.debug_struct("Dir");
-        #[cfg(not(target_os = "vita"))]
+        #[cfg(not(any(target_os = "horizon", target_os = "vita")))]
         s.field("fd", unsafe { &c::dirfd(self.libc_dir.as_ptr()) });
         s.finish()
     }

--- a/src/backend/libc/fs/mod.rs
+++ b/src/backend/libc/fs/mod.rs
@@ -5,6 +5,7 @@ pub mod inotify;
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -10,7 +10,7 @@ use crate::ffi;
 use crate::ffi::CStr;
 #[cfg(all(apple, feature = "alloc"))]
 use crate::ffi::CString;
-#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
 use crate::fs::Access;
 #[cfg(not(any(target_os = "espidf", target_os = "redox")))]
 use crate::fs::AtFlags;
@@ -18,12 +18,18 @@ use crate::fs::AtFlags;
     netbsdlike,
     target_os = "dragonfly",
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "nto",
     target_os = "redox",
     target_os = "vita",
 )))]
 use crate::fs::FallocateFlags;
-#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 use crate::fs::FlockOperation;
 #[cfg(any(linux_kernel, target_os = "freebsd"))]
 use crate::fs::MemfdFlags;
@@ -35,6 +41,7 @@ use crate::fs::SealFlags;
     solarish,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "netbsd",
     target_os = "nto",
     target_os = "redox",
@@ -75,6 +82,7 @@ use {
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
 )))]
@@ -247,6 +255,7 @@ pub(crate) fn openat(
     solarish,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "netbsd",
     target_os = "nto",
     target_os = "redox",
@@ -777,7 +786,12 @@ fn statat_old(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io::Result<
     }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "emscripten", target_os = "vita")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "emscripten",
+    target_os = "vita"
+)))]
 pub(crate) fn access(path: &CStr, access: Access) -> io::Result<()> {
     unsafe { ret(c::access(c_str(path), access.bits())) }
 }
@@ -785,6 +799,7 @@ pub(crate) fn access(path: &CStr, access: Access) -> io::Result<()> {
 #[cfg(not(any(
     target_os = "emscripten",
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita"
 )))]
@@ -853,7 +868,12 @@ pub(crate) fn accessat(
     Ok(())
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "vita")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "redox",
+    target_os = "vita"
+)))]
 pub(crate) fn utimensat(
     dirfd: BorrowedFd<'_>,
     path: &CStr,
@@ -1169,6 +1189,7 @@ pub(crate) fn chownat(
 #[cfg(not(any(
     apple,
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -1250,6 +1271,7 @@ pub(crate) fn copy_file_range(
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
 )))]
@@ -1335,6 +1357,7 @@ pub(crate) fn fcntl_add_seals(fd: BorrowedFd<'_>, seals: SealFlags) -> io::Resul
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -1460,6 +1483,7 @@ pub(crate) fn fchown(fd: BorrowedFd<'_>, owner: Option<Uid>, group: Option<Gid>)
 
 #[cfg(not(any(
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "solaris",
     target_os = "vita",
     target_os = "wasi"
@@ -1487,6 +1511,7 @@ pub(crate) fn syncfs(fd: BorrowedFd<'_>) -> io::Result<()> {
 
 #[cfg(not(any(
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -1561,6 +1586,7 @@ fn fstat_old(fd: BorrowedFd<'_>) -> io::Result<Stat> {
     solarish,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "netbsd",
     target_os = "nto",
     target_os = "redox",
@@ -1604,7 +1630,7 @@ fn libc_statvfs_to_statvfs(from: c::statvfs) -> StatVfs {
     }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
 pub(crate) fn futimens(fd: BorrowedFd<'_>, times: &Timestamps) -> io::Result<()> {
     // Old 32-bit version: libc has `futimens` but it is not y2038 safe by
     // default. But there may be a `__futimens64` we can use.
@@ -1708,6 +1734,7 @@ fn futimens_old(fd: BorrowedFd<'_>, times: &Timestamps) -> io::Result<()> {
     netbsdlike,
     target_os = "dragonfly",
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "nto",
     target_os = "redox",
     target_os = "vita",
@@ -1787,6 +1814,7 @@ pub(crate) fn fsync(fd: BorrowedFd<'_>) -> io::Result<()> {
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
 )))]

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -2,7 +2,7 @@ use crate::backend::c;
 use crate::ffi;
 use bitflags::bitflags;
 
-#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
 bitflags! {
     /// `*_OK` constants for use with [`accessat`].
     ///
@@ -27,7 +27,7 @@ bitflags! {
     }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "redox")))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "redox")))]
 bitflags! {
     /// `AT_*` constants for use with [`openat`], [`statat`], and other `*at`
     /// functions.
@@ -83,6 +83,22 @@ bitflags! {
     }
 }
 
+#[cfg(target_os = "horizon")]
+bitflags! {
+    /// `AT_*` constants for use with [`openat`], [`statat`], and other `*at`
+    /// functions.
+    ///
+    /// [`openat`]: crate::fs::openat
+    /// [`statat`]: crate::fs::statat
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+    pub struct AtFlags: u32 {
+        /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
+        const _ = !0;
+    }
+}
+
+#[cfg(not(target_os = "horizon"))]
 bitflags! {
     /// `S_I*` constants for use with [`openat`], [`chmodat`], and [`fchmod`].
     ///
@@ -152,6 +168,21 @@ bitflags! {
         #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
         const SVTX = c::S_ISVTX as RawMode;
 
+        /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
+        const _ = !0;
+    }
+}
+
+#[cfg(target_os = "horizon")]
+bitflags! {
+    /// `S_I*` constants for use with [`openat`], [`chmodat`], and [`fchmod`].
+    ///
+    /// [`openat`]: crate::fs::openat
+    /// [`chmodat`]: crate::fs::chmodat
+    /// [`fchmod`]: crate::fs::fchmod
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+    pub struct Mode: RawMode {
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
         const _ = !0;
     }
@@ -228,11 +259,11 @@ bitflags! {
         const CREATE = bitcast!(c::O_CREAT);
 
         /// `O_DIRECTORY`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
         const DIRECTORY = bitcast!(c::O_DIRECTORY);
 
         /// `O_DSYNC`
-        #[cfg(not(any(target_os = "dragonfly", target_os = "espidf", target_os = "l4re", target_os = "redox", target_os = "vita")))]
+        #[cfg(not(any(target_os = "dragonfly", target_os = "espidf", target_os = "horizon", target_os = "l4re", target_os = "redox", target_os = "vita")))]
         const DSYNC = bitcast!(c::O_DSYNC);
 
         /// `O_EXCL`
@@ -246,7 +277,7 @@ bitflags! {
         const FSYNC = bitcast!(c::O_FSYNC);
 
         /// `O_NOFOLLOW`
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
         const NOFOLLOW = bitcast!(c::O_NOFOLLOW);
 
         /// `O_NONBLOCK`
@@ -264,7 +295,7 @@ bitflags! {
         const RDWR = bitcast!(c::O_RDWR);
 
         /// `O_NOCTTY`
-        #[cfg(not(any(target_os = "espidf", target_os = "l4re", target_os = "redox", target_os = "vita")))]
+        #[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "l4re", target_os = "redox", target_os = "vita")))]
         const NOCTTY = bitcast!(c::O_NOCTTY);
 
         /// `O_RSYNC`
@@ -347,6 +378,7 @@ bitflags! {
             target_os = "aix",
             target_os = "espidf",
             target_os = "haiku",
+            target_os = "horizon",
             target_os = "wasi",
             target_os = "vita",
             solarish
@@ -601,6 +633,7 @@ impl FileType {
     target_os = "solaris",
     target_os = "dragonfly",
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "haiku",
     target_os = "redox",
     target_os = "vita",
@@ -711,6 +744,7 @@ bitflags! {
 #[cfg(not(any(
     netbsdlike,
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "nto",
     target_os = "redox",
     target_os = "vita"
@@ -838,11 +872,11 @@ bitflags! {
         const NOEXEC = c::ST_NOEXEC as u64;
 
         /// `ST_NOSUID`
-        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+        #[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
         const NOSUID = c::ST_NOSUID as u64;
 
         /// `ST_RDONLY`
-        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+        #[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
         const RDONLY = c::ST_RDONLY as u64;
 
         /// `ST_RELATIME`
@@ -865,7 +899,12 @@ bitflags! {
 // Solaris doesn't support `flock` and doesn't define `LOCK_SH` etc., but we
 // reuse this `FlockOperation` enum for `fcntl_lock`, so on Solaris we use
 // our own made-up integer values.
-#[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u32)]
 pub enum FlockOperation {
@@ -998,6 +1037,7 @@ pub struct Stat {
     solarish,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "netbsd",
     target_os = "nto",
     target_os = "redox",
@@ -1019,6 +1059,7 @@ pub type StatFs = c::statfs64;
     solarish,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "nto",
     target_os = "redox",
     target_os = "vita",

--- a/src/backend/libc/mod.rs
+++ b/src/backend/libc/mod.rs
@@ -111,7 +111,13 @@ pub(crate) mod io;
 #[cfg(linux_kernel)]
 #[cfg(feature = "io_uring")]
 pub(crate) mod io_uring;
-#[cfg(not(any(windows, target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 #[cfg(feature = "mm")]
 pub(crate) mod mm;
 #[cfg(linux_kernel)]
@@ -145,7 +151,7 @@ pub(crate) mod rand;
 #[cfg(not(target_os = "wasi"))]
 #[cfg(feature = "system")]
 pub(crate) mod system;
-#[cfg(not(any(windows, target_os = "vita")))]
+#[cfg(not(any(windows, target_os = "horizon", target_os = "vita")))]
 #[cfg(feature = "termios")]
 pub(crate) mod termios;
 #[cfg(not(windows))]
@@ -185,6 +191,7 @@ pub(crate) mod prctl;
     windows,
     target_os = "android",
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "vita",
     target_os = "wasi"
 )))]

--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -102,6 +102,7 @@ impl SocketAddrUnix {
                 bsd,
                 target_os = "aix",
                 target_os = "haiku",
+                target_os = "horizon",
                 target_os = "nto",
                 target_os = "hurd",
             ))]
@@ -109,9 +110,15 @@ impl SocketAddrUnix {
             #[cfg(target_os = "vita")]
             ss_len: 0,
             sun_family: c::AF_UNIX as _,
-            #[cfg(any(bsd, target_os = "nto"))]
+            #[cfg(any(bsd, target_os = "horizon", target_os = "nto"))]
             sun_path: [0; 104],
-            #[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "nto")))]
+            #[cfg(not(any(
+                bsd,
+                target_os = "aix",
+                target_os = "haiku",
+                target_os = "horizon",
+                target_os = "nto"
+            )))]
             sun_path: [0; 108],
             #[cfg(target_os = "haiku")]
             sun_path: [0; 126],
@@ -286,6 +293,7 @@ pub(crate) fn offsetof_sun_path() -> usize {
             bsd,
             target_os = "aix",
             target_os = "haiku",
+            target_os = "horizon",
             target_os = "hurd",
             target_os = "nto",
         ))]
@@ -312,9 +320,15 @@ pub(crate) fn offsetof_sun_path() -> usize {
             target_os = "vita"
         )))]
         sun_family: 0_u16,
-        #[cfg(any(bsd, target_os = "nto"))]
+        #[cfg(any(bsd, target_os = "horizon", target_os = "nto"))]
         sun_path: [0; 104],
-        #[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "nto")))]
+        #[cfg(not(any(
+            bsd,
+            target_os = "aix",
+            target_os = "haiku",
+            target_os = "horizon",
+            target_os = "nto"
+        )))]
         sun_path: [0; 108],
         #[cfg(target_os = "haiku")]
         sun_path: [0; 126],

--- a/src/backend/libc/net/mod.rs
+++ b/src/backend/libc/net/mod.rs
@@ -1,6 +1,12 @@
 pub(crate) mod addr;
 pub(crate) mod ext;
-#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "vita")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "redox",
+    target_os = "vita"
+)))]
 pub(crate) mod msghdr;
 #[cfg(linux_kernel)]
 pub(crate) mod netdevice;

--- a/src/backend/libc/net/read_sockaddr.rs
+++ b/src/backend/libc/net/read_sockaddr.rs
@@ -87,8 +87,10 @@ pub(crate) unsafe fn read_sa_family(storage: *const c::sockaddr) -> u16 {
             target_os = "vita"
         )))]
         sa_family: 0_u16,
-        #[cfg(not(target_os = "haiku"))]
+        #[cfg(not(any(target_os = "haiku", target_os = "horizon")))]
         sa_data: [0; 14],
+        #[cfg(target_os = "horizon")]
+        sa_data: [0; 26],
         #[cfg(target_os = "haiku")]
         sa_data: [0; 30],
     };

--- a/src/backend/libc/net/send_recv.rs
+++ b/src/backend/libc/net/send_recv.rs
@@ -19,6 +19,7 @@ bitflags! {
             target_os = "espidf",
             target_os = "nto",
             target_os = "haiku",
+            target_os = "horizon",
             target_os = "hurd",
             target_os = "redox",
             target_os = "vita",
@@ -30,7 +31,7 @@ bitflags! {
         #[cfg(not(windows))]
         const DONTWAIT = bitcast!(c::MSG_DONTWAIT);
         /// `MSG_EOR`
-        #[cfg(not(windows))]
+        #[cfg(not(any(windows, target_os = "horizon")))]
         const EOR = bitcast!(c::MSG_EOR);
         /// `MSG_MORE`
         #[cfg(not(any(
@@ -73,6 +74,7 @@ bitflags! {
             target_os = "aix",
             target_os = "espidf",
             target_os = "haiku",
+            target_os = "horizon",
             target_os = "nto",
             target_os = "redox",
             target_os = "vita",
@@ -89,6 +91,7 @@ bitflags! {
             target_os = "aix",
             target_os = "espidf",
             target_os = "haiku",
+            target_os = "horizon",
             target_os = "hurd",
             target_os = "nto",
             target_os = "redox",
@@ -103,7 +106,7 @@ bitflags! {
         // Apple, illumos, and NetBSD have `MSG_TRUNC` but it's not documented
         // for use with `recv` and friends, and in practice appears to be
         // ignored.
-        #[cfg(not(any(apple, solarish, target_os = "netbsd")))]
+        #[cfg(not(any(apple, solarish, target_os = "horizon", target_os = "netbsd")))]
         const TRUNC = bitcast!(c::MSG_TRUNC);
         /// `MSG_WAITALL`
         const WAITALL = bitcast!(c::MSG_WAITALL);
@@ -125,11 +128,13 @@ bitflags! {
         /// `MSG_OOB`
         const OOB = bitcast!(c::MSG_OOB);
         /// `MSG_EOR`
-        #[cfg(not(windows))]
+        #[cfg(not(any(windows, target_os = "horizon")))]
         const EOR = bitcast!(c::MSG_EOR);
         /// `MSG_TRUNC`
+        #[cfg(not(target_os = "horizon"))]
         const TRUNC = bitcast!(c::MSG_TRUNC);
         /// `MSG_CTRUNC`
+        #[cfg(not(target_os = "horizon"))]
         const CTRUNC = bitcast!(c::MSG_CTRUNC);
 
         /// `MSG_CMSG_CLOEXEC`

--- a/src/backend/libc/net/sockopt.rs
+++ b/src/backend/libc/net/sockopt.rs
@@ -383,6 +383,7 @@ pub(crate) fn socket_send_buffer_size(fd: BorrowedFd<'_>) -> io::Result<usize> {
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "hurd",
     target_os = "netbsd",
     target_os = "nto",
@@ -851,6 +852,7 @@ pub(crate) fn ipv6_original_dst(fd: BorrowedFd<'_>) -> io::Result<SocketAddrV6> 
     windows,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita"
 )))]
@@ -864,6 +866,7 @@ pub(crate) fn set_ipv6_tclass(fd: BorrowedFd<'_>, value: u32) -> io::Result<()> 
     windows,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita"
 )))]

--- a/src/backend/libc/net/syscalls.rs
+++ b/src/backend/libc/net/syscalls.rs
@@ -17,7 +17,13 @@ use crate::net::{
 use crate::utils::as_ptr;
 use core::mem::{size_of, MaybeUninit};
 use core::ptr::null_mut;
-#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "vita")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "redox",
+    target_os = "vita"
+)))]
 use {
     super::msghdr::{noaddr_msghdr, with_msghdr, with_recv_msghdr},
     super::send_recv::ReturnFlags,
@@ -177,7 +183,13 @@ pub(crate) fn accept(sockfd: BorrowedFd<'_>) -> io::Result<OwnedFd> {
     }
 }
 
-#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "vita")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "redox",
+    target_os = "vita"
+)))]
 pub(crate) fn recvmsg(
     sockfd: BorrowedFd<'_>,
     iov: &mut [IoSliceMut<'_>],
@@ -206,7 +218,13 @@ pub(crate) fn recvmsg(
     })
 }
 
-#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "vita")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "redox",
+    target_os = "vita"
+)))]
 pub(crate) fn sendmsg(
     sockfd: BorrowedFd<'_>,
     iov: &[IoSlice<'_>],
@@ -223,7 +241,13 @@ pub(crate) fn sendmsg(
     }
 }
 
-#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "vita")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "redox",
+    target_os = "vita"
+)))]
 pub(crate) fn sendmsg_addr(
     sockfd: BorrowedFd<'_>,
     addr: &impl SocketAddrArg,
@@ -267,6 +291,7 @@ pub(crate) fn sendmmsg(
     target_os = "aix",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "nto",
     target_os = "redox",
     target_os = "vita",
@@ -301,6 +326,7 @@ pub(crate) fn acceptfrom(sockfd: BorrowedFd<'_>) -> io::Result<(OwnedFd, Option<
     target_os = "aix",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "nto",
     target_os = "redox",
     target_os = "vita",
@@ -329,6 +355,7 @@ pub(crate) fn acceptfrom_with(
     target_os = "aix",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "nto",
     target_os = "redox",
     target_os = "vita",
@@ -345,6 +372,7 @@ pub(crate) fn accept_with(sockfd: BorrowedFd<'_>, _flags: SocketFlags) -> io::Re
     target_os = "aix",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "nto",
     target_os = "redox",
     target_os = "vita",

--- a/src/backend/libc/param/auxv.rs
+++ b/src/backend/libc/param/auxv.rs
@@ -17,7 +17,7 @@ pub(crate) fn page_size() -> usize {
     unsafe { c::sysconf(c::_SC_PAGESIZE) as usize }
 }
 
-#[cfg(not(any(target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(target_os = "horizon", target_os = "vita", target_os = "wasi")))]
 #[inline]
 pub(crate) fn clock_ticks_per_second() -> u64 {
     unsafe { c::sysconf(c::_SC_CLK_TCK) as u64 }

--- a/src/backend/libc/pipe/syscalls.rs
+++ b/src/backend/libc/pipe/syscalls.rs
@@ -37,6 +37,7 @@ pub(crate) fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     target_os = "aix",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "nto",
     target_os = "wasi"
 )))]

--- a/src/backend/libc/pipe/types.rs
+++ b/src/backend/libc/pipe/types.rs
@@ -20,6 +20,7 @@ bitflags! {
             solarish,
             target_os = "espidf",
             target_os = "haiku",
+            target_os = "horizon",
             target_os = "hurd",
             target_os = "nto",
             target_os = "openbsd",

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -33,6 +33,7 @@ use crate::io;
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -56,6 +57,7 @@ use crate::process::{RawPid, WaitOptions, WaitStatus};
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -63,8 +65,9 @@ use crate::process::{RawPid, WaitOptions, WaitStatus};
 use crate::process::{Resource, Rlimit};
 #[cfg(not(any(
     target_os = "espidf",
-    target_os = "redox",
+    target_os = "horizon",
     target_os = "openbsd",
+    target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
 )))]
@@ -155,6 +158,7 @@ pub(crate) fn nice(inc: i32) -> io::Result<i32> {
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "vita",
     target_os = "wasi"
 )))]
@@ -172,6 +176,7 @@ pub(crate) fn getpriority_user(uid: Uid) -> io::Result<i32> {
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "vita",
     target_os = "wasi"
 )))]
@@ -189,6 +194,7 @@ pub(crate) fn getpriority_pgrp(pgid: Option<Pid>) -> io::Result<i32> {
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "vita",
     target_os = "wasi"
 )))]
@@ -206,6 +212,7 @@ pub(crate) fn getpriority_process(pid: Option<Pid>) -> io::Result<i32> {
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "vita",
     target_os = "wasi"
 )))]
@@ -217,6 +224,7 @@ pub(crate) fn setpriority_user(uid: Uid, priority: i32) -> io::Result<()> {
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "vita",
     target_os = "wasi"
 )))]
@@ -234,6 +242,7 @@ pub(crate) fn setpriority_pgrp(pgid: Option<Pid>, priority: i32) -> io::Result<(
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "vita",
     target_os = "wasi"
 )))]
@@ -251,6 +260,7 @@ pub(crate) fn setpriority_process(pid: Option<Pid>, priority: i32) -> io::Result
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -267,6 +277,7 @@ pub(crate) fn getrlimit(limit: Resource) -> Rlimit {
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -297,6 +308,7 @@ pub(crate) fn prlimit(pid: Option<Pid>, limit: Resource, new: Rlimit) -> io::Res
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -319,6 +331,7 @@ fn rlimit_from_libc(lim: c::rlimit) -> Rlimit {
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -372,8 +385,9 @@ pub(crate) fn _waitpid(
 
 #[cfg(not(any(
     target_os = "espidf",
-    target_os = "redox",
+    target_os = "horizon",
     target_os = "openbsd",
+    target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
 )))]
@@ -393,8 +407,9 @@ pub(crate) fn waitid(id: WaitId<'_>, options: WaitIdOptions) -> io::Result<Optio
 
 #[cfg(not(any(
     target_os = "espidf",
-    target_os = "redox",
+    target_os = "horizon",
     target_os = "openbsd",
+    target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
 )))]
@@ -417,8 +432,9 @@ fn _waitid_all(options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
 
 #[cfg(not(any(
     target_os = "espidf",
-    target_os = "redox",
+    target_os = "horizon",
     target_os = "openbsd",
+    target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
 )))]
@@ -441,8 +457,9 @@ fn _waitid_pid(pid: Pid, options: WaitIdOptions) -> io::Result<Option<WaitIdStat
 
 #[cfg(not(any(
     target_os = "espidf",
-    target_os = "redox",
+    target_os = "horizon",
     target_os = "openbsd",
+    target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
 )))]
@@ -489,6 +506,7 @@ fn _waitid_pidfd(fd: BorrowedFd<'_>, options: WaitIdOptions) -> io::Result<Optio
 /// returned successfully.
 #[cfg(not(any(
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "vita",
@@ -660,6 +678,7 @@ pub(crate) fn getgroups(buf: &mut [Gid]) -> io::Result<usize> {
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"

--- a/src/backend/libc/process/types.rs
+++ b/src/backend/libc/process/types.rs
@@ -16,6 +16,7 @@ use crate::backend::c;
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"

--- a/src/backend/libc/process/wait.rs
+++ b/src/backend/libc/process/wait.rs
@@ -1,9 +1,16 @@
 use crate::backend::c;
 
 pub(crate) use c::{
-    WCONTINUED, WEXITSTATUS, WIFCONTINUED, WIFEXITED, WIFSIGNALED, WIFSTOPPED, WNOHANG, WSTOPSIG,
-    WTERMSIG, WUNTRACED,
+    WEXITSTATUS, WIFCONTINUED, WIFEXITED, WIFSIGNALED, WIFSTOPPED, WNOHANG, WSTOPSIG, WTERMSIG,
 };
 
-#[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(target_os = "horizon"))]
+pub(crate) use c::{WCONTINUED, WUNTRACED};
+
+#[cfg(not(any(
+    target_os = "horizon",
+    target_os = "openbsd",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 pub(crate) use c::{WEXITED, WNOWAIT, WSTOPPED};

--- a/src/backend/libc/system/syscalls.rs
+++ b/src/backend/libc/system/syscalls.rs
@@ -50,6 +50,7 @@ pub(crate) fn sysinfo() -> Sysinfo {
 #[cfg(not(any(
     target_os = "emscripten",
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -69,6 +70,7 @@ pub(crate) fn sethostname(name: &[u8]) -> io::Result<()> {
     target_os = "espidf",
     target_os = "illumos",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "solaris",
     target_os = "vita",

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -350,12 +350,12 @@ pub(crate) fn tcgetsid(fd: BorrowedFd<'_>) -> io::Result<Pid> {
     }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "wasi")))]
 pub(crate) fn tcsetwinsize(fd: BorrowedFd<'_>, winsize: Winsize) -> io::Result<()> {
     unsafe { ret(c::ioctl(borrowed_fd(fd), c::TIOCSWINSZ, &winsize)) }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "wasi")))]
 pub(crate) fn tcgetwinsize(fd: BorrowedFd<'_>) -> io::Result<Winsize> {
     unsafe {
         let mut buf = MaybeUninit::<Winsize>::uninit();

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -52,6 +52,7 @@ weak!(fn __nanosleep64(*const LibcTimespec, *mut LibcTimespec) -> c::c_int);
     target_os = "espidf",
     target_os = "freebsd", // FreeBSD 12 has clock_nanosleep, but libc targets FreeBSD 11.
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "vita",
@@ -114,6 +115,7 @@ pub(crate) fn clock_nanosleep_relative(id: ClockId, request: &Timespec) -> Nanos
         apple,
         target_os = "emscripten",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "vita"
     ))
 ))]
@@ -161,6 +163,7 @@ fn clock_nanosleep_relative_old(
     target_os = "espidf",
     target_os = "freebsd", // FreeBSD 12 has clock_nanosleep, but libc targets FreeBSD 11.
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "vita",
@@ -218,6 +221,7 @@ pub(crate) fn clock_nanosleep_absolute(id: ClockId, request: &Timespec) -> io::R
         apple,
         target_os = "emscripten",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "vita"
     ))
 ))]

--- a/src/clockid.rs
+++ b/src/clockid.rs
@@ -39,6 +39,7 @@ pub enum ClockId {
     /// `CLOCK_PROCESS_CPUTIME_ID`
     #[cfg(not(any(
         solarish,
+        target_os = "horizon",
         target_os = "netbsd",
         target_os = "redox",
         target_os = "vita"
@@ -49,6 +50,7 @@ pub enum ClockId {
     /// `CLOCK_THREAD_CPUTIME_ID`
     #[cfg(not(any(
         solarish,
+        target_os = "horizon",
         target_os = "netbsd",
         target_os = "redox",
         target_os = "vita"

--- a/src/fs/abs.rs
+++ b/src/fs/abs.rs
@@ -1,12 +1,13 @@
 //! POSIX-style filesystem functions which operate on bare paths.
 
 use crate::fd::OwnedFd;
-#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
 use crate::fs::Access;
 #[cfg(not(any(
     solarish,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "netbsd",
     target_os = "nto",
     target_os = "redox",
@@ -237,7 +238,7 @@ pub fn mkdir<P: path::Arg>(path: P, mode: Mode) -> io::Result<()> {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/access.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/access.2.html
-#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
 #[inline]
 pub fn access<P: path::Arg>(path: P, access: Access) -> io::Result<()> {
     path.into_with_c_str(|path| backend::fs::syscalls::access(path, access))
@@ -256,6 +257,7 @@ pub fn access<P: path::Arg>(path: P, access: Access) -> io::Result<()> {
     solarish,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "netbsd",
     target_os = "nto",
     target_os = "redox",

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -8,7 +8,7 @@
 
 use crate::fd::OwnedFd;
 use crate::ffi::CStr;
-#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
 use crate::fs::Access;
 #[cfg(not(target_os = "espidf"))]
 use crate::fs::AtFlags;
@@ -35,13 +35,23 @@ use {crate::fs::Timestamps, crate::timespec::Nsecs};
 /// `UTIME_NOW` for use with [`utimensat`].
 ///
 /// [`utimensat`]: crate::fs::utimensat
-#[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "vita")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "redox",
+    target_os = "vita"
+)))]
 pub const UTIME_NOW: Nsecs = backend::c::UTIME_NOW as Nsecs;
 
 /// `UTIME_OMIT` for use with [`utimensat`].
 ///
 /// [`utimensat`]: crate::fs::utimensat
-#[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "vita")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "redox",
+    target_os = "vita"
+)))]
 pub const UTIME_OMIT: Nsecs = backend::c::UTIME_OMIT as Nsecs;
 
 /// `openat(dirfd, path, oflags, mode)`—Opens a file.
@@ -358,7 +368,7 @@ pub fn statat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, flags: AtFlags) -> io:
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/faccessat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/faccessat.2.html
-#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
 #[inline]
 #[doc(alias = "faccessat")]
 pub fn accessat<P: path::Arg, Fd: AsFd>(
@@ -378,7 +388,7 @@ pub fn accessat<P: path::Arg, Fd: AsFd>(
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/utimensat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/utimensat.2.html
-#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
 #[inline]
 pub fn utimensat<P: path::Arg, Fd: AsFd>(
     dirfd: Fd,
@@ -440,7 +450,13 @@ pub fn fclonefileat<Fd: AsFd, DstFd: AsFd, P: path::Arg>(
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/mknodat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/mknodat.2.html
-#[cfg(not(any(apple, target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(
+    apple,
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 #[inline]
 pub fn mknodat<P: path::Arg, Fd: AsFd>(
     dirfd: Fd,

--- a/src/fs/fcntl.rs
+++ b/src/fs/fcntl.rs
@@ -7,6 +7,7 @@
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -93,6 +94,7 @@ pub fn fcntl_add_seals<Fd: AsFd>(fd: Fd, seals: SealFlags) -> io::Result<()> {
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -11,6 +11,7 @@ use backend::fd::AsFd;
     netbsdlike,
     target_os = "dragonfly",
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "nto",
     target_os = "redox",
     target_os = "vita",
@@ -18,6 +19,7 @@ use backend::fd::AsFd;
 use backend::fs::types::FallocateFlags;
 #[cfg(not(any(
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "solaris",
     target_os = "vita",
     target_os = "wasi"
@@ -30,6 +32,7 @@ use backend::fs::types::Stat;
     solarish,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "netbsd",
     target_os = "nto",
     target_os = "redox",
@@ -179,6 +182,7 @@ pub fn fstat<Fd: AsFd>(fd: Fd) -> io::Result<Stat> {
     solarish,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "netbsd",
     target_os = "nto",
     target_os = "redox",
@@ -218,7 +222,7 @@ pub fn fstatvfs<Fd: AsFd>(fd: Fd) -> io::Result<StatVfs> {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/futimens.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/utimensat.2.html
-#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
 #[inline]
 pub fn futimens<Fd: AsFd>(fd: Fd, times: &Timestamps) -> io::Result<()> {
     backend::fs::syscalls::futimens(fd.as_fd(), times)
@@ -243,6 +247,7 @@ pub fn futimens<Fd: AsFd>(fd: Fd, times: &Timestamps) -> io::Result<()> {
     netbsdlike,
     target_os = "dragonfly",
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "nto",
     target_os = "redox",
     target_os = "vita",
@@ -285,6 +290,7 @@ pub fn fsync<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
 )))]
@@ -314,6 +320,7 @@ pub fn ftruncate<Fd: AsFd>(fd: Fd, length: u64) -> io::Result<()> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/flock.2.html
 #[cfg(not(any(
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "solaris",
     target_os = "vita",
     target_os = "wasi"

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -15,6 +15,7 @@ mod dir;
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
 )))]
@@ -36,6 +37,7 @@ mod ioctl;
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -56,6 +58,7 @@ mod special;
 mod statx;
 #[cfg(not(any(
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -79,6 +82,7 @@ pub use dir::{Dir, DirEntry};
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
 )))]
@@ -98,6 +102,7 @@ pub use ioctl::*;
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -118,6 +123,7 @@ pub use special::*;
 pub use statx::*;
 #[cfg(not(any(
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"

--- a/src/fs/special.rs
+++ b/src/fs/special.rs
@@ -27,6 +27,7 @@ use backend::fd::{BorrowedFd, RawFd};
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/fcntl.h.html
 // SAFETY: `AT_FDCWD` is a reserved value that is never dynamically
 // allocated, so it'll remain valid for the duration of `'static`.
+#[cfg(not(target_os = "horizon"))]
 #[doc(alias = "AT_FDCWD")]
 pub const CWD: BorrowedFd<'static> =
     unsafe { BorrowedFd::<'static>::borrow_raw(c::AT_FDCWD as RawFd) };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,13 @@ pub mod io;
 #[cfg_attr(docsrs, doc(cfg(feature = "io_uring")))]
 pub mod io_uring;
 pub mod ioctl;
-#[cfg(not(any(windows, target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 #[cfg(feature = "mm")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mm")))]
 pub mod mm;
@@ -268,6 +274,7 @@ pub mod rand;
     windows,
     target_os = "android",
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "vita",
     target_os = "wasi"
 )))]
@@ -282,7 +289,7 @@ pub mod stdio;
 #[cfg(not(any(windows, target_os = "wasi")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "system")))]
 pub mod system;
-#[cfg(not(any(windows, target_os = "vita")))]
+#[cfg(not(any(windows, target_os = "horizon", target_os = "vita")))]
 #[cfg(feature = "termios")]
 #[cfg_attr(docsrs, doc(cfg(feature = "termios")))]
 pub mod termios;

--- a/src/net/send_recv/mod.rs
+++ b/src/net/send_recv/mod.rs
@@ -11,10 +11,22 @@ use core::cmp::min;
 
 pub use backend::net::send_recv::{RecvFlags, ReturnFlags, SendFlags};
 
-#[cfg(not(any(windows, target_os = "espidf", target_os = "vita", target_os = "redox")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "redox",
+    target_os = "vita"
+)))]
 mod msg;
 
-#[cfg(not(any(windows, target_os = "espidf", target_os = "redox", target_os = "vita")))]
+#[cfg(not(any(
+    windows,
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "redox",
+    target_os = "vita"
+)))]
 pub use msg::*;
 
 /// `recv(fd, buf, flags)`—Reads data from a socket.

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -466,6 +466,7 @@ pub fn socket_send_buffer_size<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "hurd",
     target_os = "netbsd",
     target_os = "nto",
@@ -1228,6 +1229,7 @@ pub fn ipv6_original_dst<Fd: AsFd>(fd: Fd) -> io::Result<SocketAddrV6> {
     windows,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita"
 )))]
@@ -1247,6 +1249,7 @@ pub fn set_ipv6_tclass<Fd: AsFd>(fd: Fd, value: u32) -> io::Result<()> {
     windows,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita"
 )))]

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -23,15 +23,20 @@ impl SocketType {
     pub const DGRAM: Self = Self(c::SOCK_DGRAM as _);
 
     /// `SOCK_SEQPACKET`
-    #[cfg(not(target_os = "espidf"))]
+    #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
     pub const SEQPACKET: Self = Self(c::SOCK_SEQPACKET as _);
 
     /// `SOCK_RAW`
-    #[cfg(not(target_os = "espidf"))]
+    #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
     pub const RAW: Self = Self(c::SOCK_RAW as _);
 
     /// `SOCK_RDM`
-    #[cfg(not(any(target_os = "espidf", target_os = "haiku", target_os = "redox")))]
+    #[cfg(not(any(
+        target_os = "espidf",
+        target_os = "haiku",
+        target_os = "horizon",
+        target_os = "redox"
+    )))]
     pub const RDM: Self = Self(c::SOCK_RDM as _);
 
     /// Constructs a `SocketType` from a raw integer.
@@ -92,6 +97,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -109,6 +115,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -119,12 +126,18 @@ impl AddressFamily {
     #[cfg(not(any(
         target_os = "aix",
         target_os = "espidf",
+        target_os = "horizon",
         target_os = "redox",
         target_os = "vita",
     )))]
     pub const IPX: Self = Self(c::AF_IPX as _);
     /// `AF_APPLETALK`
-    #[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "vita")))]
+    #[cfg(not(any(
+        target_os = "espidf",
+        target_os = "horizon",
+        target_os = "redox",
+        target_os = "vita"
+    )))]
     pub const APPLETALK: Self = Self(c::AF_APPLETALK as _);
     /// `AF_NETROM`
     #[cfg(not(any(
@@ -134,6 +147,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -148,6 +162,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -162,6 +177,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -175,6 +191,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -189,6 +206,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -199,6 +217,7 @@ impl AddressFamily {
     #[cfg(not(any(
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "redox",
         target_os = "vita"
     )))]
@@ -211,6 +230,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -225,6 +245,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -238,6 +259,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -256,6 +278,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -270,6 +293,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -284,6 +308,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -298,6 +323,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -312,6 +338,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -322,6 +349,7 @@ impl AddressFamily {
     #[cfg(not(any(
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "redox",
         target_os = "vita"
     )))]
@@ -333,6 +361,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -347,6 +376,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -361,6 +391,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -375,6 +406,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -389,6 +421,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -403,6 +436,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -416,6 +450,7 @@ impl AddressFamily {
         windows,
         target_os = "aix",
         target_os = "espidf",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "redox",
         target_os = "vita",
@@ -429,6 +464,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -443,6 +479,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -456,6 +493,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "redox",
         target_os = "vita",
@@ -469,6 +507,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -483,6 +522,7 @@ impl AddressFamily {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "redox",
@@ -745,6 +785,7 @@ pub mod ipproto {
         solarish,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "vita"
     )))]
     pub const IGMP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_IGMP as _));
@@ -754,6 +795,7 @@ pub mod ipproto {
         windows,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "redox",
         target_os = "vita"
     )))]
@@ -765,6 +807,7 @@ pub mod ipproto {
         solarish,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "redox",
         target_os = "vita"
     )))]
@@ -774,6 +817,7 @@ pub mod ipproto {
         solarish,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "vita"
     )))]
     pub const PUP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_PUP as _));
@@ -784,6 +828,7 @@ pub mod ipproto {
         solarish,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "vita"
     )))]
     pub const IDP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_IDP as _));
@@ -793,6 +838,7 @@ pub mod ipproto {
         windows,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "redox",
         target_os = "vita"
     )))]
@@ -806,6 +852,7 @@ pub mod ipproto {
         target_os = "dragonfly",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "nto",
         target_os = "openbsd",
         target_os = "redox",
@@ -820,6 +867,7 @@ pub mod ipproto {
         windows,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "redox",
         target_os = "vita"
     )))]
@@ -830,6 +878,7 @@ pub mod ipproto {
         windows,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "redox",
         target_os = "vita"
     )))]
@@ -839,6 +888,7 @@ pub mod ipproto {
         solarish,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "redox",
         target_os = "vita"
     )))]
@@ -848,6 +898,7 @@ pub mod ipproto {
         solarish,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "redox",
         target_os = "vita"
     )))]
@@ -860,6 +911,7 @@ pub mod ipproto {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
@@ -873,6 +925,7 @@ pub mod ipproto {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
@@ -885,6 +938,7 @@ pub mod ipproto {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "redox",
         target_os = "vita",
     )))]
@@ -895,6 +949,7 @@ pub mod ipproto {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "redox",
         target_os = "vita"
     )))]
@@ -907,6 +962,7 @@ pub mod ipproto {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
@@ -918,6 +974,7 @@ pub mod ipproto {
         target_os = "dragonfly",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "openbsd",
         target_os = "redox",
         target_os = "vita",
@@ -933,6 +990,7 @@ pub mod ipproto {
         target_os = "dragonfly",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
@@ -947,6 +1005,7 @@ pub mod ipproto {
         target_os = "dragonfly",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "netbsd",
         target_os = "nto",
         target_os = "redox",
@@ -957,7 +1016,7 @@ pub mod ipproto {
     #[cfg(linux_kernel)]
     pub const ETHERNET: Protocol = Protocol(new_raw_protocol(c::IPPROTO_ETHERNET as _));
     /// `IPPROTO_RAW`
-    #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+    #[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
     pub const RAW: Protocol = Protocol(new_raw_protocol(c::IPPROTO_RAW as _));
     /// `IPPROTO_MPTCP`
     #[cfg(not(any(
@@ -969,6 +1028,7 @@ pub mod ipproto {
         target_os = "espidf",
         target_os = "fuchsia",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
@@ -979,6 +1039,7 @@ pub mod ipproto {
         solarish,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "redox",
         target_os = "vita"
     )))]
@@ -994,6 +1055,7 @@ pub mod ipproto {
         target_os = "dragonfly",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
@@ -1004,6 +1066,7 @@ pub mod ipproto {
         solarish,
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "redox",
         target_os = "vita"
     )))]
@@ -1601,6 +1664,7 @@ bitflags! {
             target_os = "aix",
             target_os = "espidf",
             target_os = "haiku",
+            target_os = "horizon",
             target_os = "nto",
             target_os = "vita",
         )))]

--- a/src/param/auxv.rs
+++ b/src/param/auxv.rs
@@ -38,7 +38,7 @@ pub fn page_size() -> usize {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/sysconf.html
 /// [Linux]: https://man7.org/linux/man-pages/man3/sysconf.3.html
-#[cfg(not(any(target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(target_os = "horizon", target_os = "vita", target_os = "wasi")))]
 #[inline]
 #[doc(alias = "_SC_CLK_TCK")]
 pub fn clock_ticks_per_second() -> u64 {

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -36,6 +36,7 @@ pub use backend::pipe::types::{IoSliceRaw, SpliceFlags};
     windows,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "hurd",
     target_os = "redox",
     target_os = "vita",
@@ -101,6 +102,7 @@ pub fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     target_os = "aix",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "nto"
 )))]
 #[inline]

--- a/src/process/ioctl.rs
+++ b/src/process/ioctl.rs
@@ -22,7 +22,13 @@ use backend::fd::AsFd;
 /// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=tty&sektion=4
 /// [NetBSD]: https://man.netbsd.org/tty.4
 /// [OpenBSD]: https://man.openbsd.org/tty.4
-#[cfg(not(any(windows, target_os = "aix", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    windows,
+    target_os = "aix",
+    target_os = "horizon",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 #[inline]
 #[doc(alias = "TIOCSCTTY")]
 pub fn ioctl_tiocsctty<Fd: AsFd>(fd: Fd) -> io::Result<()> {
@@ -32,7 +38,13 @@ pub fn ioctl_tiocsctty<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 #[cfg(not(any(windows, target_os = "aix", target_os = "redox", target_os = "wasi")))]
 struct Tiocsctty;
 
-#[cfg(not(any(windows, target_os = "aix", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    windows,
+    target_os = "aix",
+    target_os = "horizon",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 unsafe impl ioctl::Ioctl for Tiocsctty {
     type Output = ();
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -9,6 +9,7 @@ mod exit;
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -28,7 +29,12 @@ mod pidfd_getfd;
 mod pivot_root;
 #[cfg(linux_kernel)]
 mod prctl;
-#[cfg(not(any(target_os = "fuchsia", target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "fuchsia",
+    target_os = "horizon",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 // WASI doesn't have [gs]etpriority.
 mod priority;
 #[cfg(freebsdlike)]
@@ -36,6 +42,7 @@ mod procctl;
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -64,6 +71,7 @@ pub use exit::*;
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -83,13 +91,19 @@ pub use pidfd_getfd::*;
 pub use pivot_root::*;
 #[cfg(linux_kernel)]
 pub use prctl::*;
-#[cfg(not(any(target_os = "fuchsia", target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "fuchsia",
+    target_os = "horizon",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 pub use priority::*;
 #[cfg(freebsdlike)]
 pub use procctl::*;
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"

--- a/src/process/types.rs
+++ b/src/process/types.rs
@@ -11,6 +11,7 @@ use core::mem::transmute;
 /// File lock data structure used in [`fcntl_getlk`].
 ///
 /// [`fcntl_getlk`]: crate::process::fcntl_getlk()
+#[cfg(not(target_os = "horizon"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Flock {
     /// Starting offset for lock
@@ -26,6 +27,7 @@ pub struct Flock {
     pub offset_type: FlockOffsetType,
 }
 
+#[cfg(not(target_os = "horizon"))]
 impl Flock {
     pub(crate) const unsafe fn from_raw_unchecked(raw_fl: c::flock) -> Self {
         Self {
@@ -48,6 +50,7 @@ impl Flock {
     }
 }
 
+#[cfg(not(target_os = "horizon"))]
 impl From<FlockType> for Flock {
     fn from(value: FlockType) -> Self {
         Self {
@@ -63,6 +66,7 @@ impl From<FlockType> for Flock {
 /// `F_*LCK` constants for use with [`fcntl_getlk`].
 ///
 /// [`fcntl_getlk`]: crate::process::fcntl_getlk()
+#[cfg(not(target_os = "horizon"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(i16)]
 pub enum FlockType {
@@ -77,6 +81,7 @@ pub enum FlockType {
 /// `F_SEEK*` constants for use with [`fcntl_getlk`].
 ///
 /// [`fcntl_getlk`]: crate::process::fcntl_getlk()
+#[cfg(not(target_os = "horizon"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(i16)]
 pub enum FlockOffsetType {

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -26,11 +26,13 @@ bitflags! {
         /// Return if a child has stopped (but not traced via [`ptrace`]).
         ///
         /// [`ptrace`]: https://man7.org/linux/man-pages/man2/ptrace.2.html
+        #[cfg(not(target_os = "horizon"))]
         const UNTRACED = bitcast!(backend::process::wait::WUNTRACED);
         /// Return if a stopped child has been resumed by delivery of
         /// [`Signal::Cont`].
         ///
         /// [`Signal::Cont`]: crate::process::Signal::Cont
+        #[cfg(not(target_os = "horizon"))]
         const CONTINUED = bitcast!(backend::process::wait::WCONTINUED);
 
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
@@ -38,7 +40,12 @@ bitflags! {
     }
 }
 
-#[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "horizon",
+    target_os = "openbsd",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 bitflags! {
     /// Options for modifying the behavior of [`waitid`].
     #[repr(transparent)]
@@ -142,7 +149,12 @@ impl WaitStatus {
 /// The status of a process after calling [`waitid`].
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-#[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "horizon",
+    target_os = "openbsd",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 pub struct WaitIdStatus(pub(crate) backend::c::siginfo_t);
 
 #[cfg(linux_raw)]
@@ -154,7 +166,12 @@ unsafe impl Send for WaitIdStatus {}
 // SAFETY: Same as with `Send`.
 unsafe impl Sync for WaitIdStatus {}
 
-#[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "horizon",
+    target_os = "openbsd",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 impl WaitIdStatus {
     /// Returns whether the process is currently stopped.
     #[inline]
@@ -397,7 +414,12 @@ pub fn wait(waitopts: WaitOptions) -> io::Result<Option<(Pid, WaitStatus)>> {
 
 /// `waitid(_, _, _, opts)`—Wait for the specified child process to change
 /// state.
-#[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "horizon",
+    target_os = "openbsd",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 #[inline]
 pub fn waitid<'a, Id: Into<WaitId<'a>>>(
     id: Id,

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -37,7 +37,7 @@ bitflags::bitflags! {
         const RDWR = c::O_RDWR as c::c_uint;
 
         /// `O_NOCTTY`
-        #[cfg(not(any(target_os = "espidf", target_os = "l4re", target_os = "redox", target_os = "vita")))]
+        #[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "l4re", target_os = "redox", target_os = "vita")))]
         const NOCTTY = c::O_NOCTTY as c::c_uint;
 
         /// `O_CLOEXEC`

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -82,6 +82,7 @@ impl Signal {
         solarish,
         target_os = "aix",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "hurd",
         target_os = "nto",
         target_os = "vita",
@@ -141,7 +142,13 @@ impl Signal {
     #[cfg(not(any(target_os = "haiku", target_os = "vita")))]
     pub const IO: Self = Self(unsafe { NonZeroI32::new_unchecked(c::SIGIO) });
     /// `SIGPWR`
-    #[cfg(not(any(bsd, target_os = "haiku", target_os = "hurd", target_os = "vita")))]
+    #[cfg(not(any(
+        bsd,
+        target_os = "haiku",
+        target_os = "horizon",
+        target_os = "hurd",
+        target_os = "vita"
+    )))]
     #[doc(alias = "PWR")]
     pub const POWER: Self = Self(unsafe { NonZeroI32::new_unchecked(c::SIGPWR) });
     /// `SIGSYS`, aka `SIGUNUSED`
@@ -265,6 +272,7 @@ impl fmt::Debug for Signal {
                 solarish,
                 target_os = "aix",
                 target_os = "haiku",
+                target_os = "horizon",
                 target_os = "hurd",
                 target_os = "nto",
                 target_os = "vita",
@@ -307,7 +315,13 @@ impl fmt::Debug for Signal {
             Self::WINCH => "Signal::WINCH".fmt(f),
             #[cfg(not(any(target_os = "haiku", target_os = "vita")))]
             Self::IO => "Signal::IO".fmt(f),
-            #[cfg(not(any(bsd, target_os = "haiku", target_os = "hurd", target_os = "vita")))]
+            #[cfg(not(any(
+                bsd,
+                target_os = "haiku",
+                target_os = "horizon",
+                target_os = "hurd",
+                target_os = "vita"
+            )))]
             Self::POWER => "Signal::POWER".fmt(f),
             Self::SYS => "Signal::SYS".fmt(f),
             #[cfg(any(

--- a/src/system.rs
+++ b/src/system.rs
@@ -155,6 +155,7 @@ pub fn sysinfo() -> Sysinfo {
 #[cfg(not(any(
     target_os = "emscripten",
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -176,6 +177,7 @@ pub fn sethostname(name: &[u8]) -> io::Result<()> {
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "illumos",
     target_os = "redox",
     target_os = "solaris",

--- a/src/termios/ioctl.rs
+++ b/src/termios/ioctl.rs
@@ -21,7 +21,12 @@ use backend::c;
 /// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=tty&sektion=4
 /// [NetBSD]: https://man.netbsd.org/tty.4
 /// [OpenBSD]: https://man.openbsd.org/tty.4
-#[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    windows,
+    target_os = "horizon",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 #[inline]
 #[doc(alias = "TIOCEXCL")]
 pub fn ioctl_tiocexcl<Fd: AsFd>(fd: Fd) -> io::Result<()> {
@@ -44,7 +49,12 @@ pub fn ioctl_tiocexcl<Fd: AsFd>(fd: Fd) -> io::Result<()> {
 /// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=tty&sektion=4
 /// [NetBSD]: https://man.netbsd.org/tty.4
 /// [OpenBSD]: https://man.openbsd.org/tty.4
-#[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(
+    windows,
+    target_os = "horizon",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 #[inline]
 #[doc(alias = "TIOCNXCL")]
 pub fn ioctl_tiocnxcl<Fd: AsFd>(fd: Fd) -> io::Result<()> {

--- a/src/termios/tc.rs
+++ b/src/termios/tc.rs
@@ -39,7 +39,12 @@ pub fn tcgetattr<Fd: AsFd>(fd: Fd) -> io::Result<Termios> {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man4/tty_ioctl.4.html
-#[cfg(not(any(windows, target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(
+    windows,
+    target_os = "horizon",
+    target_os = "espidf",
+    target_os = "wasi"
+)))]
 #[inline]
 #[doc(alias = "TIOCGWINSZ")]
 pub fn tcgetwinsize<Fd: AsFd>(fd: Fd) -> io::Result<Winsize> {
@@ -212,7 +217,7 @@ pub fn tcgetsid<Fd: AsFd>(fd: Fd) -> io::Result<Pid> {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man4/tty_ioctl.4.html
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
 #[inline]
 #[doc(alias = "TIOCSWINSZ")]
 pub fn tcsetwinsize<Fd: AsFd>(fd: Fd, winsize: Winsize) -> io::Result<()> {

--- a/src/thread/clock.rs
+++ b/src/thread/clock.rs
@@ -34,6 +34,7 @@ pub use crate::clockid::ClockId;
     target_os = "espidf",
     target_os = "freebsd", // FreeBSD 12 has clock_nanosleep, but libc targets FreeBSD 11.
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "vita",
@@ -63,6 +64,7 @@ pub fn clock_nanosleep_relative(id: ClockId, request: &Timespec) -> NanosleepRel
     target_os = "espidf",
     target_os = "freebsd", // FreeBSD 12 has clock_nanosleep, but libc targets FreeBSD 11.
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "vita",


### PR DESCRIPTION
This disables the "mm" and "termios" module entirely on armv6k-nintendo-3ds, as the libc module appears to be lacking basic flags such as `MAP_ANONYMOUS`, `PROT_READ`, and others. But it's at least a first step.

Fixes #1023.