### PR TITLE
Delete `#[cfg_attr(wasi, path = "backend/wasi/mod.rs")]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,6 @@ mod weak;
 // Pick the backend implementation to use.
 #[cfg_attr(libc, path = "backend/libc/mod.rs")]
 #[cfg_attr(linux_raw, path = "backend/linux_raw/mod.rs")]
-#[cfg_attr(wasi, path = "backend/wasi/mod.rs")]
 mod backend;
 
 /// Export the `*Fd` types and traits that are used in rustix's public API.


### PR DESCRIPTION
Closes #1539.

As far as I can tell, nothing in build.rs enables `cfg(wasi)`, unlike `cfg(libc)` and `cfg(linux_raw)`.

Enabling it manually results in:

```console
bytecodealliance:rustix$  RUSTFLAGS=--cfg=wasi cargo check --target=wasm32-wasip2

warning: unused attribute
   --> src/lib.rs:197:18
    |
197 | #[cfg_attr(wasi, path = "backend/wasi/mod.rs")]
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
    |
note: attribute also specified here
   --> src/lib.rs:195:18
    |
195 | #[cfg_attr(libc, path = "backend/libc/mod.rs")]
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: `#[warn(unused_attributes)]` (part of `#[warn(unused)]`) on by default
```