### PR TITLE
libc: add MS_NOSYMFOLLOW support

### DIFF
--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -63,6 +63,8 @@ pub(crate) const ETH_P_XDSA: c_int = linux_raw_sys::if_ether::ETH_P_XDSA as _;
 pub(crate) const ETH_P_MAP: c_int = linux_raw_sys::if_ether::ETH_P_MAP as _;
 #[cfg(all(linux_kernel, feature = "net"))]
 pub(crate) const ETH_P_MCTP: c_int = linux_raw_sys::if_ether::ETH_P_MCTP as _;
+#[cfg(all(linux_kernel, feature = "mount"))]
+pub(crate) const MS_NOSYMFOLLOW: c_ulong = linux_raw_sys::general::MS_NOSYMFOLLOW as _;
 
 #[cfg(all(
     linux_kernel,

--- a/src/backend/libc/mount/types.rs
+++ b/src/backend/libc/mount/types.rs
@@ -56,6 +56,9 @@ bitflags! {
         /// `MS_SYNCHRONOUS`
         const SYNCHRONOUS = c::MS_SYNCHRONOUS;
 
+        /// `MS_NOSYMFOLLOW`
+        const NOSYMFOLLOW = c::MS_NOSYMFOLLOW;
+
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
         const _ = !0;
     }


### PR DESCRIPTION
Linux platforms that are forced to use the libc backend cannot access
MS_NOSYMFOLLOW. The upstream libc crate doesn't expose MS_NOSYMFOLLOW,
but on Linux we can just remap linux-raw-sys.

FreeBSD also has nosymfollow support in the form of MNT_NOSYMFOLLOW, but
rustix::mount is not provided for FreeBSD.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>