### PR TITLE
Alphabetize targets in `any` and `all` in `cfg` directives.

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -78,12 +78,12 @@ use {
 #[cfg(not(any(
     apple,
     netbsdlike,
-    target_os = "solaris",
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "haiku",
     target_os = "horizon",
     target_os = "redox",
+    target_os = "solaris",
     target_os = "vita",
 )))]
 use {crate::fs::Advice, core::num::NonZeroU64};
@@ -1258,12 +1258,12 @@ pub(crate) fn copy_file_range(
 #[cfg(not(any(
     apple,
     netbsdlike,
-    target_os = "solaris",
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "haiku",
     target_os = "horizon",
     target_os = "redox",
+    target_os = "solaris",
     target_os = "vita",
 )))]
 pub(crate) fn fadvise(

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -376,12 +376,12 @@ bitflags! {
         /// functions, use [`rustix::fs::fcntl_setfl`] instead.
         #[cfg(not(any(
             target_os = "aix",
+            target_os = "cygwin",
             target_os = "espidf",
             target_os = "haiku",
             target_os = "horizon",
             target_os = "wasi",
             target_os = "vita",
-            target_os = "cygwin",
             solarish
         )))]
         const ASYNC = bitcast!(c::O_ASYNC);
@@ -631,12 +631,12 @@ impl FileType {
 #[cfg(not(any(
     apple,
     netbsdlike,
-    target_os = "solaris",
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "horizon",
     target_os = "haiku",
     target_os = "redox",
+    target_os = "solaris",
     target_os = "vita",
 )))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -782,6 +782,7 @@ bitflags! {
             bsd,
             solarish,
             target_os = "aix",
+            target_os = "cygwin",
             target_os = "emscripten",
             target_os = "fuchsia",
             target_os = "haiku",
@@ -789,7 +790,6 @@ bitflags! {
             target_os = "l4re",
             target_os = "linux",
             target_os = "wasi",
-            target_os = "cygwin",
         )))]
         const NO_HIDE_STALE = bitcast!(c::FALLOC_FL_NO_HIDE_STALE);
         /// `FALLOC_FL_COLLAPSE_RANGE`
@@ -1059,6 +1059,7 @@ pub type StatFs = c::statfs64;
 /// `fsid_t` for use with [`StatFs`].
 #[cfg(not(any(
     solarish,
+    target_os = "cygwin"
     target_os = "espidf",
     target_os = "haiku",
     target_os = "horizon",
@@ -1066,7 +1067,6 @@ pub type StatFs = c::statfs64;
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi",
-    target_os = "cygwin"
 )))]
 pub type Fsid = c::fsid_t;
 

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -1059,7 +1059,7 @@ pub type StatFs = c::statfs64;
 /// `fsid_t` for use with [`StatFs`].
 #[cfg(not(any(
     solarish,
-    target_os = "cygwin"
+    target_os = "cygwin",
     target_os = "espidf",
     target_os = "haiku",
     target_os = "horizon",

--- a/src/backend/libc/io/errno.rs
+++ b/src/backend/libc/io/errno.rs
@@ -276,6 +276,7 @@ impl Errno {
         windows,
         target_os = "aix",
         target_os = "android",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -285,7 +286,6 @@ impl Errno {
         target_os = "redox",
         target_os = "vita",
         target_os = "wasi",
-        target_os = "cygwin",
     )))]
     pub const HWPOISON: Self = Self(c::EHWPOISON);
     /// `EIDRM`
@@ -327,6 +327,7 @@ impl Errno {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -335,7 +336,6 @@ impl Errno {
         target_os = "nto",
         target_os = "vita",
         target_os = "wasi",
-        target_os = "cygwin",
     )))]
     pub const ISNAM: Self = Self(c::EISNAM);
     /// `EKEYEXPIRED`
@@ -344,6 +344,7 @@ impl Errno {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -352,7 +353,6 @@ impl Errno {
         target_os = "nto",
         target_os = "vita",
         target_os = "wasi",
-        target_os = "cygwin",
     )))]
     pub const KEYEXPIRED: Self = Self(c::EKEYEXPIRED);
     /// `EKEYREJECTED`
@@ -361,6 +361,7 @@ impl Errno {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -369,7 +370,6 @@ impl Errno {
         target_os = "nto",
         target_os = "vita",
         target_os = "wasi",
-        target_os = "cygwin",
     )))]
     pub const KEYREJECTED: Self = Self(c::EKEYREJECTED);
     /// `EKEYREVOKED`
@@ -378,6 +378,7 @@ impl Errno {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -386,7 +387,6 @@ impl Errno {
         target_os = "nto",
         target_os = "vita",
         target_os = "wasi",
-        target_os = "cygwin",
     )))]
     pub const KEYREVOKED: Self = Self(c::EKEYREVOKED);
     /// `EL2HLT`
@@ -531,6 +531,7 @@ impl Errno {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -539,7 +540,6 @@ impl Errno {
         target_os = "nto",
         target_os = "vita",
         target_os = "wasi",
-        target_os = "cygwin",
     )))]
     pub const MEDIUMTYPE: Self = Self(c::EMEDIUMTYPE);
     /// `EMFILE`
@@ -561,6 +561,7 @@ impl Errno {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -569,7 +570,6 @@ impl Errno {
         target_os = "nto",
         target_os = "vita",
         target_os = "wasi",
-        target_os = "cygwin",
     )))]
     pub const NAVAIL: Self = Self(c::ENAVAIL);
     /// `ENEEDAUTH`
@@ -642,6 +642,7 @@ impl Errno {
         bsd,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -650,7 +651,6 @@ impl Errno {
         target_os = "nto",
         target_os = "vita",
         target_os = "wasi",
-        target_os = "cygwin",
     )))]
     pub const NOKEY: Self = Self(c::ENOKEY);
     /// `ENOLCK`
@@ -767,6 +767,7 @@ impl Errno {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -775,7 +776,6 @@ impl Errno {
         target_os = "nto",
         target_os = "vita",
         target_os = "wasi",
-        target_os = "cygwin",
     )))]
     pub const NOTNAM: Self = Self(c::ENOTNAM);
     /// `ENOTRECOVERABLE`
@@ -896,6 +896,7 @@ impl Errno {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -904,13 +905,13 @@ impl Errno {
         target_os = "nto",
         target_os = "vita",
         target_os = "wasi",
-        target_os = "cygwin",
     )))]
     pub const REMOTEIO: Self = Self(c::EREMOTEIO);
     /// `ERESTART`
     #[cfg(not(any(
         bsd,
         windows,
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -918,7 +919,6 @@ impl Errno {
         target_os = "l4re",
         target_os = "vita",
         target_os = "wasi",
-        target_os = "cygwin",
     )))]
     pub const RESTART: Self = Self(c::ERESTART);
     /// `ERFKILL`
@@ -928,6 +928,7 @@ impl Errno {
         windows,
         target_os = "aix",
         target_os = "android",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -937,7 +938,6 @@ impl Errno {
         target_os = "redox",
         target_os = "vita",
         target_os = "wasi",
-        target_os = "cygwin",
     )))]
     pub const RFKILL: Self = Self(c::ERFKILL);
     /// `EROFS`
@@ -1028,6 +1028,7 @@ impl Errno {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -1036,7 +1037,6 @@ impl Errno {
         target_os = "nto",
         target_os = "vita",
         target_os = "wasi",
-        target_os = "cygwin",
     )))]
     pub const UCLEAN: Self = Self(c::EUCLEAN);
     /// `EUNATCH`

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -95,6 +95,7 @@ pub(crate) fn writev(fd: BorrowedFd<'_>, bufs: &[IoSlice<'_>]) -> io::Result<usi
 }
 
 #[cfg(not(any(
+    target_os = "cygwin",
     target_os = "espidf",
     target_os = "haiku",
     target_os = "horizon",
@@ -102,7 +103,6 @@ pub(crate) fn writev(fd: BorrowedFd<'_>, bufs: &[IoSlice<'_>]) -> io::Result<usi
     target_os = "redox",
     target_os = "solaris",
     target_os = "vita",
-    target_os = "cygwin",
 )))]
 pub(crate) fn preadv(
     fd: BorrowedFd<'_>,
@@ -122,6 +122,7 @@ pub(crate) fn preadv(
 }
 
 #[cfg(not(any(
+    target_os = "cygwin",
     target_os = "espidf",
     target_os = "haiku",
     target_os = "nto",
@@ -129,7 +130,6 @@ pub(crate) fn preadv(
     target_os = "redox",
     target_os = "solaris",
     target_os = "vita",
-    target_os = "cygwin",
 )))]
 pub(crate) fn pwritev(fd: BorrowedFd<'_>, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
     // Silently cast; we'll get `EINVAL` if the value is negative.

--- a/src/backend/libc/mm/types.rs
+++ b/src/backend/libc/mm/types.rs
@@ -82,13 +82,13 @@ bitflags! {
             solarish,
             target_os = "aix",
             target_os = "android",
+            target_os = "cygwin",
             target_os = "emscripten",
             target_os = "fuchsia",
             target_os = "haiku",
             target_os = "hurd",
             target_os = "nto",
             target_os = "redox",
-            target_os = "cygwin",
         )))]
         const SHARED_VALIDATE = bitcast!(c::MAP_SHARED_VALIDATE);
         /// `MAP_PRIVATE`
@@ -98,11 +98,11 @@ bitflags! {
             bsd,
             solarish,
             target_os = "aix",
+            target_os = "cygwin",
             target_os = "haiku",
             target_os = "hurd",
             target_os = "nto",
             target_os = "redox",
-            target_os = "cygwin",
         )))]
         const DENYWRITE = bitcast!(c::MAP_DENYWRITE);
         /// `MAP_FIXED`
@@ -113,13 +113,13 @@ bitflags! {
             solarish,
             target_os = "aix",
             target_os = "android",
+            target_os = "cygwin",
             target_os = "emscripten",
             target_os = "fuchsia",
             target_os = "haiku",
             target_os = "hurd",
             target_os = "nto",
             target_os = "redox",
-            target_os = "cygwin",
         )))]
         const FIXED_NOREPLACE = bitcast!(c::MAP_FIXED_NOREPLACE);
         /// `MAP_GROWSDOWN`
@@ -127,11 +127,11 @@ bitflags! {
             bsd,
             solarish,
             target_os = "aix",
+            target_os = "cygwin",
             target_os = "haiku",
             target_os = "hurd",
             target_os = "nto",
             target_os = "redox",
-            target_os = "cygwin",
         )))]
         const GROWSDOWN = bitcast!(c::MAP_GROWSDOWN);
         /// `MAP_HUGETLB`
@@ -139,11 +139,11 @@ bitflags! {
             bsd,
             solarish,
             target_os = "aix",
+            target_os = "cygwin",
             target_os = "haiku",
             target_os = "hurd",
             target_os = "nto",
             target_os = "redox",
-            target_os = "cygwin",
         )))]
         const HUGETLB = bitcast!(c::MAP_HUGETLB);
         /// `MAP_HUGE_2MB`
@@ -152,13 +152,13 @@ bitflags! {
             solarish,
             target_os = "aix",
             target_os = "android",
+            target_os = "cygwin",
             target_os = "emscripten",
             target_os = "fuchsia",
             target_os = "haiku",
             target_os = "hurd",
             target_os = "nto",
             target_os = "redox",
-            target_os = "cygwin",
         )))]
         const HUGE_2MB = bitcast!(c::MAP_HUGE_2MB);
         /// `MAP_HUGE_1GB`
@@ -167,13 +167,13 @@ bitflags! {
             solarish,
             target_os = "aix",
             target_os = "android",
+            target_os = "cygwin",
             target_os = "emscripten",
             target_os = "fuchsia",
             target_os = "haiku",
             target_os = "hurd",
             target_os = "nto",
             target_os = "redox",
-            target_os = "cygwin",
         )))]
         const HUGE_1GB = bitcast!(c::MAP_HUGE_1GB);
         /// `MAP_LOCKED`
@@ -181,11 +181,11 @@ bitflags! {
             bsd,
             solarish,
             target_os = "aix",
+            target_os = "cygwin",
             target_os = "haiku",
             target_os = "hurd",
             target_os = "nto",
             target_os = "redox",
-            target_os = "cygwin",
         )))]
         const LOCKED = bitcast!(c::MAP_LOCKED);
         /// `MAP_NOCORE`
@@ -208,11 +208,11 @@ bitflags! {
             bsd,
             solarish,
             target_os = "aix",
+            target_os = "cygwin",
             target_os = "haiku",
             target_os = "hurd",
             target_os = "nto",
             target_os = "redox",
-            target_os = "cygwin",
         )))]
         const POPULATE = bitcast!(c::MAP_POPULATE);
         /// `MAP_STACK`
@@ -220,10 +220,10 @@ bitflags! {
             apple,
             solarish,
             target_os = "aix",
+            target_os = "cygwin",
             target_os = "haiku",
             target_os = "hurd",
             target_os = "redox",
-            target_os = "cygwin",
         )))]
         const STACK = bitcast!(c::MAP_STACK);
         /// `MAP_PREFAULT_READ`
@@ -235,6 +235,7 @@ bitflags! {
             solarish,
             target_os = "aix",
             target_os = "android",
+            target_os = "cygwin",
             target_os = "emscripten",
             target_os = "fuchsia",
             target_os = "haiku",
@@ -245,7 +246,6 @@ bitflags! {
                 linux_kernel,
                 any(target_arch = "mips", target_arch = "mips32r6", target_arch = "mips64", target_arch = "mips64r6"),
             ),
-            target_os = "cygwin",
         )))]
         const SYNC = bitcast!(c::MAP_SYNC);
         /// `MAP_UNINITIALIZED`

--- a/src/backend/libc/net/msghdr.rs
+++ b/src/backend/libc/net/msghdr.rs
@@ -57,12 +57,12 @@ fn msg_iov_len(len: usize) -> c::c_int {
     solarish,
     target_env = "musl",
     target_os = "aix",
+    target_os = "cygwin",
     target_os = "emscripten",
     target_os = "fuchsia",
     target_os = "haiku",
     target_os = "hurd",
     target_os = "nto",
-    target_os = "cygwin",
 ))]
 #[inline]
 fn msg_control_len(len: usize) -> c::socklen_t {
@@ -76,6 +76,7 @@ fn msg_control_len(len: usize) -> c::socklen_t {
     windows,
     target_env = "musl",
     target_os = "aix",
+    target_os = "cygwin",
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "fuchsia",
@@ -85,7 +86,6 @@ fn msg_control_len(len: usize) -> c::socklen_t {
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi",
-    target_os = "cygwin",
 )))]
 #[inline]
 fn msg_control_len(len: usize) -> c::size_t {

--- a/src/backend/libc/net/send_recv.rs
+++ b/src/backend/libc/net/send_recv.rs
@@ -16,6 +16,7 @@ bitflags! {
             solarish,
             windows,
             target_os = "aix",
+            target_os = "cygwin",
             target_os = "espidf",
             target_os = "nto",
             target_os = "haiku",
@@ -23,7 +24,6 @@ bitflags! {
             target_os = "hurd",
             target_os = "redox",
             target_os = "vita",
-            target_os = "cygwin",
         )))]
         const CONFIRM = bitcast!(c::MSG_CONFIRM);
         /// `MSG_DONTROUTE`
@@ -40,12 +40,12 @@ bitflags! {
             solarish,
             windows,
             target_os = "aix",
+            target_os = "cygwin",
             target_os = "haiku",
             target_os = "hurd",
             target_os = "nto",
             target_os = "redox",
             target_os = "vita",
-            target_os = "cygwin",
         )))]
         const MORE = bitcast!(c::MSG_MORE);
         #[cfg(not(any(apple, windows, target_os = "redox", target_os = "vita")))]
@@ -91,6 +91,7 @@ bitflags! {
             solarish,
             windows,
             target_os = "aix",
+            target_os = "cygwin",
             target_os = "espidf",
             target_os = "haiku",
             target_os = "horizon",
@@ -98,7 +99,6 @@ bitflags! {
             target_os = "nto",
             target_os = "redox",
             target_os = "vita",
-            target_os = "cygwin",
         )))]
         const ERRQUEUE = bitcast!(c::MSG_ERRQUEUE);
         /// `MSG_OOB`

--- a/src/backend/libc/net/sockopt.rs
+++ b/src/backend/libc/net/sockopt.rs
@@ -20,6 +20,7 @@ use crate::net::xdp::{XdpMmapOffsets, XdpOptionsFlags, XdpRingOffset, XdpStatist
     apple,
     windows,
     target_os = "aix",
+    target_os = "cygwin",
     target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "espidf",
@@ -27,7 +28,6 @@ use crate::net::xdp::{XdpMmapOffsets, XdpOptionsFlags, XdpRingOffset, XdpStatist
     target_os = "netbsd",
     target_os = "nto",
     target_os = "vita",
-    target_os = "cygwin",
 )))]
 use crate::net::AddressFamily;
 #[cfg(any(
@@ -380,6 +380,7 @@ pub(crate) fn socket_send_buffer_size(fd: BorrowedFd<'_>) -> io::Result<usize> {
     apple,
     windows,
     target_os = "aix",
+    target_os = "cygwin",
     target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "espidf",
@@ -389,7 +390,6 @@ pub(crate) fn socket_send_buffer_size(fd: BorrowedFd<'_>) -> io::Result<usize> {
     target_os = "netbsd",
     target_os = "nto",
     target_os = "vita",
-    target_os = "cygwin",
 )))]
 pub(crate) fn socket_domain(fd: BorrowedFd<'_>) -> io::Result<AddressFamily> {
     let domain: c::c_int = getsockopt(fd, c::SOL_SOCKET, c::SO_DOMAIN)?;

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -64,13 +64,13 @@ use crate::process::{RawPid, WaitOptions, WaitStatus};
 )))]
 use crate::process::{Resource, Rlimit};
 #[cfg(not(any(
+    target_os = "cygwin"
     target_os = "espidf",
     target_os = "horizon",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi",
-    target_os = "cygwin"
 )))]
 use crate::process::{WaitId, WaitIdOptions, WaitIdStatus};
 use core::mem::MaybeUninit;
@@ -385,13 +385,13 @@ pub(crate) fn _waitpid(
 }
 
 #[cfg(not(any(
+    target_os = "cygwin"
     target_os = "espidf",
     target_os = "horizon",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi",
-    target_os = "cygwin"
 )))]
 #[inline]
 pub(crate) fn waitid(id: WaitId<'_>, options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
@@ -408,13 +408,13 @@ pub(crate) fn waitid(id: WaitId<'_>, options: WaitIdOptions) -> io::Result<Optio
 }
 
 #[cfg(not(any(
+    target_os = "cygwin"
     target_os = "espidf",
     target_os = "horizon",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi",
-    target_os = "cygwin"
 )))]
 #[inline]
 fn _waitid_all(options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
@@ -434,13 +434,13 @@ fn _waitid_all(options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
 }
 
 #[cfg(not(any(
+    target_os = "cygwin"
     target_os = "espidf",
     target_os = "horizon",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi",
-    target_os = "cygwin"
 )))]
 #[inline]
 fn _waitid_pid(pid: Pid, options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
@@ -460,13 +460,13 @@ fn _waitid_pid(pid: Pid, options: WaitIdOptions) -> io::Result<Option<WaitIdStat
 }
 
 #[cfg(not(any(
+    target_os = "cygwin"
     target_os = "espidf",
     target_os = "horizon",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi",
-    target_os = "cygwin"
 )))]
 #[inline]
 fn _waitid_pgid(pgid: Option<Pid>, options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
@@ -510,13 +510,13 @@ fn _waitid_pidfd(fd: BorrowedFd<'_>, options: WaitIdOptions) -> io::Result<Optio
 /// The caller must ensure that `status` is initialized and that `waitid`
 /// returned successfully.
 #[cfg(not(any(
+    target_os = "cygwin"
     target_os = "espidf",
     target_os = "horizon",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi",
-    target_os = "cygwin"
 )))]
 #[inline]
 unsafe fn cvt_waitid_status(status: MaybeUninit<c::siginfo_t>) -> Option<WaitIdStatus> {

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -64,7 +64,7 @@ use crate::process::{RawPid, WaitOptions, WaitStatus};
 )))]
 use crate::process::{Resource, Rlimit};
 #[cfg(not(any(
-    target_os = "cygwin"
+    target_os = "cygwin",
     target_os = "espidf",
     target_os = "horizon",
     target_os = "openbsd",
@@ -385,7 +385,7 @@ pub(crate) fn _waitpid(
 }
 
 #[cfg(not(any(
-    target_os = "cygwin"
+    target_os = "cygwin",
     target_os = "espidf",
     target_os = "horizon",
     target_os = "openbsd",
@@ -408,7 +408,7 @@ pub(crate) fn waitid(id: WaitId<'_>, options: WaitIdOptions) -> io::Result<Optio
 }
 
 #[cfg(not(any(
-    target_os = "cygwin"
+    target_os = "cygwin",
     target_os = "espidf",
     target_os = "horizon",
     target_os = "openbsd",
@@ -434,7 +434,7 @@ fn _waitid_all(options: WaitIdOptions) -> io::Result<Option<WaitIdStatus>> {
 }
 
 #[cfg(not(any(
-    target_os = "cygwin"
+    target_os = "cygwin",
     target_os = "espidf",
     target_os = "horizon",
     target_os = "openbsd",
@@ -460,7 +460,7 @@ fn _waitid_pid(pid: Pid, options: WaitIdOptions) -> io::Result<Option<WaitIdStat
 }
 
 #[cfg(not(any(
-    target_os = "cygwin"
+    target_os = "cygwin",
     target_os = "espidf",
     target_os = "horizon",
     target_os = "openbsd",
@@ -510,7 +510,7 @@ fn _waitid_pidfd(fd: BorrowedFd<'_>, options: WaitIdOptions) -> io::Result<Optio
 /// The caller must ensure that `status` is initialized and that `waitid`
 /// returned successfully.
 #[cfg(not(any(
-    target_os = "cygwin"
+    target_os = "cygwin",
     target_os = "espidf",
     target_os = "horizon",
     target_os = "openbsd",

--- a/src/backend/libc/process/types.rs
+++ b/src/backend/libc/process/types.rs
@@ -42,18 +42,18 @@ pub enum Resource {
     #[cfg(not(any(
         apple,
         solarish,
+        target_os = "cygwin",
         target_os = "haiku",
         target_os = "nto",
-        target_os = "cygwin",
     )))]
     Rss = bitcast!(c::RLIMIT_RSS),
     /// `RLIMIT_NPROC`
-    #[cfg(not(any(solarish, target_os = "haiku", target_os = "cygwin")))]
+    #[cfg(not(any(solarish, target_os = "cygwin", target_os = "haiku")))]
     Nproc = bitcast!(c::RLIMIT_NPROC),
     /// `RLIMIT_NOFILE`
     Nofile = bitcast!(c::RLIMIT_NOFILE),
     /// `RLIMIT_MEMLOCK`
-    #[cfg(not(any(solarish, target_os = "aix", target_os = "haiku", target_os = "cygwin")))]
+    #[cfg(not(any(solarish, target_os = "aix", target_os = "cygwin", target_os = "haiku")))]
     Memlock = bitcast!(c::RLIMIT_MEMLOCK),
     /// `RLIMIT_AS`
     #[cfg(not(target_os = "openbsd"))]
@@ -63,10 +63,10 @@ pub enum Resource {
         bsd,
         solarish,
         target_os = "aix",
+        target_os = "cygwin"
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
-        target_os = "cygwin"
     )))]
     Locks = bitcast!(c::RLIMIT_LOCKS),
     /// `RLIMIT_SIGPENDING`
@@ -74,10 +74,10 @@ pub enum Resource {
         bsd,
         solarish,
         target_os = "aix",
+        target_os = "cygwin"
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
-        target_os = "cygwin"
     )))]
     Sigpending = bitcast!(c::RLIMIT_SIGPENDING),
     /// `RLIMIT_MSGQUEUE`
@@ -85,10 +85,10 @@ pub enum Resource {
         bsd,
         solarish,
         target_os = "aix",
+        target_os = "cygwin"
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
-        target_os = "cygwin"
     )))]
     Msgqueue = bitcast!(c::RLIMIT_MSGQUEUE),
     /// `RLIMIT_NICE`
@@ -96,10 +96,10 @@ pub enum Resource {
         bsd,
         solarish,
         target_os = "aix",
+        target_os = "cygwin"
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
-        target_os = "cygwin"
     )))]
     Nice = bitcast!(c::RLIMIT_NICE),
     /// `RLIMIT_RTPRIO`
@@ -107,10 +107,10 @@ pub enum Resource {
         bsd,
         solarish,
         target_os = "aix",
+        target_os = "cygwin"
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
-        target_os = "cygwin"
     )))]
     Rtprio = bitcast!(c::RLIMIT_RTPRIO),
     /// `RLIMIT_RTTIME`
@@ -119,11 +119,11 @@ pub enum Resource {
         solarish,
         target_os = "aix",
         target_os = "android",
+        target_os = "cygwin",
         target_os = "emscripten",
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
-        target_os = "cygwin",
     )))]
     Rttime = bitcast!(c::RLIMIT_RTTIME),
 }

--- a/src/backend/libc/process/types.rs
+++ b/src/backend/libc/process/types.rs
@@ -63,7 +63,7 @@ pub enum Resource {
         bsd,
         solarish,
         target_os = "aix",
-        target_os = "cygwin"
+        target_os = "cygwin",
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
@@ -74,7 +74,7 @@ pub enum Resource {
         bsd,
         solarish,
         target_os = "aix",
-        target_os = "cygwin"
+        target_os = "cygwin",
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
@@ -85,7 +85,7 @@ pub enum Resource {
         bsd,
         solarish,
         target_os = "aix",
-        target_os = "cygwin"
+        target_os = "cygwin",
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
@@ -96,7 +96,7 @@ pub enum Resource {
         bsd,
         solarish,
         target_os = "aix",
-        target_os = "cygwin"
+        target_os = "cygwin",
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",
@@ -107,7 +107,7 @@ pub enum Resource {
         bsd,
         solarish,
         target_os = "aix",
-        target_os = "cygwin"
+        target_os = "cygwin",
         target_os = "haiku",
         target_os = "hurd",
         target_os = "nto",

--- a/src/backend/libc/process/wait.rs
+++ b/src/backend/libc/process/wait.rs
@@ -8,10 +8,10 @@ pub(crate) use c::{
 pub(crate) use c::{WCONTINUED, WUNTRACED};
 
 #[cfg(not(any(
+    target_os = "cygwin",
     target_os = "horizon",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "wasi",
-    target_os = "cygwin"
 )))]
 pub(crate) use c::{WEXITED, WNOWAIT, WSTOPPED};

--- a/src/backend/libc/system/syscalls.rs
+++ b/src/backend/libc/system/syscalls.rs
@@ -66,6 +66,7 @@ pub(crate) fn sethostname(name: &[u8]) -> io::Result<()> {
 
 #[cfg(not(any(
     target_os = "android",
+    target_os = "cygwin"
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "illumos",
@@ -75,7 +76,6 @@ pub(crate) fn sethostname(name: &[u8]) -> io::Result<()> {
     target_os = "solaris",
     target_os = "vita",
     target_os = "wasi",
-    target_os = "cygwin"
 )))]
 pub(crate) fn setdomainname(name: &[u8]) -> io::Result<()> {
     unsafe {

--- a/src/backend/libc/system/syscalls.rs
+++ b/src/backend/libc/system/syscalls.rs
@@ -66,7 +66,7 @@ pub(crate) fn sethostname(name: &[u8]) -> io::Result<()> {
 
 #[cfg(not(any(
     target_os = "android",
-    target_os = "cygwin"
+    target_os = "cygwin",
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "illumos",

--- a/src/backend/linux_raw/system/syscalls.rs
+++ b/src/backend/linux_raw/system/syscalls.rs
@@ -8,7 +8,6 @@
 use super::types::RawUname;
 use crate::backend::c;
 use crate::backend::conv::{c_int, ret, ret_infallible, slice};
-#[cfg(any(target_os = "linux", target_os = "android"))]
 use crate::fd::BorrowedFd;
 use crate::ffi::CStr;
 use crate::io;

--- a/src/clockid.rs
+++ b/src/clockid.rs
@@ -12,10 +12,10 @@ use crate::fd::BorrowedFd;
 #[cfg(not(any(apple, target_os = "wasi")))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(
-    not(any(target_os = "aix", target_os = "dragonfly", target_os = "cygwin")),
+    not(any(target_os = "aix", target_os = "cygwin", target_os = "dragonfly")),
     repr(i32)
 )]
-#[cfg_attr(any(target_os = "dragonfly", target_os = "cygwin"), repr(u64))]
+#[cfg_attr(any(target_os = "cygwin", target_os = "dragonfly"), repr(u64))]
 #[cfg_attr(target_os = "aix", repr(i64))]
 #[non_exhaustive]
 pub enum ClockId {

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -269,11 +269,11 @@ mod tests {
 
         #[cfg(not(any(
             solarish,
+            target_os = "cygwin",
             target_os = "haiku",
             target_os = "nto",
             target_os = "redox",
             target_os = "wasi",
-            target_os = "cygwin"
         )))]
         {
             check_renamed_type!(Fsid, fsid_t);

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -11,12 +11,12 @@ mod dir;
 #[cfg(not(any(
     apple,
     netbsdlike,
-    target_os = "solaris",
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "haiku",
     target_os = "horizon",
     target_os = "redox",
+    target_os = "solaris",
     target_os = "vita",
 )))]
 mod fadvise;
@@ -78,12 +78,12 @@ pub use dir::{Dir, DirEntry};
 #[cfg(not(any(
     apple,
     netbsdlike,
-    target_os = "solaris",
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "haiku",
     target_os = "horizon",
     target_os = "redox",
+    target_os = "solaris",
     target_os = "vita",
 )))]
 pub use fadvise::fadvise;

--- a/src/io/read_write.rs
+++ b/src/io/read_write.rs
@@ -214,6 +214,7 @@ pub fn writev<Fd: AsFd>(fd: Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
 /// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Scatter_002dGather.html#index-preadv64
 #[cfg(not(any(
     windows,
+    target_os = "cygwin"
     target_os = "espidf",
     target_os = "haiku",
     target_os = "horizon",
@@ -221,7 +222,6 @@ pub fn writev<Fd: AsFd>(fd: Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
     target_os = "redox",
     target_os = "solaris",
     target_os = "vita",
-    target_os = "cygwin"
 )))]
 #[inline]
 pub fn preadv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
@@ -253,6 +253,7 @@ pub fn preadv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io:
 /// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/I_002fO-Primitives.html#index-pwrite64
 #[cfg(not(any(
     windows,
+    target_os = "cygwin"
     target_os = "espidf",
     target_os = "haiku",
     target_os = "horizon",
@@ -260,7 +261,6 @@ pub fn preadv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io:
     target_os = "redox",
     target_os = "solaris",
     target_os = "vita",
-    target_os = "cygwin"
 )))]
 #[inline]
 pub fn pwritev<Fd: AsFd>(fd: Fd, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {

--- a/src/io/read_write.rs
+++ b/src/io/read_write.rs
@@ -214,7 +214,7 @@ pub fn writev<Fd: AsFd>(fd: Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
 /// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/Scatter_002dGather.html#index-preadv64
 #[cfg(not(any(
     windows,
-    target_os = "cygwin"
+    target_os = "cygwin",
     target_os = "espidf",
     target_os = "haiku",
     target_os = "horizon",
@@ -253,7 +253,7 @@ pub fn preadv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io:
 /// [glibc]: https://sourceware.org/glibc/manual/latest/html_node/I_002fO-Primitives.html#index-pwrite64
 #[cfg(not(any(
     windows,
-    target_os = "cygwin"
+    target_os = "cygwin",
     target_os = "espidf",
     target_os = "haiku",
     target_os = "horizon",

--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -328,11 +328,11 @@ type _Opcode = c::c_ulong;
 #[cfg(any(
     solarish,
     target_os = "aix",
+    target_os = "cygwin",
     target_os = "fuchsia",
     target_os = "emscripten",
     target_os = "nto",
     target_os = "wasi",
-    target_os = "cygwin"
 ))]
 type _Opcode = c::c_int;
 

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -149,6 +149,7 @@ use crate::net::xdp::{XdpMmapOffsets, XdpOptionsFlags, XdpStatistics, XdpUmemReg
     apple,
     windows,
     target_os = "aix",
+    target_os = "cygwin",
     target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "espidf",
@@ -156,7 +157,6 @@ use crate::net::xdp::{XdpMmapOffsets, XdpOptionsFlags, XdpStatistics, XdpUmemReg
     target_os = "netbsd",
     target_os = "nto",
     target_os = "vita",
-    target_os = "cygwin",
 )))]
 use crate::net::AddressFamily;
 #[cfg(any(
@@ -463,6 +463,7 @@ pub fn socket_send_buffer_size<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
     apple,
     windows,
     target_os = "aix",
+    target_os = "cygwin",
     target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "espidf",
@@ -472,7 +473,6 @@ pub fn socket_send_buffer_size<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
     target_os = "netbsd",
     target_os = "nto",
     target_os = "vita",
-    target_os = "cygwin",
 )))]
 #[inline]
 #[doc(alias = "SO_DOMAIN")]

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -95,6 +95,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -102,7 +103,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const NETLINK: Self = Self(c::AF_NETLINK as _);
     /// `AF_UNIX`, aka `AF_LOCAL`
@@ -114,6 +114,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -121,17 +122,16 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const AX25: Self = Self(c::AF_AX25 as _);
     /// `AF_IPX`
     #[cfg(not(any(
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "horizon",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const IPX: Self = Self(c::AF_IPX as _);
     /// `AF_APPLETALK`
@@ -148,6 +148,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -155,7 +156,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const NETROM: Self = Self(c::AF_NETROM as _);
     /// `AF_BRIDGE`
@@ -164,6 +164,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -171,7 +172,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const BRIDGE: Self = Self(c::AF_BRIDGE as _);
     /// `AF_ATMPVC`
@@ -180,6 +180,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -187,7 +188,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const ATMPVC: Self = Self(c::AF_ATMPVC as _);
     /// `AF_X25`
@@ -195,6 +195,7 @@ impl AddressFamily {
         bsd,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -202,7 +203,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const X25: Self = Self(c::AF_X25 as _);
     /// `AF_ROSE`
@@ -211,6 +211,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -218,7 +219,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const ROSE: Self = Self(c::AF_ROSE as _);
     /// `AF_DECnet`
@@ -236,6 +236,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -243,7 +244,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const NETBEUI: Self = Self(c::AF_NETBEUI as _);
     /// `AF_SECURITY`
@@ -252,6 +252,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -259,7 +260,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const SECURITY: Self = Self(c::AF_SECURITY as _);
     /// `AF_KEY`
@@ -267,6 +267,7 @@ impl AddressFamily {
         bsd,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -274,7 +275,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const KEY: Self = Self(c::AF_KEY as _);
     /// `AF_PACKET`
@@ -287,6 +287,7 @@ impl AddressFamily {
         bsd,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -294,7 +295,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const PACKET: Self = Self(c::AF_PACKET as _);
     /// `AF_ASH`
@@ -303,6 +303,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -310,7 +311,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const ASH: Self = Self(c::AF_ASH as _);
     /// `AF_ECONET`
@@ -319,6 +319,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -326,7 +327,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const ECONET: Self = Self(c::AF_ECONET as _);
     /// `AF_ATMSVC`
@@ -335,6 +335,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -342,7 +343,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const ATMSVC: Self = Self(c::AF_ATMSVC as _);
     /// `AF_RDS`
@@ -351,6 +351,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -358,7 +359,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const RDS: Self = Self(c::AF_RDS as _);
     /// `AF_SNA`
@@ -375,6 +375,7 @@ impl AddressFamily {
         bsd,
         solarish,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -382,7 +383,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const IRDA: Self = Self(c::AF_IRDA as _);
     /// `AF_PPPOX`
@@ -391,6 +391,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -398,7 +399,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const PPPOX: Self = Self(c::AF_PPPOX as _);
     /// `AF_WANPIPE`
@@ -407,6 +407,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -414,7 +415,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const WANPIPE: Self = Self(c::AF_WANPIPE as _);
     /// `AF_LLC`
@@ -423,6 +423,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -430,7 +431,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const LLC: Self = Self(c::AF_LLC as _);
     /// `AF_CAN`
@@ -439,6 +439,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -446,7 +447,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const CAN: Self = Self(c::AF_CAN as _);
     /// `AF_TIPC`
@@ -455,6 +455,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -462,7 +463,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const TIPC: Self = Self(c::AF_TIPC as _);
     /// `AF_BLUETOOTH`
@@ -471,12 +471,12 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "horizon",
         target_os = "hurd",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const BLUETOOTH: Self = Self(c::AF_BLUETOOTH as _);
     /// `AF_IUCV`
@@ -485,6 +485,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -492,7 +493,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const IUCV: Self = Self(c::AF_IUCV as _);
     /// `AF_RXRPC`
@@ -501,6 +501,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -508,7 +509,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const RXRPC: Self = Self(c::AF_RXRPC as _);
     /// `AF_ISDN`
@@ -516,13 +516,13 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
         target_os = "hurd",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const ISDN: Self = Self(c::AF_ISDN as _);
     /// `AF_PHONET`
@@ -531,6 +531,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -538,7 +539,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const PHONET: Self = Self(c::AF_PHONET as _);
     /// `AF_IEEE802154`
@@ -547,6 +547,7 @@ impl AddressFamily {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
@@ -554,7 +555,6 @@ impl AddressFamily {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const IEEE802154: Self = Self(c::AF_IEEE802154 as _);
     /// `AF_802`
@@ -864,12 +864,12 @@ pub mod ipproto {
     #[cfg(not(any(
         solarish,
         windows,
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const TP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_TP as _));
     /// `IPPROTO_DCCP`
@@ -878,6 +878,7 @@ pub mod ipproto {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "dragonfly",
         target_os = "espidf",
         target_os = "haiku",
@@ -886,7 +887,6 @@ pub mod ipproto {
         target_os = "openbsd",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const DCCP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_DCCP as _));
     /// `IPPROTO_IPV6`
@@ -895,24 +895,24 @@ pub mod ipproto {
     #[cfg(not(any(
         solarish,
         windows,
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const RSVP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_RSVP as _));
     /// `IPPROTO_GRE`
     #[cfg(not(any(
         solarish,
         windows,
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const GRE: Protocol = Protocol(new_raw_protocol(c::IPPROTO_GRE as _));
     /// `IPPROTO_ESP`
@@ -941,13 +941,13 @@ pub mod ipproto {
         netbsdlike,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const MTP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_MTP as _));
     /// `IPPROTO_BEETPH`
@@ -956,13 +956,13 @@ pub mod ipproto {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const BEETPH: Protocol = Protocol(new_raw_protocol(c::IPPROTO_BEETPH as _));
     /// `IPPROTO_ENCAP`
@@ -970,24 +970,24 @@ pub mod ipproto {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const ENCAP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_ENCAP as _));
     /// `IPPROTO_PIM`
     #[cfg(not(any(
         solarish,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const PIM: Protocol = Protocol(new_raw_protocol(c::IPPROTO_PIM as _));
     /// `IPPROTO_COMP`
@@ -996,18 +996,19 @@ pub mod ipproto {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "horizon",
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const COMP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_COMP as _));
     /// `IPPROTO_SCTP`
     #[cfg(not(any(
         solarish,
+        target_os = "cygwin",
         target_os = "dragonfly",
         target_os = "espidf",
         target_os = "haiku",
@@ -1015,7 +1016,6 @@ pub mod ipproto {
         target_os = "openbsd",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const SCTP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_SCTP as _));
     /// `IPPROTO_UDPLITE`
@@ -1025,6 +1025,7 @@ pub mod ipproto {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "dragonfly",
         target_os = "espidf",
         target_os = "haiku",
@@ -1032,7 +1033,6 @@ pub mod ipproto {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const UDPLITE: Protocol = Protocol(new_raw_protocol(c::IPPROTO_UDPLITE as _));
     /// `IPPROTO_MPLS`
@@ -1041,6 +1041,7 @@ pub mod ipproto {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "dragonfly",
         target_os = "espidf",
         target_os = "haiku",
@@ -1049,7 +1050,6 @@ pub mod ipproto {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const MPLS: Protocol = Protocol(new_raw_protocol(c::IPPROTO_MPLS as _));
     /// `IPPROTO_ETHERNET`
@@ -1064,6 +1064,7 @@ pub mod ipproto {
         solarish,
         windows,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "emscripten",
         target_os = "espidf",
         target_os = "fuchsia",
@@ -1072,7 +1073,6 @@ pub mod ipproto {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const MPTCP: Protocol = Protocol(new_raw_protocol(c::IPPROTO_MPTCP as _));
     /// `IPPROTO_FRAGMENT`
@@ -1093,6 +1093,7 @@ pub mod ipproto {
         netbsdlike,
         solarish,
         windows,
+        target_os = "cygwin",
         target_os = "dragonfly",
         target_os = "espidf",
         target_os = "haiku",
@@ -1100,7 +1101,6 @@ pub mod ipproto {
         target_os = "nto",
         target_os = "redox",
         target_os = "vita",
-        target_os = "cygwin",
     )))]
     pub const MH: Protocol = Protocol(new_raw_protocol(c::IPPROTO_MH as _));
     /// `IPPROTO_ROUTING`

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -485,11 +485,11 @@ pub fn wait(waitopts: WaitOptions) -> io::Result<Option<(Pid, WaitStatus)>> {
 /// `waitid(_, _, _, opts)`—Wait for the specified child process to change
 /// state.
 #[cfg(not(any(
+    target_os = "cygwin"
     target_os = "horizon",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "wasi",
-    target_os = "cygwin"
 )))]
 #[inline]
 pub fn waitid<'a, Id: Into<WaitId<'a>>>(

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -485,7 +485,7 @@ pub fn wait(waitopts: WaitOptions) -> io::Result<Option<(Pid, WaitStatus)>> {
 /// `waitid(_, _, _, opts)`—Wait for the specified child process to change
 /// state.
 #[cfg(not(any(
-    target_os = "cygwin"
+    target_os = "cygwin",
     target_os = "horizon",
     target_os = "openbsd",
     target_os = "redox",

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -90,6 +90,7 @@ impl Signal {
         bsd,
         solarish,
         target_os = "aix",
+        target_os = "cygwin",
         target_os = "haiku",
         target_os = "horizon",
         target_os = "hurd",
@@ -106,7 +107,6 @@ impl Signal {
                 target_arch = "sparc64"
             ),
         ),
-        target_os = "cygwin",
     )))]
     pub const STKFLT: Self = Self(unsafe { NonZeroI32::new_unchecked(c::SIGSTKFLT) });
     /// `SIGCHLD`
@@ -281,6 +281,7 @@ impl fmt::Debug for Signal {
                 bsd,
                 solarish,
                 target_os = "aix",
+                target_os = "cygwin",
                 target_os = "haiku",
                 target_os = "horizon",
                 target_os = "hurd",
@@ -297,7 +298,6 @@ impl fmt::Debug for Signal {
                         target_arch = "sparc64"
                     ),
                 ),
-                target_os = "cygwin",
             )))]
             Self::STKFLT => "Signal::STKFLT".fmt(f),
             #[cfg(not(target_os = "vita"))]

--- a/src/system.rs
+++ b/src/system.rs
@@ -174,6 +174,7 @@ pub fn sethostname(name: &[u8]) -> io::Result<()> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/setdomainname.2.html
 /// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=setdomainname&sektion=3
 #[cfg(not(any(
+    target_os = "cygwin",
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "haiku",
@@ -183,7 +184,6 @@ pub fn sethostname(name: &[u8]) -> io::Result<()> {
     target_os = "solaris",
     target_os = "vita",
     target_os = "wasi",
-    target_os = "cygwin"
 )))]
 #[inline]
 pub fn setdomainname(name: &[u8]) -> io::Result<()> {

--- a/src/termios/mod.rs
+++ b/src/termios/mod.rs
@@ -10,7 +10,7 @@
 //! not supported by the platform or the device.
 
 #[cfg(not(any(
-    target_os = "cygwin"
+    target_os = "cygwin",
     target_os = "espidf",
     target_os = "haiku",
     target_os = "wasi",
@@ -24,7 +24,7 @@ mod tty;
 mod types;
 
 #[cfg(not(any(
-    target_os = "cygwin"
+    target_os = "cygwin",
     target_os = "espidf",
     target_os = "haiku",
     target_os = "wasi",

--- a/src/termios/mod.rs
+++ b/src/termios/mod.rs
@@ -10,10 +10,10 @@
 //! not supported by the platform or the device.
 
 #[cfg(not(any(
+    target_os = "cygwin"
     target_os = "espidf",
     target_os = "haiku",
     target_os = "wasi",
-    target_os = "cygwin"
 )))]
 mod ioctl;
 #[cfg(not(target_os = "wasi"))]
@@ -24,10 +24,10 @@ mod tty;
 mod types;
 
 #[cfg(not(any(
+    target_os = "cygwin"
     target_os = "espidf",
     target_os = "haiku",
     target_os = "wasi",
-    target_os = "cygwin"
 )))]
 pub use ioctl::*;
 #[cfg(not(target_os = "wasi"))]

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -605,7 +605,7 @@ bitflags! {
         const ECHOCTL = c::ECHOCTL;
 
         /// `ECHOPRT`
-        #[cfg(not(any(target_os = "nto", target_os = "redox", target_os = "cygwin")))]
+        #[cfg(not(any(target_os = "cygwin", target_os = "nto", target_os = "redox")))]
         const ECHOPRT = c::ECHOPRT;
 
         /// `ECHOKE`
@@ -617,16 +617,16 @@ bitflags! {
         const FLUSHO = c::FLUSHO;
 
         /// `PENDIN`
-        #[cfg(not(any(target_os = "nto", target_os = "redox", target_os = "cygwin")))]
+        #[cfg(not(any(target_os = "cygwin", target_os = "nto", target_os = "redox")))]
         const PENDIN = c::PENDIN;
 
         /// `EXTPROC`
         #[cfg(not(any(
             target_os = "aix",
+            target_os = "cygwin",
             target_os = "haiku",
             target_os = "nto",
             target_os = "redox",
-            target_os = "cygwin",
         )))]
         const EXTPROC = c::EXTPROC;
 
@@ -956,10 +956,10 @@ pub mod speed {
                 target_arch = "sparc64",
                 bsd,
                 target_os = "aix",
+                target_os = "cygwin",
                 target_os = "haiku",
                 target_os = "nto",
                 target_os = "solaris",
-                target_os = "cygwin",
             )))]
             c::B3500000 => Some(3_500_000),
             #[cfg(not(any(
@@ -967,10 +967,10 @@ pub mod speed {
                 target_arch = "sparc64",
                 bsd,
                 target_os = "aix",
+                target_os = "cygwin",
                 target_os = "haiku",
                 target_os = "nto",
                 target_os = "solaris",
-                target_os = "cygwin",
             )))]
             c::B4000000 => Some(4_000_000),
             _ => None,
@@ -1095,10 +1095,10 @@ pub mod speed {
                 target_arch = "sparc64",
                 bsd,
                 target_os = "aix",
+                target_os = "cygwin",
                 target_os = "haiku",
                 target_os = "nto",
                 target_os = "solaris",
-                target_os = "cygwin",
             )))]
             3_500_000 => Some(c::B3500000),
             #[cfg(not(any(
@@ -1106,10 +1106,10 @@ pub mod speed {
                 target_arch = "sparc64",
                 bsd,
                 target_os = "aix",
+                target_os = "cygwin",
                 target_os = "haiku",
                 target_os = "nto",
                 target_os = "solaris",
-                target_os = "cygwin",
             )))]
             4_000_000 => Some(c::B4000000),
             _ => None,

--- a/tests/fs/chmodat.rs
+++ b/tests/fs/chmodat.rs
@@ -1,4 +1,4 @@
-#[cfg(not(any(target_os = "wasi", target_os = "cygwin")))]
+#[cfg(not(any(target_os = "cygwin", target_os = "wasi")))]
 #[test]
 fn test_chmod() {
     use rustix::fs::{chmod, open, stat, symlink, Mode, OFlags};

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -1,11 +1,11 @@
 #[cfg(not(any(
     apple,
     netbsdlike,
-    target_os = "solaris",
     target_os = "dragonfly",
     target_os = "espidf",
     target_os = "haiku",
     target_os = "redox",
+    target_os = "solaris",
 )))]
 use core::num::NonZeroU64;
 
@@ -22,7 +22,7 @@ fn test_file() {
 
     rustix::fs::chown("Cargo.toml", None, None).unwrap();
 
-    #[cfg(not(any(target_os = "emscripten", target_os = "android")))]
+    #[cfg(not(any(target_os = "android", target_os = "emscripten")))]
     #[allow(unreachable_patterns)]
     match rustix::fs::accessat(
         rustix::fs::CWD,
@@ -95,10 +95,10 @@ fn test_file() {
     #[cfg(not(any(
         apple,
         netbsdlike,
-        target_os = "solaris",
         target_os = "dragonfly",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "solaris",
     )))]
     rustix::fs::fadvise(&file, 0, NonZeroU64::new(10), rustix::fs::Advice::Normal).unwrap();
 
@@ -107,10 +107,10 @@ fn test_file() {
 
     #[cfg(not(any(
         apple,
+        target_os = "cygwin",
         target_os = "dragonfly",
         target_os = "espidf",
         target_os = "haiku",
-        target_os = "cygwin",
     )))]
     rustix::fs::fdatasync(&file).unwrap();
 

--- a/tests/fs/invalid_offset.rs
+++ b/tests/fs/invalid_offset.rs
@@ -60,11 +60,11 @@ fn invalid_offset_fallocate() {
 #[cfg(not(any(
     apple,
     netbsdlike,
-    target_os = "solaris",
+    target_os = "cygwin",
     target_os = "dragonfly",
     target_os = "haiku",
     target_os = "redox",
-    target_os = "cygwin",
+    target_os = "solaris",
 )))]
 #[test]
 fn invalid_offset_fadvise() {

--- a/tests/fs/makedev.rs
+++ b/tests/fs/makedev.rs
@@ -12,7 +12,7 @@ fn makedev_roundtrip() {
     let (maj, min) = (0x0000_0026, 0x0000_0061);
     #[cfg(target_os = "cygwin")]
     let (maj, min) = (0x0000_2526, 0x0000_6361);
-    #[cfg(not(any(apple, freebsdlike, target_os = "netbsd", target_os = "cygwin")))]
+    #[cfg(not(any(apple, freebsdlike, target_os = "cygwin", target_os = "netbsd")))]
     let (maj, min) = (0x2324_2526, 0x6564_6361);
 
     let dev = makedev(maj, min);


### PR DESCRIPTION
This isn't necessary, but it does make maintenance a little easier as it's easier to see when two `cfg`s are the same.