### PR TITLE
Change `fsconfig_*` to use `AsFd` instead of `BorrowedFd`.

### DIFF
--- a/src/mount/fsopen.rs
+++ b/src/mount/fsopen.rs
@@ -3,7 +3,7 @@
 use crate::backend::mount::types::{
     FsMountFlags, FsOpenFlags, FsPickFlags, MountAttrFlags, MoveMountFlags, OpenTreeFlags,
 };
-use crate::fd::{BorrowedFd, OwnedFd};
+use crate::fd::{AsFd, OwnedFd};
 use crate::{backend, io, path};
 
 /// `fsopen(fs_name, flags)`
@@ -24,12 +24,12 @@ pub fn fsopen<Fs: path::Arg>(fs_name: Fs, flags: FsOpenFlags) -> io::Result<Owne
 ///
 /// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsmount.md
 #[inline]
-pub fn fsmount(
-    fs_fd: BorrowedFd<'_>,
+pub fn fsmount<Fd: AsFd>(
+    fs_fd: Fd,
     flags: FsMountFlags,
     attr_flags: MountAttrFlags,
 ) -> io::Result<OwnedFd> {
-    backend::mount::syscalls::fsmount(fs_fd, flags, attr_flags)
+    backend::mount::syscalls::fsmount(fs_fd.as_fd(), flags, attr_flags)
 }
 
 /// `move_mount(from_dfd, from_pathname, to_dfd, to_pathname, flags)`
@@ -43,13 +43,15 @@ pub fn fsmount(
 /// [`mount_move`]: crate::mount::mount_move
 /// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/move_mount.md
 #[inline]
-pub fn move_mount<From: path::Arg, To: path::Arg>(
-    from_dfd: BorrowedFd<'_>,
+pub fn move_mount<From: path::Arg, To: path::Arg, FromFd: AsFd, ToFd: AsFd>(
+    from_dfd: FromFd,
     from_pathname: From,
-    to_dfd: BorrowedFd<'_>,
+    to_dfd: ToFd,
     to_pathname: To,
     flags: MoveMountFlags,
 ) -> io::Result<()> {
+    let from_dfd = from_dfd.as_fd();
+    let to_dfd = to_dfd.as_fd();
     from_pathname.into_with_c_str(|from_pathname| {
         to_pathname.into_with_c_str(|to_pathname| {
             backend::mount::syscalls::move_mount(
@@ -70,11 +72,12 @@ pub fn move_mount<From: path::Arg, To: path::Arg>(
 ///
 /// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/open_tree.md
 #[inline]
-pub fn open_tree<Path: path::Arg>(
-    dfd: BorrowedFd<'_>,
+pub fn open_tree<Path: path::Arg, Fd: AsFd>(
+    dfd: Fd,
     filename: Path,
     flags: OpenTreeFlags,
 ) -> io::Result<OwnedFd> {
+    let dfd = dfd.as_fd();
     filename.into_with_c_str(|filename| backend::mount::syscalls::open_tree(dfd, filename, flags))
 }
 
@@ -85,11 +88,12 @@ pub fn open_tree<Path: path::Arg>(
 ///
 /// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fspick.md
 #[inline]
-pub fn fspick<Path: path::Arg>(
-    dfd: BorrowedFd<'_>,
+pub fn fspick<Path: path::Arg, Fd: AsFd>(
+    dfd: Fd,
     path: Path,
     flags: FsPickFlags,
 ) -> io::Result<OwnedFd> {
+    let dfd = dfd.as_fd();
     path.into_with_c_str(|path| backend::mount::syscalls::fspick(dfd, path, flags))
 }
 
@@ -101,7 +105,8 @@ pub fn fspick<Path: path::Arg>(
 /// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
 #[inline]
 #[doc(alias = "fsconfig")]
-pub fn fsconfig_set_flag<Key: path::Arg>(fs_fd: BorrowedFd<'_>, key: Key) -> io::Result<()> {
+pub fn fsconfig_set_flag<Key: path::Arg, Fd: AsFd>(fs_fd: Fd, key: Key) -> io::Result<()> {
+    let fs_fd = fs_fd.as_fd();
     key.into_with_c_str(|key| backend::mount::syscalls::fsconfig_set_flag(fs_fd, key))
 }
 
@@ -113,11 +118,12 @@ pub fn fsconfig_set_flag<Key: path::Arg>(fs_fd: BorrowedFd<'_>, key: Key) -> io:
 /// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
 #[inline]
 #[doc(alias = "fsconfig")]
-pub fn fsconfig_set_string<Key: path::Arg, Value: path::Arg>(
-    fs_fd: BorrowedFd<'_>,
+pub fn fsconfig_set_string<Key: path::Arg, Value: path::Arg, Fd: AsFd>(
+    fs_fd: Fd,
     key: Key,
     value: Value,
 ) -> io::Result<()> {
+    let fs_fd = fs_fd.as_fd();
     key.into_with_c_str(|key| {
         value.into_with_c_str(|value| {
             backend::mount::syscalls::fsconfig_set_string(fs_fd, key, value)
@@ -133,11 +139,12 @@ pub fn fsconfig_set_string<Key: path::Arg, Value: path::Arg>(
 /// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
 #[inline]
 #[doc(alias = "fsconfig")]
-pub fn fsconfig_set_binary<Key: path::Arg>(
-    fs_fd: BorrowedFd<'_>,
+pub fn fsconfig_set_binary<Key: path::Arg, Fd: AsFd>(
+    fs_fd: Fd,
     key: Key,
     value: &[u8],
 ) -> io::Result<()> {
+    let fs_fd = fs_fd.as_fd();
     key.into_with_c_str(|key| backend::mount::syscalls::fsconfig_set_binary(fs_fd, key, value))
 }
 
@@ -149,12 +156,14 @@ pub fn fsconfig_set_binary<Key: path::Arg>(
 /// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
 #[inline]
 #[doc(alias = "fsconfig")]
-pub fn fsconfig_set_path<Key: path::Arg, Path: path::Arg>(
-    fs_fd: BorrowedFd<'_>,
+pub fn fsconfig_set_path<Key: path::Arg, Path: path::Arg, Fd: AsFd, AuxFd: AsFd>(
+    fs_fd: Fd,
     key: Key,
     path: Path,
-    fd: BorrowedFd<'_>,
+    fd: AuxFd,
 ) -> io::Result<()> {
+    let fs_fd = fs_fd.as_fd();
+    let fd = fd.as_fd();
     key.into_with_c_str(|key| {
         path.into_with_c_str(|path| {
             backend::mount::syscalls::fsconfig_set_path(fs_fd, key, path, fd)
@@ -170,11 +179,13 @@ pub fn fsconfig_set_path<Key: path::Arg, Path: path::Arg>(
 /// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
 #[inline]
 #[doc(alias = "fsconfig")]
-pub fn fsconfig_set_path_empty<Key: path::Arg>(
-    fs_fd: BorrowedFd<'_>,
+pub fn fsconfig_set_path_empty<Key: path::Arg, Fd: AsFd, AuxFd: AsFd>(
+    fs_fd: Fd,
     key: Key,
-    fd: BorrowedFd<'_>,
+    fd: AuxFd,
 ) -> io::Result<()> {
+    let fs_fd = fs_fd.as_fd();
+    let fd = fd.as_fd();
     key.into_with_c_str(|key| backend::mount::syscalls::fsconfig_set_path_empty(fs_fd, key, fd))
 }
 
@@ -186,11 +197,13 @@ pub fn fsconfig_set_path_empty<Key: path::Arg>(
 /// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
 #[inline]
 #[doc(alias = "fsconfig")]
-pub fn fsconfig_set_fd<Key: path::Arg>(
-    fs_fd: BorrowedFd<'_>,
+pub fn fsconfig_set_fd<Key: path::Arg, Fd: AsFd, AuxFd: AsFd>(
+    fs_fd: Fd,
     key: Key,
-    fd: BorrowedFd<'_>,
+    fd: AuxFd,
 ) -> io::Result<()> {
+    let fs_fd = fs_fd.as_fd();
+    let fd = fd.as_fd();
     key.into_with_c_str(|key| backend::mount::syscalls::fsconfig_set_fd(fs_fd, key, fd))
 }
 
@@ -202,8 +215,8 @@ pub fn fsconfig_set_fd<Key: path::Arg>(
 /// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
 #[inline]
 #[doc(alias = "fsconfig")]
-pub fn fsconfig_create(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
-    backend::mount::syscalls::fsconfig_create(fs_fd)
+pub fn fsconfig_create<Fd: AsFd>(fs_fd: Fd) -> io::Result<()> {
+    backend::mount::syscalls::fsconfig_create(fs_fd.as_fd())
 }
 
 /// `fsconfig(fs_fd, FSCONFIG_CMD_RECONFIGURE, key, NULL, 0)`
@@ -214,8 +227,8 @@ pub fn fsconfig_create(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
 /// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
 #[inline]
 #[doc(alias = "fsconfig")]
-pub fn fsconfig_reconfigure(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
-    backend::mount::syscalls::fsconfig_reconfigure(fs_fd)
+pub fn fsconfig_reconfigure<Fd: AsFd>(fs_fd: Fd) -> io::Result<()> {
+    backend::mount::syscalls::fsconfig_reconfigure(fs_fd.as_fd())
 }
 
 /// `fsconfig(fs_fd, FSCONFIG_CMD_CREATE_EXCL, key, NULL, 0)`
@@ -228,6 +241,6 @@ pub fn fsconfig_reconfigure(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
 /// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
 #[inline]
 #[doc(alias = "fsconfig")]
-pub fn fsconfig_create_exclusive(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
-    backend::mount::syscalls::fsconfig_create_excl(fs_fd)
+pub fn fsconfig_create_exclusive<Fd: AsFd>(fs_fd: Fd) -> io::Result<()> {
+    backend::mount::syscalls::fsconfig_create_excl(fs_fd.as_fd())
 }


### PR DESCRIPTION
This makes them more consistent with the rest of rustix and more convenient to use.

Fixes #1480.