### PR TITLE
Linux 6.15 io_uring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -272,3 +272,6 @@ check-cfg = [
     'cfg(target_arch, values("xtensa"))',
     'cfg(target_os, values("cygwin"))',
 ]
+
+[patch.crates-io]
+linux-raw-sys = { git = "https://github.com/LtdJorge/linux-raw-sys", branch = "linux-6.15" }

--- a/src/io_uring/mod.rs
+++ b/src/io_uring/mod.rs
@@ -646,6 +646,18 @@ pub enum IoringOp {
 
     /// `IORING_OP_LISTEN` (since Linux 6.11)
     Listen = sys::io_uring_op::IORING_OP_LISTEN as _,
+
+    /// `IORING_OP_RECV_ZC` (since Linux 6.15)
+    RecvZc = sys::io_uring_op::IORING_OP_RECV_ZC as _,
+
+    /// `IORING_OP_EPOLL_WAIT` (since Linux 6.15)
+    EpollWait = sys::io_uring_op::IORING_OP_EPOLL_WAIT as _,
+
+    /// `IORING_OP_READV_FIXED` (since Linux 6.15)
+    ReadvFixed = sys::io_uring_op::IORING_OP_READV_FIXED as _,
+
+    /// `IORING_OP_WRITEV_FIXED` (since Linux 6.15)
+    WritevFixed = sys::io_uring_op::IORING_OP_WRITEV_FIXED as _,
 }
 
 impl Default for IoringOp {


### PR DESCRIPTION
This PR adds Linux 6.15 io_uring ops to `IoringOp`.

Related: https://github.com/sunfishcode/linux-raw-sys/pull/156

I've included a temporary `crates.io` override for the corresponding upstream PR for `linux-raw-sys`.

Note that this PR also fixes a SIGSEGV crash that occurs if you try to debug print `io_uring_probe` or `IoringOp` on a Linux 6.15 system with current release `rustix`.

It would be nice to gracefully handle missing constants for new ops, since just upgrading the Kernel could cause a previously working program to crash, but it seems like it might require quite a lot of refactoring to achieve that, and I guess would require something like a catch-all `Unknown` variant and an explicit `From` impl to convert from numeric repr.

Is it generally understood that this is a problem to be aware of?