### PR TITLE
Rename `rustix_int_0x80` and protect it from multiple definitions.

### DIFF
--- a/tests/event/port.rs
+++ b/tests/event/port.rs
@@ -37,7 +37,10 @@ fn test_port_timeout_assumption() {
         assert_eq!(libc_errno::errno().0, libc::ETIME);
         assert_eq!(r, -1);
 
-        assert_eq!(timeout, orig_timeout);
+        assert_eq!(
+            (timeout.tv_sec, timeout.tv_nsec),
+            (orig_timeout.tv_sec, orig_timeout.tv_nsec)
+        );
     }
 }
 
@@ -72,7 +75,10 @@ fn test_port_event_assumption() {
         let r = libc::port_get(port, &mut event, &mut timeout);
         assert_ne!(r, -1);
 
-        assert_eq!(timeout, orig_timeout);
+        assert_eq!(
+            (timeout.tv_sec, timeout.tv_nsec),
+            (orig_timeout.tv_sec, orig_timeout.tv_nsec)
+        );
         assert_eq!(event.portev_user, 7 as *mut c_void);
     }
 }
@@ -154,7 +160,10 @@ fn test_port_delay_assumption() {
             let r = libc::port_get(port, &mut event, &mut timeout);
             assert_ne!(r, -1, "port_get: {:?}", std::io::Error::last_os_error());
 
-            assert_eq!(timeout, orig_timeout);
+            assert_eq!(
+                (timeout.tv_sec, timeout.tv_nsec),
+                (orig_timeout.tv_sec, orig_timeout.tv_nsec)
+            );
             assert_eq!(event.portev_user, (9 + i) as *mut c_void);
 
             let mut buf = [0_u8; 1];


### PR DESCRIPTION
In lto builds, multiple versions of the `rustix_int_0x80` assembly code can be included in the same .s file. To avoid conflicts when one of them comes from an older version of rustix, rename the symbol to `rustix_x86_int_0x80`, and to avoid conflicts with future versions, enclose the code in an `ifndef` block.

Fixes #1394.