### PR TITLE
Fix compatibility with older 32-bit kernels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -140,6 +140,22 @@ fields are `tv_sec` which holds seconds and `tv_nsec` which holds nanoseconds.
 [`rustix::event::epoll`]: https://docs.rs/rustix/1.0.0/rustix/event/epoll/index.html
 [`Timespec`]: https://docs.rs/rustix/1.0.0/rustix/time/struct.Timespec.html
 
+The timeout argument in [`rustix::thread::futex::wait`],
+[`rustix::thread::futex::lock_pi`], [`rustix::thread::futex::wait_bitset`],
+[`rustix::thread::futex::wait_requeue_pi`], and
+[`rustix::thread::futex::lock_pi2`] changed from `Option<Timespec>` to
+`Option<&Timespec>`, for consistency with the rest of rustix's API, and for
+low-level efficiency, as it means the implementation doesn't need to make a
+copy of the `Timespec` to take its address. An easy way to convert an
+`Option<Timespec>` to an `Option<&Timespec> is to use [`Option::as_ref`].
+
+[`rustix::thread::futex::wait`]: https://docs.rs/rustix/1.0.0/rustix/thread/futex/fn.wait.html
+[`rustix::thread::futex::lock_pi`]: https://docs.rs/rustix/1.0.0/rustix/thread/futex/fn.lock_pi.html
+[`rustix::thread::futex::wait_bitset`]: https://docs.rs/rustix/1.0.0/rustix/thread/futex/fn.wait_bitset.html
+[`rustix::thread::futex::wait_requeue_pi`]: https://docs.rs/rustix/1.0.0/rustix/thread/futex/fn.wait_requeue_pi.html
+[`rustix::thread::futex::lock_pi2`]: https://docs.rs/rustix/1.0.0/rustix/thread/futex/fn.lock_pi2.html
+[`Option::as_ref`]: https://doc.rust-lang.org/stable/std/option/enum.Option.html#method.as_ref
+
 Functions in [`rustix::event::port`] are renamed to remove the redundant
 `port_*` prefix.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,8 +211,11 @@ use-explicitly-provided-auxv = []
 # Specialize for Linux 4.11 or later
 linux_4_11 = []
 
+# Specialize for Linux 5.1 or later
+linux_5_1 = ["linux_4_11"]
+
 # Specialize for Linux 5.11 or later
-linux_5_11 = ["linux_4_11"]
+linux_5_11 = ["linux_5_1"]
 
 # Enable all specializations for the latest Linux versions.
 linux_latest = ["linux_5_11"]

--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -572,14 +572,12 @@ pub(crate) unsafe fn epoll_wait(
     // If we're on Linux >= 5.11, use `epoll_pwait2` via `libc::syscall`.
     #[cfg(all(linux_kernel, feature = "linux_5_11"))]
     {
-        use linux_raw_sys::general::__kernel_timespec as timespec;
-
         syscall! {
             fn epoll_pwait2(
                 epfd: c::c_int,
                 events: *mut c::epoll_event,
                 maxevents: c::c_int,
-                timeout: *const timespec,
+                timeout: *const Timespec,
                 sigmask: *const c::sigset_t
             ) via SYS_epoll_pwait2 -> c::c_int
         }

--- a/src/backend/libc/winsock_c.rs
+++ b/src/backend/libc/winsock_c.rs
@@ -62,6 +62,6 @@ pub(crate) use WinSock::{
 // in its public API. So define one, and we'll convert it internally.
 pub struct timespec {
     pub tv_sec: time_t,
-    pub tv_nsec: i64,
+    pub tv_nsec: ffi::c_long,
 }
 pub type time_t = i64;

--- a/src/backend/libc/winsock_c.rs
+++ b/src/backend/libc/winsock_c.rs
@@ -62,6 +62,6 @@ pub(crate) use WinSock::{
 // in its public API. So define one, and we'll convert it internally.
 pub struct timespec {
     pub tv_sec: time_t,
-    pub tv_nsec: ffi::c_long,
+    pub tv_nsec: crate::ffi::c_long,
 }
 pub type time_t = i64;

--- a/src/backend/linux_raw/event/syscalls.rs
+++ b/src/backend/linux_raw/event/syscalls.rs
@@ -77,7 +77,7 @@ pub(crate) unsafe fn select(
     ))]
     {
         // Linux 5.1 added `pselect6_time64`; if we have that, use it.
-        #[cfg(feature = "linux_5_11")]
+        #[cfg(feature = "linux_5_1")]
         {
             // Linux's `pselect6` mutates the timeout argument. Our public
             // interface does not do this, because it's not portable to other
@@ -107,7 +107,7 @@ pub(crate) unsafe fn select(
         // We do this unconditionally, rather than trying `pselect6_time64` and
         // falling back on `Errno::NOSYS`, because seccomp configurations will
         // sometimes abort the process on syscalls they don't recognize.
-        #[cfg(not(feature = "linux_5_11"))]
+        #[cfg(not(feature = "linux_5_1"))]
         {
             let mut timeout = match timeout {
                 Some(timeout) => Some(linux_raw_sys::general::__kernel_old_timespec {

--- a/src/backend/linux_raw/event/syscalls.rs
+++ b/src/backend/linux_raw/event/syscalls.rs
@@ -12,7 +12,7 @@ use crate::backend::conv::{
 use crate::event::{epoll, EventfdFlags, FdSetElement, PollFd, Timespec};
 use crate::fd::{BorrowedFd, OwnedFd};
 use crate::io;
-use crate::utils::{as_mut_ptr, option_as_ptr};
+use crate::utils::as_mut_ptr;
 use core::ptr::null_mut;
 use linux_raw_sys::general::{kernel_sigset_t, EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD};
 
@@ -355,15 +355,12 @@ pub(crate) unsafe fn epoll_wait(
     // We either have Linux 5.1 or the timeout didn't fit in an `i32`, so
     // `__NR_epoll_pwait2` will either succeed or fail due to our having no
     // other options.
-
-    let timeout = option_as_ptr(timeout);
-
     ret_usize(syscall!(
         __NR_epoll_pwait2,
         epfd,
         events.0,
         pass_usize(events.1),
-        timeout,
+        opt_ref(timeout),
         zero()
     ))
 }

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -1676,31 +1676,44 @@ fn test_sizes() {
 // Some linux_raw_sys structs have unsigned types for values which are
 // interpreted as signed. This defines a utility or casting to the
 // same-sized signed type.
-trait AsSigned {
-    type Signed;
-    fn as_signed(self) -> Self::Signed;
-}
-impl AsSigned for u32 {
-    type Signed = i32;
-    fn as_signed(self) -> Self::Signed {
-        self as _
+#[cfg(any(
+    target_pointer_width = "32",
+    target_arch = "mips64",
+    target_arch = "mips64r6"
+))]
+mod as_signed {
+    pub(super) trait AsSigned {
+        type Signed;
+        fn as_signed(self) -> Self::Signed;
+    }
+    impl AsSigned for u32 {
+        type Signed = i32;
+        fn as_signed(self) -> Self::Signed {
+            self as _
+        }
+    }
+    impl AsSigned for i32 {
+        type Signed = i32;
+        fn as_signed(self) -> Self::Signed {
+            self
+        }
+    }
+    impl AsSigned for u64 {
+        type Signed = i64;
+        fn as_signed(self) -> Self::Signed {
+            self as _
+        }
+    }
+    impl AsSigned for i64 {
+        type Signed = i64;
+        fn as_signed(self) -> Self::Signed {
+            self
+        }
     }
 }
-impl AsSigned for i32 {
-    type Signed = i32;
-    fn as_signed(self) -> Self::Signed {
-        self
-    }
-}
-impl AsSigned for u64 {
-    type Signed = i64;
-    fn as_signed(self) -> Self::Signed {
-        self as _
-    }
-}
-impl AsSigned for i64 {
-    type Signed = i64;
-    fn as_signed(self) -> Self::Signed {
-        self
-    }
-}
+#[cfg(any(
+    target_pointer_width = "32",
+    target_arch = "mips64",
+    target_arch = "mips64r6"
+))]
+use as_signed::*;

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -763,17 +763,17 @@ fn stat_to_stat(s64: linux_raw_sys::general::stat64) -> io::Result<Stat> {
         st_size: s64.st_size.try_into().map_err(|_| io::Errno::OVERFLOW)?,
         st_blksize: s64.st_blksize.try_into().map_err(|_| io::Errno::OVERFLOW)?,
         st_blocks: s64.st_blocks.try_into().map_err(|_| io::Errno::OVERFLOW)?,
-        st_atime: i64::from(s64.st_atime),
+        st_atime: i64::from(s64.st_atime.as_signed()),
         st_atime_nsec: s64
             .st_atime_nsec
             .try_into()
             .map_err(|_| io::Errno::OVERFLOW)?,
-        st_mtime: i64::from(s64.st_mtime),
+        st_mtime: i64::from(s64.st_mtime.as_signed()),
         st_mtime_nsec: s64
             .st_mtime_nsec
             .try_into()
             .map_err(|_| io::Errno::OVERFLOW)?,
-        st_ctime: i64::from(s64.st_ctime),
+        st_ctime: i64::from(s64.st_ctime.as_signed()),
         st_ctime_nsec: s64
             .st_ctime_nsec
             .try_into()
@@ -795,17 +795,17 @@ fn stat_to_stat(s: linux_raw_sys::general::stat) -> io::Result<Stat> {
         st_size: s.st_size.try_into().map_err(|_| io::Errno::OVERFLOW)?,
         st_blksize: s.st_blksize.try_into().map_err(|_| io::Errno::OVERFLOW)?,
         st_blocks: s.st_blocks.try_into().map_err(|_| io::Errno::OVERFLOW)?,
-        st_atime: i64::from(s.st_atime),
+        st_atime: i64::from(s.st_atime.as_signed()),
         st_atime_nsec: s
             .st_atime_nsec
             .try_into()
             .map_err(|_| io::Errno::OVERFLOW)?,
-        st_mtime: i64::from(s.st_mtime),
+        st_mtime: i64::from(s.st_mtime.as_signed()),
         st_mtime_nsec: s
             .st_mtime_nsec
             .try_into()
             .map_err(|_| io::Errno::OVERFLOW)?,
-        st_ctime: i64::from(s.st_ctime),
+        st_ctime: i64::from(s.st_ctime.as_signed()),
         st_ctime_nsec: s
             .st_ctime_nsec
             .try_into()
@@ -1671,4 +1671,36 @@ fn test_sizes() {
 
     // Assert that `Timestamps` has the expected layout.
     assert_eq_size!([linux_raw_sys::general::__kernel_timespec; 2], Timestamps);
+}
+
+// Some linux_raw_sys structs have unsigned types for values which are
+// interpreted as signed. This defines a utility or casting to the
+// same-sized signed type.
+trait AsSigned {
+    type Signed;
+    fn as_signed(self) -> Self::Signed;
+}
+impl AsSigned for u32 {
+    type Signed = i32;
+    fn as_signed(self) -> Self::Signed {
+        self as _
+    }
+}
+impl AsSigned for i32 {
+    type Signed = i32;
+    fn as_signed(self) -> Self::Signed {
+        self
+    }
+}
+impl AsSigned for u64 {
+    type Signed = i64;
+    fn as_signed(self) -> Self::Signed {
+        self as _
+    }
+}
+impl AsSigned for i64 {
+    type Signed = i64;
+    fn as_signed(self) -> Self::Signed {
+        self
+    }
 }

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -1668,9 +1668,11 @@ pub(crate) fn fremovexattr(fd: BorrowedFd<'_>, name: &CStr) -> io::Result<()> {
 #[test]
 fn test_sizes() {
     assert_eq_size!(linux_raw_sys::general::__kernel_loff_t, u64);
+    assert_eq_align!(linux_raw_sys::general::__kernel_loff_t, u64);
 
     // Assert that `Timestamps` has the expected layout.
     assert_eq_size!([linux_raw_sys::general::__kernel_timespec; 2], Timestamps);
+    assert_eq_align!([linux_raw_sys::general::__kernel_timespec; 2], Timestamps);
 }
 
 // Some linux_raw_sys structs have unsigned types for values which are
@@ -1688,24 +1690,28 @@ mod as_signed {
     }
     impl AsSigned for u32 {
         type Signed = i32;
+
         fn as_signed(self) -> Self::Signed {
             self as _
         }
     }
     impl AsSigned for i32 {
         type Signed = i32;
+
         fn as_signed(self) -> Self::Signed {
             self
         }
     }
     impl AsSigned for u64 {
         type Signed = i64;
+
         fn as_signed(self) -> Self::Signed {
             self as _
         }
     }
     impl AsSigned for i64 {
         type Signed = i64;
+
         fn as_signed(self) -> Self::Signed {
             self
         }

--- a/src/backend/linux_raw/runtime/syscalls.rs
+++ b/src/backend/linux_raw/runtime/syscalls.rs
@@ -247,25 +247,78 @@ pub(crate) unsafe fn kernel_sigtimedwait(
     timeout: Option<&Timespec>,
 ) -> io::Result<Siginfo> {
     let mut info = MaybeUninit::<Siginfo>::uninit();
-    let timeout_arg = opt_ref(timeout);
 
     // `rt_sigtimedwait_time64` was introduced in Linux 5.1. The old
     // `rt_sigtimedwait` syscall is not y2038-compatible on 32-bit
     // architectures.
     #[cfg(target_pointer_width = "32")]
     {
-        match ret_c_int(syscall!(
+        // If we don't have Linux 5.1, and the timeout fits in a
+        // `__kernel_old_timespec`, use plain `rt_sigtimedwait`.
+        //
+        // We do this unconditionally, rather than trying
+        // `rt_sigtimedwait_time64` and falling back on `Errno::NOSYS`, because
+        // seccomp configurations will sometimes abort the process on syscalls
+        // they don't recognize.
+        #[cfg(not(feature = "linux_5_1"))]
+        {
+            // If we don't have a timeout, or if we can convert the timeout to
+            // a `__kernel_old_timespec`, the use `__NR_futex`.
+            fn convert(timeout: &Timespec) -> Option<__kernel_old_timespec> {
+                Some(__kernel_old_timespec {
+                    tv_sec: (*timeout).tv_sec.try_into().ok()?,
+                    tv_nsec: (*timeout).tv_nsec.try_into().ok()?,
+                })
+            }
+            let old_timeout = if let Some(timeout) = timeout {
+                match convert(timeout) {
+                    // Could not convert timeout.
+                    None => None,
+                    // Could convert timeout. Ok!
+                    Some(old_timeout) => Some(Some(old_timeout)),
+                }
+            } else {
+                // No timeout. Ok!
+                Some(None)
+            };
+            if let Some(old_timeout) = old_timeout {
+                return ret_c_int(syscall!(
+                    __NR_rt_sigtimedwait,
+                    by_ref(set),
+                    &mut info,
+                    opt_ref(old_timeout.as_ref()),
+                    size_of::<KernelSigSet, _>()
+                ))
+                .map(|sig| {
+                    debug_assert_eq!(
+                        sig,
+                        info.assume_init_ref()
+                            .__bindgen_anon_1
+                            .__bindgen_anon_1
+                            .si_signo
+                    );
+                    info.assume_init()
+                });
+            }
+        }
+
+        ret_c_int(syscall!(
             __NR_rt_sigtimedwait_time64,
             by_ref(set),
             &mut info,
-            timeout_arg,
+            opt_ref(timeout),
             size_of::<KernelSigSet, _>()
-        )) {
-            Ok(_signum) => (),
-            Err(io::Errno::NOSYS) => kernel_sigtimedwait_old(set, timeout, &mut info)?,
-            Err(err) => return Err(err),
-        }
-        Ok(info.assume_init())
+        ))
+        .map(|sig| {
+            debug_assert_eq!(
+                sig,
+                info.assume_init_ref()
+                    .__bindgen_anon_1
+                    .__bindgen_anon_1
+                    .si_signo
+            );
+            info.assume_init()
+        })
     }
 
     #[cfg(target_pointer_width = "64")]
@@ -274,38 +327,11 @@ pub(crate) unsafe fn kernel_sigtimedwait(
             __NR_rt_sigtimedwait,
             by_ref(set),
             &mut info,
-            timeout_arg,
+            opt_ref(timeout),
             size_of::<KernelSigSet, _>()
         ))?;
         Ok(info.assume_init())
     }
-}
-
-#[cfg(target_pointer_width = "32")]
-unsafe fn kernel_sigtimedwait_old(
-    set: &KernelSigSet,
-    timeout: Option<&Timespec>,
-    info: &mut MaybeUninit<Siginfo>,
-) -> io::Result<()> {
-    let old_timeout = match timeout {
-        Some(timeout) => Some(__kernel_old_timespec {
-            tv_sec: timeout.tv_sec.try_into().map_err(|_| io::Errno::OVERFLOW)?,
-            tv_nsec: timeout.tv_nsec as _,
-        }),
-        None => None,
-    };
-
-    let old_timeout_arg = opt_ref(old_timeout.as_ref());
-
-    let _signum = ret_c_int(syscall!(
-        __NR_rt_sigtimedwait,
-        by_ref(set),
-        info,
-        old_timeout_arg,
-        size_of::<KernelSigSet, _>()
-    ))?;
-
-    Ok(())
 }
 
 #[inline]

--- a/src/backend/linux_raw/runtime/syscalls.rs
+++ b/src/backend/linux_raw/runtime/syscalls.rs
@@ -245,10 +245,10 @@ pub(crate) unsafe fn kernel_sigwaitinfo(set: &KernelSigSet) -> io::Result<Siginf
 #[inline]
 pub(crate) unsafe fn kernel_sigtimedwait(
     set: &KernelSigSet,
-    timeout: Option<Timespec>,
+    timeout: Option<&Timespec>,
 ) -> io::Result<Siginfo> {
     let mut info = MaybeUninit::<Siginfo>::uninit();
-    let timeout_ptr = option_as_ptr(timeout.as_ref());
+    let timeout_ptr = option_as_ptr(timeout);
 
     // `rt_sigtimedwait_time64` was introduced in Linux 5.1. The old
     // `rt_sigtimedwait` syscall is not y2038-compatible on 32-bit
@@ -285,7 +285,7 @@ pub(crate) unsafe fn kernel_sigtimedwait(
 #[cfg(target_pointer_width = "32")]
 unsafe fn kernel_sigtimedwait_old(
     set: &KernelSigSet,
-    timeout: Option<Timespec>,
+    timeout: Option<&Timespec>,
     info: &mut MaybeUninit<Siginfo>,
 ) -> io::Result<()> {
     let old_timeout = match timeout {

--- a/src/backend/linux_raw/thread/syscalls.rs
+++ b/src/backend/linux_raw/thread/syscalls.rs
@@ -223,9 +223,9 @@ pub(crate) unsafe fn futex_val2(
     #[cfg(target_pointer_width = "32")]
     {
         // Linux 5.1 added `futex_time64`; if we have that, use it. We don't
-        // need it, because `timeout` is just passing `val2` and not a real
-        // timeout, but it's nice to `futex_time64` for consistency with the
-        // other futex calls that do.
+        // need it here, because `timeout` is just passing `val2` and not a
+        // real timeout, but it's nice to use `futex_time64` for consistency
+        // with the other futex calls that do.
         #[cfg(feature = "linux_5_1")]
         {
             ret_usize(syscall!(
@@ -240,10 +240,6 @@ pub(crate) unsafe fn futex_val2(
         }
 
         // If we don't have Linux 5.1, use plain `futex`.
-        //
-        // We do this unconditionally, rather than trying `futex_time64` and
-        // falling back on `Errno::NOSYS`, because seccomp configurations will
-        // sometimes abort the process on syscalls they don't recognize.
         #[cfg(not(feature = "linux_5_1"))]
         {
             ret_usize(syscall!(

--- a/src/backend/linux_raw/thread/syscalls.rs
+++ b/src/backend/linux_raw/thread/syscalls.rs
@@ -8,8 +8,8 @@
 use super::types::RawCpuSet;
 use crate::backend::c;
 use crate::backend::conv::{
-    by_mut, by_ref, c_int, c_uint, ret, ret_c_int, ret_c_int_infallible, ret_c_uint, ret_usize,
-    size_of, slice, slice_just_addr, slice_just_addr_mut, zero,
+    by_mut, by_ref, c_int, c_uint, opt_ref, ret, ret_c_int, ret_c_int_infallible, ret_c_uint,
+    ret_usize, size_of, slice, slice_just_addr, slice_just_addr_mut, zero,
 };
 use crate::fd::BorrowedFd;
 use crate::io;
@@ -17,7 +17,7 @@ use crate::pid::Pid;
 use crate::thread::{
     futex, ClockId, Cpuid, MembarrierCommand, MembarrierQuery, NanosleepRelativeResult, Timespec,
 };
-use crate::utils::{as_mut_ptr, option_as_ptr};
+use crate::utils::as_mut_ptr;
 use core::mem::MaybeUninit;
 use core::sync::atomic::AtomicU32;
 #[cfg(target_pointer_width = "32")]
@@ -317,7 +317,7 @@ pub(crate) unsafe fn futex_timeout(
                     uaddr,
                     (op, flags),
                     c_uint(val),
-                    option_as_ptr(old_timeout.as_ref()),
+                    opt_ref(old_timeout.as_ref()),
                     uaddr2,
                     c_uint(val3)
                 ));
@@ -332,7 +332,7 @@ pub(crate) unsafe fn futex_timeout(
             uaddr,
             (op, flags),
             c_uint(val),
-            option_as_ptr(timeout),
+            opt_ref(timeout),
             uaddr2,
             c_uint(val3)
         ))
@@ -343,7 +343,7 @@ pub(crate) unsafe fn futex_timeout(
         uaddr,
         (op, flags),
         c_uint(val),
-        option_as_ptr(timeout),
+        opt_ref(timeout),
         uaddr2,
         c_uint(val3)
     ))
@@ -363,7 +363,7 @@ pub(crate) fn futex_waitv(
             waiters_addr,
             waiters_len,
             c_uint(flags.bits()),
-            option_as_ptr(timeout),
+            opt_ref(timeout),
             clockid
         ))
     }

--- a/src/backend/linux_raw/vdso.rs
+++ b/src/backend/linux_raw/vdso.rs
@@ -440,7 +440,9 @@ fn test_vdso() {
         let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
         #[cfg(target_arch = "riscv64")]
         let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_clock_gettime"));
-        #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
+        #[cfg(target_arch = "powerpc")]
+        let _ptr = vdso.sym(cstr!("LINUX_5.11"), cstr!("__kernel_clock_gettime64"));
+        #[cfg(target_arch = "powerpc64")]
         let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_clock_gettime"));
         #[cfg(target_arch = "s390x")]
         let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_clock_gettime"));
@@ -449,6 +451,11 @@ fn test_vdso() {
         #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
         let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime"));
 
+        // On PowerPC, "__kernel_clock_gettime64" isn't available in
+        // Linux < 5.11.
+        // On x86, "__vdso_clock_gettime64" isn't available in
+        // Linux < 5.3.
+        #[cfg(not(any(target_arch = "powerpc", target_arch = "x86")))]
         assert!(!ptr.is_null());
     }
 
@@ -472,6 +479,8 @@ fn test_vdso() {
         #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
         let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_getres"));
 
+        // Some versions of Linux appear to lack "__vdso_clock_getres" on x86.
+        #[cfg(not(target_arch = "x86"))]
         assert!(!ptr.is_null());
     }
 
@@ -486,10 +495,8 @@ fn test_vdso() {
         let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
         #[cfg(target_arch = "riscv64")]
         let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_gettimeofday"));
-        #[cfg(target_arch = "powerpc")]
-        let _ptr = vdso.sym(cstr!("LINUX_5.11"), cstr!("__kernel_clock_gettime64"));
-        #[cfg(target_arch = "powerpc64")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_clock_gettime"));
+        #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
+        let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_gettimeofday"));
         #[cfg(target_arch = "s390x")]
         let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_gettimeofday"));
         #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
@@ -497,9 +504,8 @@ fn test_vdso() {
         #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
         let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
 
-        // On PowerPC, "__kernel_clock_gettime64" isn't available in
-        // Linux < 5.11.
-        #[cfg(not(target_arch = "powerpc"))]
+        // Some versions of Linux appear to lack "__vdso_gettimeofday" on x86.
+        #[cfg(not(target_arch = "x86"))]
         assert!(!ptr.is_null());
     }
 
@@ -507,6 +513,7 @@ fn test_vdso() {
         target_arch = "x86_64",
         target_arch = "x86",
         target_arch = "riscv64",
+        target_arch = "powerpc",
         target_arch = "powerpc64",
         target_arch = "s390x",
     ))]
@@ -517,11 +524,16 @@ fn test_vdso() {
         let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_getcpu"));
         #[cfg(target_arch = "riscv64")]
         let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_getcpu"));
+        #[cfg(target_arch = "powerpc")]
+        let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_getcpu"));
         #[cfg(target_arch = "powerpc64")]
         let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_getcpu"));
         #[cfg(target_arch = "s390x")]
         let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_getcpu"));
 
+        // On PowerPC, "__kernel_getcpu" isn't available in 32-bit kernels.
+        // Some versions of Linux appear to lack "__vdso_getcpu" on x86.
+        #[cfg(not(any(target_arch = "powerpc", target_arch = "x86")))]
         assert!(!ptr.is_null());
     }
 }

--- a/src/backend/linux_raw/vdso.rs
+++ b/src/backend/linux_raw/vdso.rs
@@ -424,6 +424,7 @@ impl Vdso {
 #[cfg(linux_raw)]
 #[test]
 #[cfg_attr(any(target_arch = "mips", target_arch = "mips64"), ignore)]
+#[allow(unused_variables)]
 fn test_vdso() {
     let vdso = Vdso::new().unwrap();
     assert!(!vdso.symtab.is_null());

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -720,7 +720,7 @@ pub unsafe fn kernel_sigwaitinfo(set: &KernelSigSet) -> io::Result<Siginfo> {
 #[inline]
 pub unsafe fn kernel_sigtimedwait(
     set: &KernelSigSet,
-    timeout: Option<Timespec>,
+    timeout: Option<&Timespec>,
 ) -> io::Result<Siginfo> {
     backend::runtime::syscalls::kernel_sigtimedwait(set, timeout)
 }

--- a/src/timespec.rs
+++ b/src/timespec.rs
@@ -386,7 +386,6 @@ fn test_sizes() {
 #[allow(deprecated)]
 fn test_fix_y2038() {
     assert_eq_size!(libc::time_t, u32);
-    assert_eq_align!(libc::time_t, Timespec);
 }
 
 // Test that our workarounds are not needed.

--- a/tests/event/epoll_timeout.rs
+++ b/tests/event/epoll_timeout.rs
@@ -3,7 +3,7 @@ use rustix::event::{epoll, Timespec};
 use std::time::Instant;
 
 #[test]
-fn epoll_timeout() {
+fn epoll_timeout_nsecs() {
     let epoll_fd = epoll::create(epoll::CreateFlags::CLOEXEC).unwrap();
 
     let start = Instant::now();
@@ -23,4 +23,25 @@ fn epoll_timeout() {
     assert!(
         duration.as_secs() > 0 || (duration.as_secs() == 0 && duration.subsec_nanos() >= 1_000_000)
     );
+}
+
+#[test]
+fn epoll_timeout_secs() {
+    let epoll_fd = epoll::create(epoll::CreateFlags::CLOEXEC).unwrap();
+
+    let start = Instant::now();
+    let mut events = Vec::with_capacity(1);
+    epoll::wait(
+        &epoll_fd,
+        spare_capacity(&mut events),
+        Some(&Timespec {
+            tv_sec: 1,
+            tv_nsec: 0,
+        }),
+    )
+    .unwrap();
+
+    let duration = start.elapsed();
+
+    assert!(duration.as_secs() >= 1);
 }

--- a/tests/thread/futex.rs
+++ b/tests/thread/futex.rs
@@ -157,7 +157,7 @@ fn test_wait_timeout() {
         &lock,
         futex::Flags::empty(),
         0,
-        Some(Timespec {
+        Some(&Timespec {
             tv_sec: 1,
             tv_nsec: 13,
         }),
@@ -169,7 +169,7 @@ fn test_wait_timeout() {
         &lock,
         futex::Flags::empty(),
         0,
-        Some(Timespec {
+        Some(&Timespec {
             tv_sec: 0,
             tv_nsec: 1_000_000_000,
         }),
@@ -181,7 +181,7 @@ fn test_wait_timeout() {
         &lock,
         futex::Flags::empty(),
         0,
-        Some(Timespec {
+        Some(&Timespec {
             tv_sec: -1,
             tv_nsec: 0,
         }),


### PR DESCRIPTION
Some Linux `stat64` structs are defined with `st_atime`, `st_mtime`, and `st_ctime` fields using unsigned types, even though they hold signed values. Convert them to signed before converting them to `i64`, so that they're signed-extended.

This fixes test failures on old 32-bit Linux platforms which lack `statx`.

Also, fix handling of timestamps on 32-bit Linux platforms in select, poll, epoll, and futex.