### PR TITLE
Exclude testing of socket_domain() on AIX

### DIFF
--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -314,6 +314,7 @@ fn test_sockopts_ipv4() {
     #[cfg(not(any(
         apple,
         windows,
+        target_os = "aix",
         target_os = "cygwin",
         target_os = "dragonfly",
         target_os = "emscripten",


### PR DESCRIPTION
`socket_domain()` does not exist on AIX. Its wrapper has been excluded from `src/net/sockopt.rs` for AIX, so the test for it should also be excluded.