### PR TITLE
Use a consistent error mechanism for timeout overflow.

### DIFF
--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -229,7 +229,7 @@ pub(crate) unsafe fn select(
         Some(timeout) => {
             // Convert from `Timespec` to `c::timeval`.
             timeout_data = c::timeval {
-                tv_sec: timeout.tv_sec.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+                tv_sec: timeout.tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
                 tv_usec: ((timeout.tv_nsec + 999) / 1000) as _,
             };
             &timeout_data
@@ -306,7 +306,7 @@ pub(crate) unsafe fn select(
         Some(timeout) => {
             // Convert from `Timespec` to `c::timeval`.
             timeout_data = c::timeval {
-                tv_sec: timeout.tv_sec.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+                tv_sec: timeout.tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
                 tv_usec: ((timeout.tv_nsec + 999) / 1000) as _,
             };
             &timeout_data

--- a/src/event/port.rs
+++ b/src/event/port.rs
@@ -123,6 +123,9 @@ pub unsafe fn dissociate_fd<Fd: AsFd, RawFd: AsRawFd>(port: Fd, object: RawFd) -
 
 /// `port_get(port, timeout)`—Gets an event from a port.
 ///
+/// If an unsupported timeout is passed, this function fails with
+/// [`io::Errno::INVAL`].
+///
 /// # References
 ///  - [OpenSolaris]
 ///  - [illumos]
@@ -140,6 +143,9 @@ pub fn get<Fd: AsFd>(port: Fd, timeout: Option<&Timespec>) -> io::Result<Event> 
 /// If `events` is empty, this does nothing and returns immediately.
 ///
 /// To query the number of events without retrieving any, use [`getn_query`].
+///
+/// If an unsupported timeout is passed, this function fails with
+/// [`io::Errno::INVAL`].
 ///
 /// # References
 ///  - [OpenSolaris]

--- a/src/event/select.rs
+++ b/src/event/select.rs
@@ -69,6 +69,9 @@ pub struct FdSetElement(pub(crate) usize);
 /// `readfds`, `writefds`, `exceptfds` must point to arrays of `FdSetElement`
 /// containing at least `nfds.div_ceil(size_of::<FdSetElement>())` elements.
 ///
+/// If an unsupported timeout is passed, this function fails with
+/// [`io::Errno::INVAL`].
+///
 /// This `select` wrapper differs from POSIX in that `nfds` is not limited to
 /// `FD_SETSIZE`. Instead of using the fixed-sized `fd_set` type, this function
 /// takes raw pointers to arrays of `fd_set_num_elements(max_fd + 1, num_fds)`,


### PR DESCRIPTION
Make `select` and `kqueue::kevent` fail with `Errno::INVAL` when converting a timeout value overflows, for consistency with the other polling APIs.