### PR TITLE
Fix CI failure

### DIFF
--- a/tests/net/addr.rs
+++ b/tests/net/addr.rs
@@ -28,22 +28,23 @@ fn encode_decode() {
 fn test_unix_addr() {
     use rustix::cstr;
     use rustix::net::SocketAddrUnix;
+    use std::borrow::Cow;
 
     assert_eq!(
         SocketAddrUnix::new("/").unwrap().path().unwrap(),
-        cstr!("/").into()
+        Cow::from(cstr!("/"))
     );
     assert_eq!(
         SocketAddrUnix::new("//").unwrap().path().unwrap(),
-        cstr!("//").into()
+        Cow::from(cstr!("//"))
     );
     assert_eq!(
         SocketAddrUnix::new("/foo/bar").unwrap().path().unwrap(),
-        cstr!("/foo/bar").into()
+        Cow::from(cstr!("/foo/bar"))
     );
     assert_eq!(
         SocketAddrUnix::new("foo").unwrap().path().unwrap(),
-        cstr!("foo").into()
+        Cow::from(cstr!("foo"))
     );
     SocketAddrUnix::new("/foo\0/bar").unwrap_err();
     assert!(SocketAddrUnix::new("").unwrap().path().is_none());

--- a/tests/path/arg.rs
+++ b/tests/path/arg.rs
@@ -16,126 +16,243 @@ fn test_arg() {
     let t: &str = "hello";
     assert_eq!("hello", Arg::as_str(&t).unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: String = "hello".to_owned();
     assert_eq!("hello", Arg::as_str(&t).unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: &OsStr = OsStr::new("hello");
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: OsString = OsString::from("hello".to_owned());
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: &Path = Path::new("hello");
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: PathBuf = PathBuf::from("hello".to_owned());
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: &CStr = cstr!("hello");
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: CString = cstr!("hello").to_owned();
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     assert_eq!(
         cstr!("hello"),
-        Borrow::borrow(&Arg::as_cow_c_str(&t).unwrap())
+        Borrow::<CStr>::borrow(&Arg::as_cow_c_str(&t).unwrap())
     );
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: Components<'_> = Path::new("hello").components();
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: Component<'_> = Path::new("hello").components().next().unwrap();
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: Iter<'_> = Path::new("hello").iter();
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: Cow<'_, str> = Cow::Borrowed("hello");
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: Cow<'_, str> = Cow::Owned("hello".to_owned());
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: Cow<'_, OsStr> = Cow::Borrowed(OsStr::new("hello"));
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: Cow<'_, OsStr> = Cow::Owned(OsString::from("hello".to_owned()));
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: Cow<'_, CStr> = Cow::Borrowed(cstr!("hello"));
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: Cow<'_, CStr> = Cow::Owned(cstr!("hello").to_owned());
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: &[u8] = b"hello";
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: Vec<u8> = b"hello".to_vec();
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 
     let t: DecInt = DecInt::new(43110);
     assert_eq!("43110", t.as_str());
     assert_eq!("43110".to_owned(), Arg::to_string_lossy(&t));
-    assert_eq!(cstr!("43110"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
+    assert_eq!(
+        cstr!("43110"),
+        Borrow::<CStr>::borrow(&t.as_cow_c_str().unwrap())
+    );
     assert_eq!(cstr!("43110"), t.as_c_str());
-    assert_eq!(cstr!("43110"), Borrow::borrow(&t.into_c_str().unwrap()));
+    assert_eq!(
+        cstr!("43110"),
+        Borrow::<CStr>::borrow(&t.into_c_str().unwrap())
+    );
 }
 
 #[test]


### PR DESCRIPTION
It appears type inferences no longer works due to the [addition of several PartialEq implementations around CStr](https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/#stabilized-apis).

https://github.com/bytecodealliance/rustix/actions/runs/17935800005/job/51001634461

```
error[E0283]: type annotations needed
  --> tests/net/addr.rs:34:20
   |
34 |         cstr!("/").into()
   |                    ^^^^ cannot infer type for type parameter `U`
   |
   = note: cannot satisfy `_: From<&CStr>`
   = note: required for `&CStr` to implement `Into<_>`
```

```
error[E0283]: type annotations needed
  --> tests/path/arg.rs:19:32
   |
19 |     assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
   |                                ^^^^^^^^^^^^^^ -------------------------- type must be known at this point
   |                                |
   |                                cannot infer type of the type parameter `Borrowed` declared on the trait `Borrow`
   |
   = note: multiple `impl`s satisfying `Cow<'_, CStr>: Borrow<_>` found in the following crates: `alloc`, `core`:
           - impl<'a, B> Borrow<B> for Cow<'a, B>
             where B: ToOwned, B: ?Sized;
           - impl<T> Borrow<T> for T
             where T: ?Sized;
help: consider specifying the generic argument
   |
19 |     assert_eq!(cstr!("hello"), Borrow::<Borrowed>::borrow(&t.as_cow_c_str().unwrap()));
   |                                      ++++++++++++
```