### PR TITLE
build: Use temporary file for can_compile

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -258,7 +258,7 @@ fn can_compile<T: AsRef<str>>(test: T) -> bool {
         .arg("--target")
         .arg(target)
         .arg("-o")
-        .arg("-")
+        .arg(std::env::temp_dir().join("rustix_test_can_compile"))
         .stdout(Stdio::null()); // We don't care about the output (only whether it builds or not)
 
     // If Cargo wants to set RUSTFLAGS, use that.


### PR DESCRIPTION
The `can_compile` function in build.rs previously invoked `rustc` with `-o -`, which causes `rustc` to attempt to create a temporary metadata directory in the current working directory.

When building this in another build system such as Portage, this happens in a sandbox where the current working directory is not writeable, resulting in a sandbox access violation.

This change modifies the `can_compile` function to use a temporary directory for the output file. This forces `rustc` to create the temporary file in a writeable location, avoiding the sandbox issue.