### PR TITLE
Handle non-NUL-terminated strings in `SocketAddrUnix`.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         cargo update --package=regex --precise=1.9.0
         cargo update --package=half --precise=2.2.1
         cargo update --package=flate2 --precise=1.0.35
-        cargo update --package=textwrap --precise=v0.16.1
+        cargo update --package=textwrap --precise=0.16.1
 
     - run: >
         rustup target add

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -530,7 +530,7 @@ jobs:
         cargo update --package=regex --precise=1.9.0
         cargo update --package=half --precise=2.2.1
         cargo update --package=flate2 --precise=1.0.35
-        cargo update --package=textwrap --precise=v0.16.1
+        cargo update --package=textwrap --precise=0.16.1
 
     - run: |
         cargo test --verbose --features=all-apis --release --workspace -- --nocapture

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,7 @@ jobs:
         cargo update --package=regex --precise=1.9.0
         cargo update --package=half --precise=2.2.1
         cargo update --package=flate2 --precise=1.0.35
+        cargo update --package=textwrap --precise=v0.16.1
 
     - run: >
         rustup target add
@@ -529,6 +530,7 @@ jobs:
         cargo update --package=regex --precise=1.9.0
         cargo update --package=half --precise=2.2.1
         cargo update --package=flate2 --precise=1.0.35
+        cargo update --package=textwrap --precise=v0.16.1
 
     - run: |
         cargo test --verbose --features=all-apis --release --workspace -- --nocapture

--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -14,10 +14,7 @@ use {
     core::slice,
 };
 #[cfg(all(unix, feature = "alloc"))]
-use {
-    crate::ffi::CString,
-    alloc::borrow::{Cow, ToOwned},
-};
+use {crate::ffi::CString, alloc::borrow::Cow, alloc::vec::Vec};
 
 /// `struct sockaddr_un`
 #[cfg(unix)]
@@ -143,7 +140,8 @@ impl SocketAddrUnix {
         let bytes = self.bytes()?;
         if !bytes.is_empty() && bytes[0] != 0 {
             if self.unix.sun_path.len() == bytes.len() {
-                self.path_with_termination(bytes)
+                // SAFETY: no NULs are contained in bytes
+                unsafe { self.path_with_termination(bytes) }
             } else {
                 // SAFETY: `from_bytes_with_nul_unchecked` since the string is
                 // NUL-terminated.
@@ -155,11 +153,18 @@ impl SocketAddrUnix {
     }
 
     /// If the `sun_path` field is not NUL-terminated, terminate it.
+    ///
+    /// SAFETY: the input `bytes` must not contain any NULs
     #[cfg(feature = "alloc")]
-    fn path_with_termination(&self, bytes: &[u8]) -> Option<Cow<'_, CStr>> {
-        let mut owned = bytes.to_owned();
+    unsafe fn path_with_termination(&self, bytes: &[u8]) -> Option<Cow<'_, CStr>> {
+        let mut owned = Vec::with_capacity(bytes.len() + 1);
+        owned.extend_from_slice(bytes);
         owned.push(b'\0');
-        Some(CString::from_vec_with_nul(owned).unwrap().into())
+        // SAFETY: `from_vec_with_nul_unchecked` since the string is
+        // NUL-terminated and `bytes` does not conain any NULs.
+        Some(Cow::Owned(
+            CString::from_vec_with_nul_unchecked(owned).into(),
+        ))
     }
 
     /// For a filesystem path address, return the path as a byte sequence,

--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -14,7 +14,10 @@ use {
     core::slice,
 };
 #[cfg(all(unix, feature = "alloc"))]
-use {crate::ffi::CString, alloc::borrow::Cow};
+use {
+    crate::ffi::CString,
+    alloc::borrow::{Cow, ToOwned},
+};
 
 /// `struct sockaddr_un`
 #[cfg(unix)]

--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -268,16 +268,21 @@ impl Hash for SocketAddrUnix {
 #[cfg(unix)]
 impl fmt::Debug for SocketAddrUnix {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[cfg(feature = "alloc")]
         if let Some(path) = self.path() {
-            path.fmt(f)
-        } else {
-            #[cfg(linux_kernel)]
-            if let Some(name) = self.abstract_name() {
-                return name.fmt(f);
-            }
-
-            "(unnamed)".fmt(f)
+            return path.fmt(f);
         }
+        if let Some(bytes) = self.path_bytes() {
+            if let Ok(s) = core::str::from_utf8(bytes) {
+                return s.fmt(f);
+            }
+            return bytes.fmt(f);
+        }
+        #[cfg(linux_kernel)]
+        if let Some(name) = self.abstract_name() {
+            return name.fmt(f);
+        }
+        "(unnamed)".fmt(f)
     }
 }
 

--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -136,7 +136,7 @@ impl SocketAddrUnix {
     #[inline]
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-    pub fn path(&self) -> Option<Cow<CStr>> {
+    pub fn path(&self) -> Option<Cow<'_, CStr>> {
         let bytes = self.bytes()?;
         if !bytes.is_empty() && bytes[0] != 0 {
             if self.unix.sun_path.len() == bytes.len() {
@@ -153,7 +153,7 @@ impl SocketAddrUnix {
 
     /// If the `sun_path` field is not NUL-terminated, terminate it.
     #[cfg(feature = "alloc")]
-    fn path_with_termination(&self, bytes: &[u8]) -> Option<Cow<CStr>> {
+    fn path_with_termination(&self, bytes: &[u8]) -> Option<Cow<'_, CStr>> {
         let mut owned = bytes.to_owned();
         owned.push(b'\0');
         Some(CString::from_vec_with_nul(owned).unwrap().into())

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -98,7 +98,7 @@ impl SocketAddrUnix {
     #[inline]
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-    pub fn path(&self) -> Option<Cow<CStr>> {
+    pub fn path(&self) -> Option<Cow<'_, CStr>> {
         let bytes = self.bytes()?;
         if !bytes.is_empty() && bytes[0] != 0 {
             if self.unix.sun_path.len() == bytes.len() {
@@ -115,7 +115,7 @@ impl SocketAddrUnix {
 
     /// If the `sun_path` field is not NUL-terminated, terminate it.
     #[cfg(feature = "alloc")]
-    fn path_with_termination(&self, bytes: &[u8]) -> Option<Cow<CStr>> {
+    fn path_with_termination(&self, bytes: &[u8]) -> Option<Cow<'_, CStr>> {
         let mut owned = bytes.to_owned();
         owned.push(b'\0');
         Some(CString::from_vec_with_nul(owned).unwrap().into())

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -15,7 +15,10 @@ use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::{fmt, slice};
 #[cfg(feature = "alloc")]
-use {crate::ffi::CString, alloc::borrow::Cow};
+use {
+    crate::ffi::CString,
+    alloc::borrow::{Cow, ToOwned},
+};
 
 /// `struct sockaddr_un`
 #[derive(Clone)]

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -215,13 +215,20 @@ impl Hash for SocketAddrUnix {
 
 impl fmt::Debug for SocketAddrUnix {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[cfg(feature = "alloc")]
         if let Some(path) = self.path() {
-            path.fmt(f)
-        } else if let Some(name) = self.abstract_name() {
-            name.fmt(f)
-        } else {
-            "(unnamed)".fmt(f)
+            return path.fmt(f);
         }
+        if let Some(bytes) = self.path_bytes() {
+            if let Ok(s) = core::str::from_utf8(bytes) {
+                return s.fmt(f);
+            }
+            return bytes.fmt(f);
+        }
+        if let Some(name) = self.abstract_name() {
+            return name.fmt(f);
+        }
+        "(unnamed)".fmt(f)
     }
 }
 

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -14,6 +14,8 @@ use crate::{io, path};
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::{fmt, slice};
+#[cfg(feature = "alloc")]
+use {crate::ffi::CString, alloc::borrow::Cow};
 
 /// `struct sockaddr_un`
 #[derive(Clone)]
@@ -33,9 +35,12 @@ impl SocketAddrUnix {
     #[inline]
     fn _new(path: &CStr) -> io::Result<Self> {
         let mut unix = Self::init();
-        let bytes = path.to_bytes_with_nul();
+        let mut bytes = path.to_bytes_with_nul();
         if bytes.len() > unix.sun_path.len() {
-            return Err(io::Errno::NAMETOOLONG);
+            bytes = path.to_bytes(); // without NUL
+            if bytes.len() > unix.sun_path.len() {
+                return Err(io::Errno::NAMETOOLONG);
+            }
         }
         for (i, b) in bytes.iter().enumerate() {
             unix.sun_path[i] = bitcast!(*b);
@@ -91,12 +96,44 @@ impl SocketAddrUnix {
 
     /// For a filesystem path address, return the path.
     #[inline]
-    pub fn path(&self) -> Option<&CStr> {
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn path(&self) -> Option<Cow<CStr>> {
         let bytes = self.bytes()?;
         if !bytes.is_empty() && bytes[0] != 0 {
-            // SAFETY: `from_bytes_with_nul_unchecked` since the string is
-            // NUL-terminated.
-            Some(unsafe { CStr::from_bytes_with_nul_unchecked(bytes) })
+            if self.unix.sun_path.len() == bytes.len() {
+                self.path_with_termination(bytes)
+            } else {
+                // SAFETY: `from_bytes_with_nul_unchecked` since the string is
+                // NUL-terminated.
+                Some(unsafe { CStr::from_bytes_with_nul_unchecked(bytes) }.into())
+            }
+        } else {
+            None
+        }
+    }
+
+    /// If the `sun_path` field is not NUL-terminated, terminate it.
+    #[cfg(feature = "alloc")]
+    fn path_with_termination(&self, bytes: &[u8]) -> Option<Cow<CStr>> {
+        let mut owned = bytes.to_owned();
+        owned.push(b'\0');
+        Some(CString::from_vec_with_nul(owned).unwrap().into())
+    }
+
+    /// For a filesystem path address, return the path as a byte sequence,
+    /// excluding the NUL terminator.
+    #[inline]
+    pub fn path_bytes(&self) -> Option<&[u8]> {
+        let bytes = self.bytes()?;
+        if !bytes.is_empty() && bytes[0] != 0 {
+            if self.unix.sun_path.len() == self.len() - offsetof_sun_path() {
+                // There is no NUL terminator.
+                Some(bytes)
+            } else {
+                // Remove the NUL terminator.
+                Some(&bytes[..bytes.len() - 1])
+            }
         } else {
             None
         }

--- a/tests/net/addr.rs
+++ b/tests/net/addr.rs
@@ -31,19 +31,19 @@ fn test_unix_addr() {
 
     assert_eq!(
         SocketAddrUnix::new("/").unwrap().path().unwrap(),
-        cstr!("/")
+        cstr!("/").into()
     );
     assert_eq!(
         SocketAddrUnix::new("//").unwrap().path().unwrap(),
-        cstr!("//")
+        cstr!("//").into()
     );
     assert_eq!(
         SocketAddrUnix::new("/foo/bar").unwrap().path().unwrap(),
-        cstr!("/foo/bar")
+        cstr!("/foo/bar").into()
     );
     assert_eq!(
         SocketAddrUnix::new("foo").unwrap().path().unwrap(),
-        cstr!("foo")
+        cstr!("foo").into()
     );
     SocketAddrUnix::new("/foo\0/bar").unwrap_err();
     assert!(SocketAddrUnix::new("").unwrap().path().is_none());

--- a/tests/net/unix.rs
+++ b/tests/net/unix.rs
@@ -378,6 +378,7 @@ fn test_unix_msg() {
         Some(CString::new(path.as_os_str().as_bytes()).unwrap().into())
     );
     assert_eq!(name.path_bytes(), Some(path.as_os_str().as_bytes()));
+    #[cfg(linux_kernel)]
     assert!(!name.is_unnamed());
     do_test_unix_msg(name);
 
@@ -402,6 +403,7 @@ fn test_unix_msg_unconnected() {
         Some(CString::new(path.as_os_str().as_bytes()).unwrap().into())
     );
     assert_eq!(name.path_bytes(), Some(path.as_os_str().as_bytes()));
+    #[cfg(linux_kernel)]
     assert!(!name.is_unnamed());
     do_test_unix_msg_unconnected(name);
 
@@ -998,6 +1000,7 @@ fn test_long_named_address() {
             Some(CString::new(path.as_os_str().as_bytes()).unwrap().into())
         );
         assert_eq!(name.path_bytes(), Some(path.as_os_str().as_bytes()));
+        #[cfg(linux_kernel)]
         assert!(!name.is_unnamed());
     }
 }

--- a/tests/net/unix_alloc.rs
+++ b/tests/net/unix_alloc.rs
@@ -375,6 +375,7 @@ fn test_unix_msg() {
         Some(CString::new(path.as_os_str().as_bytes()).unwrap().into())
     );
     assert_eq!(name.path_bytes(), Some(path.as_os_str().as_bytes()));
+    #[cfg(linux_kernel)]
     assert!(!name.is_unnamed());
     do_test_unix_msg(name);
 
@@ -399,6 +400,7 @@ fn test_unix_msg_unconnected() {
         Some(CString::new(path.as_os_str().as_bytes()).unwrap().into())
     );
     assert_eq!(name.path_bytes(), Some(path.as_os_str().as_bytes()));
+    #[cfg(linux_kernel)]
     assert!(!name.is_unnamed());
     do_test_unix_msg_unconnected(name);
 

--- a/tests/net/unix_alloc.rs
+++ b/tests/net/unix_alloc.rs
@@ -361,12 +361,21 @@ fn do_test_unix_msg_unconnected(addr: SocketAddrUnix) {
 #[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "wasi")))]
 #[test]
 fn test_unix_msg() {
+    use rustix::ffi::CString;
+    use std::os::unix::ffi::OsStrExt as _;
+
     crate::init();
 
     let tmpdir = tempfile::tempdir().unwrap();
     let path = tmpdir.path().join("scp_4804");
 
     let name = SocketAddrUnix::new(&path).unwrap();
+    assert_eq!(
+        name.path(),
+        Some(CString::new(path.as_os_str().as_bytes()).unwrap().into())
+    );
+    assert_eq!(name.path_bytes(), Some(path.as_os_str().as_bytes()));
+    assert!(!name.is_unnamed());
     do_test_unix_msg(name);
 
     unlinkat(CWD, path, AtFlags::empty()).unwrap();
@@ -376,12 +385,21 @@ fn test_unix_msg() {
 #[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "wasi")))]
 #[test]
 fn test_unix_msg_unconnected() {
+    use rustix::ffi::CString;
+    use std::os::unix::ffi::OsStrExt as _;
+
     crate::init();
 
     let tmpdir = tempfile::tempdir().unwrap();
     let path = tmpdir.path().join("scp_4804");
 
     let name = SocketAddrUnix::new(&path).unwrap();
+    assert_eq!(
+        name.path(),
+        Some(CString::new(path.as_os_str().as_bytes()).unwrap().into())
+    );
+    assert_eq!(name.path_bytes(), Some(path.as_os_str().as_bytes()));
+    assert!(!name.is_unnamed());
     do_test_unix_msg_unconnected(name);
 
     unlinkat(CWD, path, AtFlags::empty()).unwrap();
@@ -398,6 +416,8 @@ fn test_abstract_unix_msg() {
     let path = tmpdir.path().join("scp_4804");
 
     let name = SocketAddrUnix::new_abstract_name(path.as_os_str().as_bytes()).unwrap();
+    assert_eq!(name.abstract_name(), Some(path.as_os_str().as_bytes()));
+    assert!(!name.is_unnamed());
     do_test_unix_msg(name);
 }
 
@@ -413,6 +433,8 @@ fn test_abstract_unix_msg_unconnected() {
     let path = tmpdir.path().join("scp_4804");
 
     let name = SocketAddrUnix::new_abstract_name(path.as_os_str().as_bytes()).unwrap();
+    assert_eq!(name.abstract_name(), Some(path.as_os_str().as_bytes()));
+    assert!(!name.is_unnamed());
     do_test_unix_msg_unconnected(name);
 }
 


### PR DESCRIPTION
Unix-domain socket address can be long enough that the NUL terminator does not fit. Handle this case by making `path()` return a `Cow<CStr>` and adding a NUL terminator as needed.

Also add a `path_bytes()` function for returning the raw bytes.

Fixes #1316.