### PR TITLE
Add a `zeroed` constructor for `io_uring::open_at`.

### DIFF
--- a/src/io_uring/mod.rs
+++ b/src/io_uring/mod.rs
@@ -1797,6 +1797,17 @@ pub struct open_how {
     pub resolve: ResolveFlags,
 }
 
+impl open_how {
+    /// Create a zero-initialized `Self`.
+    pub const fn zeroed() -> Self {
+        Self {
+            flags: 0,
+            mode: 0,
+            resolve: ResolveFlags::empty(),
+        }
+    }
+}
+
 #[allow(missing_docs)]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Default)]


### PR DESCRIPTION
Now that it's `non_exhaustive`, it's covenient to have a constructor that allows creating fully-defaulted values in `const` contexts.