### PR TITLE
Use `io_uring_ptr` for more io_uring struct fields.

### DIFF
--- a/src/io_uring/mod.rs
+++ b/src/io_uring/mod.rs
@@ -1538,7 +1538,7 @@ pub struct io_uring_probe_op {
 pub struct io_uring_files_update {
     pub offset: u32,
     pub resv: u32,
-    pub fds: u64,
+    pub fds: io_uring_ptr,
 }
 
 #[allow(missing_docs)]
@@ -1548,8 +1548,8 @@ pub struct io_uring_rsrc_register {
     pub nr: u32,
     pub flags: IoringRsrcFlags,
     pub resv2: u64,
-    pub data: u64,
-    pub tags: u64,
+    pub data: io_uring_ptr,
+    pub tags: io_uring_ptr,
 }
 
 #[allow(missing_docs)]
@@ -1558,7 +1558,7 @@ pub struct io_uring_rsrc_register {
 pub struct io_uring_rsrc_update {
     pub offset: u32,
     pub resv: u32,
-    pub data: u64,
+    pub data: io_uring_ptr,
 }
 
 #[allow(missing_docs)]
@@ -1567,8 +1567,8 @@ pub struct io_uring_rsrc_update {
 pub struct io_uring_rsrc_update2 {
     pub offset: u32,
     pub resv: u32,
-    pub data: u64,
-    pub tags: u64,
+    pub data: io_uring_ptr,
+    pub tags: io_uring_ptr,
     pub nr: u32,
     pub resv2: u32,
 }

--- a/tests/io_uring/register.rs
+++ b/tests/io_uring/register.rs
@@ -4,9 +4,9 @@ use libc::c_void;
 use rustix::fd::{AsFd, AsRawFd, BorrowedFd};
 use rustix::io::{Errno, Result};
 use rustix::io_uring::{
-    io_uring_buf, io_uring_buf_reg, io_uring_buf_ring, io_uring_params, io_uring_register_with,
-    io_uring_rsrc_update, io_uring_setup, IoringFeatureFlags, IoringRegisterFlags,
-    IoringRegisterOp,
+    io_uring_buf, io_uring_buf_reg, io_uring_buf_ring, io_uring_params, io_uring_ptr,
+    io_uring_register_with, io_uring_rsrc_update, io_uring_setup, IoringFeatureFlags,
+    IoringRegisterFlags, IoringRegisterOp,
 };
 #[cfg(feature = "mm")]
 use rustix::mm::{MapFlags, ProtFlags};
@@ -36,7 +36,7 @@ where
 
 fn register_ring(fd: BorrowedFd<'_>) -> Result<BorrowedFd<'_>> {
     let update = io_uring_rsrc_update {
-        data: fd.as_raw_fd() as u64,
+        data: io_uring_ptr::new(fd.as_raw_fd() as u64 as *mut c_void),
         offset: u32::MAX,
         resv: 0,
     };
@@ -59,7 +59,7 @@ where
 {
     let update = io_uring_rsrc_update {
         offset: fd.as_raw_fd() as u32,
-        data: 0,
+        data: io_uring_ptr::null(),
         resv: 0,
     };
 


### PR DESCRIPTION
For fields which hold pointer values, use `io_uring_ptr` instead of `u64`, to better preserve pointer provenance.