### PR TITLE
Write some more tests.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,14 @@ the functions in the [`rustix::thread::futex`] module instead.
 
 [`rustix::process::waitpid`]: https://docs.rs/rustix/1.0.0/rustix/process/fn.waitpid.html
 
+[`terminating_signal`] and other functions in [`rustix::process::WaitStatus`] changed
+from returning `u32` to returning `i32`, for better compatibility with the new
+[`Signal`] type.
+
+[`terminating_signal`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.WaitStatus.html#method.terminating_signal
+[`rustix::process::WaitStatus`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.WaitStatus.html
+[`Signal`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.Signal.html
+
 The `SLAVE` flag in [`rustix::mount::MountPropagationFlags`] is renamed to
 [`DOWNSTREAM`].
 

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -115,7 +115,7 @@ impl WaitStatus {
     /// Returns the number of the signal that stopped the process, if the
     /// process was stopped by a signal.
     #[inline]
-    pub fn stopping_signal(self) -> Option<u32> {
+    pub fn stopping_signal(self) -> Option<i32> {
         if self.stopped() {
             Some(backend::process::wait::WSTOPSIG(self.0 as _) as _)
         } else {
@@ -137,7 +137,7 @@ impl WaitStatus {
     /// Returns the number of the signal that terminated the process, if the
     /// process was terminated by a signal.
     #[inline]
-    pub fn terminating_signal(self) -> Option<u32> {
+    pub fn terminating_signal(self) -> Option<i32> {
         if self.signaled() {
             Some(backend::process::wait::WTERMSIG(self.0 as _) as _)
         } else {
@@ -215,7 +215,7 @@ impl WaitIdStatus {
     /// process was stopped by a signal.
     #[inline]
     #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
-    pub fn stopping_signal(&self) -> Option<u32> {
+    pub fn stopping_signal(&self) -> Option<i32> {
         if self.stopped() {
             Some(self.si_status() as _)
         } else {
@@ -227,7 +227,7 @@ impl WaitIdStatus {
     /// process was trapped by a signal.
     #[inline]
     #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
-    pub fn trapping_signal(&self) -> Option<u32> {
+    pub fn trapping_signal(&self) -> Option<i32> {
         if self.trapped() {
             Some(self.si_status() as _)
         } else {
@@ -251,7 +251,7 @@ impl WaitIdStatus {
     /// process was terminated by a signal.
     #[inline]
     #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
-    pub fn terminating_signal(&self) -> Option<u32> {
+    pub fn terminating_signal(&self) -> Option<i32> {
         if self.killed() || self.dumped() {
             Some(self.si_status() as _)
         } else {

--- a/tests/process/pidfd.rs
+++ b/tests/process/pidfd.rs
@@ -1,6 +1,6 @@
 //! Tests for the `pidfd` type.
 
-use libc::{kill, SIGSTOP};
+use libc::{kill, SIGCONT, SIGINT, SIGSTOP};
 #[cfg(feature = "event")]
 use rustix::event;
 use rustix::fd::AsFd as _;
@@ -24,7 +24,7 @@ fn test_pidfd_waitid() {
         Ok(pidfd) => pidfd,
         Err(io::Errno::NOSYS) => {
             // The kernel does not support pidfds.
-            unsafe { kill(child.id() as _, SIGSTOP) };
+            unsafe { kill(child.id() as _, SIGINT) };
             return;
         }
         Err(e) => panic!("failed to open pidfd: {}", e),
@@ -40,8 +40,154 @@ fn test_pidfd_waitid() {
     .expect("failed to wait")
     .unwrap();
 
-    // TODO
-    let _ = status;
+    assert!(status.stopped());
+    assert!(!status.exited());
+    assert!(!status.killed());
+    assert!(!status.trapped());
+    assert!(!status.dumped());
+    assert!(!status.continued());
+
+    assert_eq!(
+        status.stopping_signal(),
+        Some(process::Signal::STOP.as_raw())
+    );
+    assert_eq!(status.trapping_signal(), None);
+    assert_eq!(status.exit_status(), None);
+    assert_eq!(status.terminating_signal(), None);
+
+    unsafe { kill(child.id() as _, SIGCONT) };
+
+    let status = process::waitid(
+        process::WaitId::PidFd(pidfd.as_fd()),
+        process::WaitIdOptions::CONTINUED,
+    )
+    .expect("failed to wait")
+    .unwrap();
+
+    assert!(!status.stopped());
+    assert!(!status.exited());
+    assert!(!status.killed());
+    assert!(!status.trapped());
+    assert!(!status.dumped());
+    assert!(status.continued());
+
+    assert_eq!(status.stopping_signal(), None);
+    assert_eq!(status.trapping_signal(), None);
+    assert_eq!(status.exit_status(), None);
+    assert_eq!(status.terminating_signal(), None);
+
+    unsafe { kill(child.id() as _, SIGINT) };
+
+    let status = process::waitid(
+        process::WaitId::PidFd(pidfd.as_fd()),
+        process::WaitIdOptions::EXITED,
+    )
+    .expect("failed to wait")
+    .unwrap();
+
+    assert!(!status.stopped());
+    assert!(!status.exited());
+    assert!(status.killed());
+    assert!(!status.trapped());
+    assert!(!status.dumped());
+    assert!(!status.continued());
+
+    assert_eq!(status.stopping_signal(), None);
+    assert_eq!(status.trapping_signal(), None);
+    assert_eq!(status.exit_status(), None);
+    assert_eq!(status.terminating_signal(), Some(SIGINT));
+}
+
+// Similar to `test_pidfd_waitid`, but use `pidfd_send_signal` to send the
+// signals.
+#[test]
+#[serial]
+fn test_pidfd_send_signal() {
+    // Create a new process.
+    let child = Command::new("yes")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to execute child");
+
+    // Create a pidfd for the child process.
+    let pid = process::Pid::from_child(&child);
+    let pidfd = match process::pidfd_open(pid, process::PidfdFlags::empty()) {
+        Ok(pidfd) => pidfd,
+        Err(io::Errno::NOSYS) => {
+            // The kernel does not support pidfds.
+            process::kill_process(process::Pid::from_child(&child), process::Signal::INT).unwrap();
+            return;
+        }
+        Err(e) => panic!("failed to open pidfd: {}", e),
+    };
+
+    // Wait for the child process to stop.
+    process::pidfd_send_signal(&pidfd, process::Signal::STOP).unwrap();
+
+    let status = process::waitid(
+        process::WaitId::PidFd(pidfd.as_fd()),
+        process::WaitIdOptions::STOPPED,
+    )
+    .expect("failed to wait")
+    .unwrap();
+
+    assert!(status.stopped());
+    assert!(!status.exited());
+    assert!(!status.killed());
+    assert!(!status.trapped());
+    assert!(!status.dumped());
+    assert!(!status.continued());
+
+    assert_eq!(
+        status.stopping_signal(),
+        Some(process::Signal::STOP.as_raw())
+    );
+    assert_eq!(status.trapping_signal(), None);
+    assert_eq!(status.exit_status(), None);
+    assert_eq!(status.terminating_signal(), None);
+
+    process::pidfd_send_signal(&pidfd, process::Signal::CONT).unwrap();
+
+    let status = process::waitid(
+        process::WaitId::PidFd(pidfd.as_fd()),
+        process::WaitIdOptions::CONTINUED,
+    )
+    .expect("failed to wait")
+    .unwrap();
+
+    assert!(!status.stopped());
+    assert!(!status.exited());
+    assert!(!status.killed());
+    assert!(!status.trapped());
+    assert!(!status.dumped());
+    assert!(status.continued());
+
+    assert_eq!(status.stopping_signal(), None);
+    assert_eq!(status.trapping_signal(), None);
+    assert_eq!(status.exit_status(), None);
+    assert_eq!(status.terminating_signal(), None);
+
+    process::pidfd_send_signal(&pidfd, process::Signal::INT).unwrap();
+
+    let status = process::waitid(
+        process::WaitId::PidFd(pidfd.as_fd()),
+        process::WaitIdOptions::EXITED,
+    )
+    .expect("failed to wait")
+    .unwrap();
+
+    assert!(!status.stopped());
+    assert!(!status.exited());
+    assert!(status.killed());
+    assert!(!status.trapped());
+    assert!(!status.dumped());
+    assert!(!status.continued());
+
+    assert_eq!(status.stopping_signal(), None);
+    assert_eq!(status.trapping_signal(), None);
+    assert_eq!(status.exit_status(), None);
+    assert_eq!(status.terminating_signal(), Some(SIGINT));
 }
 
 #[cfg(feature = "event")]
@@ -62,6 +208,7 @@ fn test_pidfd_poll() {
         Ok(pidfd) => pidfd,
         Err(io::Errno::NOSYS) | Err(io::Errno::INVAL) => {
             // The kernel does not support non-blocking pidfds.
+            process::kill_process(process::Pid::from_child(&child), process::Signal::INT).unwrap();
             return;
         }
         Err(e) => panic!("failed to open pidfd: {}", e),
@@ -89,6 +236,15 @@ fn test_pidfd_poll() {
     .expect("failed to wait")
     .unwrap();
 
-    // TODO
-    let _ = status;
+    assert!(!status.stopped());
+    assert!(status.exited());
+    assert!(!status.killed());
+    assert!(!status.trapped());
+    assert!(!status.dumped());
+    assert!(!status.continued());
+
+    assert_eq!(status.stopping_signal(), None);
+    assert_eq!(status.trapping_signal(), None);
+    assert_eq!(status.exit_status(), Some(0));
+    assert_eq!(status.terminating_signal(), None);
 }

--- a/tests/rand/getrandom.rs
+++ b/tests/rand/getrandom.rs
@@ -4,7 +4,8 @@ use rustix::rand::{getrandom, GetRandomFlags};
 #[test]
 fn test_getrandom() {
     let mut buf = [0_u8; 256];
-    let _ = getrandom(&mut buf, GetRandomFlags::empty());
+    let len = getrandom(&mut buf, GetRandomFlags::empty()).unwrap();
+    assert!(len <= buf.len());
 }
 
 #[test]

--- a/tests/time/monotonic.rs
+++ b/tests/time/monotonic.rs
@@ -43,3 +43,31 @@ fn test_monotonic_clock_with_sleep_1ms() {
     assert!(b.tv_sec >= a.tv_sec);
     assert!(b.tv_sec != a.tv_sec || b.tv_nsec > a.tv_nsec);
 }
+
+#[test]
+fn test_monotonic_clock_vs_libc() {
+    let mut before = unsafe { core::mem::zeroed::<libc::timespec>() };
+    let r = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut before) };
+    assert_eq!(r, 0);
+
+    let a = clock_gettime(ClockId::Monotonic);
+
+    // Test that the timespec is valid.
+    assert!(a.tv_nsec < 1_000_000_000);
+
+    let mut after = unsafe { core::mem::zeroed::<libc::timespec>() };
+    let r = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut after) };
+    assert_eq!(r, 0);
+
+    let before = Timespec {
+        tv_sec: before.tv_sec.try_into().unwrap(),
+        tv_nsec: before.tv_nsec.try_into().unwrap(),
+    };
+    let after = Timespec {
+        tv_sec: after.tv_sec.try_into().unwrap(),
+        tv_nsec: after.tv_nsec.try_into().unwrap(),
+    };
+
+    assert!(before <= a);
+    assert!(a <= after);
+}

--- a/tests/time/wall.rs
+++ b/tests/time/wall.rs
@@ -1,9 +1,29 @@
-use rustix::time::{clock_gettime, ClockId};
+use rustix::time::{clock_gettime, ClockId, Timespec};
 
 #[test]
 fn test_wall_clock() {
+    let mut before = unsafe { core::mem::zeroed::<libc::timespec>() };
+    let r = unsafe { libc::clock_gettime(libc::CLOCK_REALTIME, &mut before) };
+    assert_eq!(r, 0);
+
     let a = clock_gettime(ClockId::Realtime);
 
-    // Test that the timespec is valid; there's not much else we can say.
+    // Test that the timespec is valid.
     assert!(a.tv_nsec < 1_000_000_000);
+
+    let mut after = unsafe { core::mem::zeroed::<libc::timespec>() };
+    let r = unsafe { libc::clock_gettime(libc::CLOCK_REALTIME, &mut after) };
+    assert_eq!(r, 0);
+
+    let before = Timespec {
+        tv_sec: before.tv_sec.try_into().unwrap(),
+        tv_nsec: before.tv_nsec.try_into().unwrap(),
+    };
+    let after = Timespec {
+        tv_sec: after.tv_sec.try_into().unwrap(),
+        tv_nsec: after.tv_nsec.try_into().unwrap(),
+    };
+
+    assert!(before <= a);
+    assert!(a <= after);
 }


### PR DESCRIPTION
Write some more tests for `pidfd_*`, `clock_gettime`, and `getrandom`. This turned up that the accessors on `WaitStatus` that return signal numbers should return `i32` instead of `u32`.