### PR TITLE
Fix the `test_is_io_flusher` test.

### DIFF
--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -117,10 +117,10 @@ pub(crate) use linux_raw_sys::{
     },
 };
 
-#[cfg(feature = "time")]
+#[cfg(any(feature = "io_uring", feature = "time", feature = "thread"))]
 pub use linux_raw_sys::general::__kernel_clockid_t as clockid_t;
 
-#[cfg(all(feature = "net", feature = "time"))]
+#[cfg(feature = "net")]
 pub use linux_raw_sys::net::{sock_txtime, SCM_TXTIME, SO_TXTIME};
 
 #[cfg(all(feature = "net", feature = "time"))]

--- a/tests/process/prctl.rs
+++ b/tests/process/prctl.rs
@@ -175,7 +175,9 @@ pub(crate) fn thread_has_capability(capability: CapabilitySet) -> io::Result<boo
         return Err(io::Error::last_os_error());
     }
 
-    let cap_index = capability.bits() as u32;
+    let cap_bits = capability.bits();
+    assert_eq!(cap_bits.count_ones(), 1);
+    let cap_index = cap_bits.leading_zeros();
     let (data_index, cap_index) = if cap_index < 32 {
         (0, cap_index)
     } else {


### PR DESCRIPTION
Capability sets are bitsets, so to compute an index, use `leading_zeros()` on the bitpattern.