### PR TITLE
Experiment with changing `Buffer::parts_mut` to `Buffer::as_mut_ptr`.

### DIFF
--- a/src/backend/libc/io/windows_syscalls.rs
+++ b/src/backend/libc/io/windows_syscalls.rs
@@ -8,13 +8,14 @@ use crate::backend::fd::LibcFd;
 use crate::fd::{BorrowedFd, RawFd};
 use crate::io;
 use crate::ioctl::{IoctlOutput, Opcode};
+use core::mem::MaybeUninit;
 
-pub(crate) unsafe fn read(fd: BorrowedFd<'_>, buf: (*mut u8, usize)) -> io::Result<usize> {
+pub(crate) unsafe fn read(fd: BorrowedFd<'_>, buf: *mut [MaybeUninit<u8>]) -> io::Result<usize> {
     // `read` on a socket is equivalent to `recv` with no flags.
     ret_send_recv(c::recv(
         borrowed_fd(fd),
-        buf.0.cast(),
-        send_recv_len(buf.1),
+        buf.cast::<u8>(),
+        send_recv_len(buf.len()),
         0,
     ))
 }

--- a/src/backend/libc/net/syscalls.rs
+++ b/src/backend/libc/net/syscalls.rs
@@ -33,13 +33,13 @@ use {
 
 pub(crate) unsafe fn recv(
     fd: BorrowedFd<'_>,
-    buf: (*mut u8, usize),
+    buf: *mut [MaybeUninit<u8>],
     flags: RecvFlags,
 ) -> io::Result<usize> {
     ret_send_recv(c::recv(
         borrowed_fd(fd),
-        buf.0.cast(),
-        send_recv_len(buf.1),
+        buf.cast(),
+        send_recv_len(buf.len()),
         bitflags_bits!(flags),
     ))
 }
@@ -57,7 +57,7 @@ pub(crate) fn send(fd: BorrowedFd<'_>, buf: &[u8], flags: SendFlags) -> io::Resu
 
 pub(crate) unsafe fn recvfrom(
     fd: BorrowedFd<'_>,
-    buf: (*mut u8, usize),
+    buf: *mut [MaybeUninit<u8>],
     flags: RecvFlags,
 ) -> io::Result<(usize, Option<SocketAddrAny>)> {
     let mut addr = SocketAddrBuf::new();
@@ -69,8 +69,8 @@ pub(crate) unsafe fn recvfrom(
 
     let nread = ret_send_recv(c::recvfrom(
         borrowed_fd(fd),
-        buf.0.cast(),
-        send_recv_len(buf.1),
+        buf.cast(),
+        send_recv_len(buf.len()),
         bitflags_bits!(flags),
         addr.storage.as_mut_ptr().cast::<c::sockaddr>(),
         &mut addr.len,

--- a/src/backend/libc/rand/syscalls.rs
+++ b/src/backend/libc/rand/syscalls.rs
@@ -1,14 +1,20 @@
 //! libc syscalls supporting `rustix::rand`.
 
 #[cfg(linux_kernel)]
-use {crate::backend::c, crate::backend::conv::ret_usize, crate::io, crate::rand::GetRandomFlags};
+use {
+    crate::backend::c, crate::backend::conv::ret_usize, crate::io, crate::rand::GetRandomFlags,
+    core::mem::MaybeUninit,
+};
 
 #[cfg(linux_kernel)]
-pub(crate) unsafe fn getrandom(buf: (*mut u8, usize), flags: GetRandomFlags) -> io::Result<usize> {
+pub(crate) unsafe fn getrandom(
+    buf: *mut [MaybeUninit<u8>],
+    flags: GetRandomFlags,
+) -> io::Result<usize> {
     // `getrandom` wasn't supported in glibc until 2.25.
     weak_or_syscall! {
         fn getrandom(buf: *mut c::c_void, buflen: c::size_t, flags: c::c_uint) via SYS_getrandom -> c::ssize_t
     }
 
-    ret_usize(getrandom(buf.0.cast(), buf.1, flags.bits()))
+    ret_usize(getrandom(buf.cast(), buf.len(), flags.bits()))
 }

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -242,6 +242,24 @@ pub(super) fn opt_ref<T: Sized, Num: ArgNumber>(t: Option<&T>) -> ArgReg<'_, Num
     }
 }
 
+/// Convert a buffer pointer as passed by `Buffer` to a pointer for passing to
+/// a syscall.
+///
+/// When `slice_ptr_get` is stabilized, the `.cast(::<T>()` can be replaced by
+/// `.as_mut_ptr()`.
+/// <https://doc.rust-lang.org/stable/std/primitive.pointer.html#method.as_mut_ptr>
+#[inline]
+pub(super) fn buffer_ptr<'a, Num: ArgNumber, T>(buf: *mut [MaybeUninit<T>]) -> ArgReg<'a, Num> {
+    buf.cast::<T>().into()
+}
+
+/// Convert a buffer pointer as passed by `Buffer` to a length for passing to
+/// a syscall.
+#[inline]
+pub(super) fn buffer_len<'a, Num: ArgNumber, T>(buf: *mut [MaybeUninit<T>]) -> ArgReg<'a, Num> {
+    pass_usize(buf.len())
+}
+
 /// Convert a `c_int` into an `ArgReg`.
 ///
 /// Be sure to use `raw_fd` to pass `RawFd` values.

--- a/src/backend/linux_raw/rand/syscalls.rs
+++ b/src/backend/linux_raw/rand/syscalls.rs
@@ -5,11 +5,20 @@
 //! See the `rustix::backend` module documentation for details.
 #![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
-use crate::backend::conv::{pass_usize, ret_usize};
+use crate::backend::conv::{buffer_len, buffer_ptr, ret_usize};
 use crate::io;
 use crate::rand::GetRandomFlags;
+use core::mem::MaybeUninit;
 
 #[inline]
-pub(crate) unsafe fn getrandom(buf: (*mut u8, usize), flags: GetRandomFlags) -> io::Result<usize> {
-    ret_usize(syscall!(__NR_getrandom, buf.0, pass_usize(buf.1), flags))
+pub(crate) unsafe fn getrandom(
+    buf: *mut [MaybeUninit<u8>],
+    flags: GetRandomFlags,
+) -> io::Result<usize> {
+    ret_usize(syscall!(
+        __NR_getrandom,
+        buffer_ptr(buf),
+        buffer_len(buf),
+        flags
+    ))
 }

--- a/src/event/epoll.rs
+++ b/src/event/epoll.rs
@@ -210,7 +210,7 @@ pub fn wait<EpollFd: AsFd, Buf: Buffer<Event>>(
     timeout: Option<&Timespec>,
 ) -> io::Result<Buf::Output> {
     // SAFETY: `epoll_wait` behaves.
-    let nfds = unsafe { syscalls::epoll_wait(epoll.as_fd(), event_list.parts_mut(), timeout)? };
+    let nfds = unsafe { syscalls::epoll_wait(epoll.as_fd(), event_list.as_mut_ptr(), timeout)? };
     // SAFETY: `epoll_wait` behaves.
     unsafe { Ok(event_list.assume_init(nfds)) }
 }

--- a/src/event/kqueue.rs
+++ b/src/event/kqueue.rs
@@ -430,7 +430,7 @@ pub unsafe fn kevent<Fd: AsFd, Buf: Buffer<Event>>(
     let len = syscalls::kevent(
         kqueue.as_fd(),
         changelist,
-        eventlist.parts_mut(),
+        eventlist.as_mut_ptr(),
         timeout.as_ref(),
     )
     .map(|res| res as _)?;

--- a/src/event/port.rs
+++ b/src/event/port.rs
@@ -156,7 +156,7 @@ pub fn getn<Fd: AsFd, Buf: Buffer<Event>>(
 ) -> io::Result<Buf::Output> {
     // SAFETY: `port_getn` behaves.
     let nevents =
-        unsafe { syscalls::port_getn(port.as_fd(), events.parts_mut(), min_events, timeout)? };
+        unsafe { syscalls::port_getn(port.as_fd(), events.as_mut_ptr(), min_events, timeout)? };
     // SAFETY: `port_getn` behaves.
     unsafe { Ok(events.assume_init(nevents)) }
 }

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -116,13 +116,7 @@ fn _readlinkat(dirfd: BorrowedFd<'_>, path: &CStr, mut buffer: Vec<u8>) -> io::R
         let buf = buffer.spare_capacity_mut();
 
         // SAFETY: `readlinkat` behaves.
-        let nread = unsafe {
-            backend::fs::syscalls::readlinkat(
-                dirfd.as_fd(),
-                path,
-                (buf.as_mut_ptr().cast(), buf.len()),
-            )?
-        };
+        let nread = unsafe { backend::fs::syscalls::readlinkat(dirfd.as_fd(), path, buf)? };
 
         debug_assert!(nread <= buffer.capacity());
         if nread < buffer.capacity() {
@@ -178,7 +172,7 @@ pub fn readlinkat_raw<P: path::Arg, Fd: AsFd, Buf: Buffer<u8>>(
 ) -> io::Result<Buf::Output> {
     // SAFETY: `readlinkat` behaves.
     let len = path.into_with_c_str(|path| unsafe {
-        backend::fs::syscalls::readlinkat(dirfd.as_fd(), path, buf.parts_mut())
+        backend::fs::syscalls::readlinkat(dirfd.as_fd(), path, buf.as_mut_ptr())
     })?;
     // SAFETY: `readlinkat` behaves.
     unsafe { Ok(buf.assume_init(len)) }

--- a/src/fs/xattr.rs
+++ b/src/fs/xattr.rs
@@ -40,7 +40,7 @@ pub fn getxattr<P: path::Arg, Name: path::Arg, Buf: Buffer<u8>>(
     path.into_with_c_str(|path| {
         name.into_with_c_str(|name| {
             // SAFETY: `getxattr` behaves.
-            let len = unsafe { backend::fs::syscalls::getxattr(path, name, value.parts_mut())? };
+            let len = unsafe { backend::fs::syscalls::getxattr(path, name, value.as_mut_ptr())? };
             // SAFETY: `getxattr` behaves.
             unsafe { Ok(value.assume_init(len)) }
         })
@@ -64,7 +64,7 @@ pub fn lgetxattr<P: path::Arg, Name: path::Arg, Buf: Buffer<u8>>(
     path.into_with_c_str(|path| {
         name.into_with_c_str(|name| {
             // SAFETY: `lgetxattr` behaves.
-            let len = unsafe { backend::fs::syscalls::lgetxattr(path, name, value.parts_mut())? };
+            let len = unsafe { backend::fs::syscalls::lgetxattr(path, name, value.as_mut_ptr())? };
             // SAFETY: `lgetxattr` behaves.
             unsafe { Ok(value.assume_init(len)) }
         })
@@ -86,7 +86,8 @@ pub fn fgetxattr<Fd: AsFd, Name: path::Arg, Buf: Buffer<u8>>(
 ) -> io::Result<Buf::Output> {
     name.into_with_c_str(|name| {
         // SAFETY: `fgetxattr` behaves.
-        let len = unsafe { backend::fs::syscalls::fgetxattr(fd.as_fd(), name, value.parts_mut())? };
+        let len =
+            unsafe { backend::fs::syscalls::fgetxattr(fd.as_fd(), name, value.as_mut_ptr())? };
         // SAFETY: `fgetxattr` behaves.
         unsafe { Ok(value.assume_init(len)) }
     })
@@ -159,7 +160,7 @@ pub fn fsetxattr<Fd: AsFd, Name: path::Arg>(
 pub fn listxattr<P: path::Arg, Buf: Buffer<u8>>(path: P, mut list: Buf) -> io::Result<Buf::Output> {
     path.into_with_c_str(|path| {
         // SAFETY: `listxattr` behaves.
-        let len = unsafe { backend::fs::syscalls::listxattr(path, list.parts_mut())? };
+        let len = unsafe { backend::fs::syscalls::listxattr(path, list.as_mut_ptr())? };
         // SAFETY: `listxattr` behaves.
         unsafe { Ok(list.assume_init(len)) }
     })
@@ -179,7 +180,7 @@ pub fn llistxattr<P: path::Arg, Buf: Buffer<u8>>(
 ) -> io::Result<Buf::Output> {
     path.into_with_c_str(|path| {
         // SAFETY: `flistxattr` behaves.
-        let len = unsafe { backend::fs::syscalls::llistxattr(path, list.parts_mut())? };
+        let len = unsafe { backend::fs::syscalls::llistxattr(path, list.as_mut_ptr())? };
         // SAFETY: `flistxattr` behaves.
         unsafe { Ok(list.assume_init(len)) }
     })
@@ -195,7 +196,7 @@ pub fn llistxattr<P: path::Arg, Buf: Buffer<u8>>(
 #[inline]
 pub fn flistxattr<Fd: AsFd, Buf: Buffer<u8>>(fd: Fd, mut list: Buf) -> io::Result<Buf::Output> {
     // SAFETY: `flistxattr` behaves.
-    let len = unsafe { backend::fs::syscalls::flistxattr(fd.as_fd(), list.parts_mut())? };
+    let len = unsafe { backend::fs::syscalls::flistxattr(fd.as_fd(), list.as_mut_ptr())? };
     // SAFETY: `flistxattr` behaves.
     unsafe { Ok(list.assume_init(len)) }
 }

--- a/src/io/read_write.rs
+++ b/src/io/read_write.rs
@@ -38,7 +38,7 @@ pub use backend::io::types::ReadWriteFlags;
 #[inline]
 pub fn read<Fd: AsFd, Buf: Buffer<u8>>(fd: Fd, mut buf: Buf) -> io::Result<Buf::Output> {
     // SAFETY: `read` behaves.
-    let len = unsafe { backend::io::syscalls::read(fd.as_fd(), buf.parts_mut())? };
+    let len = unsafe { backend::io::syscalls::read(fd.as_fd(), buf.as_mut_ptr())? };
     // SAFETY: `read` behaves.
     unsafe { Ok(buf.assume_init(len)) }
 }
@@ -100,7 +100,7 @@ pub fn pread<Fd: AsFd, Buf: Buffer<u8>>(
     offset: u64,
 ) -> io::Result<Buf::Output> {
     // SAFETY: `pread` behaves.
-    let len = unsafe { backend::io::syscalls::pread(fd.as_fd(), buf.parts_mut(), offset)? };
+    let len = unsafe { backend::io::syscalls::pread(fd.as_fd(), buf.as_mut_ptr(), offset)? };
     // SAFETY: `pread` behaves.
     unsafe { Ok(buf.assume_init(len)) }
 }

--- a/src/rand/getrandom.rs
+++ b/src/rand/getrandom.rs
@@ -27,7 +27,7 @@ pub use backend::rand::types::GetRandomFlags;
 #[inline]
 pub fn getrandom<Buf: Buffer<u8>>(mut buf: Buf, flags: GetRandomFlags) -> io::Result<Buf::Output> {
     // SAFETY: `getrandom` behaves.
-    let len = unsafe { backend::rand::syscalls::getrandom(buf.parts_mut(), flags)? };
+    let len = unsafe { backend::rand::syscalls::getrandom(buf.as_mut_ptr(), flags)? };
     // SAFETY: `getrandom` behaves.
     unsafe { Ok(buf.assume_init(len)) }
 }


### PR DESCRIPTION
Based on an idea suggested [here], experiment with changing from a `parts_mut` that returns `(*mut T, usize)` to a `as_mut_ptr` which returns a `*mut [MaybeUninit<T>]`.

[here]: https://hachyderm.io/deck/@wffl@im-in.space/114145162248844972