### PR TITLE
Disable "unused unsafe" warnings in the libc makedev code.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,7 @@ jobs:
         cargo update --package=half --precise=2.2.1
         cargo update --package=flate2 --precise=1.0.35
         cargo update --package=textwrap --precise=0.16.1
+        cargo update --package=once_cell --precise=1.20.3
 
     - run: >
         rustup target add
@@ -533,6 +534,7 @@ jobs:
         cargo update --package=half --precise=2.2.1
         cargo update --package=flate2 --precise=1.0.35
         cargo update --package=textwrap --precise=0.16.1
+        cargo update --package=once_cell --precise=1.20.3
 
     - run: |
         cargo test --verbose --features=all-apis --release --workspace -- --nocapture

--- a/src/backend/libc/fs/makedev.rs
+++ b/src/backend/libc/fs/makedev.rs
@@ -1,3 +1,9 @@
+// TODO: Remove the unsafe blocks. libc 0.2.171 removed `unsafe` from several
+// of these functions. Eventually we should depend on that version and remove
+// the `unsafe` blocks in the code, but for now, disable that warning so that
+// we're compatible with older libc versions.
+#![allow(unused_unsafe)]
+
 #[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
 use crate::backend::c;
 use crate::fs::Dev;


### PR DESCRIPTION
The latest version of libc makes `makedev`, `major`, and `minor` safe functions; for now; disable the warning about unused unsafe blocks wrapped around those functions, to be compatible with older and newer libc versions.