### PR TITLE
Fix `linux_5_11` on ARMv7.

### DIFF
--- a/src/backend/linux_raw/fs/syscalls.rs
+++ b/src/backend/linux_raw/fs/syscalls.rs
@@ -14,6 +14,13 @@ use crate::backend::conv::fs::oflags_for_open_how;
     target_arch = "riscv64",
     target_arch = "mips",
     target_arch = "mips32r6",
+    all(
+        target_pointer_width = "32",
+        any(
+            target_arch = "arm",
+            target_arch = "powerpc"
+        ),
+    )
 ))]
 use crate::backend::conv::zero;
 use crate::backend::conv::{


### PR DESCRIPTION
Fix the `cfg` conditions for `zero` so that it's available on armv7.

Fixes #1538.