### PR TITLE
Clean up Debug impls.

### DIFF
--- a/examples/time.rs
+++ b/examples/time.rs
@@ -3,32 +3,11 @@
 
 #[cfg(not(any(windows, target_os = "espidf")))]
 #[cfg(feature = "time")]
-struct DebugTimespec(rustix::time::Timespec);
-
-#[cfg(not(any(windows, target_os = "espidf")))]
-#[cfg(feature = "time")]
-impl core::fmt::Debug for DebugTimespec {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let mut d = f.debug_struct("Timespec");
-        d.field("tv_sec", &self.0.tv_sec);
-        d.field("tv_nsec", &self.0.tv_nsec);
-        d.finish()
-    }
-}
-
-#[cfg(not(any(windows, target_os = "espidf")))]
-#[cfg(feature = "time")]
 fn main() {
     use rustix::time::{clock_gettime, ClockId};
 
-    println!(
-        "Real time: {:?}",
-        DebugTimespec(clock_gettime(ClockId::Realtime))
-    );
-    println!(
-        "Monotonic time: {:?}",
-        DebugTimespec(clock_gettime(ClockId::Monotonic))
-    );
+    println!("Real time: {:?}", clock_gettime(ClockId::Realtime));
+    println!("Monotonic time: {:?}", clock_gettime(ClockId::Monotonic));
 
     #[cfg(any(freebsdlike, target_os = "openbsd"))]
     println!("Uptime: {:?}", clock_gettime(ClockId::Uptime));
@@ -36,31 +15,31 @@ fn main() {
     #[cfg(not(any(solarish, target_os = "netbsd", target_os = "redox")))]
     println!(
         "Process CPU time: {:?}",
-        DebugTimespec(clock_gettime(ClockId::ProcessCPUTime))
+        clock_gettime(ClockId::ProcessCPUTime)
     );
 
     #[cfg(not(any(solarish, target_os = "netbsd", target_os = "redox")))]
     println!(
         "Thread CPU time: {:?}",
-        DebugTimespec(clock_gettime(ClockId::ThreadCPUTime))
+        clock_gettime(ClockId::ThreadCPUTime)
     );
 
     #[cfg(any(linux_kernel, target_os = "freebsd"))]
     println!(
         "Realtime (coarse): {:?}",
-        DebugTimespec(clock_gettime(ClockId::RealtimeCoarse))
+        clock_gettime(ClockId::RealtimeCoarse)
     );
 
     #[cfg(any(linux_kernel, target_os = "freebsd"))]
     println!(
         "Monotonic (coarse): {:?}",
-        DebugTimespec(clock_gettime(ClockId::MonotonicCoarse))
+        clock_gettime(ClockId::MonotonicCoarse)
     );
 
     #[cfg(linux_kernel)]
     println!(
         "Monotonic (raw): {:?}",
-        DebugTimespec(clock_gettime(ClockId::MonotonicRaw))
+        clock_gettime(ClockId::MonotonicRaw)
     );
 }
 

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -42,7 +42,6 @@ use backend::fs::types::Stat;
 use backend::fs::types::StatFs;
 #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
 use backend::fs::types::StatVfs;
-use core::fmt;
 
 /// Timestamps used by [`utimensat`] and [`futimens`].
 ///
@@ -51,24 +50,13 @@ use core::fmt;
 // This is `repr(C)` and specifically laid out to match the representation used
 // by `utimensat` and `futimens`, which expect 2-element arrays of timestamps.
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Timestamps {
     /// The timestamp of the last access to a filesystem object.
     pub last_access: Timespec,
 
     /// The timestamp of the last modification of a filesystem object.
     pub last_modification: Timespec,
-}
-
-impl fmt::Debug for Timestamps {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Timestamps")
-            .field("last_access.tv_sec", &self.last_access.tv_sec)
-            .field("last_access.tv_nsec", &self.last_access.tv_nsec)
-            .field("last_modification.tv_sec", &self.last_modification.tv_sec)
-            .field("last_modification.tv_nsec", &self.last_modification.tv_nsec)
-            .finish()
-    }
 }
 
 /// The filesystem magic number for procfs.

--- a/src/fs/raw_dir.rs
+++ b/src/fs/raw_dir.rs
@@ -1,14 +1,13 @@
 //! `RawDir` and `RawDirEntry`.
 
-use core::fmt;
-use core::mem::{align_of, MaybeUninit};
-use linux_raw_sys::general::linux_dirent64;
-
 use crate::backend::fs::syscalls::getdents_uninit;
 use crate::fd::AsFd;
 use crate::ffi::CStr;
 use crate::fs::FileType;
 use crate::io;
+use core::fmt;
+use core::mem::{align_of, MaybeUninit};
+use linux_raw_sys::general::linux_dirent64;
 
 /// A directory iterator implemented with getdents.
 ///

--- a/src/net/send_recv/msg.rs
+++ b/src/net/send_recv/msg.rs
@@ -10,8 +10,6 @@ use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::addr::SocketAddrArg;
 #[cfg(linux_kernel)]
 use crate::net::UCred;
-#[cfg(feature = "std")]
-use core::fmt;
 use core::iter::FusedIterator;
 use core::marker::PhantomData;
 use core::mem::{align_of, size_of, size_of_val, take, MaybeUninit};
@@ -771,6 +769,7 @@ pub fn recvmsg<Fd: AsFd>(
 }
 
 /// The result of a successful [`recvmsg`] call.
+#[derive(Debug, Clone)]
 pub struct RecvMsg {
     /// The number of bytes received.
     ///
@@ -784,17 +783,6 @@ pub struct RecvMsg {
 
     /// The address of the socket we received from, if any.
     pub address: Option<SocketAddrAny>,
-}
-
-#[cfg(feature = "std")]
-impl fmt::Debug for RecvMsg {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RecvMsg")
-            .field("bytes", &self.bytes)
-            .field("flags", &self.flags)
-            .field("address", &self.address)
-            .finish()
-    }
 }
 
 /// An iterator over data in an ancillary buffer.

--- a/src/net/socket_addr_any.rs
+++ b/src/net/socket_addr_any.rs
@@ -9,7 +9,6 @@ use crate::net::addr::{SocketAddrArg, SocketAddrLen, SocketAddrOpaque, SocketAdd
 #[cfg(unix)]
 use crate::net::SocketAddrUnix;
 use crate::net::{AddressFamily, SocketAddr, SocketAddrV4, SocketAddrV6};
-#[cfg(feature = "std")]
 use core::fmt;
 use core::mem::{size_of, MaybeUninit};
 use core::num::NonZeroU32;
@@ -195,7 +194,6 @@ impl core::hash::Hash for SocketAddrAny {
     }
 }
 
-#[cfg(feature = "std")]
 impl fmt::Debug for SocketAddrAny {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.address_family() {

--- a/src/path/dec_int.rs
+++ b/src/path/dec_int.rs
@@ -8,6 +8,7 @@
 
 use crate::backend::fd::{AsFd, AsRawFd as _};
 use crate::ffi::CStr;
+use core::fmt;
 use core::hint::unreachable_unchecked;
 use core::mem::{self, MaybeUninit};
 use core::num::{NonZeroU8, NonZeroUsize};
@@ -20,7 +21,7 @@ use std::os::unix::ffi::OsStrExt;
 ))]
 use std::os::wasi::ffi::OsStrExt;
 #[cfg(feature = "std")]
-use {core::fmt, std::ffi::OsStr, std::path::Path};
+use {std::ffi::OsStr, std::path::Path};
 
 /// Format an integer into a decimal `Path` component, without constructing a
 /// temporary `PathBuf` or `String`.
@@ -253,7 +254,6 @@ impl AsRef<Path> for DecInt {
     }
 }
 
-#[cfg(feature = "std")]
 impl fmt::Debug for DecInt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_str().fmt(f)


### PR DESCRIPTION
`Timespec` implements `Debug` now, so we no longer need workarounds for it not doing so.

And, using `core::fmt`, `Debug` impls don't depend on `feature = "std"`.