### PR TITLE
Enable statvfs for Haiku.

### DIFF
--- a/src/fs/abs.rs
+++ b/src/fs/abs.rs
@@ -15,7 +15,7 @@ use crate::fs::Access;
     target_os = "wasi",
 )))]
 use crate::fs::StatFs;
-#[cfg(not(any(target_os = "haiku", target_os = "wasi")))]
+#[cfg(not(any(target_os = "wasi")))]
 use crate::fs::StatVfs;
 use crate::fs::{Mode, OFlags, Stat};
 #[cfg(not(target_os = "wasi"))]
@@ -283,7 +283,7 @@ pub fn statfs<P: path::Arg>(path: P) -> io::Result<StatFs> {
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/statvfs.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/statvfs.2.html
-#[cfg(not(any(target_os = "haiku", target_os = "wasi")))]
+#[cfg(not(any(target_os = "wasi")))]
 #[inline]
 pub fn statvfs<P: path::Arg>(path: P) -> io::Result<StatVfs> {
     path.into_with_c_str(backend::fs::syscalls::statvfs)

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -152,7 +152,7 @@ fn test_file() {
         assert!(statfs.f_blocks > 0);
     }
 
-    #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
     {
         let statvfs = rustix::fs::fstatvfs(&file).unwrap();
         assert!(statvfs.f_frsize > 0);


### PR DESCRIPTION
A previous commit enabled fstatvfs, but missed statvfs, which exists on Haiku as well.

Sorry for not noticing earlier.