### PR TITLE
Move all unit tests into `tests` modules.

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -2663,19 +2663,6 @@ fn fix_negative_stat_nsecs(mut stat: Stat) -> Stat {
     stat
 }
 
-#[test]
-fn test_sizes() {
-    #[cfg(linux_kernel)]
-    assert_eq_size!(c::loff_t, u64);
-
-    // Assert that `Timestamps` has the expected layout. If we're not fixing
-    // y2038, libc's type should match ours. If we are, it's smaller.
-    #[cfg(not(fix_y2038))]
-    assert_eq_size!([c::timespec; 2], Timestamps);
-    #[cfg(fix_y2038)]
-    assert!(core::mem::size_of::<[c::timespec; 2]>() < core::mem::size_of::<Timestamps>());
-}
-
 #[inline]
 #[cfg(linux_kernel)]
 pub(crate) fn inotify_init1(flags: super::inotify::CreateFlags) -> io::Result<OwnedFd> {
@@ -2710,4 +2697,22 @@ pub(crate) fn inotify_rm_watch(inot: BorrowedFd<'_>, wd: i32) -> io::Result<()> 
     let wd = wd as u32;
     // SAFETY: The fd is valid and closing an arbitrary wd is valid.
     unsafe { ret(c::inotify_rm_watch(borrowed_fd(inot), wd)) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sizes() {
+        #[cfg(linux_kernel)]
+        assert_eq_size!(c::loff_t, u64);
+
+        // Assert that `Timestamps` has the expected layout. If we're not fixing
+        // y2038, libc's type should match ours. If we are, it's smaller.
+        #[cfg(not(fix_y2038))]
+        assert_eq_size!([c::timespec; 2], Timestamps);
+        #[cfg(fix_y2038)]
+        assert!(core::mem::size_of::<[c::timespec; 2]>() < core::mem::size_of::<Timestamps>());
+    }
 }

--- a/src/backend/libc/pipe/types.rs
+++ b/src/backend/libc/pipe/types.rs
@@ -101,11 +101,17 @@ impl<'a> IoSliceRaw<'a> {
     }
 }
 
-#[cfg(not(any(apple, target_os = "wasi")))]
-#[test]
-fn test_types() {
-    assert_eq_size!(PipeFlags, c::c_int);
+#[cfg(test)]
+mod tests {
+    #[allow(unused_imports)]
+    use super::*;
 
-    #[cfg(linux_kernel)]
-    assert_eq_size!(SpliceFlags, c::c_int);
+    #[cfg(not(any(apple, target_os = "wasi")))]
+    #[test]
+    fn test_types() {
+        assert_eq_size!(PipeFlags, c::c_int);
+
+        #[cfg(linux_kernel)]
+        assert_eq_size!(SpliceFlags, c::c_int);
+    }
 }

--- a/src/backend/libc/time/types.rs
+++ b/src/backend/libc/time/types.rs
@@ -165,9 +165,15 @@ pub enum TimerfdClockId {
     BoottimeAlarm = bitcast!(c::CLOCK_BOOTTIME_ALARM),
 }
 
-#[cfg(any(linux_kernel, target_os = "fuchsia"))]
-#[test]
-fn test_types() {
-    assert_eq_size!(TimerfdFlags, c::c_int);
-    assert_eq_size!(TimerfdTimerFlags, c::c_int);
+#[cfg(test)]
+mod tests {
+    #[allow(unused_imports)]
+    use super::*;
+
+    #[cfg(any(linux_kernel, target_os = "fuchsia"))]
+    #[test]
+    fn test_types() {
+        assert_eq_size!(TimerfdFlags, c::c_int);
+        assert_eq_size!(TimerfdTimerFlags, c::c_int);
+    }
 }

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -1657,16 +1657,6 @@ pub(crate) fn fremovexattr(fd: BorrowedFd<'_>, name: &CStr) -> io::Result<()> {
     unsafe { ret(syscall_readonly!(__NR_fremovexattr, fd, name)) }
 }
 
-#[test]
-fn test_sizes() {
-    assert_eq_size!(linux_raw_sys::general::__kernel_loff_t, u64);
-    assert_eq_align!(linux_raw_sys::general::__kernel_loff_t, u64);
-
-    // Assert that `Timestamps` has the expected layout.
-    assert_eq_size!([linux_raw_sys::general::__kernel_timespec; 2], Timestamps);
-    assert_eq_align!([linux_raw_sys::general::__kernel_timespec; 2], Timestamps);
-}
-
 // Some linux_raw_sys structs have unsigned types for values which are
 // interpreted as signed. This defines a utility or casting to the
 // same-sized signed type.
@@ -1715,3 +1705,18 @@ mod to_signed {
     target_arch = "mips64r6"
 ))]
 use to_signed::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sizes() {
+        assert_eq_size!(linux_raw_sys::general::__kernel_loff_t, u64);
+        assert_eq_align!(linux_raw_sys::general::__kernel_loff_t, u64);
+
+        // Assert that `Timestamps` has the expected layout.
+        assert_eq_size!([linux_raw_sys::general::__kernel_timespec; 2], Timestamps);
+        assert_eq_align!([linux_raw_sys::general::__kernel_timespec; 2], Timestamps);
+    }
+}

--- a/src/backend/linux_raw/param/libc_auxv.rs
+++ b/src/backend/linux_raw/param/libc_auxv.rs
@@ -56,26 +56,6 @@ const _SC_CLK_TCK: c::c_int = 6;
 #[cfg(target_os = "linux")]
 const _SC_CLK_TCK: c::c_int = 2;
 
-#[test]
-fn test_abi() {
-    const_assert_eq!(self::_SC_PAGESIZE, ::libc::_SC_PAGESIZE);
-    const_assert_eq!(self::_SC_CLK_TCK, ::libc::_SC_CLK_TCK);
-    const_assert_eq!(self::AT_HWCAP, ::libc::AT_HWCAP);
-    const_assert_eq!(self::AT_HWCAP2, ::libc::AT_HWCAP2);
-    const_assert_eq!(self::AT_EXECFN, ::libc::AT_EXECFN);
-    const_assert_eq!(self::AT_SECURE, ::libc::AT_SECURE);
-    const_assert_eq!(self::AT_SYSINFO_EHDR, ::libc::AT_SYSINFO_EHDR);
-    const_assert_eq!(self::AT_MINSIGSTKSZ, ::libc::AT_MINSIGSTKSZ);
-    #[cfg(feature = "runtime")]
-    const_assert_eq!(self::AT_PHDR, ::libc::AT_PHDR);
-    #[cfg(feature = "runtime")]
-    const_assert_eq!(self::AT_PHNUM, ::libc::AT_PHNUM);
-    #[cfg(feature = "runtime")]
-    const_assert_eq!(self::AT_ENTRY, ::libc::AT_ENTRY);
-    #[cfg(feature = "runtime")]
-    const_assert_eq!(self::AT_RANDOM, ::libc::AT_RANDOM);
-}
-
 #[cfg(feature = "param")]
 #[inline]
 pub(crate) fn page_size() -> usize {
@@ -190,4 +170,29 @@ pub(crate) fn entry() -> usize {
 #[inline]
 pub(crate) fn random() -> *const [u8; 16] {
     unsafe { getauxval(AT_RANDOM) as *const [u8; 16] }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_abi() {
+        const_assert_eq!(self::_SC_PAGESIZE, ::libc::_SC_PAGESIZE);
+        const_assert_eq!(self::_SC_CLK_TCK, ::libc::_SC_CLK_TCK);
+        const_assert_eq!(self::AT_HWCAP, ::libc::AT_HWCAP);
+        const_assert_eq!(self::AT_HWCAP2, ::libc::AT_HWCAP2);
+        const_assert_eq!(self::AT_EXECFN, ::libc::AT_EXECFN);
+        const_assert_eq!(self::AT_SECURE, ::libc::AT_SECURE);
+        const_assert_eq!(self::AT_SYSINFO_EHDR, ::libc::AT_SYSINFO_EHDR);
+        const_assert_eq!(self::AT_MINSIGSTKSZ, ::libc::AT_MINSIGSTKSZ);
+        #[cfg(feature = "runtime")]
+        const_assert_eq!(self::AT_PHDR, ::libc::AT_PHDR);
+        #[cfg(feature = "runtime")]
+        const_assert_eq!(self::AT_PHNUM, ::libc::AT_PHNUM);
+        #[cfg(feature = "runtime")]
+        const_assert_eq!(self::AT_ENTRY, ::libc::AT_ENTRY);
+        #[cfg(feature = "runtime")]
+        const_assert_eq!(self::AT_RANDOM, ::libc::AT_RANDOM);
+    }
 }

--- a/src/backend/linux_raw/vdso.rs
+++ b/src/backend/linux_raw/vdso.rs
@@ -420,121 +420,126 @@ impl Vdso {
     }
 }
 
-// Disable on MIPS since QEMU on MIPS doesn't provide a vDSO.
-#[cfg(linux_raw)]
-#[test]
-#[cfg_attr(any(target_arch = "mips", target_arch = "mips64"), ignore)]
-#[allow(unused_variables)]
-fn test_vdso() {
-    let vdso = Vdso::new().unwrap();
-    assert!(!vdso.symtab.is_null());
-    assert!(!vdso.symstrings.is_null());
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    {
-        #[cfg(target_arch = "x86_64")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime"));
-        #[cfg(target_arch = "arm")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
-        #[cfg(target_arch = "aarch64")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6.39"), cstr!("__kernel_clock_gettime"));
-        #[cfg(target_arch = "x86")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
-        #[cfg(target_arch = "riscv64")]
-        let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_clock_gettime"));
-        #[cfg(target_arch = "powerpc")]
-        let _ptr = vdso.sym(cstr!("LINUX_5.11"), cstr!("__kernel_clock_gettime64"));
-        #[cfg(target_arch = "powerpc64")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_clock_gettime"));
-        #[cfg(target_arch = "s390x")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_clock_gettime"));
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
-        #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime"));
+    // Disable on MIPS since QEMU on MIPS doesn't provide a vDSO.
+    #[cfg(linux_raw)]
+    #[test]
+    #[cfg_attr(any(target_arch = "mips", target_arch = "mips64"), ignore)]
+    #[allow(unused_variables)]
+    fn test_vdso() {
+        let vdso = Vdso::new().unwrap();
+        assert!(!vdso.symtab.is_null());
+        assert!(!vdso.symstrings.is_null());
 
-        // On PowerPC, "__kernel_clock_gettime64" isn't available in
-        // Linux < 5.11.
-        // On x86, "__vdso_clock_gettime64" isn't available in
-        // Linux < 5.3.
-        #[cfg(not(any(target_arch = "powerpc", target_arch = "x86")))]
-        assert!(!ptr.is_null());
-    }
+        {
+            #[cfg(target_arch = "x86_64")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime"));
+            #[cfg(target_arch = "arm")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
+            #[cfg(target_arch = "aarch64")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6.39"), cstr!("__kernel_clock_gettime"));
+            #[cfg(target_arch = "x86")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
+            #[cfg(target_arch = "riscv64")]
+            let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_clock_gettime"));
+            #[cfg(target_arch = "powerpc")]
+            let _ptr = vdso.sym(cstr!("LINUX_5.11"), cstr!("__kernel_clock_gettime64"));
+            #[cfg(target_arch = "powerpc64")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_clock_gettime"));
+            #[cfg(target_arch = "s390x")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_clock_gettime"));
+            #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime64"));
+            #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_gettime"));
 
-    {
-        #[cfg(target_arch = "x86_64")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_getres"));
-        #[cfg(target_arch = "arm")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_getres"));
-        #[cfg(target_arch = "aarch64")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6.39"), cstr!("__kernel_clock_getres"));
-        #[cfg(target_arch = "x86")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_getres"));
-        #[cfg(target_arch = "riscv64")]
-        let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_clock_getres"));
-        #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
-        let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_clock_getres"));
-        #[cfg(target_arch = "s390x")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_clock_getres"));
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_getres"));
-        #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_getres"));
+            // On PowerPC, "__kernel_clock_gettime64" isn't available in
+            // Linux < 5.11.
+            // On x86, "__vdso_clock_gettime64" isn't available in
+            // Linux < 5.3.
+            #[cfg(not(any(target_arch = "powerpc", target_arch = "x86")))]
+            assert!(!ptr.is_null());
+        }
 
-        // Some versions of Linux appear to lack "__vdso_clock_getres" on x86.
-        #[cfg(not(target_arch = "x86"))]
-        assert!(!ptr.is_null());
-    }
+        {
+            #[cfg(target_arch = "x86_64")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_getres"));
+            #[cfg(target_arch = "arm")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_getres"));
+            #[cfg(target_arch = "aarch64")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6.39"), cstr!("__kernel_clock_getres"));
+            #[cfg(target_arch = "x86")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_getres"));
+            #[cfg(target_arch = "riscv64")]
+            let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_clock_getres"));
+            #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
+            let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_clock_getres"));
+            #[cfg(target_arch = "s390x")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_clock_getres"));
+            #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_getres"));
+            #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_clock_getres"));
 
-    {
-        #[cfg(target_arch = "x86_64")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
-        #[cfg(target_arch = "arm")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
-        #[cfg(target_arch = "aarch64")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6.39"), cstr!("__kernel_gettimeofday"));
-        #[cfg(target_arch = "x86")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
-        #[cfg(target_arch = "riscv64")]
-        let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_gettimeofday"));
-        #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
-        let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_gettimeofday"));
-        #[cfg(target_arch = "s390x")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_gettimeofday"));
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
-        #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
+            // Some versions of Linux appear to lack "__vdso_clock_getres" on x86.
+            #[cfg(not(target_arch = "x86"))]
+            assert!(!ptr.is_null());
+        }
 
-        // Some versions of Linux appear to lack "__vdso_gettimeofday" on x86.
-        #[cfg(not(target_arch = "x86"))]
-        assert!(!ptr.is_null());
-    }
+        {
+            #[cfg(target_arch = "x86_64")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
+            #[cfg(target_arch = "arm")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
+            #[cfg(target_arch = "aarch64")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6.39"), cstr!("__kernel_gettimeofday"));
+            #[cfg(target_arch = "x86")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
+            #[cfg(target_arch = "riscv64")]
+            let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_gettimeofday"));
+            #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
+            let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_gettimeofday"));
+            #[cfg(target_arch = "s390x")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_gettimeofday"));
+            #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
+            #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_gettimeofday"));
 
-    #[cfg(any(
-        target_arch = "x86_64",
-        target_arch = "x86",
-        target_arch = "riscv64",
-        target_arch = "powerpc",
-        target_arch = "powerpc64",
-        target_arch = "s390x",
-    ))]
-    {
-        #[cfg(target_arch = "x86_64")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_getcpu"));
-        #[cfg(target_arch = "x86")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_getcpu"));
-        #[cfg(target_arch = "riscv64")]
-        let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_getcpu"));
-        #[cfg(target_arch = "powerpc")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_getcpu"));
-        #[cfg(target_arch = "powerpc64")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_getcpu"));
-        #[cfg(target_arch = "s390x")]
-        let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_getcpu"));
+            // Some versions of Linux appear to lack "__vdso_gettimeofday" on x86.
+            #[cfg(not(target_arch = "x86"))]
+            assert!(!ptr.is_null());
+        }
 
-        // On PowerPC, "__kernel_getcpu" isn't available in 32-bit kernels.
-        // Some versions of Linux appear to lack "__vdso_getcpu" on x86.
-        #[cfg(not(any(target_arch = "powerpc", target_arch = "x86")))]
-        assert!(!ptr.is_null());
+        #[cfg(any(
+            target_arch = "x86_64",
+            target_arch = "x86",
+            target_arch = "riscv64",
+            target_arch = "powerpc",
+            target_arch = "powerpc64",
+            target_arch = "s390x",
+        ))]
+        {
+            #[cfg(target_arch = "x86_64")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_getcpu"));
+            #[cfg(target_arch = "x86")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6"), cstr!("__vdso_getcpu"));
+            #[cfg(target_arch = "riscv64")]
+            let ptr = vdso.sym(cstr!("LINUX_4.15"), cstr!("__vdso_getcpu"));
+            #[cfg(target_arch = "powerpc")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_getcpu"));
+            #[cfg(target_arch = "powerpc64")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6.15"), cstr!("__kernel_getcpu"));
+            #[cfg(target_arch = "s390x")]
+            let ptr = vdso.sym(cstr!("LINUX_2.6.29"), cstr!("__kernel_getcpu"));
+
+            // On PowerPC, "__kernel_getcpu" isn't available in 32-bit kernels.
+            // Some versions of Linux appear to lack "__vdso_getcpu" on x86.
+            #[cfg(not(any(target_arch = "powerpc", target_arch = "x86")))]
+            assert!(!ptr.is_null());
+        }
     }
 }

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -54,24 +54,30 @@ macro_rules! cstr {
     }};
 }
 
-#[test]
-fn test_cstr() {
-    use crate::ffi::CString;
-    use alloc::borrow::ToOwned as _;
-    assert_eq!(cstr!(""), &*CString::new("").unwrap());
-    assert_eq!(cstr!("").to_owned(), CString::new("").unwrap());
-    assert_eq!(cstr!("hello"), &*CString::new("hello").unwrap());
-    assert_eq!(cstr!("hello").to_owned(), CString::new("hello").unwrap());
-}
+#[cfg(test)]
+mod tests {
+    #[allow(unused_imports)]
+    use super::*;
 
-#[test]
-#[should_panic]
-fn test_invalid_cstr() {
-    let _ = cstr!("hello\0world");
-}
+    #[test]
+    fn test_cstr() {
+        use crate::ffi::CString;
+        use alloc::borrow::ToOwned as _;
+        assert_eq!(cstr!(""), &*CString::new("").unwrap());
+        assert_eq!(cstr!("").to_owned(), CString::new("").unwrap());
+        assert_eq!(cstr!("hello"), &*CString::new("hello").unwrap());
+        assert_eq!(cstr!("hello").to_owned(), CString::new("hello").unwrap());
+    }
 
-#[test]
-#[should_panic]
-fn test_invalid_empty_cstr() {
-    let _ = cstr!("\0");
+    #[test]
+    #[should_panic]
+    fn test_invalid_cstr() {
+        let _ = cstr!("hello\0world");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_empty_cstr() {
+        let _ = cstr!("\0");
+    }
 }

--- a/src/ioctl/linux.rs
+++ b/src/ioctl/linux.rs
@@ -83,36 +83,42 @@ mod consts {
     pub(super) const DIR_BITS: Opcode = 3;
 }
 
-#[cfg(not(any(
+#[cfg(test)]
+mod tests {
+    #[allow(unused_imports)]
+    use super::*;
+
+    #[cfg(not(any(
     // These have no ioctl opcodes defined in linux_raw_sys so we can't use
     // that as a known-good value for this test.
     target_arch = "sparc",
     target_arch = "sparc64"
 )))]
-#[test]
-fn check_known_opcodes() {
-    use crate::backend::c::{c_long, c_uint};
-    use core::mem::size_of;
+    #[test]
+    fn check_known_opcodes() {
+        use crate::backend::c::{c_long, c_uint};
+        use core::mem::size_of;
 
-    // _IOR('U', 15, unsigned int)
-    assert_eq!(
-        compose_opcode(
-            Direction::Read,
-            b'U' as Opcode,
-            15,
-            size_of::<c_uint>() as Opcode
-        ),
-        linux_raw_sys::ioctl::USBDEVFS_CLAIMINTERFACE as Opcode
-    );
+        // _IOR('U', 15, unsigned int)
+        assert_eq!(
+            compose_opcode(
+                Direction::Read,
+                b'U' as Opcode,
+                15,
+                size_of::<c_uint>() as Opcode
+            ),
+            linux_raw_sys::ioctl::USBDEVFS_CLAIMINTERFACE as Opcode
+        );
 
-    // _IOW('v', 2, long)
-    assert_eq!(
-        compose_opcode(
-            Direction::Write,
-            b'v' as Opcode,
-            2,
-            size_of::<c_long>() as Opcode
-        ),
-        linux_raw_sys::ioctl::FS_IOC_SETVERSION as Opcode
-    );
+        // _IOW('v', 2, long)
+        assert_eq!(
+            compose_opcode(
+                Direction::Write,
+                b'v' as Opcode,
+                2,
+                size_of::<c_long>() as Opcode
+            ),
+            linux_raw_sys::ioctl::FS_IOC_SETVERSION as Opcode
+        );
+    }
 }

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -2043,43 +2043,48 @@ pub struct UCred {
     pub gid: crate::ugid::Gid,
 }
 
-#[test]
-fn test_sizes() {
-    #[cfg(target_os = "linux")]
-    use crate::backend::c;
-    use crate::ffi::c_int;
-    use crate::net::addr::SocketAddrStorage;
-    use core::mem::transmute;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    // Backend code needs to cast these to `c_int` so make sure that cast isn't
-    // lossy.
-    assert_eq_size!(RawProtocol, c_int);
-    assert_eq_size!(Protocol, c_int);
-    assert_eq_size!(Option<RawProtocol>, c_int);
-    assert_eq_size!(Option<Protocol>, c_int);
-    assert_eq_size!(RawSocketType, c_int);
-    assert_eq_size!(SocketType, c_int);
-    assert_eq_size!(SocketFlags, c_int);
-    assert_eq_size!(SocketAddrStorage, c::sockaddr_storage);
+    #[test]
+    fn test_sizes() {
+        #[cfg(target_os = "linux")]
+        use crate::backend::c;
+        use crate::ffi::c_int;
+        use crate::net::addr::SocketAddrStorage;
+        use core::mem::transmute;
 
-    // Rustix doesn't depend on `Option<Protocol>` matching the ABI of a raw
-    // integer for correctness, but it should work nonetheless.
-    #[allow(unsafe_code)]
-    unsafe {
-        let t: Option<Protocol> = None;
-        assert_eq!(0_u32, transmute::<Option<Protocol>, u32>(t));
+        // Backend code needs to cast these to `c_int` so make sure that cast isn't
+        // lossy.
+        assert_eq_size!(RawProtocol, c_int);
+        assert_eq_size!(Protocol, c_int);
+        assert_eq_size!(Option<RawProtocol>, c_int);
+        assert_eq_size!(Option<Protocol>, c_int);
+        assert_eq_size!(RawSocketType, c_int);
+        assert_eq_size!(SocketType, c_int);
+        assert_eq_size!(SocketFlags, c_int);
+        assert_eq_size!(SocketAddrStorage, c::sockaddr_storage);
 
-        let t: Option<Protocol> = Some(Protocol::from_raw(RawProtocol::new(4567).unwrap()));
-        assert_eq!(4567_u32, transmute::<Option<Protocol>, u32>(t));
+        // Rustix doesn't depend on `Option<Protocol>` matching the ABI of a raw
+        // integer for correctness, but it should work nonetheless.
+        #[allow(unsafe_code)]
+        unsafe {
+            let t: Option<Protocol> = None;
+            assert_eq!(0_u32, transmute::<Option<Protocol>, u32>(t));
+
+            let t: Option<Protocol> = Some(Protocol::from_raw(RawProtocol::new(4567).unwrap()));
+            assert_eq!(4567_u32, transmute::<Option<Protocol>, u32>(t));
+        }
+
+        #[cfg(linux_kernel)]
+        assert_eq_size!(UCred, libc::ucred);
+
+        #[cfg(target_os = "linux")]
+        assert_eq_size!(super::xdp::XdpUmemReg, c::xdp_umem_reg);
+        #[cfg(target_os = "linux")]
+        assert_eq_size!(super::xdp::XdpOptions, c::xdp_options);
+        #[cfg(target_os = "linux")]
+        assert_eq_size!(super::xdp::XdpDesc, c::xdp_desc);
     }
-
-    #[cfg(linux_kernel)]
-    assert_eq_size!(UCred, libc::ucred);
-
-    #[cfg(target_os = "linux")]
-    assert_eq_size!(super::xdp::XdpUmemReg, c::xdp_umem_reg);
-    #[cfg(target_os = "linux")]
-    assert_eq_size!(super::xdp::XdpOptions, c::xdp_options);
-    #[cfg(target_os = "linux")]
-    assert_eq_size!(super::xdp::XdpDesc, c::xdp_desc);
 }

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -87,20 +87,25 @@ impl Pid {
     }
 }
 
-#[test]
-fn test_sizes() {
-    use core::mem::transmute;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    assert_eq_size!(RawPid, NonZeroI32);
-    assert_eq_size!(RawPid, Pid);
-    assert_eq_size!(RawPid, Option<Pid>);
+    #[test]
+    fn test_sizes() {
+        use core::mem::transmute;
 
-    // Rustix doesn't depend on `Option<Pid>` matching the ABI of a raw integer
-    // for correctness, but it should work nonetheless.
-    const_assert_eq!(0 as RawPid, unsafe {
-        transmute::<Option<Pid>, RawPid>(None)
-    });
-    const_assert_eq!(4567 as RawPid, unsafe {
-        transmute::<Option<Pid>, RawPid>(Some(Pid::from_raw_unchecked(4567)))
-    });
+        assert_eq_size!(RawPid, NonZeroI32);
+        assert_eq_size!(RawPid, Pid);
+        assert_eq_size!(RawPid, Option<Pid>);
+
+        // Rustix doesn't depend on `Option<Pid>` matching the ABI of a raw integer
+        // for correctness, but it should work nonetheless.
+        const_assert_eq!(0 as RawPid, unsafe {
+            transmute::<Option<Pid>, RawPid>(None)
+        });
+        const_assert_eq!(4567 as RawPid, unsafe {
+            transmute::<Option<Pid>, RawPid>(Some(Pid::from_raw_unchecked(4567)))
+        });
+    }
 }

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -1433,206 +1433,211 @@ pub struct Winsize {
     pub ws_ypixel: u16,
 }
 
-#[test]
-fn termios_layouts() {
-    check_renamed_type!(InputModes, tcflag_t);
-    check_renamed_type!(OutputModes, tcflag_t);
-    check_renamed_type!(ControlModes, tcflag_t);
-    check_renamed_type!(LocalModes, tcflag_t);
-    assert_eq_size!(u8, libc::cc_t);
-    assert_eq_size!(types::tcflag_t, libc::tcflag_t);
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    check_renamed_struct!(Winsize, winsize, ws_row, ws_col, ws_xpixel, ws_ypixel);
+    #[test]
+    fn termios_layouts() {
+        check_renamed_type!(InputModes, tcflag_t);
+        check_renamed_type!(OutputModes, tcflag_t);
+        check_renamed_type!(ControlModes, tcflag_t);
+        check_renamed_type!(LocalModes, tcflag_t);
+        assert_eq_size!(u8, libc::cc_t);
+        assert_eq_size!(types::tcflag_t, libc::tcflag_t);
 
-    // On platforms with a termios/termios2 split, check `termios`.
-    #[cfg(linux_raw)]
-    {
-        check_renamed_type!(Termios, termios2);
-        check_renamed_struct_renamed_field!(Termios, termios2, input_modes, c_iflag);
-        check_renamed_struct_renamed_field!(Termios, termios2, output_modes, c_oflag);
-        check_renamed_struct_renamed_field!(Termios, termios2, control_modes, c_cflag);
-        check_renamed_struct_renamed_field!(Termios, termios2, local_modes, c_lflag);
-        check_renamed_struct_renamed_field!(Termios, termios2, line_discipline, c_line);
-        check_renamed_struct_renamed_field!(Termios, termios2, special_codes, c_cc);
-        check_renamed_struct_renamed_field!(Termios, termios2, input_speed, c_ispeed);
-        check_renamed_struct_renamed_field!(Termios, termios2, output_speed, c_ospeed);
+        check_renamed_struct!(Winsize, winsize, ws_row, ws_col, ws_xpixel, ws_ypixel);
 
-        // We assume that `termios` has the same layout as `termios2` minus the
-        // `c_ispeed` and `c_ospeed` fields.
-        check_renamed_struct_renamed_field!(Termios, termios, input_modes, c_iflag);
-        check_renamed_struct_renamed_field!(Termios, termios, output_modes, c_oflag);
-        check_renamed_struct_renamed_field!(Termios, termios, control_modes, c_cflag);
-        check_renamed_struct_renamed_field!(Termios, termios, local_modes, c_lflag);
-        check_renamed_struct_renamed_field!(Termios, termios, special_codes, c_cc);
-
-        // On everything except PowerPC, `termios` matches `termios2` except
-        // for the addition of `c_ispeed` and `c_ospeed`.
-        #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
-        const_assert_eq!(
-            memoffset::offset_of!(Termios, input_speed),
-            core::mem::size_of::<c::termios>()
-        );
-
-        // On PowerPC, `termios2` is `termios`.
-        #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
-        assert_eq_size!(c::termios2, c::termios);
-    }
-
-    #[cfg(not(linux_raw))]
-    {
-        // On MIPS, SPARC, and Android, the libc lacks the ospeed and ispeed
-        // fields.
-        #[cfg(all(
-            not(all(
-                target_env = "gnu",
-                any(
-                    target_arch = "mips",
-                    target_arch = "mips32r6",
-                    target_arch = "mips64",
-                    target_arch = "mips64r6",
-                    target_arch = "sparc",
-                    target_arch = "sparc64"
-                )
-            )),
-            not(all(libc, target_os = "android"))
-        ))]
-        check_renamed_type!(Termios, termios);
-        #[cfg(not(all(
-            not(all(
-                target_env = "gnu",
-                any(
-                    target_arch = "mips",
-                    target_arch = "mips32r6",
-                    target_arch = "mips64",
-                    target_arch = "mips64r6",
-                    target_arch = "sparc",
-                    target_arch = "sparc64"
-                )
-            )),
-            not(all(libc, target_os = "android"))
-        )))]
-        const_assert!(core::mem::size_of::<Termios>() >= core::mem::size_of::<c::termios>());
-
-        check_renamed_struct_renamed_field!(Termios, termios, input_modes, c_iflag);
-        check_renamed_struct_renamed_field!(Termios, termios, output_modes, c_oflag);
-        check_renamed_struct_renamed_field!(Termios, termios, control_modes, c_cflag);
-        check_renamed_struct_renamed_field!(Termios, termios, local_modes, c_lflag);
-        #[cfg(any(
-            linux_like,
-            target_env = "newlib",
-            target_os = "fuchsia",
-            target_os = "haiku",
-            target_os = "redox"
-        ))]
-        check_renamed_struct_renamed_field!(Termios, termios, line_discipline, c_line);
-        check_renamed_struct_renamed_field!(Termios, termios, special_codes, c_cc);
-        #[cfg(not(any(
-            linux_kernel,
-            solarish,
-            target_os = "emscripten",
-            target_os = "fuchsia"
-        )))]
+        // On platforms with a termios/termios2 split, check `termios`.
+        #[cfg(linux_raw)]
         {
-            check_renamed_struct_renamed_field!(Termios, termios, input_speed, c_ispeed);
-            check_renamed_struct_renamed_field!(Termios, termios, output_speed, c_ospeed);
+            check_renamed_type!(Termios, termios2);
+            check_renamed_struct_renamed_field!(Termios, termios2, input_modes, c_iflag);
+            check_renamed_struct_renamed_field!(Termios, termios2, output_modes, c_oflag);
+            check_renamed_struct_renamed_field!(Termios, termios2, control_modes, c_cflag);
+            check_renamed_struct_renamed_field!(Termios, termios2, local_modes, c_lflag);
+            check_renamed_struct_renamed_field!(Termios, termios2, line_discipline, c_line);
+            check_renamed_struct_renamed_field!(Termios, termios2, special_codes, c_cc);
+            check_renamed_struct_renamed_field!(Termios, termios2, input_speed, c_ispeed);
+            check_renamed_struct_renamed_field!(Termios, termios2, output_speed, c_ospeed);
+
+            // We assume that `termios` has the same layout as `termios2` minus the
+            // `c_ispeed` and `c_ospeed` fields.
+            check_renamed_struct_renamed_field!(Termios, termios, input_modes, c_iflag);
+            check_renamed_struct_renamed_field!(Termios, termios, output_modes, c_oflag);
+            check_renamed_struct_renamed_field!(Termios, termios, control_modes, c_cflag);
+            check_renamed_struct_renamed_field!(Termios, termios, local_modes, c_lflag);
+            check_renamed_struct_renamed_field!(Termios, termios, special_codes, c_cc);
+
+            // On everything except PowerPC, `termios` matches `termios2` except
+            // for the addition of `c_ispeed` and `c_ospeed`.
+            #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
+            const_assert_eq!(
+                memoffset::offset_of!(Termios, input_speed),
+                core::mem::size_of::<c::termios>()
+            );
+
+            // On PowerPC, `termios2` is `termios`.
+            #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
+            assert_eq_size!(c::termios2, c::termios);
         }
-        #[cfg(any(target_env = "musl", target_os = "fuchsia"))]
+
+        #[cfg(not(linux_raw))]
         {
-            check_renamed_struct_renamed_field!(Termios, termios, input_speed, __c_ispeed);
-            check_renamed_struct_renamed_field!(Termios, termios, output_speed, __c_ospeed);
+            // On MIPS, SPARC, and Android, the libc lacks the ospeed and ispeed
+            // fields.
+            #[cfg(all(
+                not(all(
+                    target_env = "gnu",
+                    any(
+                        target_arch = "mips",
+                        target_arch = "mips32r6",
+                        target_arch = "mips64",
+                        target_arch = "mips64r6",
+                        target_arch = "sparc",
+                        target_arch = "sparc64"
+                    )
+                )),
+                not(all(libc, target_os = "android"))
+            ))]
+            check_renamed_type!(Termios, termios);
+            #[cfg(not(all(
+                not(all(
+                    target_env = "gnu",
+                    any(
+                        target_arch = "mips",
+                        target_arch = "mips32r6",
+                        target_arch = "mips64",
+                        target_arch = "mips64r6",
+                        target_arch = "sparc",
+                        target_arch = "sparc64"
+                    )
+                )),
+                not(all(libc, target_os = "android"))
+            )))]
+            const_assert!(core::mem::size_of::<Termios>() >= core::mem::size_of::<c::termios>());
+
+            check_renamed_struct_renamed_field!(Termios, termios, input_modes, c_iflag);
+            check_renamed_struct_renamed_field!(Termios, termios, output_modes, c_oflag);
+            check_renamed_struct_renamed_field!(Termios, termios, control_modes, c_cflag);
+            check_renamed_struct_renamed_field!(Termios, termios, local_modes, c_lflag);
+            #[cfg(any(
+                linux_like,
+                target_env = "newlib",
+                target_os = "fuchsia",
+                target_os = "haiku",
+                target_os = "redox"
+            ))]
+            check_renamed_struct_renamed_field!(Termios, termios, line_discipline, c_line);
+            check_renamed_struct_renamed_field!(Termios, termios, special_codes, c_cc);
+            #[cfg(not(any(
+                linux_kernel,
+                solarish,
+                target_os = "emscripten",
+                target_os = "fuchsia"
+            )))]
+            {
+                check_renamed_struct_renamed_field!(Termios, termios, input_speed, c_ispeed);
+                check_renamed_struct_renamed_field!(Termios, termios, output_speed, c_ospeed);
+            }
+            #[cfg(any(target_env = "musl", target_os = "fuchsia"))]
+            {
+                check_renamed_struct_renamed_field!(Termios, termios, input_speed, __c_ispeed);
+                check_renamed_struct_renamed_field!(Termios, termios, output_speed, __c_ospeed);
+            }
         }
+
+        check_renamed_type!(OptionalActions, c_int);
+        check_renamed_type!(QueueSelector, c_int);
+        check_renamed_type!(Action, c_int);
     }
 
-    check_renamed_type!(OptionalActions, c_int);
-    check_renamed_type!(QueueSelector, c_int);
-    check_renamed_type!(Action, c_int);
-}
-
-#[test]
-#[cfg(not(any(
-    solarish,
-    target_os = "emscripten",
-    target_os = "haiku",
-    target_os = "redox"
-)))]
-fn termios_legacy() {
-    // Check that our doc aliases above are correct.
-    const_assert_eq!(c::EXTA, c::B19200);
-    const_assert_eq!(c::EXTB, c::B38400);
-}
-
-#[cfg(bsd)]
-#[test]
-fn termios_bsd() {
-    // On BSD platforms we can assume that the `B*` constants have their
-    // arbitrary integer speed value. Confirm this.
-    const_assert_eq!(c::B0, 0);
-    const_assert_eq!(c::B50, 50);
-    const_assert_eq!(c::B19200, 19200);
-    const_assert_eq!(c::B38400, 38400);
-}
-
-#[test]
-#[cfg(not(bsd))]
-fn termios_speed_encoding() {
-    assert_eq!(speed::encode(0), Some(c::B0));
-    assert_eq!(speed::encode(50), Some(c::B50));
-    assert_eq!(speed::encode(19200), Some(c::B19200));
-    assert_eq!(speed::encode(38400), Some(c::B38400));
-    assert_eq!(speed::encode(1), None);
-    assert_eq!(speed::encode(!0), None);
-
-    #[cfg(not(linux_kernel))]
-    {
-        assert_eq!(speed::decode(c::B0), Some(0));
-        assert_eq!(speed::decode(c::B50), Some(50));
-        assert_eq!(speed::decode(c::B19200), Some(19200));
-        assert_eq!(speed::decode(c::B38400), Some(38400));
-    }
-}
-
-#[cfg(linux_kernel)]
-#[test]
-fn termios_ioctl_contiguity() {
-    // When using `termios2`, we assume that we can add the optional actions
-    // value to the ioctl request code. Test this assumption.
-
-    const_assert_eq!(c::TCSETS2, c::TCSETS2 + 0);
-    const_assert_eq!(c::TCSETSW2, c::TCSETS2 + 1);
-    const_assert_eq!(c::TCSETSF2, c::TCSETS2 + 2);
-
-    const_assert_eq!(c::TCSANOW - c::TCSANOW, 0);
-    const_assert_eq!(c::TCSADRAIN - c::TCSANOW, 1);
-    const_assert_eq!(c::TCSAFLUSH - c::TCSANOW, 2);
-
-    // MIPS is different here.
-    #[cfg(any(
-        target_arch = "mips",
-        target_arch = "mips32r6",
-        target_arch = "mips64",
-        target_arch = "mips64r6"
-    ))]
-    {
-        assert_eq!(i128::from(c::TCSANOW) - i128::from(c::TCSETS), 0);
-        assert_eq!(i128::from(c::TCSADRAIN) - i128::from(c::TCSETS), 1);
-        assert_eq!(i128::from(c::TCSAFLUSH) - i128::from(c::TCSETS), 2);
-    }
+    #[test]
     #[cfg(not(any(
-        target_arch = "mips",
-        target_arch = "mips32r6",
-        target_arch = "mips64",
-        target_arch = "mips64r6"
+        solarish,
+        target_os = "emscripten",
+        target_os = "haiku",
+        target_os = "redox"
     )))]
-    {
-        const_assert_eq!(c::TCSANOW, 0);
-        const_assert_eq!(c::TCSADRAIN, 1);
-        const_assert_eq!(c::TCSAFLUSH, 2);
+    fn termios_legacy() {
+        // Check that our doc aliases above are correct.
+        const_assert_eq!(c::EXTA, c::B19200);
+        const_assert_eq!(c::EXTB, c::B38400);
     }
-}
 
-#[cfg(linux_kernel)]
-#[test]
-fn termios_cibaud() {
-    // Test an assumption.
-    const_assert_eq!(c::CIBAUD, c::CBAUD << c::IBSHIFT);
+    #[cfg(bsd)]
+    #[test]
+    fn termios_bsd() {
+        // On BSD platforms we can assume that the `B*` constants have their
+        // arbitrary integer speed value. Confirm this.
+        const_assert_eq!(c::B0, 0);
+        const_assert_eq!(c::B50, 50);
+        const_assert_eq!(c::B19200, 19200);
+        const_assert_eq!(c::B38400, 38400);
+    }
+
+    #[test]
+    #[cfg(not(bsd))]
+    fn termios_speed_encoding() {
+        assert_eq!(speed::encode(0), Some(c::B0));
+        assert_eq!(speed::encode(50), Some(c::B50));
+        assert_eq!(speed::encode(19200), Some(c::B19200));
+        assert_eq!(speed::encode(38400), Some(c::B38400));
+        assert_eq!(speed::encode(1), None);
+        assert_eq!(speed::encode(!0), None);
+
+        #[cfg(not(linux_kernel))]
+        {
+            assert_eq!(speed::decode(c::B0), Some(0));
+            assert_eq!(speed::decode(c::B50), Some(50));
+            assert_eq!(speed::decode(c::B19200), Some(19200));
+            assert_eq!(speed::decode(c::B38400), Some(38400));
+        }
+    }
+
+    #[cfg(linux_kernel)]
+    #[test]
+    fn termios_ioctl_contiguity() {
+        // When using `termios2`, we assume that we can add the optional actions
+        // value to the ioctl request code. Test this assumption.
+
+        const_assert_eq!(c::TCSETS2, c::TCSETS2 + 0);
+        const_assert_eq!(c::TCSETSW2, c::TCSETS2 + 1);
+        const_assert_eq!(c::TCSETSF2, c::TCSETS2 + 2);
+
+        const_assert_eq!(c::TCSANOW - c::TCSANOW, 0);
+        const_assert_eq!(c::TCSADRAIN - c::TCSANOW, 1);
+        const_assert_eq!(c::TCSAFLUSH - c::TCSANOW, 2);
+
+        // MIPS is different here.
+        #[cfg(any(
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "mips64",
+            target_arch = "mips64r6"
+        ))]
+        {
+            assert_eq!(i128::from(c::TCSANOW) - i128::from(c::TCSETS), 0);
+            assert_eq!(i128::from(c::TCSADRAIN) - i128::from(c::TCSETS), 1);
+            assert_eq!(i128::from(c::TCSAFLUSH) - i128::from(c::TCSETS), 2);
+        }
+        #[cfg(not(any(
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "mips64",
+            target_arch = "mips64r6"
+        )))]
+        {
+            const_assert_eq!(c::TCSANOW, 0);
+            const_assert_eq!(c::TCSADRAIN, 1);
+            const_assert_eq!(c::TCSAFLUSH, 2);
+        }
+    }
+
+    #[cfg(linux_kernel)]
+    #[test]
+    fn termios_cibaud() {
+        // Test an assumption.
+        const_assert_eq!(c::CIBAUD, c::CBAUD << c::IBSHIFT);
+    }
 }

--- a/src/ugid.rs
+++ b/src/ugid.rs
@@ -105,10 +105,15 @@ pub(crate) fn translate_fchown_args(
     (ow as c::uid_t, gr as c::gid_t)
 }
 
-#[test]
-fn test_sizes() {
-    assert_eq_size!(RawUid, u32);
-    assert_eq_size!(RawGid, u32);
-    assert_eq_size!(RawUid, libc::uid_t);
-    assert_eq_size!(RawGid, libc::gid_t);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sizes() {
+        assert_eq_size!(RawUid, u32);
+        assert_eq_size!(RawGid, u32);
+        assert_eq_size!(RawUid, libc::uid_t);
+        assert_eq_size!(RawGid, libc::gid_t);
+    }
 }


### PR DESCRIPTION
This makes the code more idiomatic. As discussed in rust-lang/cargo#10559, the `use super::*;` pattern makes this style easier to use.