### PR TITLE
DRAFT: Support `Buffer` on `&mut MaybeUninit<T>`

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -154,6 +154,25 @@ impl<T> private::Sealed<T> for &mut Vec<T> {
     }
 }
 
+impl<'a, T> private::Sealed<T> for &'a mut MaybeUninit<T> {
+    type Output = Option<&'a mut T>;
+
+    #[inline]
+    fn parts_mut(&mut self) -> (*mut T, usize) {
+        (self.as_mut_ptr(), 1)
+    }
+
+    #[inline]
+    unsafe fn assume_init(self, len: usize) -> Self::Output {
+        if len == 0 {
+            None
+        } else {
+            // SAFETY: The user asserts that the object is now initialized.
+            Some(MaybeUninit::assume_init_mut(self))
+        }
+    }
+}
+
 impl<'a, T> private::Sealed<T> for &'a mut [MaybeUninit<T>] {
     type Output = (&'a mut [T], &'a mut [MaybeUninit<T>]);
 


### PR DESCRIPTION
This returns an output of `Option<&mut T>`: `Some` for `.assume_init(1)`,
and `None` for `.assume_init(0)`.

This is a draft because it's not clear yet whether `Option` is the best
possible return value. For syscalls that will *always* initialize the
buffer if they return successfully, this isn't ideal, because it
requires handling an `Ok(None)` case that'll never happen. However, for
syscalls that *can* return zero output successfully, like `read`, we'd
need some way to handle that case.
