### PR TITLE
Fix the size of `FdSetElement` on 32-bit Windows.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,7 @@ jobs:
         sparcv9-sun-solaris
         aarch64-linux-android
         aarch64-apple-ios
+        i686-pc-windows-msvc
     - if: matrix.rust != '1.63'
       run: >
         rustup target add
@@ -132,6 +133,7 @@ jobs:
     - run: cargo check --workspace --release -vv --target=sparcv9-sun-solaris --features=all-apis --all-targets
     - run: cargo check --workspace --release -vv --target=aarch64-apple-ios --features=all-apis --all-targets
     - run: cargo check --workspace --release -vv --target=aarch64-linux-android --features=all-apis --all-targets
+    - run: cargo check --workspace --release -vv --target=i686-pc-windows-msvc --features=all-apis --all-targets
 
   check_no_default_features:
     name: Check --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,10 @@ memoffset = "0.9.0"
 flate2 = "1.0"
 static_assertions = "1.1.0"
 
+# With Rust 1.70 this can be removed in favor of `std::sync::OnceLock`.
+[target.'cfg(windows)'.dev-dependencies]
+once_cell = "1.20.3"
+
 [target.'cfg(all(criterion, not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]
 criterion = "0.4"
 

--- a/src/backend/libc/mod.rs
+++ b/src/backend/libc/mod.rs
@@ -79,11 +79,11 @@ pub(crate) mod fd {
     /// [`AsFd`]: https://doc.rust-lang.org/stable/std/os/fd/trait.AsFd.html
     pub trait AsFd {
         /// An `as_fd` function for Winsock, where an `Fd` is a `Socket`.
-        fn as_fd(&self) -> BorrowedFd;
+        fn as_fd(&self) -> BorrowedFd<'_>;
     }
     impl<T: AsSocket> AsFd for T {
         #[inline]
-        fn as_fd(&self) -> BorrowedFd {
+        fn as_fd(&self) -> BorrowedFd<'_> {
             self.as_socket()
         }
     }

--- a/src/backend/libc/net/sockopt.rs
+++ b/src/backend/libc/net/sockopt.rs
@@ -1002,7 +1002,7 @@ pub(crate) fn tcp_congestion(fd: BorrowedFd<'_>) -> io::Result<String> {
     unsafe {
         let value = value.assume_init();
         let slice: &[u8] = core::mem::transmute(&value[..optlen as usize]);
-        assert!(slice.iter().any(|b| *b == b'\0'));
+        assert!(slice.contains(&b'\0'));
         Ok(
             core::str::from_utf8(CStr::from_ptr(slice.as_ptr().cast()).to_bytes())
                 .unwrap()

--- a/src/backend/linux_raw/net/sockopt.rs
+++ b/src/backend/linux_raw/net/sockopt.rs
@@ -809,7 +809,7 @@ pub(crate) fn tcp_congestion(fd: BorrowedFd<'_>) -> io::Result<String> {
     unsafe {
         let value = value.assume_init();
         let slice: &[u8] = core::mem::transmute(&value[..optlen as usize]);
-        assert!(slice.iter().any(|b| *b == b'\0'));
+        assert!(slice.contains(&b'\0'));
         Ok(
             core::str::from_utf8(CStr::from_ptr(slice.as_ptr().cast()).to_bytes())
                 .unwrap()

--- a/tests/event/main.rs
+++ b/tests/event/main.rs
@@ -21,7 +21,8 @@ mod select;
 
 #[cfg(windows)]
 mod windows {
-    use std::sync::OnceLock;
+    // With Rust 1.70 this can be `std::sync::OnceLock`.
+    use once_cell::sync::OnceCell as OnceLock;
 
     pub struct Thing;
 

--- a/tests/event/select.rs
+++ b/tests/event/select.rs
@@ -104,8 +104,8 @@ fn test_select_with_great_fds() {
     }
     setrlimit(Resource::Nofile, rlimit).unwrap();
 
-    // Create a fd at `FD_SETSIZE + 1` out of thin air. Use `libc` instead of
-    // `OwnedFd::from_raw_fd` because grabbing a fd out of thin air violates
+    // Create an fd at `FD_SETSIZE + 1` out of thin air. Use `libc` instead of
+    // `OwnedFd::from_raw_fd` because grabbing an fd out of thin air violates
     // Rust's concept of I/O safety (and wouldn't make sense to do in anything
     // other than a test like this).
     let great_fd = unsafe { libc::dup2(reader.as_raw_fd(), libc::FD_SETSIZE as RawFd + 1) };

--- a/tests/net/main.rs
+++ b/tests/net/main.rs
@@ -26,7 +26,8 @@ mod v6;
 
 #[cfg(windows)]
 mod windows {
-    use std::sync::OnceLock;
+    // With Rust 1.70 this can be `std::sync::OnceLock`.
+    use once_cell::sync::OnceCell as OnceLock;
 
     pub struct Thing;
 


### PR DESCRIPTION
On rustix on Windows, `RawFd` is `SOCKET`, which is the size of `usize`, so make `FdSet` 32-bit on 32-bitt Windows to match it.