### PR TITLE
Mark 32-bit x86 freebsd as needing y2038 fixes.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -159,7 +159,7 @@ fn main() {
             || (arch == "aarch64" && os == "linux" && abi == Ok("ilp32".to_string())))
         && (apple
             || os == "android"
-            || (os == "freebsd" && arch = "x86")
+            || (os == "freebsd" && arch == "x86")
             || os == "haiku"
             || env == "gnu"
             || (env == "musl" && arch == "x86")

--- a/build.rs
+++ b/build.rs
@@ -159,6 +159,7 @@ fn main() {
             || (arch == "aarch64" && os == "linux" && abi == Ok("ilp32".to_string())))
         && (apple
             || os == "android"
+            || (os == "freebsd" && arch = "x86")
             || os == "haiku"
             || env == "gnu"
             || (env == "musl" && arch == "x86")

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -79,11 +79,15 @@ mod tests {
         ))]
         assert_eq_size!(u16, linux_raw_sys::general::__kernel_mode_t);
 
-        // Ensure that seconds fields are 64-bit.
-        let some_stat: Stat = unsafe { core::mem::zeroed() };
-        assert_eq!(some_stat.st_atime, 0_i64);
-        assert_eq!(some_stat.st_mtime, 0_i64);
-        assert_eq!(some_stat.st_ctime, 0_i64);
+        // Ensure that seconds fields are 64-bit on non-y2038-bug platforms, and
+        // on Linux where we use statx.
+        #[cfg(any(linux_kernel, not(fix_y2038)))]
+        {
+            let some_stat: Stat = unsafe { core::mem::zeroed() };
+            assert_eq!(some_stat.st_atime, 0_i64);
+            assert_eq!(some_stat.st_mtime, 0_i64);
+            assert_eq!(some_stat.st_ctime, 0_i64);
+        }
 
         // Ensure that file offsets are 64-bit.
         assert_eq!(some_stat.st_size, 0_i64);

--- a/src/fs/constants.rs
+++ b/src/fs/constants.rs
@@ -79,11 +79,12 @@ mod tests {
         ))]
         assert_eq_size!(u16, linux_raw_sys::general::__kernel_mode_t);
 
+        let some_stat: Stat = unsafe { core::mem::zeroed() };
+
         // Ensure that seconds fields are 64-bit on non-y2038-bug platforms, and
         // on Linux where we use statx.
         #[cfg(any(linux_kernel, not(fix_y2038)))]
         {
-            let some_stat: Stat = unsafe { core::mem::zeroed() };
             assert_eq!(some_stat.st_atime, 0_i64);
             assert_eq!(some_stat.st_mtime, 0_i64);
             assert_eq!(some_stat.st_ctime, 0_i64);


### PR DESCRIPTION
On 32-bit x86 freebsd, time_t is 32-bit, so enable y2038 fixes.