### PR TITLE
Make it possible to use Path and friends on wasip2 without the so named feature

### DIFF
--- a/src/path/arg.rs
+++ b/src/path/arg.rs
@@ -243,9 +243,7 @@ impl Arg for &OsStr {
 
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
-        Ok(Cow::Owned(
-            CString::new(self.as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        self.into_c_str()
     }
 
     #[inline]
@@ -253,9 +251,7 @@ impl Arg for &OsStr {
     where
         Self: 'b,
     {
-        Ok(Cow::Owned(
-            CString::new(self.as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        return self.as_bytes().into_c_str();
     }
 
     #[inline]
@@ -264,7 +260,7 @@ impl Arg for &OsStr {
         Self: Sized,
         F: FnOnce(&CStr) -> io::Result<T>,
     {
-        with_c_str(self.as_bytes(), f)
+        return self.as_bytes().into_with_c_str(f);
     }
 }
 
@@ -283,10 +279,7 @@ impl Arg for &OsString {
 
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
-        Ok(Cow::Owned(
-            CString::new(OsString::as_os_str(self).as_bytes())
-                .map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        self.as_os_str().into_c_str()
     }
 
     #[inline]
@@ -303,12 +296,11 @@ impl Arg for &OsString {
         Self: Sized,
         F: FnOnce(&CStr) -> io::Result<T>,
     {
-        with_c_str(self.as_bytes(), f)
+        self.as_os_str().into_with_c_str(f)
     }
 }
 
 #[cfg(feature = "std")]
-#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl Arg for OsString {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
@@ -322,9 +314,7 @@ impl Arg for OsString {
 
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
-        Ok(Cow::Owned(
-            CString::new(self.as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        self.as_os_str().into_c_str()
     }
 
     #[inline]
@@ -332,9 +322,7 @@ impl Arg for OsString {
     where
         Self: 'b,
     {
-        Ok(Cow::Owned(
-            CString::new(self.into_vec()).map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        self.into_vec().into_c_str()
     }
 
     #[inline]
@@ -343,12 +331,11 @@ impl Arg for OsString {
         Self: Sized,
         F: FnOnce(&CStr) -> io::Result<T>,
     {
-        f(&CString::new(self.into_vec()).map_err(|_cstr_err| io::Errno::INVAL)?)
+        f(&self.into_c_str()?)
     }
 }
 
 #[cfg(feature = "std")]
-#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl Arg for &Path {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
@@ -362,9 +349,7 @@ impl Arg for &Path {
 
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
-        Ok(Cow::Owned(
-            CString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        self.as_os_str().into_c_str()
     }
 
     #[inline]
@@ -372,9 +357,7 @@ impl Arg for &Path {
     where
         Self: 'b,
     {
-        Ok(Cow::Owned(
-            CString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        self.as_os_str().into_c_str()
     }
 
     #[inline]
@@ -383,19 +366,15 @@ impl Arg for &Path {
         Self: Sized,
         F: FnOnce(&CStr) -> io::Result<T>,
     {
-        with_c_str(self.as_os_str().as_bytes(), f)
+        self.as_os_str().into_with_c_str(f)
     }
 }
 
 #[cfg(feature = "std")]
-#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl Arg for &PathBuf {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
-        PathBuf::as_path(self)
-            .as_os_str()
-            .to_str()
-            .ok_or(io::Errno::INVAL)
+        self.as_os_str().to_str().ok_or(io::Errno::INVAL)
     }
 
     #[inline]
@@ -405,10 +384,7 @@ impl Arg for &PathBuf {
 
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
-        Ok(Cow::Owned(
-            CString::new(PathBuf::as_path(self).as_os_str().as_bytes())
-                .map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        self.as_os_str().into_c_str()
     }
 
     #[inline]
@@ -425,12 +401,11 @@ impl Arg for &PathBuf {
         Self: Sized,
         F: FnOnce(&CStr) -> io::Result<T>,
     {
-        with_c_str(self.as_os_str().as_bytes(), f)
+        self.as_os_str().into_with_c_str(f)
     }
 }
 
 #[cfg(feature = "std")]
-#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl Arg for PathBuf {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
@@ -444,9 +419,7 @@ impl Arg for PathBuf {
 
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
-        Ok(Cow::Owned(
-            CString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        self.as_os_str().into_c_str()
     }
 
     #[inline]
@@ -454,9 +427,7 @@ impl Arg for PathBuf {
     where
         Self: 'b,
     {
-        Ok(Cow::Owned(
-            CString::new(self.into_os_string().into_vec()).map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        self.into_os_string().into_c_str()
     }
 
     #[inline]
@@ -465,10 +436,7 @@ impl Arg for PathBuf {
         Self: Sized,
         F: FnOnce(&CStr) -> io::Result<T>,
     {
-        f(
-            &CString::new(self.into_os_string().into_vec())
-                .map_err(|_cstr_err| io::Errno::INVAL)?,
-        )
+        self.into_os_string().into_with_c_str(f)
     }
 }
 
@@ -637,9 +605,7 @@ impl<'a> Arg for Cow<'a, OsStr> {
 
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
-        Ok(Cow::Owned(
-            CString::new(self.as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        (&**self).into_c_str()
     }
 
     #[inline]
@@ -647,13 +613,10 @@ impl<'a> Arg for Cow<'a, OsStr> {
     where
         Self: 'b,
     {
-        Ok(Cow::Owned(
-            match self {
-                Cow::Owned(os) => CString::new(os.into_vec()),
-                Cow::Borrowed(os) => CString::new(os.as_bytes()),
-            }
-            .map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        match self {
+            Cow::Owned(os) => os.into_c_str(),
+            Cow::Borrowed(os) => os.into_c_str(),
+        }
     }
 
     #[inline]
@@ -662,7 +625,7 @@ impl<'a> Arg for Cow<'a, OsStr> {
         Self: Sized,
         F: FnOnce(&CStr) -> io::Result<T>,
     {
-        with_c_str(self.as_bytes(), f)
+        (&*self).into_with_c_str(f)
     }
 }
 
@@ -717,9 +680,7 @@ impl<'a> Arg for Component<'a> {
 
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
-        Ok(Cow::Owned(
-            CString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        self.as_os_str().into_c_str()
     }
 
     #[inline]
@@ -727,9 +688,7 @@ impl<'a> Arg for Component<'a> {
     where
         Self: 'b,
     {
-        Ok(Cow::Owned(
-            CString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        self.as_os_str().into_c_str()
     }
 
     #[inline]
@@ -738,12 +697,11 @@ impl<'a> Arg for Component<'a> {
         Self: Sized,
         F: FnOnce(&CStr) -> io::Result<T>,
     {
-        with_c_str(self.as_os_str().as_bytes(), f)
+        self.as_os_str().into_with_c_str(f)
     }
 }
 
 #[cfg(feature = "std")]
-#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl<'a> Arg for Components<'a> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
@@ -757,10 +715,7 @@ impl<'a> Arg for Components<'a> {
 
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
-        Ok(Cow::Owned(
-            CString::new(self.as_path().as_os_str().as_bytes())
-                .map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        self.as_path().into_c_str()
     }
 
     #[inline]
@@ -768,10 +723,7 @@ impl<'a> Arg for Components<'a> {
     where
         Self: 'b,
     {
-        Ok(Cow::Owned(
-            CString::new(self.as_path().as_os_str().as_bytes())
-                .map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        self.as_path().into_c_str()
     }
 
     #[inline]
@@ -780,12 +732,11 @@ impl<'a> Arg for Components<'a> {
         Self: Sized,
         F: FnOnce(&CStr) -> io::Result<T>,
     {
-        with_c_str(self.as_path().as_os_str().as_bytes(), f)
+        self.as_path().into_with_c_str(f)
     }
 }
 
 #[cfg(feature = "std")]
-#[cfg(any(not(target_os = "wasi"), not(target_env = "p2"), wasip2))]
 impl<'a> Arg for Iter<'a> {
     #[inline]
     fn as_str(&self) -> io::Result<&str> {
@@ -799,10 +750,7 @@ impl<'a> Arg for Iter<'a> {
 
     #[inline]
     fn as_cow_c_str(&self) -> io::Result<Cow<'_, CStr>> {
-        Ok(Cow::Owned(
-            CString::new(self.as_path().as_os_str().as_bytes())
-                .map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        self.as_path().into_c_str()
     }
 
     #[inline]
@@ -810,10 +758,7 @@ impl<'a> Arg for Iter<'a> {
     where
         Self: 'b,
     {
-        Ok(Cow::Owned(
-            CString::new(self.as_path().as_os_str().as_bytes())
-                .map_err(|_cstr_err| io::Errno::INVAL)?,
-        ))
+        self.as_path().into_c_str()
     }
 
     #[inline]
@@ -822,7 +767,7 @@ impl<'a> Arg for Iter<'a> {
         Self: Sized,
         F: FnOnce(&CStr) -> io::Result<T>,
     {
-        with_c_str(self.as_path().as_os_str().as_bytes(), f)
+        self.as_path().into_with_c_str(f)
     }
 }
 


### PR DESCRIPTION
(draft because this is a bit of a hack and needs some discussion first)

At the moment, it's not possible to use `&Path`, `&OsStr`, etc. with rustix on WASIp2 without the nightly compiler (requires the `wasip2` feature) as `OsStrExt` and `OsStringExt` require the `wasip2` feature on WASIp2 so we can't use `as_bytes()` on `OsStr` and friends.

However, the recommendation on the [upstream issue](https://github.com/rust-lang/rust/issues/130323#issuecomment-2350430693) is to just use `to_str` as WASI paths are Unicode. This PR does exactly that.

@alexcrichton am I interpreting your comment correctly?

Alternatives:

- Wait. I'd prefer not to do this as I don't see a quick path to stabilization here.
- Work around this downstream. I'm submitting this to try to get [tempfile working](https://github.com/Stebalien/tempfile/pull/382) on the wasip2 platform on rust stable. I'm also happy to work around this downstream (in tempfile itself).
- Use [`OsStr::as_encoded_bytes`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html#method.as_encoded_bytes) on wasi instead of `OsStrExt::as_bytes`. It will technically work but it also technically relies on an unstable representation (one that will likely never change on WASI, but still...).

---

This PR has two parts:

1. The first commit DRYs up the code a bit to avoid having to implement too many platform-specific conditionals. I tried to keep this change minimal but I'm also happy to go ahead and DRY up the rest of the code (there's a fair amount of duplicate code in this file).
2. The second commit special-cases conversions for `OsString` and `OsStr`, converting to utf8 strings where necessary.