### PR TITLE
Handle `Duration` overflow gracefully in `kevent`.

### DIFF
--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -6,6 +6,8 @@ use crate::backend::conv::ret;
 use crate::backend::conv::ret_c_int;
 #[cfg(any(linux_kernel, target_os = "illumos", target_os = "redox"))]
 use crate::backend::conv::ret_u32;
+#[cfg(bsd)]
+use crate::event::kqueue::Event;
 #[cfg(solarish)]
 use crate::event::port::Event;
 #[cfg(any(
@@ -47,8 +49,6 @@ use {crate::backend::conv::borrowed_fd, crate::fd::BorrowedFd};
     target_os = "redox"
 ))]
 use {crate::backend::conv::ret_owned_fd, crate::fd::OwnedFd};
-#[cfg(bsd)]
-use {crate::event::kqueue::Event, crate::utils::as_ptr};
 
 #[cfg(any(
     linux_kernel,
@@ -96,8 +96,28 @@ pub(crate) unsafe fn kevent(
     kq: BorrowedFd<'_>,
     changelist: &[Event],
     eventlist: (*mut Event, usize),
-    timeout: Option<&c::timespec>,
+    timeout: Option<&Timespec>,
 ) -> io::Result<c::c_int> {
+    // If we don't have to fix y2038 on this platform, `Timespec` is the same
+    // as `c::timespec` and it's easy.
+    #[cfg(not(fix_y2038))]
+    let timeout = crate::timespec::option_as_libc_timespec_ptr(timeout);
+
+    // If we do have to fix y2038 on this platform, convert to `c::timespec`.
+    #[cfg(fix_y2038)]
+    let converted_timeout;
+    #[cfg(fix_y2038)]
+    let timeout = match timeout {
+        None => null(),
+        Some(timeout) => {
+            converted_timeout = c::timespec {
+                tv_sec: timeout.tv_sec.try_into().map_err(|_| io::Errno::OVERFLOW)?,
+                tv_nsec: timeout.tv_nsec as _,
+            };
+            &converted_timeout
+        }
+    };
+
     ret_c_int(c::kevent(
         borrowed_fd(kq),
         changelist.as_ptr().cast(),
@@ -107,7 +127,7 @@ pub(crate) unsafe fn kevent(
             .map_err(|_| io::Errno::OVERFLOW)?,
         eventlist.0.cast(),
         eventlist.1.try_into().map_err(|_| io::Errno::OVERFLOW)?,
-        timeout.map_or(null(), as_ptr),
+        timeout,
     ))
 }
 

--- a/src/event/kqueue.rs
+++ b/src/event/kqueue.rs
@@ -4,6 +4,7 @@ use crate::buffer::Buffer;
 use crate::fd::{AsFd, OwnedFd, RawFd};
 use crate::pid::Pid;
 use crate::signal::Signal;
+use crate::timespec::Timespec;
 use crate::{backend, io};
 
 use backend::c::{self, intptr_t, kevent as kevent_t, uintptr_t};
@@ -418,28 +419,48 @@ pub fn kqueue() -> io::Result<OwnedFd> {
 /// [OpenBSD]: https://man.openbsd.org/kevent.2
 /// [NetBSD]: https://man.netbsd.org/kevent.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=kevent&section=2
-pub unsafe fn kevent<Fd: AsFd, Buf: Buffer<Event>>(
+pub unsafe fn kevent_timespec<Fd: AsFd, Buf: Buffer<Event>>(
     kqueue: Fd,
     changelist: &[Event],
     mut eventlist: Buf,
+    timeout: Option<&Timespec>,
+) -> io::Result<Buf::Output> {
+    // Populate the event list with events.
+    let len = syscalls::kevent(kqueue.as_fd(), changelist, eventlist.parts_mut(), timeout)
+        .map(|res| res as _)?;
+
+    Ok(eventlist.assume_init(len))
+}
+
+/// `kevent(kqueue, changelist, eventlist, timeout)`—Wait for events on a
+/// `kqueue`.
+///
+/// This is a wrapper around [`kevent_timespec`] which takes a `Duration`
+/// instead of a `Timespec` for the timemout value. `Timespec` has a signed
+/// `i64` seconds field; if converting `Duration` to `Timespec` overflows,
+/// `None` is passed as the timeout instead, such such a large timeout would
+/// be effectively infinite in practice.
+///
+/// # Safety
+///
+/// The file descriptors referred to by the `Event` structs must be valid for
+/// the lifetime of the `kqueue` file descriptor.
+pub unsafe fn kevent<Fd: AsFd, Buf: Buffer<Event>>(
+    kqueue: Fd,
+    changelist: &[Event],
+    eventlist: Buf,
     timeout: Option<Duration>,
 ) -> io::Result<Buf::Output> {
     let timeout = match timeout {
-        Some(timeout) => Some(backend::c::timespec {
-            tv_sec: timeout.as_secs().try_into().map_err(|_| io::Errno::INVAL)?,
-            tv_nsec: timeout.subsec_nanos() as _,
-        }),
+        Some(timeout) => match timeout.as_secs().try_into() {
+            Ok(tv_sec) => Some(Timespec {
+                tv_sec,
+                tv_nsec: timeout.subsec_nanos() as _,
+            }),
+            Err(_) => None,
+        },
         None => None,
     };
 
-    // Populate the event list with events.
-    let len = syscalls::kevent(
-        kqueue.as_fd(),
-        changelist,
-        eventlist.parts_mut(),
-        timeout.as_ref(),
-    )
-    .map(|res| res as _)?;
-
-    Ok(eventlist.assume_init(len))
+    kevent_timespec(kqueue, changelist, eventlist, timeout.as_ref())
 }


### PR DESCRIPTION
Add a `kevent_timespec` function, which is similar to `kevent`, but which takes a `Timespec` rather than a `Duration`, so that it can behave consistently with the other functions in `rustix::event`. This also more closely reflects how the underlying `kevent` function takes a `timespec` argument.

And, change the existing `kevent` to treat overflow in its `Duration` argument by saturating to an effectively infinite timeout. This supports users that use `Duration::MAX` to indicate an effectively infinite timeout.