### PR TITLE
libc: use upstreamed SIGEMT support for mips and sparc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustc-std-workspace-alloc = { version = "1.0.0", optional = true } # not aliased
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_endian = "little", any(target_arch = "s390x", target_arch = "powerpc")), any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc"), all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "s390x"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
 linux-raw-sys = { version = "0.11.0", default-features = false, features = ["auxvec", "general", "errno", "ioctl", "no_std", "elf"] }
 libc_errno = { package = "errno", version = "0.3.10", default-features = false, optional = true }
-libc = { version = "0.2.171", default-features = false, optional = true }
+libc = { version = "0.2.177", default-features = false, optional = true }
 
 # Dependencies for platforms where only libc is supported:
 #
@@ -43,7 +43,7 @@ libc = { version = "0.2.171", default-features = false, optional = true }
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_endian = "little", any(target_arch = "s390x", target_arch = "powerpc")), any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc"), all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "s390x"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.10", default-features = false }
-libc = { version = "0.2.171", default-features = false }
+libc = { version = "0.2.177", default-features = false }
 
 # Additional dependencies for Linux with the libc backend:
 #

--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -66,19 +66,6 @@ pub(crate) const ETH_P_MCTP: c_int = linux_raw_sys::if_ether::ETH_P_MCTP as _;
 #[cfg(all(linux_raw_dep, feature = "mount"))]
 pub(crate) const MS_NOSYMFOLLOW: c_ulong = linux_raw_sys::general::MS_NOSYMFOLLOW as _;
 
-#[cfg(all(
-    linux_kernel,
-    any(
-        target_arch = "mips",
-        target_arch = "mips32r6",
-        target_arch = "mips64",
-        target_arch = "mips64r6",
-        target_arch = "sparc",
-        target_arch = "sparc64"
-    )
-))]
-pub(crate) const SIGEMT: c_int = linux_raw_sys::general::SIGEMT as _;
-
 // TODO: Upstream these.
 #[cfg(all(linux_raw_dep, feature = "termios"))]
 pub(crate) const IUCLC: tcflag_t = linux_raw_sys::general::IUCLC as _;


### PR DESCRIPTION
SIGEMT support for mips and sparc linux in libc has been merged upstream and is now available in 0.2.177.