### PR TITLE
Make the flock tests more robust

### DIFF
--- a/tests/fs/flock.rs
+++ b/tests/fs/flock.rs
@@ -3,29 +3,30 @@
 fn test_flock() {
     use rustix::fs::{flock, openat, FlockOperation, Mode, OFlags, CWD};
 
-    let f = openat(CWD, "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
+    let tf = tempfile::NamedTempFile::new().unwrap();
+    let f = openat(CWD, tf.path(), OFlags::RDONLY, Mode::empty()).unwrap();
     flock(&f, FlockOperation::LockExclusive).unwrap();
     flock(&f, FlockOperation::Unlock).unwrap();
-    let g = openat(CWD, "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
+    let g = openat(CWD, tf.path(), OFlags::RDONLY, Mode::empty()).unwrap();
     flock(&g, FlockOperation::LockExclusive).unwrap();
     flock(&g, FlockOperation::Unlock).unwrap();
     drop(f);
     drop(g);
 
-    let f = openat(CWD, "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
+    let f = openat(CWD, tf.path(), OFlags::RDONLY, Mode::empty()).unwrap();
     flock(&f, FlockOperation::LockShared).unwrap();
-    let g = openat(CWD, "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
+    let g = openat(CWD, tf.path(), OFlags::RDONLY, Mode::empty()).unwrap();
     flock(&g, FlockOperation::LockShared).unwrap();
     flock(&f, FlockOperation::Unlock).unwrap();
     flock(&g, FlockOperation::Unlock).unwrap();
     drop(f);
     drop(g);
 
-    let f = openat(CWD, "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
+    let f = openat(CWD, tf.path(), OFlags::RDONLY, Mode::empty()).unwrap();
     flock(&f, FlockOperation::LockShared).unwrap();
     flock(&f, FlockOperation::LockExclusive).unwrap();
     flock(&f, FlockOperation::Unlock).unwrap();
-    let g = openat(CWD, "Cargo.toml", OFlags::RDONLY, Mode::empty()).unwrap();
+    let g = openat(CWD, tf.path(), OFlags::RDONLY, Mode::empty()).unwrap();
     flock(&g, FlockOperation::LockShared).unwrap();
     flock(&g, FlockOperation::LockExclusive).unwrap();
     flock(&g, FlockOperation::Unlock).unwrap();


### PR DESCRIPTION
Instead of attempting to lock Cargo.toml, use a temporary file.  This fixes test failures that result from the source file system not supporting flock, like some NFS file systems.