### PR TITLE
Fix typos found by typos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -322,7 +322,7 @@ renamed to [`SocketAddrXdpFlags`].
 [`SocketAddrXdpFlags`]: https://docs.rs/rustix/1.0.0/rustix/net/xdp/struct.SocketAddrXdpFlags.html
 
 [`rustix::io_uring::io_uring_setup`] is now unsafe, due its `io_uring_params`
-argument optionallly containing a raw file descriptor.
+argument optionally containing a raw file descriptor.
 
 [`rustix::io_uring::io_uring_setup`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/fn.io_uring_setup.html
 

--- a/tests/fs/negative_timestamp.rs
+++ b/tests/fs/negative_timestamp.rs
@@ -1,6 +1,6 @@
 #[cfg(not(target_os = "redox"))]
 #[test]
-fn negative_file_timetamp() {
+fn negative_file_timestamp() {
     use rustix::fs::{
         fstat, futimens, lstat, open, stat, statat, AtFlags, Mode, OFlags, Timespec, Timestamps,
         CWD,


### PR DESCRIPTION
Ignore list:

```toml
[default.extend-words]
ACCES = "ACCES"
BA = "BA"
EXTA = "EXTA"
FFOR = "FFOR"
FRE = "FRE"
PN = "PN"
THR = "THR"
WOTH = "WOTH"
WRONLY = "WRONLY"
inot = "inot"
nto = "nto"
tio = "tio"
typ = "typ"
```