### PR TITLE
Use `i32` for exit statuses too.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,11 +35,12 @@ the functions in the [`rustix::thread::futex`] module instead.
 
 [`terminating_signal`] and other functions in [`rustix::process::WaitStatus`] changed
 from returning `u32` to returning `i32`, for better compatibility with the new
-[`Signal`] type.
+[`Signal`] type and [`exit`].
 
 [`terminating_signal`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.WaitStatus.html#method.terminating_signal
 [`rustix::process::WaitStatus`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.WaitStatus.html
 [`Signal`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.Signal.html
+[`exit`]: std::process::exit
 
 The `SLAVE` flag in [`rustix::mount::MountPropagationFlags`] is renamed to
 [`DOWNSTREAM`].

--- a/src/backend/linux_raw/process/syscalls.rs
+++ b/src/backend/linux_raw/process/syscalls.rs
@@ -298,7 +298,7 @@ pub(crate) fn _waitpid(
     waitopts: WaitOptions,
 ) -> io::Result<Option<(Pid, WaitStatus)>> {
     unsafe {
-        let mut status = MaybeUninit::<u32>::uninit();
+        let mut status = MaybeUninit::<i32>::uninit();
         let pid = ret_c_int(syscall!(
             __NR_wait4,
             c_int(pid as _),

--- a/src/backend/linux_raw/process/wait.rs
+++ b/src/backend/linux_raw/process/wait.rs
@@ -7,37 +7,37 @@ pub(crate) use linux_raw_sys::general::{
 };
 
 #[inline]
-pub(crate) fn WIFSTOPPED(status: u32) -> bool {
+pub(crate) fn WIFSTOPPED(status: i32) -> bool {
     (status & 0xff) == 0x7f
 }
 
 #[inline]
-pub(crate) fn WSTOPSIG(status: u32) -> u32 {
+pub(crate) fn WSTOPSIG(status: i32) -> i32 {
     (status >> 8) & 0xff
 }
 
 #[inline]
-pub(crate) fn WIFCONTINUED(status: u32) -> bool {
+pub(crate) fn WIFCONTINUED(status: i32) -> bool {
     status == 0xffff
 }
 
 #[inline]
-pub(crate) fn WIFSIGNALED(status: u32) -> bool {
+pub(crate) fn WIFSIGNALED(status: i32) -> bool {
     ((status & 0x7f) + 1) as i8 >= 2
 }
 
 #[inline]
-pub(crate) fn WTERMSIG(status: u32) -> u32 {
+pub(crate) fn WTERMSIG(status: i32) -> i32 {
     status & 0x7f
 }
 
 #[inline]
-pub(crate) fn WIFEXITED(status: u32) -> bool {
+pub(crate) fn WIFEXITED(status: i32) -> bool {
     (status & 0x7f) == 0
 }
 
 #[inline]
-pub(crate) fn WEXITSTATUS(status: u32) -> u32 {
+pub(crate) fn WEXITSTATUS(status: i32) -> i32 {
     (status >> 8) & 0xff
 }
 
@@ -107,15 +107,17 @@ mod tests {
             4095,
             4096,
             4097,
-            u32::MAX,
+            i32::MAX,
+            i32::MIN,
+            u32::MAX as i32,
         ] {
-            assert_eq!(WIFSTOPPED(status), libc::WIFSTOPPED(status as i32));
-            assert_eq!(WSTOPSIG(status), libc::WSTOPSIG(status as i32) as u32);
-            assert_eq!(WIFCONTINUED(status), libc::WIFCONTINUED(status as i32));
-            assert_eq!(WIFSIGNALED(status), libc::WIFSIGNALED(status as i32));
-            assert_eq!(WTERMSIG(status), libc::WTERMSIG(status as i32) as u32);
-            assert_eq!(WIFEXITED(status), libc::WIFEXITED(status as i32));
-            assert_eq!(WEXITSTATUS(status), libc::WEXITSTATUS(status as i32) as u32);
+            assert_eq!(WIFSTOPPED(status), libc::WIFSTOPPED(status));
+            assert_eq!(WSTOPSIG(status), libc::WSTOPSIG(status));
+            assert_eq!(WIFCONTINUED(status), libc::WIFCONTINUED(status));
+            assert_eq!(WIFSIGNALED(status), libc::WIFSIGNALED(status));
+            assert_eq!(WTERMSIG(status), libc::WTERMSIG(status));
+            assert_eq!(WIFEXITED(status), libc::WIFEXITED(status));
+            assert_eq!(WEXITSTATUS(status), libc::WEXITSTATUS(status));
         }
     }
 }

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -215,7 +215,7 @@ impl WaitIdStatus {
     /// Returns the number of the signal that stopped the process, if the
     /// process was stopped by a signal.
     #[inline]
-    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
+    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
     pub fn stopping_signal(&self) -> Option<i32> {
         if self.stopped() {
             Some(self.si_status() as _)
@@ -227,7 +227,7 @@ impl WaitIdStatus {
     /// Returns the number of the signal that trapped the process, if the
     /// process was trapped by a signal.
     #[inline]
-    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
+    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
     pub fn trapping_signal(&self) -> Option<i32> {
         if self.trapped() {
             Some(self.si_status() as _)
@@ -239,7 +239,7 @@ impl WaitIdStatus {
     /// Returns the exit status number returned by the process, if it exited
     /// normally.
     #[inline]
-    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
+    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
     pub fn exit_status(&self) -> Option<i32> {
         if self.exited() {
             Some(self.si_status())
@@ -251,7 +251,7 @@ impl WaitIdStatus {
     /// Returns the number of the signal that terminated the process, if the
     /// process was terminated by a signal.
     #[inline]
-    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
+    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
     pub fn terminating_signal(&self) -> Option<i32> {
         if self.killed() || self.dumped() {
             Some(self.si_status() as _)
@@ -296,7 +296,11 @@ impl WaitIdStatus {
         self.0.si_code
     }
 
-    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
+    // This is disabled on NetBSD because the libc crate's `si_status()`
+    // implementation doesn't appear to match what's in NetBSD's headers and we
+    // don't get a meaningful value returned.
+    // TODO: Report this upstream.
+    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
     #[allow(unsafe_code)]
     fn si_status(&self) -> crate::ffi::c_int {
         // SAFETY: POSIX [specifies] that the `siginfo_t` returned by a
@@ -322,19 +326,19 @@ impl fmt::Debug for WaitIdStatus {
         s.field("trapped", &self.trapped());
         s.field("dumped", &self.dumped());
         s.field("continued", &self.continued());
-        #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
+        #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
         if let Some(stopping_signal) = self.stopping_signal() {
             s.field("stopping_signal", &stopping_signal);
         }
-        #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
+        #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
         if let Some(trapping_signal) = self.trapping_signal() {
             s.field("trapping_signal", &trapping_signal);
         }
-        #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
+        #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
         if let Some(exit_status) = self.exit_status() {
             s.field("exit_status", &exit_status);
         }
-        #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
+        #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
         if let Some(terminating_signal) = self.terminating_signal() {
             s.field("terminating_signal", &terminating_signal);
         }

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -215,7 +215,7 @@ impl WaitIdStatus {
     /// Returns the number of the signal that stopped the process, if the
     /// process was stopped by a signal.
     #[inline]
-    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
+    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
     pub fn stopping_signal(&self) -> Option<i32> {
         if self.stopped() {
             Some(self.si_status() as _)
@@ -227,7 +227,7 @@ impl WaitIdStatus {
     /// Returns the number of the signal that trapped the process, if the
     /// process was trapped by a signal.
     #[inline]
-    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
+    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
     pub fn trapping_signal(&self) -> Option<i32> {
         if self.trapped() {
             Some(self.si_status() as _)
@@ -239,7 +239,7 @@ impl WaitIdStatus {
     /// Returns the exit status number returned by the process, if it exited
     /// normally.
     #[inline]
-    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
+    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
     pub fn exit_status(&self) -> Option<i32> {
         if self.exited() {
             Some(self.si_status())
@@ -251,7 +251,7 @@ impl WaitIdStatus {
     /// Returns the number of the signal that terminated the process, if the
     /// process was terminated by a signal.
     #[inline]
-    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
+    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
     pub fn terminating_signal(&self) -> Option<i32> {
         if self.killed() || self.dumped() {
             Some(self.si_status() as _)
@@ -296,7 +296,7 @@ impl WaitIdStatus {
         self.0.si_code
     }
 
-    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
+    #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
     #[allow(unsafe_code)]
     fn si_status(&self) -> crate::ffi::c_int {
         // SAFETY: POSIX [specifies] that the `siginfo_t` returned by a
@@ -322,15 +322,19 @@ impl fmt::Debug for WaitIdStatus {
         s.field("trapped", &self.trapped());
         s.field("dumped", &self.dumped());
         s.field("continued", &self.continued());
+        #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
         if let Some(stopping_signal) = self.stopping_signal() {
             s.field("stopping_signal", &stopping_signal);
         }
+        #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
         if let Some(trapping_signal) = self.trapping_signal() {
             s.field("trapping_signal", &trapping_signal);
         }
+        #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
         if let Some(exit_status) = self.exit_status() {
             s.field("exit_status", &exit_status);
         }
+        #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
         if let Some(terminating_signal) = self.terminating_signal() {
             s.field("terminating_signal", &terminating_signal);
         }

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -218,7 +218,7 @@ impl WaitIdStatus {
     #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
     pub fn stopping_signal(&self) -> Option<i32> {
         if self.stopped() {
-            Some(self.si_status() as _)
+            Some(self.si_status())
         } else {
             None
         }
@@ -230,7 +230,7 @@ impl WaitIdStatus {
     #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
     pub fn trapping_signal(&self) -> Option<i32> {
         if self.trapped() {
-            Some(self.si_status() as _)
+            Some(self.si_status())
         } else {
             None
         }
@@ -254,7 +254,7 @@ impl WaitIdStatus {
     #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "netbsd")))]
     pub fn terminating_signal(&self) -> Option<i32> {
         if self.killed() || self.dumped() {
-            Some(self.si_status() as _)
+            Some(self.si_status())
         } else {
             None
         }

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -307,6 +307,12 @@ impl WaitIdStatus {
     }
 }
 
+#[cfg(not(any(
+    target_os = "horizon",
+    target_os = "openbsd",
+    target_os = "redox",
+    target_os = "wasi"
+)))]
 impl fmt::Debug for WaitIdStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut s = f.debug_struct("WaitIdStatus");

--- a/tests/process/pidfd.rs
+++ b/tests/process/pidfd.rs
@@ -197,7 +197,7 @@ fn test_pidfd_send_signal() {
 #[serial]
 fn test_pidfd_poll() {
     // Create a new process.
-    let child = Command::new("sleep")
+    let mut child = Command::new("sleep")
         .arg("1")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -211,6 +211,7 @@ fn test_pidfd_poll() {
         Err(io::Errno::NOSYS) | Err(io::Errno::INVAL) => {
             // The kernel does not support non-blocking pidfds.
             process::kill_process(process::Pid::from_child(&child), process::Signal::INT).unwrap();
+            child.wait().unwrap();
             return;
         }
         Err(e) => panic!("failed to open pidfd: {}", e),

--- a/tests/process/pidfd.rs
+++ b/tests/process/pidfd.rs
@@ -12,7 +12,7 @@ use std::process::Command;
 #[serial]
 fn test_pidfd_waitid() {
     // Create a new process.
-    let child = Command::new("yes")
+    let mut child = Command::new("yes")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .spawn()
@@ -25,6 +25,7 @@ fn test_pidfd_waitid() {
         Err(io::Errno::NOSYS) => {
             // The kernel does not support pidfds.
             unsafe { kill(child.id() as _, SIGINT) };
+            child.wait().unwrap();
             return;
         }
         Err(e) => panic!("failed to open pidfd: {}", e),
@@ -104,7 +105,7 @@ fn test_pidfd_waitid() {
 #[serial]
 fn test_pidfd_send_signal() {
     // Create a new process.
-    let child = Command::new("yes")
+    let mut child = Command::new("yes")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .spawn()
@@ -117,6 +118,7 @@ fn test_pidfd_send_signal() {
         Err(io::Errno::NOSYS) => {
             // The kernel does not support pidfds.
             process::kill_process(process::Pid::from_child(&child), process::Signal::INT).unwrap();
+            child.wait().unwrap();
             return;
         }
         Err(e) => panic!("failed to open pidfd: {}", e),

--- a/tests/process/wait.rs
+++ b/tests/process/wait.rs
@@ -161,7 +161,7 @@ fn test_waitid() {
     assert!(status.continued());
 
     let status = process::waitid(
-        process::WaitId::All,
+        process::WaitId::Pid(pid),
         process::WaitIdOptions::EXITED | process::WaitIdOptions::NOHANG,
     )
     .expect("failed to wait");

--- a/tests/process/wait.rs
+++ b/tests/process/wait.rs
@@ -117,7 +117,7 @@ fn test_waitid() {
         .unwrap();
 
     assert!(status.stopped());
-    #[cfg(not(target_os = "fuchsia"))]
+    #[cfg(not(any(target_os = "fuchsia", target_os = "netbsd")))]
     assert_eq!(status.stopping_signal(), Some(SIGSTOP as _));
     assert_eq!(status.raw_signo(), libc::SIGCHLD);
     assert_eq!(status.raw_errno(), 0);
@@ -143,7 +143,7 @@ fn test_waitid() {
     .unwrap();
 
     assert!(status.stopped());
-    #[cfg(not(target_os = "fuchsia"))]
+    #[cfg(not(any(target_os = "fuchsia", target_os = "netbsd")))]
     assert_eq!(status.stopping_signal(), Some(SIGSTOP as _));
     assert_eq!(status.raw_signo(), libc::SIGCHLD);
     assert_eq!(status.raw_errno(), 0);
@@ -178,7 +178,7 @@ fn test_waitid() {
     .unwrap();
 
     assert!(status.killed());
-    #[cfg(not(target_os = "fuchsia"))]
+    #[cfg(not(any(target_os = "fuchsia", target_os = "netbsd")))]
     assert_eq!(status.terminating_signal(), Some(SIGKILL as _));
 
     let status = process::waitid(process::WaitId::Pid(pid), process::WaitIdOptions::EXITED)
@@ -186,6 +186,6 @@ fn test_waitid() {
         .unwrap();
 
     assert!(status.killed());
-    #[cfg(not(target_os = "fuchsia"))]
+    #[cfg(not(any(target_os = "fuchsia", target_os = "netbsd")))]
     assert_eq!(status.terminating_signal(), Some(SIGKILL as _));
 }

--- a/tests/process/wait.rs
+++ b/tests/process/wait.rs
@@ -117,7 +117,7 @@ fn test_waitid() {
         .unwrap();
 
     assert!(status.stopped());
-    #[cfg(not(any(target_os = "fuchsia", target_os = "netbsd")))]
+    #[cfg(not(target_os = "fuchsia"))]
     assert_eq!(status.stopping_signal(), Some(SIGSTOP as _));
     assert_eq!(status.raw_signo(), libc::SIGCHLD);
     assert_eq!(status.raw_errno(), 0);
@@ -143,7 +143,7 @@ fn test_waitid() {
     .unwrap();
 
     assert!(status.stopped());
-    #[cfg(not(any(target_os = "fuchsia", target_os = "netbsd")))]
+    #[cfg(not(target_os = "fuchsia"))]
     assert_eq!(status.stopping_signal(), Some(SIGSTOP as _));
     assert_eq!(status.raw_signo(), libc::SIGCHLD);
     assert_eq!(status.raw_errno(), 0);
@@ -178,7 +178,7 @@ fn test_waitid() {
     .unwrap();
 
     assert!(status.killed());
-    #[cfg(not(any(target_os = "fuchsia", target_os = "netbsd")))]
+    #[cfg(not(target_os = "fuchsia"))]
     assert_eq!(status.terminating_signal(), Some(SIGKILL as _));
 
     let status = process::waitid(process::WaitId::Pid(pid), process::WaitIdOptions::EXITED)
@@ -186,6 +186,6 @@ fn test_waitid() {
         .unwrap();
 
     assert!(status.killed());
-    #[cfg(not(any(target_os = "fuchsia", target_os = "netbsd")))]
+    #[cfg(not(target_os = "fuchsia"))]
     assert_eq!(status.terminating_signal(), Some(SIGKILL as _));
 }


### PR DESCRIPTION
Following up on #1378, make process exit statuses be `i32` too, for compatibility with `exit`, `exit_group`, and related things.