### PR TITLE
Add more documentation about `setuid` and friends.

### DIFF
--- a/src/not_implemented.rs
+++ b/src/not_implemented.rs
@@ -78,6 +78,15 @@ pub mod libc_internals {
     not_implemented!(tkill);
     not_implemented!(sched_setscheduler);
     not_implemented!(rseq);
+    not_implemented!(setuid);
+    not_implemented!(setgid);
+    not_implemented!(seteuid);
+    not_implemented!(setegid);
+    not_implemented!(setreuid);
+    not_implemented!(setregid);
+    not_implemented!(setresuid);
+    not_implemented!(setresgid);
+    not_implemented!(setgroups);
 
     not_implemented!(pthread_atfork);
     not_implemented!(pthread_attr_destroy);

--- a/src/thread/id.rs
+++ b/src/thread/id.rs
@@ -57,9 +57,9 @@ pub fn gettid() -> Pid {
 ///
 /// # Warning
 ///
-/// This is not the setxid you are looking for… POSIX requires xids to be
+/// This is not the `setuid` you are looking for… POSIX requires uids to be
 /// process granular, but on Linux they are per-thread. Thus, this call only
-/// changes the xid for the current *thread*, not the entire process even
+/// changes the uid for the current *thread*, not the entire process even
 /// though that is in violation of the POSIX standard.
 ///
 /// For details on this distinction, see the C library vs. kernel differences
@@ -83,9 +83,9 @@ pub fn set_thread_uid(uid: Uid) -> io::Result<()> {
 ///
 /// # Warning
 ///
-/// This is not the setresxid you are looking for… POSIX requires xids to be
+/// This is not the `setresuid` you are looking for… POSIX requires uids to be
 /// process granular, but on Linux they are per-thread. Thus, this call only
-/// changes the xid for the current *thread*, not the entire process even
+/// changes the uid for the current *thread*, not the entire process even
 /// though that is in violation of the POSIX standard.
 ///
 /// For details on this distinction, see the C library vs. kernel differences
@@ -106,9 +106,9 @@ pub fn set_thread_res_uid(ruid: Uid, euid: Uid, suid: Uid) -> io::Result<()> {
 ///
 /// # Warning
 ///
-/// This is not the setxid you are looking for… POSIX requires xids to be
+/// This is not the `setgid` you are looking for… POSIX requires gids to be
 /// process granular, but on Linux they are per-thread. Thus, this call only
-/// changes the xid for the current *thread*, not the entire process even
+/// changes the gid for the current *thread*, not the entire process even
 /// though that is in violation of the POSIX standard.
 ///
 /// For details on this distinction, see the C library vs. kernel differences
@@ -132,9 +132,9 @@ pub fn set_thread_gid(gid: Gid) -> io::Result<()> {
 ///
 /// # Warning
 ///
-/// This is not the setresxid you are looking for… POSIX requires xids to be
+/// This is not the `setresgid` you are looking for… POSIX requires gids to be
 /// process granular, but on Linux they are per-thread. Thus, this call only
-/// changes the xid for the current *thread*, not the entire process even
+/// changes the gid for the current *thread*, not the entire process even
 /// though that is in violation of the POSIX standard.
 ///
 /// For details on this distinction, see the C library vs. kernel differences


### PR DESCRIPTION
These functions can't be implemented in rustix becuse they require the implementation to be aware of all threads in the program and to be able to use reserved signal values.