### PR TITLE
Always cast `pread`, `lseek` etc. offsets to `off_t`.

### DIFF
--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -1404,9 +1404,8 @@ pub(crate) fn seek(fd: BorrowedFd<'_>, pos: SeekFrom) -> io::Result<u64> {
         }
     };
 
-    // ESP-IDF and Vita don't support 64-bit offsets.
-    #[cfg(any(target_os = "espidf", target_os = "vita"))]
-    let offset: i32 = offset.try_into().map_err(|_| io::Errno::OVERFLOW)?;
+    // ESP-IDF and Vita don't support 64-bit offsets, for example.
+    let offset = offset.try_into().map_err(|_| io::Errno::OVERFLOW)?;
 
     let offset = unsafe { ret_off_t(c::lseek(borrowed_fd(fd), offset, whence))? };
     Ok(offset as u64)
@@ -1734,9 +1733,12 @@ pub(crate) fn fallocate(
     offset: u64,
     len: u64,
 ) -> io::Result<()> {
-    // Silently cast; we'll get `EINVAL` if the value is negative.
+    // Silently cast to `i64`; we'll get `EINVAL` if the value is negative.
     let offset = offset as i64;
     let len = len as i64;
+
+    // ESP-IDF and Vita don't support 64-bit offsets, for example.
+    let offset = offset.try_into().map_err(|_| io::Errno::OVERFLOW)?;
 
     #[cfg(any(linux_kernel, target_os = "fuchsia"))]
     unsafe {

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -1739,6 +1739,7 @@ pub(crate) fn fallocate(
 
     // ESP-IDF and Vita don't support 64-bit offsets, for example.
     let offset = offset.try_into().map_err(|_| io::Errno::OVERFLOW)?;
+    let len = len.try_into().map_err(|_| io::Errno::OVERFLOW)?;
 
     #[cfg(any(linux_kernel, target_os = "fuchsia"))]
     unsafe {

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -52,9 +52,8 @@ pub(crate) unsafe fn pread(
     // Silently cast; we'll get `EINVAL` if the value is negative.
     let offset = offset as i64;
 
-    // ESP-IDF and Vita don't support 64-bit offsets.
-    #[cfg(any(target_os = "espidf", target_os = "vita"))]
-    let offset: i32 = offset.try_into().map_err(|_| io::Errno::OVERFLOW)?;
+    // ESP-IDF and Vita don't support 64-bit offsets, for example.
+    let offset = offset.try_into().map_err(|_| io::Errno::OVERFLOW)?;
 
     ret_usize(c::pread(borrowed_fd(fd), buf.0.cast(), len, offset))
 }
@@ -65,9 +64,8 @@ pub(crate) fn pwrite(fd: BorrowedFd<'_>, buf: &[u8], offset: u64) -> io::Result<
     // Silently cast; we'll get `EINVAL` if the value is negative.
     let offset = offset as i64;
 
-    // ESP-IDF and Vita don't support 64-bit offsets.
-    #[cfg(any(target_os = "espidf", target_os = "vita"))]
-    let offset: i32 = offset.try_into().map_err(|_| io::Errno::OVERFLOW)?;
+    // ESP-IDF and Vita don't support 64-bit offsets, for example.
+    let offset = offset.try_into().map_err(|_| io::Errno::OVERFLOW)?;
 
     unsafe { ret_usize(c::pwrite(borrowed_fd(fd), buf.as_ptr().cast(), len, offset)) }
 }
@@ -111,6 +109,10 @@ pub(crate) fn preadv(
 ) -> io::Result<usize> {
     // Silently cast; we'll get `EINVAL` if the value is negative.
     let offset = offset as i64;
+
+    // ESP-IDF and Vita don't support 64-bit offsets, for example.
+    let offset = offset.try_into().map_err(|_| io::Errno::OVERFLOW)?;
+
     unsafe {
         ret_usize(c::preadv(
             borrowed_fd(fd),
@@ -134,6 +136,10 @@ pub(crate) fn preadv(
 pub(crate) fn pwritev(fd: BorrowedFd<'_>, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
     // Silently cast; we'll get `EINVAL` if the value is negative.
     let offset = offset as i64;
+
+    // ESP-IDF and Vita don't support 64-bit offsets, for example.
+    let offset = offset.try_into().map_err(|_| io::Errno::OVERFLOW)?;
+
     unsafe {
         ret_usize(c::pwritev(
             borrowed_fd(fd),


### PR DESCRIPTION
When calling libc functions that take `off_t` arguments, always cast to `off_t`. On platforms where this cast is a no-op, these casts should be optimized away. This eliminates the need for explicit `cfg`s for platforms which need the casts.

Fixes #1432.