### PR TITLE
Temporarily disable the `do_test_unix_msg` tests on FreeBSD.

### DIFF
--- a/tests/net/unix.rs
+++ b/tests/net/unix.rs
@@ -362,6 +362,7 @@ fn do_test_unix_msg_unconnected(addr: SocketAddrUnix) {
 }
 
 #[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(target_os = "freebsd"))] // TODO: Investigate why these tests fail on FreeBSD.
 #[test]
 fn test_unix_msg() {
     use rustix::ffi::CString;
@@ -445,6 +446,7 @@ fn test_abstract_unix_msg_unconnected() {
 
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[cfg(feature = "pipe")]
+#[cfg(not(target_os = "freebsd"))] // TODO: Investigate why these tests fail on FreeBSD.
 #[test]
 fn test_unix_msg_with_scm_rights() {
     crate::init();
@@ -741,6 +743,7 @@ fn test_unix_peercred_implicit() {
 /// over multiple control messages.
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[cfg(feature = "pipe")]
+#[cfg(not(target_os = "freebsd"))] // TODO: Investigate why these tests fail on FreeBSD.
 #[test]
 fn test_unix_msg_with_combo() {
     crate::init();

--- a/tests/net/unix_alloc.rs
+++ b/tests/net/unix_alloc.rs
@@ -359,6 +359,7 @@ fn do_test_unix_msg_unconnected(addr: SocketAddrUnix) {
 }
 
 #[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(target_os = "freebsd"))] // TODO: Investigate why these tests fail on FreeBSD.
 #[test]
 fn test_unix_msg() {
     use rustix::ffi::CString;
@@ -442,6 +443,7 @@ fn test_abstract_unix_msg_unconnected() {
 
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[cfg(feature = "pipe")]
+#[cfg(not(target_os = "freebsd"))] // TODO: Investigate why these tests fail on FreeBSD.
 #[test]
 fn test_unix_msg_with_scm_rights() {
     crate::init();
@@ -681,6 +683,7 @@ fn test_unix_peercred() {
 /// over multiple control messages.
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 #[cfg(feature = "pipe")]
+#[cfg(not(target_os = "freebsd"))] // TODO: Investigate why these tests fail on FreeBSD.
 #[test]
 fn test_unix_msg_with_combo() {
     crate::init();


### PR DESCRIPTION
These tests appear to be failing on FreeBSD 15 due to a difference in behavior on `SOCK_SEQPACKET` FreeBSD 15. They pass on FreeBSD 14 and on other OS's.