### PR TITLE
Alphabetize cfg's.

### DIFF
--- a/src/backend/libc/net/sockopt.rs
+++ b/src/backend/libc/net/sockopt.rs
@@ -71,7 +71,7 @@ use alloc::borrow::ToOwned as _;
 use alloc::string::String;
 #[cfg(apple)]
 use c::TCP_KEEPALIVE as TCP_KEEPIDLE;
-#[cfg(not(any(apple, target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
+#[cfg(not(any(apple, target_os = "haiku", target_os = "nto", target_os = "openbsd")))]
 use c::TCP_KEEPIDLE;
 use core::mem::{size_of, MaybeUninit};
 use core::time::Duration;
@@ -887,9 +887,9 @@ pub(crate) fn tcp_nodelay(fd: BorrowedFd<'_>) -> io::Result<bool> {
 
 #[inline]
 #[cfg(not(any(
-    target_os = "openbsd",
     target_os = "haiku",
     target_os = "nto",
+    target_os = "openbsd",
     target_os = "redox"
 )))]
 pub(crate) fn set_tcp_keepcnt(fd: BorrowedFd<'_>, count: u32) -> io::Result<()> {
@@ -898,9 +898,9 @@ pub(crate) fn set_tcp_keepcnt(fd: BorrowedFd<'_>, count: u32) -> io::Result<()> 
 
 #[inline]
 #[cfg(not(any(
-    target_os = "openbsd",
     target_os = "haiku",
     target_os = "nto",
+    target_os = "openbsd",
     target_os = "redox"
 )))]
 pub(crate) fn tcp_keepcnt(fd: BorrowedFd<'_>) -> io::Result<u32> {
@@ -908,14 +908,14 @@ pub(crate) fn tcp_keepcnt(fd: BorrowedFd<'_>) -> io::Result<u32> {
 }
 
 #[inline]
-#[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
+#[cfg(not(any(target_os = "haiku", target_os = "nto", target_os = "openbsd")))]
 pub(crate) fn set_tcp_keepidle(fd: BorrowedFd<'_>, duration: Duration) -> io::Result<()> {
     let secs: c::c_uint = duration_to_secs(duration)?;
     setsockopt(fd, c::IPPROTO_TCP, TCP_KEEPIDLE, secs)
 }
 
 #[inline]
-#[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
+#[cfg(not(any(target_os = "haiku", target_os = "nto", target_os = "openbsd")))]
 pub(crate) fn tcp_keepidle(fd: BorrowedFd<'_>) -> io::Result<Duration> {
     let secs: c::c_uint = getsockopt(fd, c::IPPROTO_TCP, TCP_KEEPIDLE)?;
     Ok(Duration::from_secs(secs as u64))
@@ -923,9 +923,9 @@ pub(crate) fn tcp_keepidle(fd: BorrowedFd<'_>) -> io::Result<Duration> {
 
 #[inline]
 #[cfg(not(any(
-    target_os = "openbsd",
     target_os = "haiku",
     target_os = "nto",
+    target_os = "openbsd",
     target_os = "redox"
 )))]
 pub(crate) fn set_tcp_keepintvl(fd: BorrowedFd<'_>, duration: Duration) -> io::Result<()> {
@@ -935,9 +935,9 @@ pub(crate) fn set_tcp_keepintvl(fd: BorrowedFd<'_>, duration: Duration) -> io::R
 
 #[inline]
 #[cfg(not(any(
-    target_os = "openbsd",
     target_os = "haiku",
     target_os = "nto",
+    target_os = "openbsd",
     target_os = "redox"
 )))]
 pub(crate) fn tcp_keepintvl(fd: BorrowedFd<'_>) -> io::Result<Duration> {

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -1,7 +1,7 @@
 //! libc syscalls supporting `rustix::process`.
 
 use crate::backend::c;
-#[cfg(not(any(target_os = "wasi", target_os = "fuchsia")))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 use crate::backend::conv::borrowed_fd;
 #[cfg(any(target_os = "linux", feature = "fs"))]
 use crate::backend::conv::c_str;
@@ -20,7 +20,7 @@ use crate::backend::conv::ret_pid_t;
 #[cfg(all(feature = "alloc", not(target_os = "wasi")))]
 use crate::backend::conv::ret_usize;
 use crate::backend::conv::{ret, ret_c_int};
-#[cfg(not(any(target_os = "wasi", target_os = "fuchsia")))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 use crate::fd::BorrowedFd;
 #[cfg(target_os = "linux")]
 use crate::fd::{AsRawFd as _, OwnedFd, RawFd};

--- a/src/backend/libc/process/types.rs
+++ b/src/backend/libc/process/types.rs
@@ -38,7 +38,7 @@ pub enum Resource {
     Core = bitcast!(c::RLIMIT_CORE),
     /// `RLIMIT_RSS`
     // "nto" has `RLIMIT_RSS`, but it has the same value as `RLIMIT_AS`.
-    #[cfg(not(any(apple, solarish, target_os = "nto", target_os = "haiku")))]
+    #[cfg(not(any(apple, solarish, target_os = "haiku", target_os = "nto")))]
     Rss = bitcast!(c::RLIMIT_RSS),
     /// `RLIMIT_NPROC`
     #[cfg(not(any(solarish, target_os = "haiku")))]

--- a/src/backend/libc/termios/types.rs
+++ b/src/backend/libc/termios/types.rs
@@ -13,5 +13,5 @@ use crate::ffi;
 pub type tcflag_t = ffi::c_ulong;
 #[cfg(target_os = "redox")]
 pub type tcflag_t = u32;
-#[cfg(not(any(target_os = "wasi", apple, target_os = "redox")))]
+#[cfg(not(any(apple, target_os = "redox", target_os = "wasi")))]
 pub type tcflag_t = ffi::c_uint;

--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -326,8 +326,8 @@ type _Opcode = c::c_ulong;
     target_os = "aix",
     target_os = "fuchsia",
     target_os = "emscripten",
-    target_os = "wasi",
-    target_os = "nto"
+    target_os = "nto",
+    target_os = "wasi"
 ))]
 type _Opcode = c::c_int;
 

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -1287,9 +1287,9 @@ pub fn tcp_nodelay<Fd: AsFd>(fd: Fd) -> io::Result<bool> {
 ///
 /// [module-level documentation]: self#references-for-get_tcp_-and-set_tcp_-functions
 #[cfg(not(any(
-    target_os = "openbsd",
     target_os = "haiku",
     target_os = "nto",
+    target_os = "openbsd",
     target_os = "redox"
 )))]
 #[inline]
@@ -1304,9 +1304,9 @@ pub fn set_tcp_keepcnt<Fd: AsFd>(fd: Fd, value: u32) -> io::Result<()> {
 ///
 /// [module-level documentation]: self#references-for-get_tcp_-and-set_tcp_-functions
 #[cfg(not(any(
-    target_os = "openbsd",
     target_os = "haiku",
     target_os = "nto",
+    target_os = "openbsd",
     target_os = "redox"
 )))]
 #[inline]
@@ -1322,7 +1322,7 @@ pub fn tcp_keepcnt<Fd: AsFd>(fd: Fd) -> io::Result<u32> {
 /// See the [module-level documentation] for more.
 ///
 /// [module-level documentation]: self#references-for-get_tcp_-and-set_tcp_-functions
-#[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
+#[cfg(not(any(target_os = "haiku", target_os = "nto", target_os = "openbsd")))]
 #[inline]
 #[doc(alias = "TCP_KEEPIDLE")]
 pub fn set_tcp_keepidle<Fd: AsFd>(fd: Fd, value: Duration) -> io::Result<()> {
@@ -1336,7 +1336,7 @@ pub fn set_tcp_keepidle<Fd: AsFd>(fd: Fd, value: Duration) -> io::Result<()> {
 /// See the [module-level documentation] for more.
 ///
 /// [module-level documentation]: self#references-for-get_tcp_-and-set_tcp_-functions
-#[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
+#[cfg(not(any(target_os = "haiku", target_os = "nto", target_os = "openbsd")))]
 #[inline]
 #[doc(alias = "TCP_KEEPIDLE")]
 pub fn tcp_keepidle<Fd: AsFd>(fd: Fd) -> io::Result<Duration> {
@@ -1349,9 +1349,9 @@ pub fn tcp_keepidle<Fd: AsFd>(fd: Fd) -> io::Result<Duration> {
 ///
 /// [module-level documentation]: self#references-for-get_tcp_-and-set_tcp_-functions
 #[cfg(not(any(
-    target_os = "openbsd",
     target_os = "haiku",
     target_os = "nto",
+    target_os = "openbsd",
     target_os = "redox"
 )))]
 #[inline]
@@ -1366,9 +1366,9 @@ pub fn set_tcp_keepintvl<Fd: AsFd>(fd: Fd, value: Duration) -> io::Result<()> {
 ///
 /// [module-level documentation]: self#references-for-get_tcp_-and-set_tcp_-functions
 #[cfg(not(any(
-    target_os = "openbsd",
     target_os = "haiku",
     target_os = "nto",
+    target_os = "openbsd",
     target_os = "redox"
 )))]
 #[inline]

--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -202,16 +202,16 @@ fn test_sockopts_tcp(s: &OwnedFd) {
     assert!(!sockopt::tcp_nodelay(s).unwrap());
 
     #[cfg(not(any(
-        target_os = "openbsd",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "openbsd",
         target_os = "redox"
     )))]
     {
         assert!(sockopt::tcp_keepcnt(s).is_ok());
         assert!(sockopt::tcp_keepintvl(s).is_ok());
     }
-    #[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
+    #[cfg(not(any(target_os = "haiku", target_os = "nto", target_os = "openbsd")))]
     {
         assert!(sockopt::tcp_keepidle(s).is_ok());
     }
@@ -228,7 +228,7 @@ fn test_sockopts_tcp(s: &OwnedFd) {
     // Check that the nodelay flag is cleared.
     assert!(!sockopt::tcp_nodelay(s).unwrap());
 
-    #[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "nto")))]
+    #[cfg(not(any(target_os = "haiku", target_os = "nto", target_os = "openbsd")))]
     {
         #[cfg(not(target_os = "redox"))]
         {

--- a/tests/process/wait.rs
+++ b/tests/process/wait.rs
@@ -92,10 +92,10 @@ fn test_waitpgid() {
 }
 
 #[cfg(not(any(
-    target_os = "wasi",
     target_os = "emscripten",
+    target_os = "openbsd",
     target_os = "redox",
-    target_os = "openbsd"
+    target_os = "wasi"
 )))]
 #[test]
 #[serial]


### PR DESCRIPTION
For tidiness, keep the `target_os = "..."` lists sorted alphabetically.