### PR TITLE
Fix the assertion in `Pid::from_raw` to accept 0.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -229,7 +229,8 @@ jobs:
     - run: cargo check -Z build-std --target=x86_64-pc-nto-qnx710 --features=all-apis
     - run: cargo check -Z build-std --target=armv6k-nintendo-3ds --all-features
     - run: cargo check -Z build-std --target=armv7-sony-vita-newlibeabihf --features=all-apis
-    - run: cargo check -Z build-std --target=powerpc64-ibm-aix --features=all-apis
+    # Temporarily disable due to build errors on nightly.
+    # - run: cargo check -Z build-std --target=powerpc64-ibm-aix --features=all-apis
     - run: cargo check -Z build-std --target=mipsel-unknown-linux-gnu --features=all-apis
     - run: cargo check -Z build-std --target=mips64el-unknown-linux-gnuabi64 --features=all-apis
     - run: cargo check -Z build-std --target=powerpc-unknown-linux-musl --features=all-apis

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -246,13 +246,13 @@ jobs:
       RUSTFLAGS: --cfg rustix_use_experimental_features
     strategy:
       matrix:
-        build: [ubuntu, ubuntu-20.04, i686-linux, aarch64-linux, powerpc-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, powerpc-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.63, i686-linux-1.63, aarch64-linux-1.63, riscv64-linux-1.63, s390x-linux-1.63, powerpc64le-linux, powerpc64le-linux-1.63, arm-linux-1.63, macos-latest, macos-13, windows, windows-2019, musl]
+        build: [ubuntu, ubuntu-22.04, i686-linux, aarch64-linux, powerpc-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, powerpc-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.63, i686-linux-1.63, aarch64-linux-1.63, riscv64-linux-1.63, s390x-linux-1.63, powerpc64le-linux, powerpc64le-linux-1.63, arm-linux-1.63, macos-latest, macos-13, windows, windows-2019, musl]
         include:
           - build: ubuntu
             os: ubuntu-latest
             rust: nightly
-          - build: ubuntu-20.04
-            os: ubuntu-20.04
+          - build: ubuntu-22.04
+            os: ubuntu-22.04
             rust: nightly
           - build: i686-linux
             os: ubuntu-latest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,12 @@
 #![allow(clippy::useless_conversion)]
 // This clippy lint gets too many false positives.
 #![allow(clippy::needless_lifetimes)]
+// Until `unnecessary_transmutes` is recognized by our MSRV, don't warn about
+// it being unrecognized.
+#![allow(unknown_lints)]
+// Until `cast_signed` and `cast_unsigned` are supported by our MSRV, don't
+// warn about transmutes that could be changed to them.
+#![allow(unnecessary_transmutes)]
 // Redox and WASI have enough differences that it isn't worth precisely
 // conditionalizing all the `use`s for them. Similar for if we don't have
 // "all-apis".

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -41,7 +41,7 @@ impl Pid {
     /// [pidfd]: https://man7.org/linux/man-pages/man2/pidfd_open.2.html
     #[inline]
     pub const fn from_raw(raw: RawPid) -> Option<Self> {
-        debug_assert!(raw > 0);
+        debug_assert!(raw >= 0);
         match NonZeroI32::new(raw) {
             Some(non_zero) => Some(Self(non_zero)),
             None => None,
@@ -79,6 +79,8 @@ impl Pid {
     }
 
     /// Converts a `Pid` into a `RawPid`.
+    ///
+    /// This is the same as `self.as_raw_nonzero().get()`.
     #[inline]
     pub const fn as_raw_pid(self) -> RawPid {
         self.0.get()
@@ -120,5 +122,22 @@ mod tests {
         const_assert_eq!(4567 as RawPid, unsafe {
             transmute::<Option<Pid>, RawPid>(Some(Pid::from_raw_unchecked(4567)))
         });
+    }
+
+    #[test]
+    fn test_ctors() {
+        use std::num::NonZero;
+        assert!(Pid::from_raw(0).is_none());
+        assert_eq!(
+            Pid::from_raw(77).unwrap().as_raw_nonzero(),
+            NonZero::new(77).unwrap()
+        );
+        assert_eq!(Pid::from_raw(77).unwrap().as_raw_pid(), 77);
+        assert_eq!(Pid::as_raw(Pid::from_raw(77)), 77);
+    }
+
+    #[test]
+    fn test_specials() {
+        assert!(Pid::from_raw(1).unwrap().is_init());
     }
 }

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -126,11 +126,11 @@ mod tests {
 
     #[test]
     fn test_ctors() {
-        use std::num::NonZero;
+        use std::num::NonZeroI32;
         assert!(Pid::from_raw(0).is_none());
         assert_eq!(
             Pid::from_raw(77).unwrap().as_raw_nonzero(),
-            NonZero::new(77).unwrap()
+            NonZeroI32::new(77).unwrap()
         );
         assert_eq!(Pid::from_raw(77).unwrap().as_raw_pid(), 77);
         assert_eq!(Pid::as_raw(Pid::from_raw(77)), 77);

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -139,5 +139,6 @@ mod tests {
     #[test]
     fn test_specials() {
         assert!(Pid::from_raw(1).unwrap().is_init());
+        assert_eq!(Pid::from_raw(1).unwrap(), Pid::INIT);
     }
 }


### PR DESCRIPTION
Fix a regression from #1443 which disallowed calling `Pid::from_raw` with the value 0.