### PR TITLE
Add trap instructions after `noreturn` syscalls.

### DIFF
--- a/src/backend/linux_raw/arch/aarch64.rs
+++ b/src/backend/linux_raw/arch/aarch64.rs
@@ -51,6 +51,7 @@ pub(in crate::backend) unsafe fn syscall1_readonly(
 pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "svc 0",
+        "brk #0x1",
         in("x8") nr.to_asm(),
         in("x0") a0.to_asm(),
         options(nostack, noreturn)

--- a/src/backend/linux_raw/arch/arm.rs
+++ b/src/backend/linux_raw/arch/arm.rs
@@ -48,6 +48,7 @@ pub(in crate::backend) unsafe fn syscall1_readonly(
 pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "svc 0",
+        "udf #16",
         in("r7") nr.to_asm(),
         in("r0") a0.to_asm(),
         options(nostack, noreturn)

--- a/src/backend/linux_raw/arch/mips.rs
+++ b/src/backend/linux_raw/arch/mips.rs
@@ -101,6 +101,7 @@ pub(in crate::backend) unsafe fn syscall1_readonly(
 pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "syscall",
+        "teq $0,$0",
         in("$2" /*$v0*/) nr.to_asm(),
         in("$4" /*$a0*/) a0.to_asm(),
         options(nostack, noreturn)

--- a/src/backend/linux_raw/arch/mips32r6.rs
+++ b/src/backend/linux_raw/arch/mips32r6.rs
@@ -101,6 +101,7 @@ pub(in crate::backend) unsafe fn syscall1_readonly(
 pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "syscall",
+        "teq $0,$0",
         in("$2" /*$v0*/) nr.to_asm(),
         in("$4" /*$a0*/) a0.to_asm(),
         options(nostack, noreturn)

--- a/src/backend/linux_raw/arch/mips64.rs
+++ b/src/backend/linux_raw/arch/mips64.rs
@@ -101,6 +101,7 @@ pub(in crate::backend) unsafe fn syscall1_readonly(
 pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "syscall",
+        "teq $0,$0",
         in("$2" /*$v0*/) nr.to_asm(),
         in("$4" /*$a0*/) a0.to_asm(),
         options(nostack, noreturn)

--- a/src/backend/linux_raw/arch/mips64r6.rs
+++ b/src/backend/linux_raw/arch/mips64r6.rs
@@ -105,6 +105,7 @@ pub(in crate::backend) unsafe fn syscall1_readonly(
 pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "syscall",
+        "teq $0,$0",
         in("$2" /*$v0*/) nr.to_asm(),
         in("$4" /*$a0*/) a0.to_asm(),
         options(nostack, noreturn)

--- a/src/backend/linux_raw/arch/powerpc.rs
+++ b/src/backend/linux_raw/arch/powerpc.rs
@@ -96,6 +96,7 @@ pub(in crate::backend) unsafe fn syscall1_readonly(
 pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "sc",
+        "trap",
         in("r0") nr.to_asm(),
         in("r3") a0.to_asm(),
         options(nostack, noreturn)

--- a/src/backend/linux_raw/arch/powerpc64.rs
+++ b/src/backend/linux_raw/arch/powerpc64.rs
@@ -96,6 +96,7 @@ pub(in crate::backend) unsafe fn syscall1_readonly(
 pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "sc",
+        "trap",
         in("r0") nr.to_asm(),
         in("r3") a0.to_asm(),
         options(nostack, noreturn)

--- a/src/backend/linux_raw/arch/riscv64.rs
+++ b/src/backend/linux_raw/arch/riscv64.rs
@@ -48,6 +48,7 @@ pub(in crate::backend) unsafe fn syscall1_readonly(
 pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "ecall",
+        "unimp",
         in("a7") nr.to_asm(),
         in("a0") a0.to_asm(),
         options(nostack, noreturn)

--- a/src/backend/linux_raw/arch/s390x.rs
+++ b/src/backend/linux_raw/arch/s390x.rs
@@ -48,9 +48,10 @@ pub(in crate::backend) unsafe fn syscall1_readonly(
 pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "svc 0",
+        "j .+2",
         in("r1") nr.to_asm(),
         in("r2") a0.to_asm(),
-        options(nostack, preserves_flags, noreturn)
+        options(nostack, noreturn)
     )
 }
 

--- a/src/backend/linux_raw/arch/thumb.rs
+++ b/src/backend/linux_raw/arch/thumb.rs
@@ -65,6 +65,7 @@ pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: Ar
     asm!(
         "mov r7, {nr}",
         "svc 0",
+        "udf #16",
         nr = in(reg) nr.to_asm(),
         in("r0") a0.to_asm(),
         options(nostack, noreturn)

--- a/src/backend/linux_raw/arch/x86.rs
+++ b/src/backend/linux_raw/arch/x86.rs
@@ -56,6 +56,7 @@ pub(in crate::backend) unsafe fn indirect_syscall1_noreturn(
 ) -> ! {
     asm!(
         "call {callee}",
+        "ud2",
         callee = in(reg) callee,
         in("eax") nr.to_asm(),
         in("ebx") a0.to_asm(),
@@ -245,6 +246,7 @@ pub(in crate::backend) unsafe fn syscall1_readonly(
 pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "int $$0x80",
+        "ud2",
         in("eax") nr.to_asm(),
         in("ebx") a0.to_asm(),
         options(nostack, noreturn)

--- a/src/backend/linux_raw/arch/x86_64.rs
+++ b/src/backend/linux_raw/arch/x86_64.rs
@@ -56,6 +56,7 @@ pub(in crate::backend) unsafe fn syscall1_readonly(
 pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
     asm!(
         "syscall",
+        "ud2",
         in("rax") nr.to_asm(),
         in("rdi") a0.to_asm(),
         options(nostack, noreturn)


### PR DESCRIPTION
As discussed in #1433, add trap instructions after noreturn syscalls.