### PR TITLE
Miscellaneous clippy fixes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,14 @@ them with field values and `..Default::default()`, construct them with
 
 [`rustix::io_uring`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/index.html
 
+[`rustix::process::Resource`], [`rustix::thread::MembarrierCommand`], and
+[`rustix::thread::Capability`] are now marked `#[non_exhaustive]` to ease
+migration in case new constants are defined in the future.
+
+[`rustix::process::Resource`]: https://docs.rs/rustix/1.0.0/rustix/process/enum.Resource.html
+[`rustix::thread::MembarrierCommand`]: https://docs.rs/rustix/1.0.0/rustix/thread/enum.MembarrierCommand.html
+[`rustix::thread::Capability`]: https://docs.rs/rustix/1.0.0/rustix/thread/enum.Capability.html
+
 `rustix::process::WaitidOptions` and `rustix::process::WaitidStatus` are
 renamed to
 [`rustix::process::WaitIdOptions`] and [`rustix::process::WaitIdStatus`] (note

--- a/src/backend/libc/process/types.rs
+++ b/src/backend/libc/process/types.rs
@@ -24,6 +24,7 @@ use crate::backend::c;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(target_os = "l4re"), repr(u32))]
 #[cfg_attr(target_os = "l4re", repr(u64))]
+#[non_exhaustive]
 pub enum Resource {
     /// `RLIMIT_CPU`
     Cpu = bitcast!(c::RLIMIT_CPU),

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -631,11 +631,8 @@ unsafe fn futex_old_timespec(
 
     let old_timeout = if let Some(timeout) = timeout {
         Some(linux_raw_sys::general::__kernel_old_timespec {
-            tv_sec: (*timeout).tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
-            tv_nsec: (*timeout)
-                .tv_nsec
-                .try_into()
-                .map_err(|_| io::Errno::INVAL)?,
+            tv_sec: timeout.tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
+            tv_nsec: timeout.tv_nsec.try_into().map_err(|_| io::Errno::INVAL)?,
         })
     } else {
         None

--- a/src/backend/libc/thread/types.rs
+++ b/src/backend/libc/thread/types.rs
@@ -14,6 +14,7 @@ use crate::backend::c;
 #[cfg(linux_kernel)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum MembarrierCommand {
     /// `MEMBARRIER_CMD_GLOBAL`
     #[doc(alias = "Shared")]

--- a/src/backend/linux_raw/event/syscalls.rs
+++ b/src/backend/linux_raw/event/syscalls.rs
@@ -35,8 +35,8 @@ pub(crate) fn poll(fds: &mut [PollFd<'_>], timeout: Option<&Timespec>) -> io::Re
             // a `__kernel_old_timespec`, the use `__NR_ppoll`.
             fn convert(timeout: &Timespec) -> Option<__kernel_old_timespec> {
                 Some(__kernel_old_timespec {
-                    tv_sec: (*timeout).tv_sec.try_into().ok()?,
-                    tv_nsec: (*timeout).tv_nsec.try_into().ok()?,
+                    tv_sec: timeout.tv_sec.try_into().ok()?,
+                    tv_nsec: timeout.tv_nsec.try_into().ok()?,
                 })
             }
             let old_timeout = if let Some(timeout) = timeout {
@@ -151,8 +151,8 @@ pub(crate) unsafe fn select(
             // a `__kernel_old_timespec`, the use `__NR_pselect6`.
             fn convert(timeout: &Timespec) -> Option<__kernel_old_timespec> {
                 Some(__kernel_old_timespec {
-                    tv_sec: (*timeout).tv_sec.try_into().ok()?,
-                    tv_nsec: (*timeout).tv_nsec.try_into().ok()?,
+                    tv_sec: timeout.tv_sec.try_into().ok()?,
+                    tv_nsec: timeout.tv_nsec.try_into().ok()?,
                 })
             }
             let old_timeout = if let Some(timeout) = timeout {

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -763,17 +763,17 @@ fn stat_to_stat(s64: linux_raw_sys::general::stat64) -> io::Result<Stat> {
         st_size: s64.st_size.try_into().map_err(|_| io::Errno::OVERFLOW)?,
         st_blksize: s64.st_blksize.try_into().map_err(|_| io::Errno::OVERFLOW)?,
         st_blocks: s64.st_blocks.try_into().map_err(|_| io::Errno::OVERFLOW)?,
-        st_atime: i64::from(s64.st_atime.as_signed()),
+        st_atime: i64::from(s64.st_atime.to_signed()),
         st_atime_nsec: s64
             .st_atime_nsec
             .try_into()
             .map_err(|_| io::Errno::OVERFLOW)?,
-        st_mtime: i64::from(s64.st_mtime.as_signed()),
+        st_mtime: i64::from(s64.st_mtime.to_signed()),
         st_mtime_nsec: s64
             .st_mtime_nsec
             .try_into()
             .map_err(|_| io::Errno::OVERFLOW)?,
-        st_ctime: i64::from(s64.st_ctime.as_signed()),
+        st_ctime: i64::from(s64.st_ctime.to_signed()),
         st_ctime_nsec: s64
             .st_ctime_nsec
             .try_into()
@@ -795,17 +795,17 @@ fn stat_to_stat(s: linux_raw_sys::general::stat) -> io::Result<Stat> {
         st_size: s.st_size.try_into().map_err(|_| io::Errno::OVERFLOW)?,
         st_blksize: s.st_blksize.try_into().map_err(|_| io::Errno::OVERFLOW)?,
         st_blocks: s.st_blocks.try_into().map_err(|_| io::Errno::OVERFLOW)?,
-        st_atime: i64::from(s.st_atime.as_signed()),
+        st_atime: i64::from(s.st_atime.to_signed()),
         st_atime_nsec: s
             .st_atime_nsec
             .try_into()
             .map_err(|_| io::Errno::OVERFLOW)?,
-        st_mtime: i64::from(s.st_mtime.as_signed()),
+        st_mtime: i64::from(s.st_mtime.to_signed()),
         st_mtime_nsec: s
             .st_mtime_nsec
             .try_into()
             .map_err(|_| io::Errno::OVERFLOW)?,
-        st_ctime: i64::from(s.st_ctime.as_signed()),
+        st_ctime: i64::from(s.st_ctime.to_signed()),
         st_ctime_nsec: s
             .st_ctime_nsec
             .try_into()
@@ -1683,36 +1683,36 @@ fn test_sizes() {
     target_arch = "mips64",
     target_arch = "mips64r6"
 ))]
-mod as_signed {
-    pub(super) trait AsSigned {
+mod to_signed {
+    pub(super) trait ToSigned {
         type Signed;
-        fn as_signed(self) -> Self::Signed;
+        fn to_signed(self) -> Self::Signed;
     }
-    impl AsSigned for u32 {
+    impl ToSigned for u32 {
         type Signed = i32;
 
-        fn as_signed(self) -> Self::Signed {
+        fn to_signed(self) -> Self::Signed {
             self as _
         }
     }
-    impl AsSigned for i32 {
+    impl ToSigned for i32 {
         type Signed = i32;
 
-        fn as_signed(self) -> Self::Signed {
+        fn to_signed(self) -> Self::Signed {
             self
         }
     }
-    impl AsSigned for u64 {
+    impl ToSigned for u64 {
         type Signed = i64;
 
-        fn as_signed(self) -> Self::Signed {
+        fn to_signed(self) -> Self::Signed {
             self as _
         }
     }
-    impl AsSigned for i64 {
+    impl ToSigned for i64 {
         type Signed = i64;
 
-        fn as_signed(self) -> Self::Signed {
+        fn to_signed(self) -> Self::Signed {
             self
         }
     }
@@ -1722,4 +1722,4 @@ mod as_signed {
     target_arch = "mips64",
     target_arch = "mips64r6"
 ))]
-use as_signed::*;
+use to_signed::*;

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -103,7 +103,7 @@ impl SocketAddrUnix {
         if !bytes.is_empty() && bytes[0] != 0 {
             if self.unix.sun_path.len() == bytes.len() {
                 // SAFETY: no NULs are contained in bytes
-                unsafe { self.path_with_termination(bytes) }
+                unsafe { Self::path_with_termination(bytes) }
             } else {
                 // SAFETY: `from_bytes_with_nul_unchecked` since the string is
                 // NUL-terminated.
@@ -118,7 +118,8 @@ impl SocketAddrUnix {
     ///
     /// SAFETY: the input `bytes` must not contain any NULs
     #[cfg(feature = "alloc")]
-    unsafe fn path_with_termination(&self, bytes: &[u8]) -> Option<Cow<'_, CStr>> {
+    #[cold]
+    unsafe fn path_with_termination(bytes: &[u8]) -> Option<Cow<'_, CStr>> {
         let mut owned = Vec::with_capacity(bytes.len() + 1);
         owned.extend_from_slice(bytes);
         owned.push(b'\0');

--- a/src/backend/linux_raw/process/types.rs
+++ b/src/backend/linux_raw/process/types.rs
@@ -6,6 +6,7 @@
 /// [`prlimit`]: crate::process::prlimit
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum Resource {
     /// `RLIMIT_CPU`
     Cpu = linux_raw_sys::general::RLIMIT_CPU,

--- a/src/backend/linux_raw/runtime/syscalls.rs
+++ b/src/backend/linux_raw/runtime/syscalls.rs
@@ -26,7 +26,7 @@ use crate::signal::Signal;
 use crate::timespec::Timespec;
 use core::ffi::c_void;
 use core::mem::MaybeUninit;
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(target_pointer_width = "32", not(feature = "linux_5_1")))]
 use linux_raw_sys::general::__kernel_old_timespec;
 #[cfg(target_arch = "x86_64")]
 use linux_raw_sys::general::ARCH_SET_FS;
@@ -266,8 +266,8 @@ pub(crate) unsafe fn kernel_sigtimedwait(
             // a `__kernel_old_timespec`, the use `__NR_futex`.
             fn convert(timeout: &Timespec) -> Option<__kernel_old_timespec> {
                 Some(__kernel_old_timespec {
-                    tv_sec: (*timeout).tv_sec.try_into().ok()?,
-                    tv_nsec: (*timeout).tv_nsec.try_into().ok()?,
+                    tv_sec: timeout.tv_sec.try_into().ok()?,
+                    tv_nsec: timeout.tv_nsec.try_into().ok()?,
                 })
             }
             let old_timeout = if let Some(timeout) = timeout {

--- a/src/backend/linux_raw/thread/syscalls.rs
+++ b/src/backend/linux_raw/thread/syscalls.rs
@@ -292,8 +292,8 @@ pub(crate) unsafe fn futex_timeout(
             // a `__kernel_old_timespec`, the use `__NR_futex`.
             fn convert(timeout: &Timespec) -> Option<__kernel_old_timespec> {
                 Some(__kernel_old_timespec {
-                    tv_sec: (*timeout).tv_sec.try_into().ok()?,
-                    tv_nsec: (*timeout).tv_nsec.try_into().ok()?,
+                    tv_sec: timeout.tv_sec.try_into().ok()?,
+                    tv_nsec: timeout.tv_nsec.try_into().ok()?,
                 })
             }
             let old_timeout = if let Some(timeout) = timeout {

--- a/src/backend/linux_raw/thread/types.rs
+++ b/src/backend/linux_raw/thread/types.rs
@@ -9,6 +9,7 @@ use linux_raw_sys::general::membarrier_cmd;
 /// [`membarrier_query`]: crate::thread::membarrier_query
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum MembarrierCommand {
     /// `MEMBARRIER_CMD_GLOBAL`
     #[doc(alias = "Shared")]

--- a/src/io_uring/mod.rs
+++ b/src/io_uring/mod.rs
@@ -1786,6 +1786,7 @@ pub struct iovec {
 #[allow(missing_docs)]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Default)]
+#[non_exhaustive]
 pub struct open_how {
     /// An [`OFlags`] value represented as a `u64`.
     pub flags: u64,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -63,6 +63,7 @@ pub use crate::{kernel_sigset::KernelSigSet, signal::Signal};
 ///
 /// This type does not have the same layout as `libc::sigaction`.
 #[cfg(linux_raw)]
+#[allow(missing_docs)]
 #[derive(Debug, Default, Clone)]
 #[repr(C)]
 pub struct KernelSigaction {

--- a/src/thread/prctl.rs
+++ b/src/thread/prctl.rs
@@ -180,6 +180,7 @@ const PR_CAPBSET_READ: c_int = 23;
 /// Linux per-thread capability.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum Capability {
     /// In a system with the `_POSIX_CHOWN_RESTRICTED` option defined, this
     /// overrides the restriction of changing file ownership and group


### PR DESCRIPTION
Add `#[non_exhaustive]` to several more types, for better future evolution.