### PR TITLE
Fix compilation error on 32-bit Apple

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,6 +233,7 @@ jobs:
     - run: cargo check -Z build-std --target=mips64el-unknown-linux-gnuabi64 --features=all-apis
     - run: cargo check -Z build-std --target=powerpc-unknown-linux-musl --features=all-apis
     - run: cargo check -Z build-std --target=powerpc64le-unknown-linux-musl --features=all-apis
+    - run: cargo check -Z build-std --target=armv7k-apple-watchos --features=all-apis
 
 
   test:

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -2654,12 +2654,12 @@ pub(crate) fn fremovexattr(fd: BorrowedFd<'_>, name: &CStr) -> io::Result<()> {
 /// See [`crate::timespec::fix_negative_nsec`] for details.
 #[cfg(apple)]
 fn fix_negative_stat_nsecs(mut stat: Stat) -> Stat {
-    stat.st_atime_nsec =
-        crate::timespec::fix_negative_nsecs(&mut stat.st_atime, stat.st_atime_nsec as _) as _;
-    stat.st_mtime_nsec =
-        crate::timespec::fix_negative_nsecs(&mut stat.st_mtime, stat.st_mtime_nsec as _) as _;
-    stat.st_ctime_nsec =
-        crate::timespec::fix_negative_nsecs(&mut stat.st_ctime, stat.st_ctime_nsec as _) as _;
+    (stat.st_atime, stat.st_atime_nsec) =
+        crate::timespec::fix_negative_nsecs(stat.st_atime, stat.st_atime_nsec);
+    (stat.st_mtime, stat.st_mtime_nsec) =
+        crate::timespec::fix_negative_nsecs(stat.st_mtime, stat.st_mtime_nsec);
+    (stat.st_ctime, stat.st_ctime_nsec) =
+        crate::timespec::fix_negative_nsecs(stat.st_ctime, stat.st_ctime_nsec);
     stat
 }
 

--- a/src/backend/libc/time/syscalls.rs
+++ b/src/backend/libc/time/syscalls.rs
@@ -475,7 +475,10 @@ fn timerfd_gettime_old(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
 
 /// See [`crate::timespec::fix_negative_nsecs`] for details.
 #[cfg(apple)]
+#[cfg(not(fix_y2038))]
 fn fix_negative_timespec_nsecs(mut ts: Timespec) -> Timespec {
-    ts.tv_nsec = crate::timespec::fix_negative_nsecs(&mut ts.tv_sec, ts.tv_nsec as _) as _;
+    let (sec, nsec) = crate::timespec::fix_negative_nsecs(ts.tv_sec as _, ts.tv_nsec as _);
+    ts.tv_sec = sec as _;
+    ts.tv_nsec = nsec as _;
     ts
 }


### PR DESCRIPTION
Fixes an error we're seeing in `cc-rs` ([link](https://github.com/rust-lang/cc-rs/actions/runs/13743942258/job/38436533137?pr=1373)), because `time_t` is `c_long`, which is `i32` on 32-bit Apple platforms:
```
error[E0308]: mismatched types
    --> src/backend/libc/fs/syscalls.rs:2658:45
     |
2658 |         crate::timespec::fix_negative_nsecs(&mut stat.st_atime, stat.st_atime_nsec as _) as _;
     |         ----------------------------------- ^^^^^^^^^^^^^^^^^^ expected `&mut i64`, found `&mut i32`
     |         |
     |         arguments to this function are incorrect
     |
     = note: expected mutable reference `&mut i64`
                found mutable reference `&mut i32`
note: function defined here
    --> src/timespec.rs:341:15
     |
341  | pub(crate) fn fix_negative_nsecs(secs: &mut i64, mut nsecs: i32) -> i32 {
     |               ^^^^^^^^^^^^^^^^^^ --------------

error[E0308]: mismatched types
    --> src/backend/libc/fs/syscalls.rs:2660:45
     |
2660 |         crate::timespec::fix_negative_nsecs(&mut stat.st_mtime, stat.st_mtime_nsec as _) as _;
     |         ----------------------------------- ^^^^^^^^^^^^^^^^^^ expected `&mut i64`, found `&mut i32`
     |         |
     |         arguments to this function are incorrect
     |
     = note: expected mutable reference `&mut i64`
                found mutable reference `&mut i32`
note: function defined here
    --> src/timespec.rs:341:15
     |
341  | pub(crate) fn fix_negative_nsecs(secs: &mut i64, mut nsecs: i32) -> i32 {
     |               ^^^^^^^^^^^^^^^^^^ --------------

error[E0308]: mismatched types
    --> src/backend/libc/fs/syscalls.rs:2662:45
     |
2662 |         crate::timespec::fix_negative_nsecs(&mut stat.st_ctime, stat.st_ctime_nsec as _) as _;
     |         ----------------------------------- ^^^^^^^^^^^^^^^^^^ expected `&mut i64`, found `&mut i32`
     |         |
     |         arguments to this function are incorrect
     |
     = note: expected mutable reference `&mut i64`
                found mutable reference `&mut i32`
note: function defined here
    --> src/timespec.rs:341:15
     |
341  | pub(crate) fn fix_negative_nsecs(secs: &mut i64, mut nsecs: i32) -> i32 {
     |               ^^^^^^^^^^^^^^^^^^ --------------

For more information about this error, try `rustc --explain E0308`.
error: could not compile `rustix` (lib) due to 3 previous errors
```
