### PR TITLE
Rudimentary `sanitize_memory` support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,6 +262,7 @@ check-cfg = [
     'cfg(linux_raw)',
     'cfg(linux_raw_dep)',
     'cfg(lower_upper_exp_for_non_zero)',
+    'cfg(sanitize_memory)',
     'cfg(netbsdlike)',
     'cfg(rustc_attrs)',
     'cfg(rustc_diagnostics)',

--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -509,6 +509,10 @@ pub(crate) fn fstat(fd: BorrowedFd<'_>) -> io::Result<Stat> {
     unsafe {
         let mut result = MaybeUninit::<Stat>::uninit();
         ret(syscall!(__NR_fstat, fd, &mut result))?;
+
+        #[cfg(sanitize_memory)]
+        crate::msan::unpoison_maybe_uninit(&result);
+
         Ok(result.assume_init())
     }
 }

--- a/src/backend/linux_raw/rand/syscalls.rs
+++ b/src/backend/linux_raw/rand/syscalls.rs
@@ -11,5 +11,12 @@ use crate::rand::GetRandomFlags;
 
 #[inline]
 pub(crate) unsafe fn getrandom(buf: (*mut u8, usize), flags: GetRandomFlags) -> io::Result<usize> {
-    ret_usize(syscall!(__NR_getrandom, buf.0, pass_usize(buf.1), flags))
+    let r = ret_usize(syscall!(__NR_getrandom, buf.0, pass_usize(buf.1), flags));
+
+    #[cfg(sanitize_memory)]
+    if let Ok(len) = r {
+        crate::msan::unpoison(buf.0, len);
+    }
+
+    r
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,8 @@ pub(crate) mod maybe_polyfill;
 pub(crate) mod check_types;
 #[macro_use]
 pub(crate) mod bitcast;
+#[cfg(sanitize_memory)]
+pub(crate) mod msan;
 
 // linux_raw: Weak symbols are used by the use-libc-auxv feature for
 // glibc 2.15 support.

--- a/src/msan.rs
+++ b/src/msan.rs
@@ -1,0 +1,12 @@
+use core::ffi::c_void;
+use core::mem::size_of;
+
+extern "C" {
+    /// <https://github.com/gcc-mirror/gcc/blob/28219f7f99a80519d1c6ab5e5dc83b4c7f8d7251/libsanitizer/include/sanitizer/msan_interface.h#L40>
+    #[link_name = "__msan_unpoison"]
+    pub(crate) fn unpoison(a: *const c_void, size: usize);
+}
+
+pub(crate) fn unpoison_maybe_uninit<T>(t: &MaybeUninit<T>) {
+    unpoison(t.as_ptr(), size_of::<T>())
+}


### PR DESCRIPTION
This adds a simple mechanism for informing msan of memory initializations that happen within `asm` blocks, and uses it in `fstat`, `read`, `pread`, and `getrandom`. More functions can be added in the future.

Fixes #1531.