### PR TITLE
Miscellaneous documentaion cleanups.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 [`rustix::pipe::fcntl_setpipe_size`] now returns the new size, which may be
 greater than the requested size.
 
-[`rustix::pipe::fcntl_setpipe_size`]: https://docs.rs/rustix/1.0.0/rustix/pipe/fn.fcntl_setpipe_size.html
+[`rustix::pipe::fcntl_setpipe_size`]: https://docs.rs/rustix/1/rustix/pipe/fn.fcntl_setpipe_size.html
 
 When a `&mut Vec<_>` is passed to [`rustix::event::epoll::wait`],
 [`rustix::event::kqueue::kevent`], or [`rustix::event::port::getn`], these
@@ -15,38 +15,38 @@ using [`spare_capacity`], and then to clear the `Vec` by iterating using
 `.drain(..)` after each call. For an example of using `spare_capacity` in this
 way, see [here].
 
-[`rustix::event::epoll::wait`]: https://docs.rs/rustix/1.0.0/rustix/event/epoll/fn.wait.html
-[`rustix::event::kqueue::kevent`]: https://docs.rs/rustix/1.0.0/x86_64-unknown-freebsd/rustix/event/kqueue/fn.kevent.html
-[`rustix::event::port::getn`]: https://docs.rs/rustix/1.0.0/x86_64-unknown-illumos/rustix/event/port/fn.getn.html
-[`spare_capacity`]: https://docs.rs/rustix/1.0.0/rustix/buffer/fn.spare_capacity.html
-[here]: https://docs.rs/rustix/1.0.0/rustix/event/epoll/index.html#examples
+[`rustix::event::epoll::wait`]: https://docs.rs/rustix/1/rustix/event/epoll/fn.wait.html
+[`rustix::event::kqueue::kevent`]: https://docs.rs/rustix/1/x86_64-unknown-freebsd/rustix/event/kqueue/fn.kevent.html
+[`rustix::event::port::getn`]: https://docs.rs/rustix/1/x86_64-unknown-illumos/rustix/event/port/fn.getn.html
+[`spare_capacity`]: https://docs.rs/rustix/1/rustix/buffer/fn.spare_capacity.html
+[here]: https://docs.rs/rustix/1/rustix/event/epoll/index.html#examples
 
 ## API changes
 
 `rustix::thread::FutexOperation` and `rustix::thread::futex` are removed. Use
 the functions in the [`rustix::thread::futex`] module instead.
 
-[`rustix::thread::futex`]: https://docs.rs/rustix/1.0.0/rustix/thread/futex/index.html
+[`rustix::thread::futex`]: https://docs.rs/rustix/1/rustix/thread/futex/index.html
 
 [`rustix::process::waitpid`]'s return type changed from `WaitStatus` to
 `(Pid, WaitStatus)`, to additionally return the pid of the child.
 
-[`rustix::process::waitpid`]: https://docs.rs/rustix/1.0.0/rustix/process/fn.waitpid.html
+[`rustix::process::waitpid`]: https://docs.rs/rustix/1/rustix/process/fn.waitpid.html
 
 [`terminating_signal`] and other functions in [`rustix::process::WaitStatus`] changed
 from returning `u32` to returning `i32`, for better compatibility with the new
 [`Signal`] type and [`exit`].
 
-[`terminating_signal`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.WaitStatus.html#method.terminating_signal
-[`rustix::process::WaitStatus`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.WaitStatus.html
-[`Signal`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.Signal.html
+[`terminating_signal`]: https://docs.rs/rustix/1/rustix/process/struct.WaitStatus.html#method.terminating_signal
+[`rustix::process::WaitStatus`]: https://docs.rs/rustix/1/rustix/process/struct.WaitStatus.html
+[`Signal`]: https://docs.rs/rustix/1/rustix/process/struct.Signal.html
 [`exit`]: std::process::exit
 
 The `SLAVE` flag in [`rustix::mount::MountPropagationFlags`] is renamed to
 [`DOWNSTREAM`].
 
-[`rustix::mount::MountPropagationFlags`]: https://docs.rs/rustix/1.0.0/rustix/mount/struct.MountPropagationFlags.html
-[`DOWNSTREAM`]: https://docs.rs/rustix/1.0.0/rustix/mount/struct.MountPropagationFlags.html#associatedconstant.DOWNSTREAM
+[`rustix::mount::MountPropagationFlags`]: https://docs.rs/rustix/1/rustix/mount/struct.MountPropagationFlags.html
+[`DOWNSTREAM`]: https://docs.rs/rustix/1/rustix/mount/struct.MountPropagationFlags.html#associatedconstant.DOWNSTREAM
 
 The "cc" and "libc-extra-traits" features are removed. The "cc" feature hasn't
 had any effect for several major releases. If you need the traits provided by
@@ -56,80 +56,80 @@ had any effect for several major releases. If you need the traits provided by
 `rustix::net::Shutdown::ReadWrite` is renamed to
 [`rustix::net::Shutdown::Both`] to [align with std].
 
-[`rustix::net::Shutdown::Both`]: https://docs.rs/rustix/1.0.0/rustix/net/enum.Shutdown.html#variant.Both
+[`rustix::net::Shutdown::Both`]: https://docs.rs/rustix/1/rustix/net/enum.Shutdown.html#variant.Both
 [align with std]: https://doc.rust-lang.org/stable/std/net/enum.Shutdown.html#variant.Both
 
 The `rustix::io_uring::io_uring_register_files_skip` function is replaced with
 a [`IORING_REGISTER_FILES_SKIP`] constant, similar to the [`rustix::fs::CWD`]
 constant.
 
-[`IORING_REGISTER_FILES_SKIP`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/constant.IORING_REGISTER_FILES_SKIP.html
-[`rustix::fs::CWD`]: https://docs.rs/rustix/1.0.0/rustix/fs/constant.CWD.html
+[`IORING_REGISTER_FILES_SKIP`]: https://docs.rs/rustix/1/rustix/io_uring/constant.IORING_REGISTER_FILES_SKIP.html
+[`rustix::fs::CWD`]: https://docs.rs/rustix/1/rustix/fs/constant.CWD.html
 
 [`rustix::io_uring::io_uring_register`] now has a [`IoringRegisterFlags`]
 argument, and `rustix::io_uring::io_uring_register_with` is removed.
 
-[`rustix::io_uring::io_uring_register`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/fn.io_uring_register.html
-[`IoringRegisterFlags`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/struct.IoringRegisterFlags.html
+[`rustix::io_uring::io_uring_register`]: https://docs.rs/rustix/1/rustix/io_uring/fn.io_uring_register.html
+[`IoringRegisterFlags`]: https://docs.rs/rustix/1/rustix/io_uring/struct.IoringRegisterFlags.html
 
 Several structs in [`rustix::io_uring`] are now marked `#[non_exhaustive]`
 because they contain padding or reserved fields. Instead of constructing
 them with field values and `..Default::default()`, construct them with
 `Default::default()` and separately assign the fields.
 
-[`rustix::io_uring`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/index.html
+[`rustix::io_uring`]: https://docs.rs/rustix/1/rustix/io_uring/index.html
 
 [`rustix::process::Resource`], [`rustix::thread::MembarrierCommand`], and
 [`rustix::thread::Capability`] are now marked `#[non_exhaustive]` to ease
 migration in case new constants are defined in the future.
 
-[`rustix::process::Resource`]: https://docs.rs/rustix/1.0.0/rustix/process/enum.Resource.html
-[`rustix::thread::MembarrierCommand`]: https://docs.rs/rustix/1.0.0/rustix/thread/enum.MembarrierCommand.html
-[`rustix::thread::Capability`]: https://docs.rs/rustix/1.0.0/rustix/thread/enum.Capability.html
+[`rustix::process::Resource`]: https://docs.rs/rustix/1/rustix/process/enum.Resource.html
+[`rustix::thread::MembarrierCommand`]: https://docs.rs/rustix/1/rustix/thread/enum.MembarrierCommand.html
+[`rustix::thread::Capability`]: https://docs.rs/rustix/1/rustix/thread/enum.Capability.html
 
 `rustix::process::WaitidOptions` and `rustix::process::WaitidStatus` are
 renamed to
 [`rustix::process::WaitIdOptions`] and [`rustix::process::WaitIdStatus`] (note
 the capitalization), for consistency with [`rustix::process::WaitId`].
 
-[`rustix::process::WaitIdOptions`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.WaitIdOptions.html
-[`rustix::process::WaitIdStatus`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.WaitIdStatus.html
-[`rustix::process::WaitId`]: https://docs.rs/rustix/1.0.0/rustix/process/enum.WaitId.html
+[`rustix::process::WaitIdOptions`]: https://docs.rs/rustix/1/rustix/process/struct.WaitIdOptions.html
+[`rustix::process::WaitIdStatus`]: https://docs.rs/rustix/1/rustix/process/struct.WaitIdStatus.html
+[`rustix::process::WaitId`]: https://docs.rs/rustix/1/rustix/process/enum.WaitId.html
 
 The offsets in [`rustix::fs::SeekFrom::Hole`] and
 [`rustix::fs::SeekFrom::Data`] are changed from `i64` to `u64`, to
 [align with std], since they represent absolute offsets.
 
-[`rustix::fs::SeekFrom::Hole`]: https://docs.rs/rustix/1.0.0/rustix/fs/enum.SeekFrom.html#variant.Hole
-[`rustix::fs::SeekFrom::Data`]: https://docs.rs/rustix/1.0.0/rustix/fs/enum.SeekFrom.html#variant.Data
+[`rustix::fs::SeekFrom::Hole`]: https://docs.rs/rustix/1/rustix/fs/enum.SeekFrom.html#variant.Hole
+[`rustix::fs::SeekFrom::Data`]: https://docs.rs/rustix/1/rustix/fs/enum.SeekFrom.html#variant.Data
 [align with std]: https://doc.rust-lang.org/stable/std/io/enum.SeekFrom.html#variant.Start
 
 Functions in [`rustix::net::sockopt`] are renamed to remove the `get_` prefix,
 to [align with Rust conventions].
 
-[`rustix::net::sockopt`]: https://docs.rs/rustix/1.0.0/rustix/net/sockopt/index.html
+[`rustix::net::sockopt`]: https://docs.rs/rustix/1/rustix/net/sockopt/index.html
 [align with Rust conventions]: https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter
 
 `rustix::process::sched_*` and `rustix::process::membarrier_*` are moved from
 [`rustix::process`] to [`rustix::thread`], as they operate on the current
 thread rather than the current process.
 
-[`rustix::process`]: https://docs.rs/rustix/1.0.0/rustix/process/index.html
-[`rustix::thread`]: https://docs.rs/rustix/1.0.0/rustix/thread/index.html
+[`rustix::process`]: https://docs.rs/rustix/1/rustix/process/index.html
+[`rustix::thread`]: https://docs.rs/rustix/1/rustix/thread/index.html
 
 The `udata` in [`rustix::event::kqueue::Event`] is changed from `isize` to
 `*mut c_void` to better propagate pointer provenance. To use arbitrary integer
 values, convert using the [`without_provenance_mut`] and the [`.addr()`]
 functions.
 
-[`rustix::event::kqueue::Event`]: https://docs.rs/rustix/1.0.0/x86_64-unknown-freebsd/rustix/event/kqueue/struct.Event.html
+[`rustix::event::kqueue::Event`]: https://docs.rs/rustix/1/x86_64-unknown-freebsd/rustix/event/kqueue/struct.Event.html
 [`without_provenance_mut`]: https://doc.rust-lang.org/stable/std/ptr/fn.without_provenance_mut.html
 [`.addr()`]: https://doc.rust-lang.org/stable/std/primitive.pointer.html#method.addr
 
 `rustix::mount::mount_recursive_bind` is renamed to
 [`rustix::mount::mount_bind_recursive`]. See [this comment] for details.
 
-[`rustix::mount::mount_bind_recursive`]: https://docs.rs/rustix/1.0.0/rustix/mount/fn.mount_bind_recursive.html
+[`rustix::mount::mount_bind_recursive`]: https://docs.rs/rustix/1/rustix/mount/fn.mount_bind_recursive.html
 [this comment]: https://github.com/bytecodealliance/rustix/pull/763#issuecomment-1662756184
 
 The `rustix::procfs` is removed. This functionality is now available in the
@@ -139,23 +139,23 @@ The `rustix::procfs` is removed. This functionality is now available in the
 
 `rustix::net::RecvMsgReturn` is renamed to [`rustix::net::RecvMsg`].
 
-[`rustix::net::RecvMsg`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.RecvMsg.html
+[`rustix::net::RecvMsg`]: https://docs.rs/rustix/1/rustix/net/struct.RecvMsg.html
 
 The `flags` field of [`rustix::net::RecvMsg`] changed type from [`RecvFlags`]
 to a new [`ReturnFlags`], since it supports a different set of flags.
 
-[`rustix::net::RecvMsg`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.RecvMsg.html
-[`RecvFlags`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.RecvFlags.html
-[`ReturnFlags`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.ReturnFlags.html
+[`rustix::net::RecvMsg`]: https://docs.rs/rustix/1/rustix/net/struct.RecvMsg.html
+[`RecvFlags`]: https://docs.rs/rustix/1/rustix/net/struct.RecvFlags.html
+[`ReturnFlags`]: https://docs.rs/rustix/1/rustix/net/struct.ReturnFlags.html
 
 [`rustix::event::poll`]'s and [`rustix::event::epoll`]'s `timeout` argument
 changed from a `c_int` where `-1` means no timeout and non-negative numbers
 mean a timeout in milliseconds to an `Option<&Timespec>`. The [`Timespec`]'s
 fields are `tv_sec` which holds seconds and `tv_nsec` which holds nanoseconds.
 
-[`rustix::event::poll`]: https://docs.rs/rustix/1.0.0/rustix/event/fn.poll.html
-[`rustix::event::epoll`]: https://docs.rs/rustix/1.0.0/rustix/event/epoll/index.html
-[`Timespec`]: https://docs.rs/rustix/1.0.0/rustix/time/struct.Timespec.html
+[`rustix::event::poll`]: https://docs.rs/rustix/1/rustix/event/fn.poll.html
+[`rustix::event::epoll`]: https://docs.rs/rustix/1/rustix/event/epoll/index.html
+[`Timespec`]: https://docs.rs/rustix/1/rustix/time/struct.Timespec.html
 
 The timeout argument in [`rustix::thread::futex::wait`],
 [`rustix::thread::futex::lock_pi`], [`rustix::thread::futex::wait_bitset`],
@@ -166,29 +166,29 @@ low-level efficiency, as it means the implementation doesn't need to make a
 copy of the `Timespec` to take its address. An easy way to convert an
 `Option<Timespec>` to an `Option<&Timespec> is to use [`Option::as_ref`].
 
-[`rustix::thread::futex::wait`]: https://docs.rs/rustix/1.0.0/rustix/thread/futex/fn.wait.html
-[`rustix::thread::futex::lock_pi`]: https://docs.rs/rustix/1.0.0/rustix/thread/futex/fn.lock_pi.html
-[`rustix::thread::futex::wait_bitset`]: https://docs.rs/rustix/1.0.0/rustix/thread/futex/fn.wait_bitset.html
-[`rustix::thread::futex::wait_requeue_pi`]: https://docs.rs/rustix/1.0.0/rustix/thread/futex/fn.wait_requeue_pi.html
-[`rustix::thread::futex::lock_pi2`]: https://docs.rs/rustix/1.0.0/rustix/thread/futex/fn.lock_pi2.html
+[`rustix::thread::futex::wait`]: https://docs.rs/rustix/1/rustix/thread/futex/fn.wait.html
+[`rustix::thread::futex::lock_pi`]: https://docs.rs/rustix/1/rustix/thread/futex/fn.lock_pi.html
+[`rustix::thread::futex::wait_bitset`]: https://docs.rs/rustix/1/rustix/thread/futex/fn.wait_bitset.html
+[`rustix::thread::futex::wait_requeue_pi`]: https://docs.rs/rustix/1/rustix/thread/futex/fn.wait_requeue_pi.html
+[`rustix::thread::futex::lock_pi2`]: https://docs.rs/rustix/1/rustix/thread/futex/fn.lock_pi2.html
 [`Option::as_ref`]: https://doc.rust-lang.org/stable/std/option/enum.Option.html#method.as_ref
 
 Functions in [`rustix::event::port`] are renamed to remove the redundant
 `port_*` prefix.
 
-[`rustix::event::port`]: https://docs.rs/rustix/1.0.0/x86_64-unknown-illumos/rustix/event/port/index.html
+[`rustix::event::port`]: https://docs.rs/rustix/1/x86_64-unknown-illumos/rustix/event/port/index.html
 
 `rustix::fs::inotify::InotifyEvent` is renamed to
 [`rustix::fs::inotify::Event`] to remove the redundant prefix.
 
-[`rustix::fs::inotify::Event`]: https://docs.rs/rustix/1.0.0/rustix/fs/inotify/struct.Event.html
+[`rustix::fs::inotify::Event`]: https://docs.rs/rustix/1/rustix/fs/inotify/struct.Event.html
 
 `rustix::fs::StatExt` is removed, and the timestamp fields `st_atime`,
 `st_mtime`, and `st_ctime` of [`rustix::fs::Stat`] may now be accessed
 directly. They are now signed instead of unsigned, so that they can represent
 times before the epoch.
 
-[`rustix::fs::Stat`]: https://docs.rs/rustix/1.0.0/rustix/fs/struct.Stat.html
+[`rustix::fs::Stat`]: https://docs.rs/rustix/1/rustix/fs/struct.Stat.html
 
 `rustix::io::is_read_write` is removed, as it's higher-level functionality that
 can be implemented in terms of lower-level rustix calls.
@@ -198,43 +198,43 @@ the number of received bytes in their return types, as this number may differ
 from the number of bytes written to the buffer when
 [`rustix::net::RecvFlags::TRUNC`] is used.
 
-[`rustix::net::recv`]: https://docs.rs/rustix/1.0.0/rustix/net/fn.recv.html
-[`rustix::net::recvfrom`]: https://docs.rs/rustix/1.0.0/rustix/net/fn.recvfrom.html
-[`rustix::net::RecvFlags::TRUNC`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.RecvFlags.html#associatedconstant.TRUNC
+[`rustix::net::recv`]: https://docs.rs/rustix/1/rustix/net/fn.recv.html
+[`rustix::net::recvfrom`]: https://docs.rs/rustix/1/rustix/net/fn.recvfrom.html
+[`rustix::net::RecvFlags::TRUNC`]: https://docs.rs/rustix/1/rustix/net/struct.RecvFlags.html#associatedconstant.TRUNC
 
 [`rustix::process::Signal`] constants are now upper-cased; for example,
 `Signal::Int` is now named [`Signal::INT`]. Also, `Signal` is no longer
 directly convertible to `i32`; use [`Signal::as_raw`] instead.
 
-[`rustix::process::Signal`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.Signal.html
-[`Signal::INT`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.Signal.html#variant.Int
-[`Signal::as_raw`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.Signal.html#method.as_raw
+[`rustix::process::Signal`]: https://docs.rs/rustix/1/rustix/process/struct.Signal.html
+[`Signal::INT`]: https://docs.rs/rustix/1/rustix/process/struct.Signal.html#variant.Int
+[`Signal::as_raw`]: https://docs.rs/rustix/1/rustix/process/struct.Signal.html#method.as_raw
 
 `Signal::from_raw` is renamed to [`Signal::from_named_raw`].
 
-[`Signal::from_named_raw`]: https://docs.rs/rustix/1.0.0/rustix/process/struct.Signal.html#method.from_named_raw
+[`Signal::from_named_raw`]: https://docs.rs/rustix/1/rustix/process/struct.Signal.html#method.from_named_raw
 
 The associated constant `rustix::ioctl::Ioctl::OPCODE` is now replaced with an
 associated method [`rustix::ioctl::Ioctl::opcode`], to support ioctls where the
 opcode is computed rather than a constant.
 
-[`rustix::ioctl::Ioctl::opcode`]: https://docs.rs/rustix/1.0.0/rustix/ioctl/trait.Ioctl.html#tymethod.opcode
+[`rustix::ioctl::Ioctl::opcode`]: https://docs.rs/rustix/1/rustix/ioctl/trait.Ioctl.html#tymethod.opcode
 
 The `ifindex` argument in
 [`rustix::net::sockopt::set_ip_add_membership_with_ifindex`] and
 [`rustix::net::sockopt::set_ip_drop_membership_with_ifindex`]
 changed from `i32` to `u32`.
 
-[`rustix::net::sockopt::set_ip_add_membership_with_ifindex`]: https://docs.rs/rustix/1.0.0/rustix/net/sockopt/fn.set_ip_add_membership_with_ifindex.html
-[`rustix::net::sockopt::set_ip_drop_membership_with_ifindex`]: https://docs.rs/rustix/1.0.0/rustix/net/sockopt/fn.set_ip_drop_membership_with_ifindex.html
+[`rustix::net::sockopt::set_ip_add_membership_with_ifindex`]: https://docs.rs/rustix/1/rustix/net/sockopt/fn.set_ip_add_membership_with_ifindex.html
+[`rustix::net::sockopt::set_ip_drop_membership_with_ifindex`]: https://docs.rs/rustix/1/rustix/net/sockopt/fn.set_ip_drop_membership_with_ifindex.html
 
 The `list` argument in [`rustix::fs::listxattr`], [`rustix::fs::flistxattr`],
 and [`rustix::fs::llistxattr`] changed from `[c_char]`, which is `[i8]` on some
 architectures, to `[u8]`.
 
-[`rustix::fs::listxattr`]: https://docs.rs/rustix/1.0.0/rustix/fs/fn.listxattr.html
-[`rustix::fs::flistxattr`]: https://docs.rs/rustix/1.0.0/rustix/fs/fn.flistxattr.html
-[`rustix::fs::llistxattr`]: https://docs.rs/rustix/1.0.0/rustix/fs/fn.llistxattr.html
+[`rustix::fs::listxattr`]: https://docs.rs/rustix/1/rustix/fs/fn.listxattr.html
+[`rustix::fs::flistxattr`]: https://docs.rs/rustix/1/rustix/fs/fn.flistxattr.html
+[`rustix::fs::llistxattr`]: https://docs.rs/rustix/1/rustix/fs/fn.llistxattr.html
 
 On NetBSD, the nanoseconds fields of [`Stat`] have been renamed, for consistency
 with other platforms:
@@ -246,12 +246,12 @@ with other platforms:
 | `st_ctimensec` | `st_ctime_nsec` |
 | `st_birthtimensec` | `st_birthtime_nsec` |
 
-[`Stat`]: https://docs.rs/rustix/1.0.0/x86_64-unknown-netbsd/rustix/fs/struct.Stat.html
+[`Stat`]: https://docs.rs/rustix/1/x86_64-unknown-netbsd/rustix/fs/struct.Stat.html
 
 [`rustix::mount::mount`]'s `data` argument is now an `Option`, so it can now
 be used in place of `mount2`, and `mount2` is now removed.
 
-[`rustix::mount::mount`]: https://docs.rs/rustix/1.0.0/rustix/mount/fn.mount.html
+[`rustix::mount::mount`]: https://docs.rs/rustix/1/rustix/mount/fn.mount.html
 
 The [`rustix::net`] functions ending with `_v4`, `_v6`, `_unix` and `_xdp` have
 been merged into a single function that accepts any address type.
@@ -267,26 +267,26 @@ Specifically, the following functions are removed:
   * `sendto_any`, `sendto_v4`, `sendto_v6`, `sendto_unix`, `sendto_xdp` in
     favor of [`sendto`].
 
-[`rustix::net`]: https://docs.rs/rustix/1.0.0/rustix/net/index.html
-[`bind`]: https://docs.rs/rustix/1.0.0/rustix/net/fn.bind.html
-[`connect`]: https://docs.rs/rustix/1.0.0/rustix/net/fn.connect.html
-[`connect_unspec`]: https://docs.rs/rustix/1.0.0/rustix/net/fn.connect_unspec.html
-[`sendmsg_addr`]: https://docs.rs/rustix/1.0.0/rustix/net/fn.sendmsg_addr.html
-[`sendmsg`]: https://docs.rs/rustix/1.0.0/rustix/net/fn.sendmsg.html
-[`sendto`]: https://docs.rs/rustix/1.0.0/rustix/net/fn.sendto.html
+[`rustix::net`]: https://docs.rs/rustix/1/rustix/net/index.html
+[`bind`]: https://docs.rs/rustix/1/rustix/net/fn.bind.html
+[`connect`]: https://docs.rs/rustix/1/rustix/net/fn.connect.html
+[`connect_unspec`]: https://docs.rs/rustix/1/rustix/net/fn.connect_unspec.html
+[`sendmsg_addr`]: https://docs.rs/rustix/1/rustix/net/fn.sendmsg_addr.html
+[`sendmsg`]: https://docs.rs/rustix/1/rustix/net/fn.sendmsg.html
+[`sendto`]: https://docs.rs/rustix/1/rustix/net/fn.sendto.html
 
 The `SocketAddrAny` enum has changed to a [`SocketAddrAny`] struct which can
 contain any kind of socket address. It can be converted to and from the more
 specific socket types using `From`/`Into`/`TryFrom`/`TryInto` conversions.
 
-[`SocketAddrAny`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.SocketAddrAny.html
+[`SocketAddrAny`]: https://docs.rs/rustix/1/rustix/net/struct.SocketAddrAny.html
 
 The `len` parameter to [`rustix::fs::fadvise`] has changed from `u64` to
 `Option<NonZeroU64>`, to reflect that zero is a special case meaning the
 advice applies to the end of the file. To convert an arbitrary `u64` value to
 `Option<NonZeroU64>`, use `NonZeroU64::new`.
 
-[`rustix::fs::fadvise`]: https://docs.rs/rustix/1.0.0/rustix/fs/fn.fadvise.html
+[`rustix::fs::fadvise`]: https://docs.rs/rustix/1/rustix/fs/fn.fadvise.html
 
 [`rustix::io_uring::io_uring_enter`] no longer has `arg` and `size` arguments
 providing a raw `*mut c_void` and `usize` describing the argument value. To
@@ -295,46 +295,46 @@ and `io_uring_enter_arg`, which take a [`KernelSigSet`] or an
 `io_uring_getevents_arg`, respectively. These are more ergonomic, and provide
 a better path to adding `IORING_ENTER_EXT_ARG_REG` support in the future.
 
-[`rustix::io_uring::io_uring_enter`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/fn.io_uring_enter.html
-[`KernelSigSet`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/struct.KernelSigSet.html
+[`rustix::io_uring::io_uring_enter`]: https://docs.rs/rustix/1/rustix/io_uring/fn.io_uring_enter.html
+[`KernelSigSet`]: https://docs.rs/rustix/1/rustix/io_uring/struct.KernelSigSet.html
 
 The [`sigmask`] and [`ts`] fields of [`rustix::io_uring::getevents_arg`]
 changed from `u64` to [`rustix::io_uring::io_uring_ptr`], to better preserve
 pointer provenance.
 
-[`sigmask`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/struct.io_uring_getevents_arg.html#structfield.sigmask
-[`ts`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/struct.io_uring_getevents_arg.html#structfield.ts
-[`rustix::io_uring::getevents_arg`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/struct.io_uring_getevents_arg.html
-[`rustix::io_uring::io_uring_ptr`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/struct.io_uring_ptr.html
+[`sigmask`]: https://docs.rs/rustix/1/rustix/io_uring/struct.io_uring_getevents_arg.html#structfield.sigmask
+[`ts`]: https://docs.rs/rustix/1/rustix/io_uring/struct.io_uring_getevents_arg.html#structfield.ts
+[`rustix::io_uring::getevents_arg`]: https://docs.rs/rustix/1/rustix/io_uring/struct.io_uring_getevents_arg.html
+[`rustix::io_uring::io_uring_ptr`]: https://docs.rs/rustix/1/rustix/io_uring/struct.io_uring_ptr.html
 
 The aliases for [`fcntl_dupfd_cloexec`], [`fcntl_getfd`], and [`fcntl_setfd`]
 in `rustix::fs` are removed; these functions are just available in
 [`rustix::io`] now.
 
-[`fcntl_dupfd_cloexec`]: https://docs.rs/rustix/1.0.0/rustix/io/fn.fcntl_dupfd_cloexec.html
-[`fcntl_getfd`]: https://docs.rs/rustix/1.0.0/rustix/io/fn.fcntl_getfd.html
-[`fcntl_setfd`]: https://docs.rs/rustix/1.0.0/rustix/io/fn.fcntl_setfd.html
-[`rustix::io`]: https://docs.rs/rustix/1.0.0/rustix/io/index.html
+[`fcntl_dupfd_cloexec`]: https://docs.rs/rustix/1/rustix/io/fn.fcntl_dupfd_cloexec.html
+[`fcntl_getfd`]: https://docs.rs/rustix/1/rustix/io/fn.fcntl_getfd.html
+[`fcntl_setfd`]: https://docs.rs/rustix/1/rustix/io/fn.fcntl_setfd.html
+[`rustix::io`]: https://docs.rs/rustix/1/rustix/io/index.html
 
 [`SocketAddrXdp`] no longer has a shared UMEM field. A new
 [`SocketAddrXdpWithSharedUmem`] is added for the purpose of calling `bind` and
 passing it an XDP address with a shared UMEM fd. And `SockaddrXdpFlags` is
 renamed to [`SocketAddrXdpFlags`].
 
-[`SocketAddrXdp`]: https://docs.rs/rustix/1.0.0/rustix/net/xdp/struct.SocketAddrXdp.html
-[`SocketAddrXdpWithSharedUmem`]: https://docs.rs/rustix/1.0.0/rustix/net/xdp/struct.SocketAddrXdpWithSharedUmem.html
-[`SocketAddrXdpFlags`]: https://docs.rs/rustix/1.0.0/rustix/net/xdp/struct.SocketAddrXdpFlags.html
+[`SocketAddrXdp`]: https://docs.rs/rustix/1/rustix/net/xdp/struct.SocketAddrXdp.html
+[`SocketAddrXdpWithSharedUmem`]: https://docs.rs/rustix/1/rustix/net/xdp/struct.SocketAddrXdpWithSharedUmem.html
+[`SocketAddrXdpFlags`]: https://docs.rs/rustix/1/rustix/net/xdp/struct.SocketAddrXdpFlags.html
 
 [`rustix::io_uring::io_uring_setup`] is now unsafe, due its `io_uring_params`
 argument optionally containing a raw file descriptor.
 
-[`rustix::io_uring::io_uring_setup`]: https://docs.rs/rustix/1.0.0/rustix/io_uring/fn.io_uring_setup.html
+[`rustix::io_uring::io_uring_setup`]: https://docs.rs/rustix/1/rustix/io_uring/fn.io_uring_setup.html
 
 The buffer for [`SendAncillaryBuffer`] and [`RecvAncillaryBuffer`] is now
 a `[MaybeUninit<u8>]` instead of a `[u8]`.
 
-[`SendAncillaryBuffer`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.SendAncillaryBuffer.html
-[`RecvAncillaryBuffer`]: https://docs.rs/rustix/1.0.0/rustix/net/struct.RecvAncillaryBuffer.html
+[`SendAncillaryBuffer`]: https://docs.rs/rustix/1/rustix/net/struct.SendAncillaryBuffer.html
+[`RecvAncillaryBuffer`]: https://docs.rs/rustix/1/rustix/net/struct.RecvAncillaryBuffer.html
 
 [`read`], [`pread`], [`recv`], [`recvfrom`], [`getrandom`], [`readlinkat_raw`],
 [`epoll::wait`], [`kevent`], [`port::getn`], [`getxattr`], [`lgetxattr`],
@@ -351,23 +351,23 @@ implicitly cleared before results were appended. When passing a `Vec` to
 not cleared first. Consider clearing the vector before calling `epoll::wait`,
 `kevent`, or `port::getn`, or consuming it using `.drain(..)` before reusing it.
 
-[`read`]: https://docs.rs/rustix/1.0.0/rustix/io/fn.read.html
-[`pread`]: https://docs.rs/rustix/1.0.0/rustix/io/fn.pread.html
-[`recv`]: https://docs.rs/rustix/1.0.0/rustix/net/fn.recv.html
-[`recvfrom`]: https://docs.rs/rustix/1.0.0/rustix/net/fn.recvfrom.html
-[`getrandom`]: https://docs.rs/rustix/1.0.0/rustix/rand/fn.getrandom.html
-[`readlinkat_raw`]: https://docs.rs/rustix/1.0.0/rustix/fs/fn.readlinkat_raw.html
-[`epoll::wait`]: https://docs.rs/rustix/1.0.0/rustix/event/epoll/fn.wait.html
-[`getxattr`]: https://docs.rs/rustix/1.0.0/rustix/fs/fn.getxattr.html
-[`lgetxattr`]: https://docs.rs/rustix/1.0.0/rustix/fs/fn.lgetxattr.html
-[`fgetxattr`]: https://docs.rs/rustix/1.0.0/rustix/fs/fn.fgetxattr.html
-[`listxattr`]: https://docs.rs/rustix/1.0.0/rustix/fs/fn.listxattr.html
-[`llistxattr`]: https://docs.rs/rustix/1.0.0/rustix/fs/fn.llistxattr.html
-[`flistxattr`]: https://docs.rs/rustix/1.0.0/rustix/fs/fn.flistxattr.html
-[`kevent`]: https://docs.rs/rustix/1.0.0/x86_64-unknown-freebsd/rustix/event/kqueue/fn.kevent.html
-[`port::getn`]: https://docs.rs/rustix/1.0.0/x86_64-unknown-illumos/rustix/event/port/fn.getn.html
-[`Buffer` trait]: https://docs.rs/rustix/1.0.0/rustix/buffer/trait.Buffer.html
-[`spare_capacity`]: https://docs.rs/rustix/1.0.0/rustix/buffer/fn.spare_capacity.html
+[`read`]: https://docs.rs/rustix/1/rustix/io/fn.read.html
+[`pread`]: https://docs.rs/rustix/1/rustix/io/fn.pread.html
+[`recv`]: https://docs.rs/rustix/1/rustix/net/fn.recv.html
+[`recvfrom`]: https://docs.rs/rustix/1/rustix/net/fn.recvfrom.html
+[`getrandom`]: https://docs.rs/rustix/1/rustix/rand/fn.getrandom.html
+[`readlinkat_raw`]: https://docs.rs/rustix/1/rustix/fs/fn.readlinkat_raw.html
+[`epoll::wait`]: https://docs.rs/rustix/1/rustix/event/epoll/fn.wait.html
+[`getxattr`]: https://docs.rs/rustix/1/rustix/fs/fn.getxattr.html
+[`lgetxattr`]: https://docs.rs/rustix/1/rustix/fs/fn.lgetxattr.html
+[`fgetxattr`]: https://docs.rs/rustix/1/rustix/fs/fn.fgetxattr.html
+[`listxattr`]: https://docs.rs/rustix/1/rustix/fs/fn.listxattr.html
+[`llistxattr`]: https://docs.rs/rustix/1/rustix/fs/fn.llistxattr.html
+[`flistxattr`]: https://docs.rs/rustix/1/rustix/fs/fn.flistxattr.html
+[`kevent`]: https://docs.rs/rustix/1/x86_64-unknown-freebsd/rustix/event/kqueue/fn.kevent.html
+[`port::getn`]: https://docs.rs/rustix/1/x86_64-unknown-illumos/rustix/event/port/fn.getn.html
+[`Buffer` trait]: https://docs.rs/rustix/1/rustix/buffer/trait.Buffer.html
+[`spare_capacity`]: https://docs.rs/rustix/1/rustix/buffer/fn.spare_capacity.html
 
 The [`rustix::ioctl::Opcode`] type has changed from a struct to a raw integer
 value, and the associated utilities are change to `const` functions. In place
@@ -385,13 +385,13 @@ use this:
 
 In place of `BadOpcode`, use the opcode value directly.
 
-[`rustix::ioctl::Opcode`]: https://docs.rs/rustix/1.0.0/rustix/ioctl/type.Opcode.html
-[`ioctl::opcode`]: https://docs.rs/rustix/1.0.0/rustix/ioctl/opcode/index.html
+[`rustix::ioctl::Opcode`]: https://docs.rs/rustix/1/rustix/ioctl/type.Opcode.html
+[`ioctl::opcode`]: https://docs.rs/rustix/1/rustix/ioctl/opcode/index.html
 
 [`rustix::event::port::getn`]'s `min_events` argument is now a `u32`, to
 reflect the type in the underlying system API.
 
-[`rustix::event::port::getn`]: https://docs.rs/rustix/1.0.0/x86_64-unknown-illumos/rustix/event/port/fn.getn.html
+[`rustix::event::port::getn`]: https://docs.rs/rustix/1/x86_64-unknown-illumos/rustix/event/port/fn.getn.html
 
 All explicitly deprecated functions and types have been removed. Their
 deprecation messages will have identified alternatives.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,8 @@ cargo test --features=all-apis
 ```
 
 And, rustix has two backends, linux_raw and libc, and only one is used in
-any given build. To test with the libc backend explicitly, additionally
-enable the `use-libc` feature:
+any given build. To test on Linux with the libc backend explicitly,
+additionally enable the `use-libc` feature:
 
 ```console
 cargo test --features=all-apis,use-libc

--- a/src/backend/linux_raw/arch/mod.rs
+++ b/src/backend/linux_raw/arch/mod.rs
@@ -56,8 +56,8 @@ pub(in crate::backend) mod asm;
 pub(in crate::backend) use self::asm as choose;
 
 // On 32-bit x86, use vDSO wrappers for all syscalls. We could use the
-// architecture syscall instruction (`int 0x80`), but the vDSO kernel_vsyscall
-// mechanism is much faster.
+// architecture syscall instruction (`int 0x80`), but the vDSO
+// `__kernel_vsyscall` mechanism is much faster.
 #[cfg(target_arch = "x86")]
 pub(in crate::backend) use super::vdso_wrappers::x86_via_vdso as choose;
 

--- a/src/backend/linux_raw/net/sockopt.rs
+++ b/src/backend/linux_raw/net/sockopt.rs
@@ -261,7 +261,7 @@ fn duration_from_linux_sock_timeval(time: __kernel_sock_timeval) -> Option<Durat
     }
 }
 
-/// Like `duration_from_linux` but uses Linux's old 32-bit
+/// Like `duration_from_linux_sock_timeval` but uses Linux's old 32-bit
 /// `__kernel_old_timeval`.
 fn duration_from_linux_old_timeval(time: __kernel_old_timeval) -> Option<Duration> {
     if time.tv_sec == 0 && time.tv_usec == 0 {
@@ -297,7 +297,7 @@ fn duration_to_linux_sock_timeval(timeout: Option<Duration>) -> io::Result<__ker
     })
 }
 
-/// Like `duration_to_linux` but uses Linux's old 32-bit
+/// Like `duration_to_linux_sock_timeval` but uses Linux's old 32-bit
 /// `__kernel_old_timeval`.
 fn duration_to_linux_old_timeval(timeout: Option<Duration>) -> io::Result<__kernel_old_timeval> {
     Ok(match timeout {

--- a/src/backend/linux_raw/param/auxv.rs
+++ b/src/backend/linux_raw/param/auxv.rs
@@ -282,7 +282,7 @@ fn maybe_init_auxv() {
 /// /proc/self/auxv for kernels that don't support `PR_GET_AUXV`.
 #[cold]
 fn init_auxv_impl() -> Result<(), ()> {
-    // 512 AUX elements ought to be enough for anybody…
+    // 512 bytes of AUX elements ought to be enough for anybody…
     let mut buffer = [0_u8; 512];
 
     // If we don't have "alloc", just try to read into our statically-sized

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,4 +1,4 @@
-//! Utilities to help with buffering.
+//! Utilities for functions that return data via buffers.
 
 #![allow(unsafe_code)]
 
@@ -22,7 +22,7 @@ use core::slice;
 ///
 /// Passing a `&mut [u8]`:
 ///
-/// ```rust
+/// ```
 /// # use rustix::io::read;
 /// # fn example(fd: rustix::fd::BorrowedFd) -> rustix::io::Result<()> {
 /// let mut buf = [0_u8; 64];
@@ -34,7 +34,7 @@ use core::slice;
 ///
 /// Passing a `&mut [MaybeUninit<u8>]`:
 ///
-/// ```rust
+/// ```
 /// # use rustix::io::read;
 /// # use std::mem::MaybeUninit;
 /// # fn example(fd: rustix::fd::BorrowedFd) -> rustix::io::Result<()> {
@@ -48,7 +48,7 @@ use core::slice;
 ///
 /// Passing a [`SpareCapacity`], via the [`spare_capacity`] helper function:
 ///
-/// ```rust
+/// ```
 /// # use rustix::io::read;
 /// # use rustix::buffer::spare_capacity;
 /// # fn example(fd: rustix::fd::BorrowedFd) -> rustix::io::Result<()> {
@@ -293,7 +293,8 @@ mod private {
 
         /// Return a pointer and length for this buffer.
         ///
-        /// The length is the number of elements of type `T`, not a number of bytes.
+        /// The length is the number of elements of type `T`, not a number of
+        /// bytes.
         ///
         /// It's tempting to have this return `&mut [MaybeUninit<T>]` instead,
         /// however that would require this function to be `unsafe`, because
@@ -370,7 +371,10 @@ mod tests {
         let mut buf = [0_u8; 64];
         let nread = read(&input, &mut buf).unwrap();
         assert_eq!(nread, buf.len());
-        assert_eq!(&buf[..38], b"//! Utilities to help with buffering.\n");
+        assert_eq!(
+            &buf[..58],
+            b"//! Utilities for functions that return data via buffers.\n"
+        );
         input.seek(SeekFrom::End(-1)).unwrap();
         let nread = read(&input, &mut buf).unwrap();
         assert_eq!(nread, 1);
@@ -393,11 +397,14 @@ mod tests {
         let mut buf = [MaybeUninit::<u8>::uninit(); 64];
         let (init, uninit) = read(&input, &mut buf).unwrap();
         assert_eq!(uninit.len(), 0);
-        assert_eq!(&init[..38], b"//! Utilities to help with buffering.\n");
+        assert_eq!(
+            &init[..58],
+            b"//! Utilities for functions that return data via buffers.\n"
+        );
         assert_eq!(init.len(), buf.len());
         assert_eq!(
-            unsafe { core::mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(&mut buf[..38]) },
-            b"//! Utilities to help with buffering.\n"
+            unsafe { core::mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(&mut buf[..58]) },
+            b"//! Utilities for functions that return data via buffers.\n"
         );
         input.seek(SeekFrom::End(-1)).unwrap();
         let (init, uninit) = read(&input, &mut buf).unwrap();
@@ -423,7 +430,10 @@ mod tests {
         let nread = read(&input, spare_capacity(&mut buf)).unwrap();
         assert_eq!(nread, buf.capacity());
         assert_eq!(nread, buf.len());
-        assert_eq!(&buf[..38], b"//! Utilities to help with buffering.\n");
+        assert_eq!(
+            &buf[..58],
+            b"//! Utilities for functions that return data via buffers.\n"
+        );
         buf.clear();
         input.seek(SeekFrom::End(-1)).unwrap();
         let nread = read(&input, spare_capacity(&mut buf)).unwrap();

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -5,7 +5,10 @@
 /// strings, and passing strings to rustix as `CStr`s means that rustix doesn't
 /// need to copy them into a separate buffer to NUL-terminate them.
 ///
+/// In Rust ≥ 1.77, users can use [C-string literals] instead of this macro.
+///
 /// [`CStr`]: crate::ffi::CStr
+/// [C-string literals]: https://blog.rust-lang.org/2024/03/21/Rust-1.77.0.html#c-string-literals
 ///
 /// # Examples
 ///

--- a/src/event/pause.rs
+++ b/src/event/pause.rs
@@ -3,8 +3,8 @@ use crate::backend;
 /// `pause()`—Sleep until interrupted by a signal.
 ///
 /// The POSIX `pause` interface returns an error code, but the only thing
-/// `pause` does is sleep until interrupted by a signal, so it always
-/// returns the same thing with the same error code, so in rustix, the
+/// `pause` does is sleep until interrupted by a signal. If it were exposed in
+/// the API here it would always return `Errno::INTR`, so for simplicity the
 /// return value is omitted.
 ///
 /// # References

--- a/src/fs/memfd_create.rs
+++ b/src/fs/memfd_create.rs
@@ -4,6 +4,10 @@ use backend::fs::types::MemfdFlags;
 
 /// `memfd_create(name, flags)`—Create an anonymous file.
 ///
+/// For a higher-level API to this functionality, see the [memfd] crate.
+///
+/// [memfd]: https://crates.io/crates/memfd
+///
 /// # References
 ///  - [Linux]
 ///  - [glibc]

--- a/src/fs/xattr.rs
+++ b/src/fs/xattr.rs
@@ -27,10 +27,16 @@ bitflags! {
 
 /// `getxattr(path, name, value)`—Get extended filesystem attributes.
 ///
+/// For a higher-level API to xattr functionality, see the [xattr] crate.
+///
+/// [xattr]: https://crates.io/crates/xattr
+///
 /// # References
 ///  - [Linux]
+///  - [Apple]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/getxattr.2.html
+/// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/getxattr.2.html
 #[inline]
 pub fn getxattr<P: path::Arg, Name: path::Arg, Buf: Buffer<u8>>(
     path: P,
@@ -76,8 +82,10 @@ pub fn lgetxattr<P: path::Arg, Name: path::Arg, Buf: Buffer<u8>>(
 ///
 /// # References
 ///  - [Linux]
+///  - [Apple]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/fgetxattr.2.html
+/// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fgetxattr.2.html
 #[inline]
 pub fn fgetxattr<Fd: AsFd, Name: path::Arg, Buf: Buffer<u8>>(
     fd: Fd,
@@ -97,8 +105,10 @@ pub fn fgetxattr<Fd: AsFd, Name: path::Arg, Buf: Buffer<u8>>(
 ///
 /// # References
 ///  - [Linux]
+///  - [Apple]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/setxattr.2.html
+/// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/setxattr.2.html
 #[inline]
 pub fn setxattr<P: path::Arg, Name: path::Arg>(
     path: P,
@@ -136,8 +146,10 @@ pub fn lsetxattr<P: path::Arg, Name: path::Arg>(
 ///
 /// # References
 ///  - [Linux]
+///  - [Apple]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/fsetxattr.2.html
+/// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fsetxattr.2.html
 #[inline]
 pub fn fsetxattr<Fd: AsFd, Name: path::Arg>(
     fd: Fd,
@@ -155,6 +167,7 @@ pub fn fsetxattr<Fd: AsFd, Name: path::Arg>(
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/listxattr.2.html
+/// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/listxattr.2.html
 #[inline]
 pub fn listxattr<P: path::Arg, Buf: Buffer<u8>>(path: P, mut list: Buf) -> io::Result<Buf::Output> {
     path.into_with_c_str(|path| {
@@ -190,8 +203,10 @@ pub fn llistxattr<P: path::Arg, Buf: Buffer<u8>>(
 ///
 /// # References
 ///  - [Linux]
+///  - [Apple]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/flistxattr.2.html
+/// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/flistxattr.2.html
 #[inline]
 pub fn flistxattr<Fd: AsFd, Buf: Buffer<u8>>(fd: Fd, mut list: Buf) -> io::Result<Buf::Output> {
     // SAFETY: `flistxattr` behaves.
@@ -204,8 +219,10 @@ pub fn flistxattr<Fd: AsFd, Buf: Buffer<u8>>(fd: Fd, mut list: Buf) -> io::Resul
 ///
 /// # References
 ///  - [Linux]
+///  - [Apple]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/removexattr.2.html
+/// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/removexattr.2.html
 pub fn removexattr<P: path::Arg, Name: path::Arg>(path: P, name: Name) -> io::Result<()> {
     path.into_with_c_str(|path| {
         name.into_with_c_str(|name| backend::fs::syscalls::removexattr(path, name))
@@ -230,8 +247,10 @@ pub fn lremovexattr<P: path::Arg, Name: path::Arg>(path: P, name: Name) -> io::R
 ///
 /// # References
 ///  - [Linux]
+///  - [Apple]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/fremovexattr.2.html
+/// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fremovexattr.2.html
 pub fn fremovexattr<Fd: AsFd, Name: path::Arg>(fd: Fd, name: Name) -> io::Result<()> {
     name.into_with_c_str(|name| backend::fs::syscalls::fremovexattr(fd.as_fd(), name))
 }

--- a/src/io_uring/mod.rs
+++ b/src/io_uring/mod.rs
@@ -2012,7 +2012,7 @@ mod tests {
         assert_eq_align!(io_uring_user_data, u64);
 
         // Test that `u64`s and pointers are properly stored in
-        // io_uring_user_data`.
+        // `io_uring_user_data`.
         unsafe {
             const MAGIC: u64 = !0x0123_4567_89ab_cdef;
             let user_data = io_uring_user_data::from_u64(MAGIC);

--- a/src/mm/mmap.rs
+++ b/src/mm/mmap.rs
@@ -411,7 +411,7 @@ pub fn mlockall(flags: MlockAllFlags) -> io::Result<()> {
 
 /// Unlocks all pages mapped into the address space of the calling process.
 ///
-/// # Warnings
+/// # Warning
 ///
 /// This function is aware of all the memory pages in the process, as if it
 /// were a debugger. It unlocks all the pages, which could potentially

--- a/src/net/send_recv/msg.rs
+++ b/src/net/send_recv/msg.rs
@@ -143,7 +143,8 @@ pub enum SendAncillaryMessage<'slice, 'fd> {
 impl SendAncillaryMessage<'_, '_> {
     /// Get the maximum size of an ancillary message.
     ///
-    /// This can be helpful in determining the size of the buffer you allocate.
+    /// This can be used to determine the size of the buffer to allocate for a
+    /// [`SendAncillaryBuffer::new`] with one message.
     pub const fn size(&self) -> usize {
         match self {
             Self::ScmRights(slice) => cmsg_space!(ScmRights(slice.len())),

--- a/src/param/init.rs
+++ b/src/param/init.rs
@@ -14,8 +14,8 @@ use crate::backend;
 /// # Safety
 ///
 /// This must be passed a pointer to the original environment variable block
-/// set up by the OS at process startup, and it must be called before any
-/// other rustix functions are called.
+/// set up by the OS at process startup, and it must be called before any other
+/// rustix functions are called.
 #[inline]
 #[doc(hidden)]
 pub unsafe fn init(envp: *mut *mut u8) {

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -80,7 +80,7 @@ impl Pid {
         }
     }
 
-    /// Test whether this pid represents the init process (pid 1).
+    /// Test whether this pid represents the init process ([`Pid::INIT`]).
     #[inline]
     pub const fn is_init(self) -> bool {
         self.0.get() == Self::INIT.0.get()

--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -19,9 +19,15 @@ pub use crate::ugid::{Gid, RawGid, RawUid, Uid};
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
+///  - [FreeBSD]
+///  - [illumos]
+///  - [NetBSD]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/getuid.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getuid.2.html
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=getuid&sektion=2
+/// [illumos]: https://www.illumos.org/man/2/getuid
+/// [NetBSD]: https://man.netbsd.org/getuid.2
 #[inline]
 #[must_use]
 pub fn getuid() -> Uid {
@@ -33,9 +39,15 @@ pub fn getuid() -> Uid {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
+///  - [FreeBSD]
+///  - [illumos]
+///  - [NetBSD]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/geteuid.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/geteuid.2.html
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=geteuid&sektion=2
+/// [illumos]: https://www.illumos.org/man/2/geteuid
+/// [NetBSD]: https://man.netbsd.org/geteuid.2
 #[inline]
 #[must_use]
 pub fn geteuid() -> Uid {
@@ -47,9 +59,15 @@ pub fn geteuid() -> Uid {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
+///  - [FreeBSD]
+///  - [illumos]
+///  - [NetBSD]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/getgid.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getgid.2.html
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=getgid&sektion=2
+/// [illumos]: https://www.illumos.org/man/2/getgid
+/// [NetBSD]: https://man.netbsd.org/getgid.2
 #[inline]
 #[must_use]
 pub fn getgid() -> Gid {
@@ -61,9 +79,15 @@ pub fn getgid() -> Gid {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
+///  - [FreeBSD]
+///  - [illumos]
+///  - [NetBSD]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/getegid.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getegid.2.html
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=getegid&sektion=2
+/// [illumos]: https://www.illumos.org/man/2/getegid
+/// [NetBSD]: https://man.netbsd.org/getegid.2
 #[inline]
 #[must_use]
 pub fn getegid() -> Gid {
@@ -75,9 +99,15 @@ pub fn getegid() -> Gid {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
+///  - [FreeBSD]
+///  - [illumos]
+///  - [NetBSD]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/getpid.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getpid.2.html
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=getpid&sektion=2
+/// [illumos]: https://www.illumos.org/man/2/getpid
+/// [NetBSD]: https://man.netbsd.org/getpid.2
 #[inline]
 #[must_use]
 pub fn getpid() -> Pid {
@@ -88,14 +118,20 @@ pub fn getpid() -> Pid {
 ///
 /// This will return `None` if the current process has no parent (or no parent
 /// accessible in the current PID namespace), such as if the current process is
-/// an init process (PID 1).
+/// the init process ([`Pid::INIT`]).
 ///
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
+///  - [FreeBSD]
+///  - [illumos]
+///  - [NetBSD]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/getppid.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getppid.2.html
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=getppid&sektion=2
+/// [illumos]: https://www.illumos.org/man/2/getppid
+/// [NetBSD]: https://man.netbsd.org/getppid.2
 #[inline]
 #[must_use]
 pub fn getppid() -> Option<Pid> {
@@ -107,9 +143,15 @@ pub fn getppid() -> Option<Pid> {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
+///  - [FreeBSD]
+///  - [illumos]
+///  - [NetBSD]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/getpgid.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getpgid.2.html
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=getpgid&sektion=2
+/// [illumos]: https://www.illumos.org/man/2/getpgid
+/// [NetBSD]: https://man.netbsd.org/getpgid.2
 #[inline]
 pub fn getpgid(pid: Option<Pid>) -> io::Result<Pid> {
     backend::process::syscalls::getpgid(pid)
@@ -120,9 +162,15 @@ pub fn getpgid(pid: Option<Pid>) -> io::Result<Pid> {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
+///  - [FreeBSD]
+///  - [illumos]
+///  - [NetBSD]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/setpgid.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/setpgid.2.html
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=setpgid&sektion=2
+/// [illumos]: https://www.illumos.org/man/2/setpgid
+/// [NetBSD]: https://man.netbsd.org/setpgid.2
 #[inline]
 pub fn setpgid(pid: Option<Pid>, pgid: Option<Pid>) -> io::Result<()> {
     backend::process::syscalls::setpgid(pid, pgid)
@@ -133,9 +181,15 @@ pub fn setpgid(pid: Option<Pid>, pgid: Option<Pid>) -> io::Result<()> {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
+///  - [FreeBSD]
+///  - [illumos]
+///  - [NetBSD]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/getpgrp.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getpgrp.2.html
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=getpgrp&sektion=2
+/// [illumos]: https://www.illumos.org/man/2/getpgrp
+/// [NetBSD]: https://man.netbsd.org/getpgrp.2
 #[inline]
 #[must_use]
 pub fn getpgrp() -> Pid {
@@ -147,9 +201,15 @@ pub fn getpgrp() -> Pid {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
+///  - [FreeBSD]
+///  - [illumos]
+///  - [NetBSD]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/getsid.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getsid.2.html
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=getsid&sektion=2
+/// [illumos]: https://www.illumos.org/man/2/getsid
+/// [NetBSD]: https://man.netbsd.org/getsid.2
 #[cfg(not(target_os = "redox"))]
 #[inline]
 pub fn getsid(pid: Option<Pid>) -> io::Result<Pid> {
@@ -161,9 +221,15 @@ pub fn getsid(pid: Option<Pid>) -> io::Result<Pid> {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
+///  - [FreeBSD]
+///  - [illumos]
+///  - [NetBSD]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/setsid.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/setsid.2.html
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=setsid&sektion=2
+/// [illumos]: https://www.illumos.org/man/2/setsid
+/// [NetBSD]: https://man.netbsd.org/setsid.2
 #[inline]
 pub fn setsid() -> io::Result<Pid> {
     backend::process::syscalls::setsid()
@@ -174,9 +240,13 @@ pub fn setsid() -> io::Result<Pid> {
 /// # References
 ///  - [POSIX]
 ///  - [Linux]
+///  - [FreeBSD]
+///  - [NetBSD]
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/getgroups.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/getgroups.2.html
+/// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=getgroups&sektion=2
+/// [NetBSD]: https://man.netbsd.org/getgroups.2
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn getgroups() -> io::Result<Vec<Gid>> {

--- a/src/process/kill.rs
+++ b/src/process/kill.rs
@@ -19,9 +19,10 @@ pub fn kill_process(pid: Pid, sig: Signal) -> io::Result<()> {
 
 /// `kill(-pid, sig)`—Sends a signal to all processes in a process group.
 ///
-/// If `pid` is 1, this sends a signal to all processes the current process has
-/// permission to send signals to, except process `1`, possibly other
-/// system-specific processes, and on some systems, the current process.
+/// If `pid` is [`Pid::INIT`], this sends a signal to all processes the current
+/// process has permission to send signals to, except process `Pid::INIT`,
+/// possibly other system-specific processes, and on some systems, the current
+/// process.
 ///
 /// # References
 ///  - [POSIX]

--- a/src/process/procctl.rs
+++ b/src/process/procctl.rs
@@ -241,7 +241,7 @@ bitflags! {
     pub struct ReaperStatusFlags: c_uint {
         /// The process has acquired reaper status.
         const OWNED = 1;
-        /// The process is the root of the reaper tree (pid 1).
+        /// The process is the root of the reaper tree ([`Pid::INIT`]).
         const REALINIT = 2;
 
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>

--- a/src/process/wait.rs
+++ b/src/process/wait.rs
@@ -407,24 +407,17 @@ pub enum WaitId<'a> {
 /// `waitpid(pid, waitopts)`—Wait for a specific process to change state.
 ///
 /// If the pid is `None`, the call will wait for any child process whose
-/// process group id matches that of the calling process.
-///
-/// Otherwise, the call will wait for the child process with the given pid.
+/// process group id matches that of the calling process. Otherwise, the call
+/// will wait for the child process with the given pid.
 ///
 /// On Success, returns the status of the selected process.
 ///
 /// If `NOHANG` was specified in the options, and the selected child process
 /// didn't change state, returns `None`.
 ///
-/// # Bugs
-///
-/// This function does not currently support waiting for given process group
-/// (the `< -1` case of `waitpid`); to do that, currently the [`waitpgid`] or
-/// [`waitid`] function must be used.
-///
-/// This function does not currently support waiting for any process (the
-/// `-1` case of `waitpid`); to do that, currently the [`wait`] function must
-/// be used.
+/// To wait for a given process group (the `< -1` case of `waitpid`), use
+/// [`waitpgid`] or [`waitid`]. To wait for any process (the `-1` case of
+/// `waitpid`), use [`wait`].
 ///
 /// # References
 ///  - [POSIX]

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -28,8 +28,6 @@ use crate::{fd::FromRawFd as _, ioctl};
 
 bitflags::bitflags! {
     /// `O_*` flags for use with [`openpt`] and [`ioctl_tiocgptpeer`].
-    ///
-    /// [`ioctl_tiocgptpeer`]: https://docs.rs/rustix/*/x86_64-unknown-linux-gnu/rustix/pty/fn.ioctl_tiocgptpeer.html
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct OpenptFlags: u32 {

--- a/src/system.rs
+++ b/src/system.rs
@@ -198,9 +198,11 @@ pub fn setdomainname(name: &[u8]) -> io::Result<()> {
 pub enum RebootCommand {
     /// Disables the Ctrl-Alt-Del keystroke.
     ///
-    /// When disabled, the keystroke will send a [`Signal::INT`] to pid 1.
+    /// When disabled, the keystroke will send a [`Signal::INT`] to
+    /// [`Pid::INIT`].
     ///
     /// [`Signal::INT`]: crate::process::Signal::INT
+    /// [`Pid::INIT`]: crate::process::Pid::INIT
     CadOff = c::LINUX_REBOOT_CMD_CAD_OFF,
     /// Enables the Ctrl-Alt-Del keystroke.
     ///

--- a/src/thread/futex.rs
+++ b/src/thread/futex.rs
@@ -1,7 +1,8 @@
 //! Linux `futex`.
 //!
 //! Futex is a very low-level mechanism for implementing concurrency primitives
-//! such as mutexes, rwlocks, and condvars.
+//! such as mutexes, rwlocks, and condvars. For a higher-level API that
+//! provides those abstractions, see [rustix-futex-syntax].
 //!
 //! # Examples
 //!
@@ -22,6 +23,7 @@
 //!
 //! [Linux `futex` system call]: https://man7.org/linux/man-pages/man2/futex.2.html
 //! [Linux `futex` feature]: https://man7.org/linux/man-pages/man7/futex.7.html
+//! [rustix-futex-sync]: https://crates.io/crates/rustix-futex-sync
 #![allow(unsafe_code)]
 
 use core::ffi::c_void;

--- a/src/thread/id.rs
+++ b/src/thread/id.rs
@@ -41,7 +41,14 @@ impl Cpuid {
 /// `gettid()`—Returns the thread ID.
 ///
 /// This returns the OS thread ID, which is not necessarily the same as the
-/// `rust::thread::Thread::id` or the pthread ID.
+/// Rust's `std::thread::Thread::id` or the pthread ID.
+///
+/// This function always does a system call. To avoid this overhead, ask the
+/// thread runtime for the ID instead, for example using [`libc::gettid`] or
+/// [`origin::thread::current_id`].
+///
+/// [`libc::gettid`]: https://docs.rs/libc/*/libc/fn.gettid.html
+/// [`origin::thread::current_id`]: https://docs.rs/origin/*/origin/thread/fn.current_id.html
 ///
 /// # References
 ///  - [Linux]

--- a/src/thread/prctl.rs
+++ b/src/thread/prctl.rs
@@ -423,7 +423,7 @@ bitflags! {
     pub struct CapabilitiesSecureBits: u32 {
         /// If this bit is set, then the kernel does not grant capabilities
         /// when a `set-user-ID-root` program is executed, or when a process
-        /// with an effective or real UID of 0 calls `execve`.
+        /// with an effective or real UID of [`Uid::ROOT`] calls `execve`.
         const NO_ROOT = 1_u32 << 0;
         /// Set [`NO_ROOT`] irreversibly.
         ///

--- a/src/time/timerfd.rs
+++ b/src/time/timerfd.rs
@@ -19,6 +19,10 @@ pub struct Itimerspec {
 
 /// `timerfd_create(clockid, flags)`—Create a timer.
 ///
+/// For a higher-level API to timerfd functionality, see the [timerfd] crate.
+///
+/// [timerfd]: https://crates.io/crates/timerfd
+///
 /// # References
 ///  - [Linux]
 ///

--- a/src/timespec.rs
+++ b/src/timespec.rs
@@ -13,7 +13,7 @@ use crate::ffi;
 #[cfg(not(fix_y2038))]
 use core::ptr::null;
 
-/// `struct timespec`
+/// `struct timespec`—A quantity of time in seconds plus nanoseconds.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(C)]
 pub struct Timespec {

--- a/src/ugid.rs
+++ b/src/ugid.rs
@@ -45,7 +45,7 @@ impl Uid {
         self.0
     }
 
-    /// Test whether this uid represents the root user (uid 0).
+    /// Test whether this uid represents the root user ([`Uid::ROOT`]).
     #[inline]
     pub const fn is_root(self) -> bool {
         self.0 == Self::ROOT.0
@@ -79,7 +79,7 @@ impl Gid {
         self.0
     }
 
-    /// Test whether this gid represents the root group (gid 0).
+    /// Test whether this gid represents the root group ([`Gid::ROOT`]).
     #[inline]
     pub const fn is_root(self) -> bool {
         self.0 == Self::ROOT.0

--- a/tests/termios/pgrp.rs
+++ b/tests/termios/pgrp.rs
@@ -44,7 +44,7 @@ fn pgrp_pseudoterminal() {
     #[cfg(not(linux_kernel))]
     assert!(matches!(tcgetpgrp(&pty), Ok(_)));
 
-    // We shouldn't be able to set the process group to pid 1.
+    // We shouldn't be able to set the process group to [`Pid::INIT`].
     match tcsetpgrp(&pty, rustix::termios::Pid::INIT).unwrap_err() {
         #[cfg(freebsdlike)]
         rustix::io::Errno::PERM => {}


### PR DESCRIPTION
 - Use `1` instead of `1.0.0` in documentation links in CHANGES.md.
 - Add more links to platform documentation.
 - Minor comment cleanups.