### PR TITLE
Fix compilation on Android.

### DIFF
--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -63,7 +63,7 @@ pub(crate) const ETH_P_XDSA: c_int = linux_raw_sys::if_ether::ETH_P_XDSA as _;
 pub(crate) const ETH_P_MAP: c_int = linux_raw_sys::if_ether::ETH_P_MAP as _;
 #[cfg(all(linux_raw_dep, feature = "net"))]
 pub(crate) const ETH_P_MCTP: c_int = linux_raw_sys::if_ether::ETH_P_MCTP as _;
-#[cfg(all(linux_kernel, feature = "mount"))]
+#[cfg(all(linux_raw_dep, feature = "mount"))]
 pub(crate) const MS_NOSYMFOLLOW: c_ulong = linux_raw_sys::general::MS_NOSYMFOLLOW as _;
 
 #[cfg(all(
@@ -80,9 +80,9 @@ pub(crate) const MS_NOSYMFOLLOW: c_ulong = linux_raw_sys::general::MS_NOSYMFOLLO
 pub(crate) const SIGEMT: c_int = linux_raw_sys::general::SIGEMT as _;
 
 // TODO: Upstream these.
-#[cfg(all(linux_kernel, feature = "termios"))]
+#[cfg(all(linux_raw_dep, feature = "termios"))]
 pub(crate) const IUCLC: tcflag_t = linux_raw_sys::general::IUCLC as _;
-#[cfg(all(linux_kernel, feature = "termios"))]
+#[cfg(all(linux_raw_dep, feature = "termios"))]
 pub(crate) const XCASE: tcflag_t = linux_raw_sys::general::XCASE as _;
 
 #[cfg(target_os = "aix")]

--- a/src/backend/libc/mount/types.rs
+++ b/src/backend/libc/mount/types.rs
@@ -57,6 +57,7 @@ bitflags! {
         const SYNCHRONOUS = c::MS_SYNCHRONOUS;
 
         /// `MS_NOSYMFOLLOW`
+        #[cfg(linux_raw_dep)]
         const NOSYMFOLLOW = c::MS_NOSYMFOLLOW;
 
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>

--- a/src/prctl.rs
+++ b/src/prctl.rs
@@ -10,6 +10,7 @@ use bitflags::bitflags;
 use core::mem::MaybeUninit;
 use core::ptr::null_mut;
 
+#[cfg(linux_raw_dep)]
 bitflags! {
     /// `PR_PAC_AP*`
     #[repr(transparent)]

--- a/src/process/prctl.rs
+++ b/src/process/prctl.rs
@@ -1083,6 +1083,7 @@ const PR_PAC_GET_ENABLED_KEYS: c_int = 61;
 /// [`prctl(PR_PAC_GET_ENABLED_KEYS,…)`]: https://www.kernel.org/doc/html/v6.13/arch/arm64/pointer-authentication.html
 #[inline]
 #[doc(alias = "PR_PAC_GET_ENABLED_KEYS")]
+#[cfg(linux_raw_dep)]
 pub fn enabled_pointer_authentication_keys() -> io::Result<PointerAuthenticationKeys> {
     let r = unsafe { prctl_1arg(PR_PAC_GET_ENABLED_KEYS)? } as c_uint;
     PointerAuthenticationKeys::from_bits(r).ok_or(io::Errno::RANGE)
@@ -1103,6 +1104,7 @@ const PR_PAC_SET_ENABLED_KEYS: c_int = 60;
 /// [`prctl(PR_PAC_SET_ENABLED_KEYS,…)`]: https://www.kernel.org/doc/html/v6.13/arch/arm64/pointer-authentication.html
 #[inline]
 #[doc(alias = "PR_PAC_SET_ENABLED_KEYS")]
+#[cfg(linux_raw_dep)]
 pub unsafe fn configure_pointer_authentication_keys<
     Config: Iterator<Item = (PointerAuthenticationKeys, bool)>,
 >(

--- a/src/termios/types.rs
+++ b/src/termios/types.rs
@@ -275,7 +275,7 @@ bitflags! {
         const ICRNL = c::ICRNL;
 
         /// `IUCLC`
-        #[cfg(any(linux_kernel, solarish, target_os = "aix", target_os = "haiku", target_os = "nto"))]
+        #[cfg(any(linux_raw_dep, solarish, target_os = "aix", target_os = "haiku", target_os = "nto"))]
         const IUCLC = c::IUCLC;
 
         /// `IXON`
@@ -597,7 +597,7 @@ bitflags! {
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct LocalModes: types::tcflag_t {
         /// `XCASE`
-        #[cfg(any(linux_kernel, target_arch = "s390x", target_os = "haiku"))]
+        #[cfg(any(linux_raw_dep, target_arch = "s390x", target_os = "haiku"))]
         const XCASE = c::XCASE;
 
         /// `ECHOCTL`

--- a/src/thread/prctl.rs
+++ b/src/thread/prctl.rs
@@ -23,9 +23,9 @@ use crate::ffi::{c_int, c_uint, c_void, CStr};
 use crate::io;
 use crate::io::Errno;
 use crate::pid::Pid;
-use crate::prctl::{
-    prctl_1arg, prctl_2args, prctl_3args, prctl_get_at_arg2_optional, PointerAuthenticationKeys,
-};
+#[cfg(linux_raw_dep)]
+use crate::prctl::PointerAuthenticationKeys;
+use crate::prctl::{prctl_1arg, prctl_2args, prctl_3args, prctl_get_at_arg2_optional};
 use crate::utils::as_ptr;
 
 use super::CapabilitySet;
@@ -851,6 +851,7 @@ const PR_PAC_RESET_KEYS: c_int = 54;
 ///
 /// [`prctl(PR_PAC_RESET_KEYS,…)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
 #[inline]
+#[cfg(linux_raw_dep)]
 pub unsafe fn reset_pointer_authentication_keys(
     keys: Option<PointerAuthenticationKeys>,
 ) -> io::Result<()> {


### PR DESCRIPTION
Make `MountFlags::NOSYMFOLLOW`, `InputModes::IUCLC`, `LocalModes::XCASE`, and `PointerAuthenticationKeys` conditional on `linux_raw_dep`, so that they don't break compiling on Android with the linux_raw_sys dependency disabled.

Fixes #1513.