### PR TITLE
Use new `hints.mostly-unused`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md", "b
 rust-version = "1.63"
 
 [hints]
+# Most users use a fraction of the rustix API surface area, so this reduces compilation times
 mostly-unused = true
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ categories = ["os::unix-apis", "date-and-time", "filesystem", "network-programmi
 include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md", "benches"]
 rust-version = "1.63"
 
+[hints]
+mostly-unused = true
+
 [dependencies]
 bitflags = { version = "2.4.0", default-features = false }
 


### PR DESCRIPTION
Most users of the `rustix` crate will use a fraction of its API surface
area.

Nightly rustc provides an option `-Zhint-mostly-unused` to tell it to
defer as much compilation as possible, which provides a substantial
performance improvement if most of that compilation doesn't end up
happening. Cargo plumbs this option through using the new `[hints]`
table. This will cause users of the `rustix` crate to default to setting
`hint-mostly-unused`. (Top-level crates can override this if they wish,
using a new profile option.)

Note that setting this hint does not increase the MSRV of the rustix
crate, as old versions of Cargo will ignore it. New versions of Cargo
will respect it automatically (and, until we stabilize it, Cargo will do
nothing unless you pass `-Zprofile-hint-mostly-unused` to cargo).

Some sample performance numbers: this takes `rustix` compilation time
with `all-apis` enabled from 5.9s to 4.3s (a 27% improvement).
