### PR TITLE
Rework Capability types

### DIFF
--- a/src/thread/libcap.rs
+++ b/src/thread/libcap.rs
@@ -8,18 +8,22 @@ use crate::{backend, io};
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CapabilitySets {
     /// `__user_cap_data_struct.effective`
-    pub effective: CapabilityFlags,
+    pub effective: CapabilitySet,
     /// `__user_cap_data_struct.permitted`
-    pub permitted: CapabilityFlags,
+    pub permitted: CapabilitySet,
     /// `__user_cap_data_struct.inheritable`
-    pub inheritable: CapabilityFlags,
+    pub inheritable: CapabilitySet,
 }
+
+/// Previous name of `CapabilitySet`.
+#[deprecated(since = "1.1.0", note = "Renamed to CapabilitySet")]
+pub type CapabilityFlags = CapabilitySet;
 
 bitflags! {
     /// `CAP_*` constants.
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct CapabilityFlags: u64 {
+    pub struct CapabilitySet: u64 {
         /// `CAP_CHOWN`
         const CHOWN = 1 << linux_raw_sys::general::CAP_CHOWN;
         /// `CAP_DAC_OVERRIDE`
@@ -156,9 +160,9 @@ fn capget(pid: Option<Pid>) -> io::Result<CapabilitySets> {
 
     // The kernel returns a partitioned bitset that we just combined above.
     Ok(CapabilitySets {
-        effective: CapabilityFlags::from_bits_retain(effective),
-        permitted: CapabilityFlags::from_bits_retain(permitted),
-        inheritable: CapabilityFlags::from_bits_retain(inheritable),
+        effective: CapabilitySet::from_bits_retain(effective),
+        permitted: CapabilitySet::from_bits_retain(permitted),
+        inheritable: CapabilitySet::from_bits_retain(inheritable),
     })
 }
 

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -23,7 +23,9 @@ pub use clock::*;
 #[cfg(linux_kernel)]
 pub use id::*;
 #[cfg(linux_kernel)]
-pub use libcap::{capabilities, set_capabilities, CapabilityFlags, CapabilitySets};
+// #[expect(deprecated, reason = "CapabilityFlags is deprecated")]
+#[allow(deprecated)]
+pub use libcap::{capabilities, set_capabilities, CapabilityFlags, CapabilitySet, CapabilitySets};
 #[cfg(linux_kernel)]
 pub use membarrier::*;
 #[cfg(linux_kernel)]

--- a/tests/process/prctl.rs
+++ b/tests/process/prctl.rs
@@ -7,7 +7,7 @@ use {
 
 use rustix::process::*;
 #[cfg(feature = "thread")]
-use rustix::thread::Capability;
+use rustix::thread::CapabilitySet;
 
 #[test]
 fn test_parent_process_death_signal() {
@@ -87,7 +87,7 @@ fn test_speculative_feature_state() {
 #[cfg(feature = "thread")]
 #[test]
 fn test_is_io_flusher() {
-    if !thread_has_capability(Capability::SystemResource).unwrap() {
+    if !thread_has_capability(CapabilitySet::SYS_RESOURCE).unwrap() {
         eprintln!("test_is_io_flusher: Test skipped due to missing capability: CAP_SYS_RESOURCE.");
         return;
     }
@@ -99,7 +99,7 @@ fn test_is_io_flusher() {
 #[cfg(feature = "system")]
 #[test]
 fn test_virtual_memory_map_config_struct_size() {
-    if !thread_has_capability(Capability::SystemResource).unwrap() {
+    if !thread_has_capability(CapabilitySet::SYS_RESOURCE).unwrap() {
         eprintln!(
             "test_virtual_memory_map_config_struct_size: Test skipped due to missing capability: \
              CAP_SYS_RESOURCE."
@@ -129,7 +129,7 @@ fn test_floating_point_emulation_control() {
 //
 
 #[cfg(feature = "thread")]
-pub(crate) fn thread_has_capability(capability: Capability) -> io::Result<bool> {
+pub(crate) fn thread_has_capability(capability: CapabilitySet) -> io::Result<bool> {
     const _LINUX_CAPABILITY_VERSION_3: u32 = 0x2008_0522;
 
     #[repr(C)]
@@ -175,7 +175,7 @@ pub(crate) fn thread_has_capability(capability: Capability) -> io::Result<bool> 
         return Err(io::Error::last_os_error());
     }
 
-    let cap_index = capability as u32;
+    let cap_index = capability.bits() as u32;
     let (data_index, cap_index) = if cap_index < 32 {
         (0, cap_index)
     } else {

--- a/tests/system/reboot.rs
+++ b/tests/system/reboot.rs
@@ -3,15 +3,15 @@
 fn test_reboot() {
     use rustix::io::Errno;
     use rustix::system::{self, RebootCommand};
-    use rustix::thread::{self, CapabilityFlags};
+    use rustix::thread::{self, CapabilitySet};
 
     let mut capabilities = thread::capabilities(None).expect("Failed to get capabilities");
 
-    capabilities.effective.set(CapabilityFlags::SYS_BOOT, false);
+    capabilities.effective.set(CapabilitySet::SYS_BOOT, false);
 
     thread::set_capabilities(None, capabilities).expect("Failed to set capabilities");
 
-    // The reboot syscall requires the `CapabilityFlags::SYS_BOOT` permission
+    // The reboot syscall requires the `CapabilitySet::SYS_BOOT` permission
     // to be called, otherwise [`Errno::PERM`] is returned
     assert_eq!(system::reboot(RebootCommand::Restart), Err(Errno::PERM));
 }

--- a/tests/thread/prctl.rs
+++ b/tests/thread/prctl.rs
@@ -18,7 +18,12 @@ fn test_name() {
 
 #[test]
 fn test_capability_is_in_bounding_set() {
-    dbg!(capability_is_in_bounding_set(Capability::ChangeOwnership).unwrap());
+    dbg!(capability_is_in_bounding_set(CapabilitySet::CHOWN).unwrap());
+    dbg!(capability_is_in_bounding_set(
+        #[allow(deprecated)]
+        Capability::ChangeOwnership
+    )
+    .unwrap());
 }
 
 #[test]
@@ -38,7 +43,12 @@ fn test_no_new_privs() {
 
 #[test]
 fn test_capability_is_in_ambient_set() {
-    dbg!(capability_is_in_ambient_set(Capability::ChangeOwnership).unwrap());
+    dbg!(capability_is_in_ambient_set(CapabilitySet::CHOWN).unwrap());
+    dbg!(capability_is_in_ambient_set(
+        #[allow(deprecated)]
+        Capability::ChangeOwnership
+    )
+    .unwrap());
 }
 
 #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
- Rename CapabilityFlags to CapabilitySet
- Deprecated Capability, use CapabilitySet instead.
- Add sealed CompatCapability trait.

Closes #1434