### PR TITLE
Add diagnostics to unknown buffer types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,6 +259,7 @@ check-cfg = [
     'cfg(lower_upper_exp_for_non_zero)',
     'cfg(netbsdlike)',
     'cfg(rustc_attrs)',
+    'cfg(rustc_diagnostics)',
     'cfg(solarish)',
     'cfg(staged_api)',
     'cfg(static_assertions)',

--- a/build.rs
+++ b/build.rs
@@ -84,6 +84,10 @@ fn main() {
         use_feature("lower_upper_exp_for_non_zero");
     }
 
+    if can_compile("#[diagnostic::on_unimplemented()] trait Foo {}") {
+        use_feature("rustc_diagnostics")
+    }
+
     // WASI support can utilize wasi_ext if present.
     if os == "wasi" {
         use_feature_or_nothing("wasi_ext");

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -94,6 +94,12 @@ use core::slice;
 /// "captured variable cannot escape `FnMut` closure body",
 /// use an explicit loop instead of `retry_on_intr`, assuming you're using
 /// that. See `error_retry_closure_uninit` in examples/buffer_errors.rs.
+#[diagnostic::on_unimplemented(
+    message = "rustix does not accept `{Self}` buffers",
+    label = "Unsupported buffer type",
+    note = "only (potentially uninitialized) byte arrays, slices, and Vecs are supported",
+    note = "please read the docs: https://docs.rs/rustix/latest/rustix/buffer/trait.Buffer.html"
+)]
 pub trait Buffer<T>: private::Sealed<T> {}
 
 // Implement `Buffer` for all the types that implement `Sealed`.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -94,11 +94,14 @@ use core::slice;
 /// "captured variable cannot escape `FnMut` closure body",
 /// use an explicit loop instead of `retry_on_intr`, assuming you're using
 /// that. See `error_retry_closure_uninit` in examples/buffer_errors.rs.
-#[diagnostic::on_unimplemented(
-    message = "rustix does not accept `{Self}` buffers",
-    label = "Unsupported buffer type",
-    note = "only (potentially uninitialized) byte arrays, slices, and Vecs are supported",
-    note = "please read the docs: https://docs.rs/rustix/latest/rustix/buffer/trait.Buffer.html"
+#[cfg_attr(
+    rustc_diagnostics,
+    diagnostic::on_unimplemented(
+        message = "rustix does not accept `{Self}` buffers",
+        label = "Unsupported buffer type",
+        note = "only (potentially uninitialized) byte arrays, slices, and Vecs are supported",
+        note = "please read the docs: https://docs.rs/rustix/latest/rustix/buffer/trait.Buffer.html"
+    )
 )]
 pub trait Buffer<T>: private::Sealed<T> {}
 


### PR DESCRIPTION
Recently discovered this was a thing, pretty cool!
```
error[E0277]: rustix does not accept `String` buffers
   --> src/buffer.rs:436:34
    |
436 |         let nread = read(&input, String::new()).unwrap();
    |                     ----         ^^^^^^^^^^^^^ Unsupported buffer type
    |                     |
    |                     required by a bound introduced by this call
    |
    = help: the trait `Buffer<u8>` is not implemented for `String`
    = note: only (potentially uninitialized) byte arrays, slices, and Vecs are supported
    = note: please read the docs: https://docs.rs/rustix/latest/rustix/buffer/trait.Buffer.html
    = help: the following other types implement trait `Buffer<T>`:
              &mut [MaybeUninit<T>; N]
              &mut [MaybeUninit<T>]
              &mut [T; N]
              &mut [T]
              &mut std::vec::Vec<MaybeUninit<T>>
              &mut std::vec::Vec<T>
              SpareCapacity<'a, T>
note: required by a bound in `read_write::read`
   --> src/io/read_write.rs:39:28
    |
39  | pub fn read<Fd: AsFd, Buf: Buffer<u8>>(fd: Fd, mut buf: Buf) -> io::Result<Buf::Output> {
    |                            ^^^^^^^^^^ required by this bound in `read`

error[E0277]: the trait bound `String: buffer::private::Sealed<u8>` is not satisfied
   --> src/buffer.rs:436:21
    |
436 |         let nread = read(&input, String::new()).unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `buffer::private::Sealed<u8>` is not implemented for `String`
    |
    = help: the following other types implement trait `buffer::private::Sealed<T>`:
              &'a mut [MaybeUninit<T>; N]
              &'a mut [MaybeUninit<T>]
              &'a mut std::vec::Vec<MaybeUninit<T>>
              &mut [T; N]
              &mut [T]
              &mut std::vec::Vec<T>
              SpareCapacity<'a, T>

For more information about this error, try `rustc --explain E0277`.
error: could not compile `rustix` (lib test) due to 2 previous errors
```