### PR TITLE
Documentation and test cleanups.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,11 +92,14 @@ The `rustix::procfs` is removed. This functionality is now available in the
 
 [rustix-linux-procfs crate]: https://crates.io/crates/rustix-linux-procfs
 
-The `flags` field of [`rustix::net::RecvMsgReturn`] changed type from
-[`RecvFlags`] to a new [`ReturnFlags`], since it supports a different set of
-flags.
+`rustix::net::RecvMsgReturn` is renamed to [`rustix::net::RecvMsg`].
 
-[`rustix::net::RecvMsgReturn`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.RecvMsgReturn.html
+[`rustix::net::RecvMsg`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.RecvMsg.html
+
+The `flags` field of [`rustix::net::RecvMsg`] changed type from [`RecvFlags`]
+to a new [`ReturnFlags`], since it supports a different set of flags.
+
+[`rustix::net::RecvMsg`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.RecvMsg.html
 [`RecvFlags`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.RecvFlags.html
 [`ReturnFlags`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.ReturnFlags.html
 
@@ -106,8 +109,8 @@ mean a timeout in milliseconds to an `Option<&Timespec>`. The [`Timespec`]'s
 fields are `tv_sec` which holds seconds and `tv_nsec` which holds nanoseconds.
 
 [`rustix::event::poll`]: https://docs.rs/rustix/1.0.0/rustix/event/fn.poll.html
-[`rustix::event::epoll`]: https://docs.rs/rustix/1.0.0/rustix/event/fn.epoll.html
-[`Timespec`]: https://docs.rs/rustix/1.0.0/rustix/time/type.Timespec.html
+[`rustix::event::epoll`]: https://docs.rs/rustix/1.0.0/rustix/event/epoll/index.html
+[`Timespec`]: https://docs.rs/rustix/1.0.0/rustix/time/struct.Timespec.html
 
 Functions in [`rustix::event::port`] are renamed to remove the redundant
 `port_*` prefix.
@@ -124,22 +127,22 @@ Functions in [`rustix::event::port`] are renamed to remove the redundant
 directly. They are now signed instead of unsigned, so that they can represent
 times before the epoch.
 
-[`rustix::fs::Stat`]: https://docs.rs/rustix/1.0.0/rustix/fs/type.Stat.html
+[`rustix::fs::Stat`]: https://docs.rs/rustix/1.0.0/rustix/fs/struct.Stat.html
 
 `rustix::io::is_read_write` is removed, as it's higher-level functionality that
 can be implemented in terms of lower-level rustix calls.
 
-[`rustix::net::recv_uninit`] and [`rustix::net::recvfrom_uninit`] now include
+[`rustix::net::recv`] and [`rustix::net::recvfrom`] now include
 the number of received bytes in their return types, as this number may differ
 from the number of bytes written to the buffer when
 [`rustix::net::RecvFlags::TRUNC`] is used.
 
-[`rustix::net::recv_uninit`]: https://docs.rs/rustix/1.0.0/rustix/net/fn.recv_uninit.html
-[`rustix::net::recvfrom_uninit`]: https://docs.rs/rustix/1.0.0/rustix/net/fn.recvfrom_uninit.html
+[`rustix::net::recv`]: https://docs.rs/rustix/1.0.0/rustix/net/fn.recv.html
+[`rustix::net::recvfrom`]: https://docs.rs/rustix/1.0.0/rustix/net/fn.recvfrom.html
 [`rustix::net::RecvFlags::TRUNC`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.RecvFlags.html#associatedconstant.TRUNC
 
 [`rustix::io_uring::io_uring_register`] now has a [`IoringRegisterFlags`]
-argument, and `rustix::io_uring::io_uring_register` is removed.
+argument, and `rustix::io_uring::io_uring_register_with` is removed.
 
 [`rustix::io_uring::io_uring_register`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/fn.io_uring_register.html
 [`IoringRegisterFlags`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/struct.IoringRegisterFlags.html
@@ -148,19 +151,15 @@ argument, and `rustix::io_uring::io_uring_register` is removed.
 `Signal::Int` is now named [`Signal::INT`]. Also, `Signal` is no longer
 directly convertible to `i32`; use [`Signal::as_raw`] instead.
 
-[`rustix::process::Signal`]: https://docs.rs/rustix/1.0.0/rustix/process/enum.Signal.html
-[`Signal::INT`]: https://docs.rs/rustix/1.0.0/rustix/process/enum.Signal.html#variant.Int
-[`Signal::as_raw`]: https://docs.rs/rustix/1.0.0/rustix/process/enum.Signal.html#method.as_raw
+[`rustix::process::Signal`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.Signal.html
+[`Signal::INT`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.Signal.html#variant.Int
+[`Signal::as_raw`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.Signal.html#method.as_raw
 
 The associated constant `rustix::ioctl::Ioctl::OPCODE` is now replaced with an
 associated method [`rustix::ioctl::Ioctl::opcode`], to support ioctls where the
 opcode is computed rather than a constant.
 
 [`rustix::ioctl::Ioctl::opcode`]: https://docs.rs/rustix/1.0.0/rustix/ioctl/trait.Ioctl.html#tymethod.opcode
-
-`rustix::net::RecvMsgReturn` is renamed to [`rustix::net::RecvMsg`].
-
-[`rustix::net::RecvMsg`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.RecvMsgReturn.html
 
 The `ifindex` argument in
 [`rustix::net::sockopt::set_ip_add_membership_with_ifindex`] and
@@ -172,7 +171,7 @@ changed from `i32` to `u32`.
 
 The `list` argument in [`rustix::fs::listxattr`], [`rustix::fs::flistxattr`],
 and [`rustix::fs::llistxattr`] changed from `[c_char]`, which is `[i8]` on some
-architectures, to [`u8`].
+architectures, to `[u8]`.
 
 [`rustix::fs::listxattr`]: https://docs.rs/rustix/1.0.0/rustix/fs/fn.listxattr.html
 [`rustix::fs::flistxattr`]: https://docs.rs/rustix/1.0.0/rustix/fs/fn.flistxattr.html
@@ -188,7 +187,7 @@ with other platforms:
 | `st_ctimensec` | `st_ctime_nsec` |
 | `st_birthtimensec` | `st_birthtime_nsec` |
 
-[`Stat`]: https://docs.rs/rustix/1.0.0/x86_64-unknown-netbsd/rustix/fs/type.Stat.html
+[`Stat`]: https://docs.rs/rustix/1.0.0/x86_64-unknown-netbsd/rustix/fs/struct.Stat.html
 
 [`rustix::mount::mount`]'s `data` argument is now an `Option`, so it can now
 be used in place of `mount2`, and `mount2` is now removed.
@@ -247,13 +246,14 @@ pointer provenance.
 
 The aliases for [`fcntl_dupfd_cloexec`], [`fcntl_getfd`], and [`fcntl_setfd`]
 in `rustix::fs` are removed; these functions are just available in
-`rustix::io` now.
+[`rustix::io`] now.
 
 [`fcntl_dupfd_cloexec`]: https://docs.rs/rustix/1.0.0/rustix/io/fn.fcntl_dupfd_cloexec.html
 [`fcntl_getfd`]: https://docs.rs/rustix/1.0.0/rustix/io/fn.fcntl_getfd.html
 [`fcntl_setfd`]: https://docs.rs/rustix/1.0.0/rustix/io/fn.fcntl_setfd.html
+[`rustix::io`]: https://docs.rs/rustix/1.0.0/rustix/io/index.html
 
-[`SocketAddrXdp`] no longer has a shared umem field. A new
+[`SocketAddrXdp`] no longer has a shared UMEM field. A new
 [`SocketAddrXdpWithSharedUmem`] is added for the purpose of calling `bind` and
 passing it an XDP address with a shared UMEM fd. And `SockaddrXdpFlags` is
 renamed to [`SocketAddrXdpFlags`].
@@ -303,11 +303,11 @@ vector before calling `epoll::wait` or `kqueue`, or consuming it using
 [`Buffer` trait]: https://docs.rs/rustix/1.0.0/rustix/buffer/trait.Buffer.html
 [`spare_capacity`]: https://docs.rs/rustix/1.0.0/rustix/buffer/fn.spare_capacity.html
 
-The `Opcode` type has changed from a struct to a raw integer value, and the
-associated utilities are change to `const` functions. In place of `ReadOpcode`,
-`WriteOpcode`, `ReadWriteOpcode`, and `NoneOpcode`, use the `read`, `write`,
-`read_write`, and `none` const functions in the [`ioctl::opcode`] module. For
-example, in place of this:
+The [`rustix::ioctl::Opcode`] type has changed from a struct to a raw integer
+value, and the associated utilities are change to `const` functions. In place
+of `ReadOpcode`, `WriteOpcode`, `ReadWriteOpcode`, and `NoneOpcode`, use the
+`read`, `write`, `read_write`, and `none` const functions in the
+[`ioctl::opcode`] module. For example, in place of this:
 ```rust
 ioctl::Setter::<ioctl::ReadOpcode<b'U', 15, c_uint>, c_uint>::new(interface)
 ```
@@ -319,6 +319,7 @@ use this:
 
 In place of `BadOpcode`, use the opcode value directly.
 
+[`rustix::ioctl::Opcode`]: https://docs.rs/rustix/1.0.0/rustix/ioctl/type.Opcode.html
 [`ioctl::opcode`]: https://docs.rs/rustix/1.0.0/rustix/ioctl/opcode/index.html
 
 All explicitly deprecated functions and types have been removed. Their

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ building.
 
 ## Cargo features
 
-The modules [`rustix::io`], [`rustix::fd`], and [`rustix::ffi`] are enabled by
-default. The rest of the API is conditional with cargo feature flags:
+The modules [`rustix::io`], [`rustix::fd`], [`rustix::ffi`], and
+[`rustix::ioctl`] are enabled by default. The rest of the API is conditional
+with cargo feature flags:
 
 | Name       | Description                                                    |
 | ---------- | -------------------------------------------------------------- |
@@ -97,6 +98,7 @@ default. The rest of the API is conditional with cargo feature flags:
 [`rustix::io`]: https://docs.rs/rustix/*/rustix/io/index.html
 [`rustix::fd`]: https://docs.rs/rustix/*/rustix/fd/index.html
 [`rustix::ffi`]: https://docs.rs/rustix/*/rustix/ffi/index.html
+[`rustix::ioctl`]: https://docs.rs/rustix/*/rustix/ffi/ioctl.html
 
 ## 64-bit Large File Support (LFS) and Year 2038 (y2038) support
 

--- a/src/backend/libc/mount/syscalls.rs
+++ b/src/backend/libc/mount/syscalls.rs
@@ -1,8 +1,5 @@
 use crate::backend::c;
-use crate::backend::conv::ret;
-#[cfg(feature = "mount")]
-use crate::backend::conv::{borrowed_fd, c_str, ret_owned_fd};
-#[cfg(feature = "mount")]
+use crate::backend::conv::{borrowed_fd, c_str, ret, ret_owned_fd};
 use crate::fd::{BorrowedFd, OwnedFd};
 use crate::ffi::CStr;
 use crate::io;
@@ -33,7 +30,6 @@ pub(crate) fn unmount(target: &CStr, flags: super::types::UnmountFlags) -> io::R
 }
 
 #[cfg(linux_kernel)]
-#[cfg(feature = "mount")]
 pub(crate) fn fsopen(fs_name: &CStr, flags: super::types::FsOpenFlags) -> io::Result<OwnedFd> {
     syscall! {
         fn fsopen(
@@ -45,7 +41,6 @@ pub(crate) fn fsopen(fs_name: &CStr, flags: super::types::FsOpenFlags) -> io::Re
 }
 
 #[cfg(linux_kernel)]
-#[cfg(feature = "mount")]
 pub(crate) fn fsmount(
     fs_fd: BorrowedFd<'_>,
     flags: super::types::FsMountFlags,
@@ -62,7 +57,6 @@ pub(crate) fn fsmount(
 }
 
 #[cfg(linux_kernel)]
-#[cfg(feature = "mount")]
 pub(crate) fn move_mount(
     from_dfd: BorrowedFd<'_>,
     from_pathname: &CStr,
@@ -91,7 +85,6 @@ pub(crate) fn move_mount(
 }
 
 #[cfg(linux_kernel)]
-#[cfg(feature = "mount")]
 pub(crate) fn open_tree(
     dfd: BorrowedFd<'_>,
     filename: &CStr,
@@ -109,7 +102,6 @@ pub(crate) fn open_tree(
 }
 
 #[cfg(linux_kernel)]
-#[cfg(feature = "mount")]
 pub(crate) fn fspick(
     dfd: BorrowedFd<'_>,
     path: &CStr,
@@ -126,7 +118,6 @@ pub(crate) fn fspick(
     unsafe { ret_owned_fd(fspick(borrowed_fd(dfd), c_str(path), flags.bits())) }
 }
 
-#[cfg(feature = "mount")]
 #[cfg(linux_kernel)]
 syscall! {
     fn fsconfig(
@@ -139,7 +130,6 @@ syscall! {
 }
 
 #[cfg(linux_kernel)]
-#[cfg(feature = "mount")]
 pub(crate) fn fsconfig_set_flag(fs_fd: BorrowedFd<'_>, key: &CStr) -> io::Result<()> {
     unsafe {
         ret(fsconfig(
@@ -153,7 +143,6 @@ pub(crate) fn fsconfig_set_flag(fs_fd: BorrowedFd<'_>, key: &CStr) -> io::Result
 }
 
 #[cfg(linux_kernel)]
-#[cfg(feature = "mount")]
 pub(crate) fn fsconfig_set_string(
     fs_fd: BorrowedFd<'_>,
     key: &CStr,
@@ -171,7 +160,6 @@ pub(crate) fn fsconfig_set_string(
 }
 
 #[cfg(linux_kernel)]
-#[cfg(feature = "mount")]
 pub(crate) fn fsconfig_set_binary(
     fs_fd: BorrowedFd<'_>,
     key: &CStr,
@@ -189,7 +177,6 @@ pub(crate) fn fsconfig_set_binary(
 }
 
 #[cfg(linux_kernel)]
-#[cfg(feature = "mount")]
 pub(crate) fn fsconfig_set_fd(
     fs_fd: BorrowedFd<'_>,
     key: &CStr,
@@ -207,7 +194,6 @@ pub(crate) fn fsconfig_set_fd(
 }
 
 #[cfg(linux_kernel)]
-#[cfg(feature = "mount")]
 pub(crate) fn fsconfig_set_path(
     fs_fd: BorrowedFd<'_>,
     key: &CStr,
@@ -226,7 +212,6 @@ pub(crate) fn fsconfig_set_path(
 }
 
 #[cfg(linux_kernel)]
-#[cfg(feature = "mount")]
 pub(crate) fn fsconfig_set_path_empty(
     fs_fd: BorrowedFd<'_>,
     key: &CStr,
@@ -244,7 +229,6 @@ pub(crate) fn fsconfig_set_path_empty(
 }
 
 #[cfg(linux_kernel)]
-#[cfg(feature = "mount")]
 pub(crate) fn fsconfig_create(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
     unsafe {
         ret(fsconfig(
@@ -258,7 +242,6 @@ pub(crate) fn fsconfig_create(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
 }
 
 #[cfg(linux_kernel)]
-#[cfg(feature = "mount")]
 pub(crate) fn fsconfig_reconfigure(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
     unsafe {
         ret(fsconfig(
@@ -272,7 +255,6 @@ pub(crate) fn fsconfig_reconfigure(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
 }
 
 #[cfg(linux_kernel)]
-#[cfg(feature = "mount")]
 pub(crate) fn fsconfig_create_excl(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
     unsafe {
         ret(fsconfig(

--- a/src/backend/libc/mount/types.rs
+++ b/src/backend/libc/mount/types.rs
@@ -83,7 +83,6 @@ bitflags! {
     }
 }
 
-#[cfg(feature = "mount")]
 #[cfg(linux_kernel)]
 bitflags! {
     /// `FSOPEN_*` constants for use with [`fsopen`].
@@ -100,7 +99,6 @@ bitflags! {
     }
 }
 
-#[cfg(feature = "mount")]
 #[cfg(linux_kernel)]
 bitflags! {
     /// `FSMOUNT_*` constants for use with [`fsmount`].
@@ -118,7 +116,6 @@ bitflags! {
 }
 
 /// `FSCONFIG_*` constants for use with the `fsconfig` syscall.
-#[cfg(feature = "mount")]
 #[cfg(linux_kernel)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u32)]
@@ -151,7 +148,6 @@ pub(crate) enum FsConfigCmd {
     CreateExclusive = 8,
 }
 
-#[cfg(feature = "mount")]
 #[cfg(linux_kernel)]
 bitflags! {
     /// `MOUNT_ATTR_*` constants for use with [`fsmount`].
@@ -201,7 +197,6 @@ bitflags! {
     }
 }
 
-#[cfg(feature = "mount")]
 #[cfg(linux_kernel)]
 bitflags! {
     /// `MOVE_MOUNT_*` constants for use with [`move_mount`].
@@ -242,7 +237,6 @@ bitflags! {
     }
 }
 
-#[cfg(feature = "mount")]
 #[cfg(linux_kernel)]
 bitflags! {
     /// `OPENTREE_*` constants for use with [`open_tree`].
@@ -274,7 +268,6 @@ bitflags! {
     }
 }
 
-#[cfg(feature = "mount")]
 #[cfg(linux_kernel)]
 bitflags! {
     /// `FSPICK_*` constants for use with [`fspick`].

--- a/src/backend/libc/time/syscalls.rs
+++ b/src/backend/libc/time/syscalls.rs
@@ -3,7 +3,6 @@
 use crate::backend::c;
 use crate::backend::conv::ret;
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[cfg(feature = "time")]
 #[cfg(any(all(target_env = "gnu", fix_y2038), not(fix_y2038)))]
 use crate::backend::time::types::LibcItimerspec;
 #[cfg(not(target_os = "wasi"))]
@@ -23,7 +22,6 @@ use crate::timespec::LibcTimespec;
 use crate::timespec::Timespec;
 use core::mem::MaybeUninit;
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[cfg(feature = "time")]
 use {
     crate::backend::conv::{borrowed_fd, ret_owned_fd},
     crate::fd::{BorrowedFd, OwnedFd},
@@ -38,11 +36,9 @@ weak!(fn __clock_settime64(c::clockid_t, *const LibcTimespec) -> c::c_int);
 weak!(fn __clock_getres64(c::clockid_t, *mut LibcTimespec) -> c::c_int);
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(all(target_env = "gnu", fix_y2038))]
-#[cfg(feature = "time")]
 weak!(fn __timerfd_gettime64(c::c_int, *mut LibcItimerspec) -> c::c_int);
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(all(target_env = "gnu", fix_y2038))]
-#[cfg(feature = "time")]
 weak!(fn __timerfd_settime64(c::c_int, c::c_int, *const LibcItimerspec, *mut LibcItimerspec) -> c::c_int);
 
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
@@ -303,13 +299,11 @@ fn clock_settime_old(id: ClockId, timespec: Timespec) -> io::Result<()> {
 }
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[cfg(feature = "time")]
 pub(crate) fn timerfd_create(id: TimerfdClockId, flags: TimerfdFlags) -> io::Result<OwnedFd> {
     unsafe { ret_owned_fd(c::timerfd_create(id as c::clockid_t, bitflags_bits!(flags))) }
 }
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[cfg(feature = "time")]
 pub(crate) fn timerfd_settime(
     fd: BorrowedFd<'_>,
     flags: TimerfdTimerFlags,
@@ -353,7 +347,6 @@ pub(crate) fn timerfd_settime(
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(fix_y2038)]
-#[cfg(feature = "time")]
 fn timerfd_settime_old(
     fd: BorrowedFd<'_>,
     flags: TimerfdTimerFlags,
@@ -420,7 +413,6 @@ fn timerfd_settime_old(
 }
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[cfg(feature = "time")]
 pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
     // Old 32-bit version: libc has `timerfd_gettime` but it is not y2038 safe
     // by default. But there may be a `__timerfd_gettime64` we can use.
@@ -453,7 +445,6 @@ pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
 
 #[cfg(any(linux_kernel, target_os = "fuchsia"))]
 #[cfg(fix_y2038)]
-#[cfg(feature = "time")]
 fn timerfd_gettime_old(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
     let mut old_result = MaybeUninit::<c::itimerspec>::uninit();
 

--- a/src/backend/linux_raw/mount/syscalls.rs
+++ b/src/backend/linux_raw/mount/syscalls.rs
@@ -6,10 +6,7 @@
 #![allow(unsafe_code)]
 #![allow(clippy::undocumented_unsafe_blocks)]
 
-use crate::backend::conv::ret;
-#[cfg(feature = "mount")]
-use crate::backend::conv::{ret_owned_fd, slice, zero};
-#[cfg(feature = "mount")]
+use crate::backend::conv::{ret, ret_owned_fd, slice, zero};
 use crate::fd::{BorrowedFd, OwnedFd};
 use crate::ffi::CStr;
 use crate::io;
@@ -39,13 +36,11 @@ pub(crate) fn unmount(target: &CStr, flags: super::types::UnmountFlags) -> io::R
     unsafe { ret(syscall_readonly!(__NR_umount2, target, flags)) }
 }
 
-#[cfg(feature = "mount")]
 #[inline]
 pub(crate) fn fsopen(fs_name: &CStr, flags: super::types::FsOpenFlags) -> io::Result<OwnedFd> {
     unsafe { ret_owned_fd(syscall_readonly!(__NR_fsopen, fs_name, flags)) }
 }
 
-#[cfg(feature = "mount")]
 #[inline]
 pub(crate) fn fsmount(
     fs_fd: BorrowedFd<'_>,
@@ -55,7 +50,6 @@ pub(crate) fn fsmount(
     unsafe { ret_owned_fd(syscall_readonly!(__NR_fsmount, fs_fd, flags, attr_flags)) }
 }
 
-#[cfg(feature = "mount")]
 #[inline]
 pub(crate) fn move_mount(
     from_dfd: BorrowedFd<'_>,
@@ -76,7 +70,6 @@ pub(crate) fn move_mount(
     }
 }
 
-#[cfg(feature = "mount")]
 #[inline]
 pub(crate) fn open_tree(
     dfd: BorrowedFd<'_>,
@@ -86,7 +79,6 @@ pub(crate) fn open_tree(
     unsafe { ret_owned_fd(syscall_readonly!(__NR_open_tree, dfd, filename, flags)) }
 }
 
-#[cfg(feature = "mount")]
 #[inline]
 pub(crate) fn fspick(
     dfd: BorrowedFd<'_>,
@@ -96,7 +88,6 @@ pub(crate) fn fspick(
     unsafe { ret_owned_fd(syscall_readonly!(__NR_fspick, dfd, path, flags)) }
 }
 
-#[cfg(feature = "mount")]
 #[inline]
 pub(crate) fn fsconfig_set_flag(fs_fd: BorrowedFd<'_>, key: &CStr) -> io::Result<()> {
     unsafe {
@@ -111,7 +102,6 @@ pub(crate) fn fsconfig_set_flag(fs_fd: BorrowedFd<'_>, key: &CStr) -> io::Result
     }
 }
 
-#[cfg(feature = "mount")]
 #[inline]
 pub(crate) fn fsconfig_set_string(
     fs_fd: BorrowedFd<'_>,
@@ -130,7 +120,6 @@ pub(crate) fn fsconfig_set_string(
     }
 }
 
-#[cfg(feature = "mount")]
 #[inline]
 pub(crate) fn fsconfig_set_binary(
     fs_fd: BorrowedFd<'_>,
@@ -150,7 +139,6 @@ pub(crate) fn fsconfig_set_binary(
     }
 }
 
-#[cfg(feature = "mount")]
 #[inline]
 pub(crate) fn fsconfig_set_fd(
     fs_fd: BorrowedFd<'_>,
@@ -169,7 +157,6 @@ pub(crate) fn fsconfig_set_fd(
     }
 }
 
-#[cfg(feature = "mount")]
 #[inline]
 pub(crate) fn fsconfig_set_path(
     fs_fd: BorrowedFd<'_>,
@@ -189,7 +176,6 @@ pub(crate) fn fsconfig_set_path(
     }
 }
 
-#[cfg(feature = "mount")]
 #[inline]
 pub(crate) fn fsconfig_set_path_empty(
     fs_fd: BorrowedFd<'_>,
@@ -208,7 +194,6 @@ pub(crate) fn fsconfig_set_path_empty(
     }
 }
 
-#[cfg(feature = "mount")]
 #[inline]
 pub(crate) fn fsconfig_create(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
     unsafe {
@@ -223,7 +208,6 @@ pub(crate) fn fsconfig_create(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
     }
 }
 
-#[cfg(feature = "mount")]
 #[inline]
 pub(crate) fn fsconfig_reconfigure(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
     unsafe {
@@ -238,7 +222,6 @@ pub(crate) fn fsconfig_reconfigure(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
     }
 }
 
-#[cfg(feature = "mount")]
 #[inline]
 pub(crate) fn fsconfig_create_excl(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
     unsafe {

--- a/src/backend/linux_raw/mount/types.rs
+++ b/src/backend/linux_raw/mount/types.rs
@@ -83,7 +83,6 @@ bitflags! {
     }
 }
 
-#[cfg(feature = "mount")]
 bitflags! {
     /// `FSOPEN_*` constants for use with [`fsopen`].
     ///
@@ -99,7 +98,6 @@ bitflags! {
     }
 }
 
-#[cfg(feature = "mount")]
 bitflags! {
     /// `FSMOUNT_*` constants for use with [`fsmount`].
     ///
@@ -116,7 +114,6 @@ bitflags! {
 }
 
 /// `FSCONFIG_*` constants for use with the `fsconfig` syscall.
-#[cfg(feature = "mount")]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u32)]
 pub(crate) enum FsConfigCmd {
@@ -148,7 +145,6 @@ pub(crate) enum FsConfigCmd {
     CreateExclusive = linux_raw_sys::general::fsconfig_command::FSCONFIG_CMD_CREATE_EXCL as u32,
 }
 
-#[cfg(feature = "mount")]
 bitflags! {
     /// `MOUNT_ATTR_*` constants for use with [`fsmount`].
     ///
@@ -197,7 +193,6 @@ bitflags! {
     }
 }
 
-#[cfg(feature = "mount")]
 bitflags! {
     /// `MOVE_MOUNT_*` constants for use with [`move_mount`].
     ///
@@ -237,7 +232,6 @@ bitflags! {
     }
 }
 
-#[cfg(feature = "mount")]
 bitflags! {
     /// `OPENTREE_*` constants for use with [`open_tree`].
     ///
@@ -268,7 +262,6 @@ bitflags! {
     }
 }
 
-#[cfg(feature = "mount")]
 bitflags! {
     /// `FSPICK_*` constants for use with [`fspick`].
     ///

--- a/src/backend/linux_raw/time/mod.rs
+++ b/src/backend/linux_raw/time/mod.rs
@@ -1,3 +1,2 @@
-#[cfg(any(feature = "time", target_arch = "x86"))]
 pub(crate) mod syscalls;
 pub(crate) mod types;

--- a/src/io_uring/mod.rs
+++ b/src/io_uring/mod.rs
@@ -49,6 +49,7 @@ pub use crate::fs::{
 pub use crate::io::ReadWriteFlags;
 pub use crate::net::addr::{SocketAddrLen, SocketAddrOpaque, SocketAddrStorage};
 pub use crate::net::{RecvFlags, SendFlags, SocketFlags};
+pub use crate::signal::Signal;
 pub use crate::sigset::SigSet;
 pub use crate::thread::futex::{
     Wait as FutexWait, WaitFlags as FutexWaitFlags, WaitPtr as FutexWaitPtr,

--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -349,23 +349,23 @@ mod tests {
     fn test_opcode_funcs() {
         // `TUNGETDEVNETNS` is defined as `_IO('T', 227)`.
         assert_eq!(
-            linux_raw_sys::ioctl::TUNGETDEVNETNS,
-            opcode::none(b'T', 227) as _
+            linux_raw_sys::ioctl::TUNGETDEVNETNS as Opcode,
+            opcode::none(b'T', 227)
         );
         // `FS_IOC_GETVERSION` is defined as `_IOR('v', 1, long)`.
         assert_eq!(
-            linux_raw_sys::ioctl::FS_IOC_GETVERSION,
-            opcode::read::<c::c_long>(b'v', 1) as _
+            linux_raw_sys::ioctl::FS_IOC_GETVERSION as Opcode,
+            opcode::read::<c::c_long>(b'v', 1)
         );
         // `TUNSETNOCSUM` is defined as `_IOW('T', 200, int)`.
         assert_eq!(
-            linux_raw_sys::ioctl::TUNSETNOCSUM,
-            opcode::write::<c::c_int>(b'T', 200) as _
+            linux_raw_sys::ioctl::TUNSETNOCSUM as Opcode,
+            opcode::write::<c::c_int>(b'T', 200)
         );
         // `FIFREEZE` is defined as `_IOWR('X', 119, int)`.
         assert_eq!(
-            linux_raw_sys::ioctl::FIFREEZE,
-            opcode::read_write::<c::c_int>(b'X', 119) as _
+            linux_raw_sys::ioctl::FIFREEZE as Opcode,
+            opcode::read_write::<c::c_int>(b'X', 119)
         );
     }
 }

--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -349,22 +349,22 @@ mod tests {
         // `TUNGETDEVNETNS` is defined as `_IO('T', 227)`.
         assert_eq!(
             linux_raw_sys::ioctl::TUNGETDEVNETNS,
-            opcode::none(b'T', 227)
+            opcode::none(b'T', 227) as _
         );
         // `FS_IOC_GETVERSION` is defined as `_IOR('v', 1, long)`.
         assert_eq!(
             linux_raw_sys::ioctl::FS_IOC_GETVERSION,
-            opcode::read::<c::c_long>(b'v', 1)
+            opcode::read::<c::c_long>(b'v', 1) as _
         );
         // `TUNSETNOCSUM` is defined as `_IOW('T', 200, int)`.
         assert_eq!(
             linux_raw_sys::ioctl::TUNSETNOCSUM,
-            opcode::write::<c::c_int>(b'T', 200)
+            opcode::write::<c::c_int>(b'T', 200) as _
         );
         // `FIFREEZE` is defined as `_IOWR('X', 119, int)`.
         assert_eq!(
             linux_raw_sys::ioctl::FIFREEZE,
-            opcode::read_write::<c::c_int>(b'X', 119)
+            opcode::read_write::<c::c_int>(b'X', 119) as _
         );
     }
 }

--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -187,7 +187,7 @@ pub unsafe trait Ioctl {
 
 /// Const functions for computing opcode values.
 ///
-/// Linux's headers define macros such as `_IO`, `_IOR`, `_IOW`, and `_IORW`
+/// Linux's headers define macros such as `_IO`, `_IOR`, `_IOW`, and `_IOWR`
 /// for defining ioctl values in a structured way that encode whether they
 /// are reading and/or writing, and other information about the ioctl. The
 /// functions in this module correspond to those macros.
@@ -252,7 +252,7 @@ pub mod opcode {
     /// type of data.
     ///
     /// This corresponds to the C macro `_IOWR(group, number, T)`.
-    #[doc(alias = "_IORW")]
+    #[doc(alias = "_IOWR")]
     #[inline]
     pub const fn read_write<T>(group: u8, number: u8) -> Opcode {
         from_components(Direction::ReadWrite, group, number, mem::size_of::<T>())
@@ -338,3 +338,33 @@ type _Opcode = c::c_uint;
 // Windows has `ioctlsocket`, which uses `i32`.
 #[cfg(windows)]
 type _Opcode = i32;
+
+#[cfg(linux_kernel)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_opcode_funcs() {
+        // `TUNGETDEVNETNS` is defined as `_IO('T', 227)`.
+        assert_eq!(
+            linux_raw_sys::ioctl::TUNGETDEVNETNS,
+            opcode::none(b'T', 227)
+        );
+        // `FS_IOC_GETVERSION` is defined as `_IOR('v', 1, long)`.
+        assert_eq!(
+            linux_raw_sys::ioctl::FS_IOC_GETVERSION,
+            opcode::read::<c::c_long>(b'v', 1)
+        );
+        // `TUNSETNOCSUM` is defined as `_IOW('T', 200, int)`.
+        assert_eq!(
+            linux_raw_sys::ioctl::TUNSETNOCSUM,
+            opcode::write::<c::c_int>(b'T', 200)
+        );
+        // `FIFREEZE` is defined as `_IOWR('X', 119, int)`.
+        assert_eq!(
+            linux_raw_sys::ioctl::FIFREEZE,
+            opcode::read_write::<c::c_int>(b'X', 119)
+        );
+    }
+}

--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -340,6 +340,7 @@ type _Opcode = c::c_uint;
 type _Opcode = i32;
 
 #[cfg(linux_kernel)]
+#[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/thread/prctl.rs
+++ b/src/thread/prctl.rs
@@ -100,7 +100,7 @@ pub fn set_name(name: &CStr) -> io::Result<()> {
 // PR_GET_SECCOMP/PR_SET_SECCOMP
 //
 
-//const PR_GET_SECCOMP: c_int = 21;
+const PR_GET_SECCOMP: c_int = 21;
 
 const SECCOMP_MODE_DISABLED: i32 = 0;
 const SECCOMP_MODE_STRICT: i32 = 1;
@@ -131,7 +131,6 @@ impl TryFrom<i32> for SecureComputingMode {
     }
 }
 
-/*
 /// Get the secure computing mode of the calling thread.
 ///
 /// If the caller is not in secure computing mode, this returns
@@ -155,7 +154,6 @@ impl TryFrom<i32> for SecureComputingMode {
 pub fn secure_computing_mode() -> io::Result<SecureComputingMode> {
     unsafe { prctl_1arg(PR_GET_SECCOMP) }.and_then(TryInto::try_into)
 }
-*/
 
 const PR_SET_SECCOMP: c_int = 22;
 

--- a/tests/fs/invalid_offset.rs
+++ b/tests/fs/invalid_offset.rs
@@ -5,7 +5,7 @@
 //! take file offsets are properly diagnosed.
 //!
 //! These tests are disabled on iOS/macOS since those platforms kill the
-//! process with `SIGXFSZ` instead of returning an error.
+//! process with `Signal::XFSZ` instead of returning an error.
 
 #![cfg(not(any(target_os = "redox", target_os = "wasi")))]
 

--- a/tests/process/prctl.rs
+++ b/tests/process/prctl.rs
@@ -98,6 +98,7 @@ fn test_is_io_flusher() {
 }
 
 #[cfg(feature = "thread")]
+#[cfg(feature = "system")]
 #[test]
 fn test_virtual_memory_map_config_struct_size() {
     if !thread_has_capability(Capability::SystemResource).unwrap() {
@@ -108,7 +109,6 @@ fn test_virtual_memory_map_config_struct_size() {
         return;
     }
 
-    #[cfg(feature = "system")]
     if !linux_kernel_config_item_is_enabled("CONFIG_CHECKPOINT_RESTORE").unwrap_or(false) {
         eprintln!(
             "test_virtual_memory_map_config_struct_size: Test skipped due to missing kernel \


### PR DESCRIPTION
Fix broken links and typos in documentaion, and add a testt for the `ioctl::opcode` functions.