### PR TITLE
Implement dirfd equivalent functions

### DIFF
--- a/src/backend/libc/fs/dir.rs
+++ b/src/backend/libc/fs/dir.rs
@@ -75,6 +75,27 @@ impl Dir {
         }
     }
 
+    /// Returns the file descriptor associated with the directory stream.
+    ///
+    /// The file descriptor is used internally by the directory stream. As a result, it is useful
+    /// only for functions which do not depend or alter the file position.
+    ///
+    /// # References
+    ///
+    ///   - [POSIX]
+    ///
+    /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/dirfd.html
+    #[inline]
+    #[doc(alias = "dirfd")]
+    pub fn fd<'a>(&'a self) -> io::Result<BorrowedFd<'a>> {
+        let raw_fd = unsafe { c::dirfd(self.libc_dir.as_ptr()) };
+        if raw_fd < 0 {
+            Err(io::Errno::last_os_error())
+        } else {
+            Ok(unsafe { BorrowedFd::borrow_raw(raw_fd) })
+        }
+    }
+
     /// Borrow `fd` and construct a `Dir` that reads entries from the given
     /// directory file descriptor.
     #[inline]

--- a/src/backend/linux_raw/fs/dir.rs
+++ b/src/backend/linux_raw/fs/dir.rs
@@ -50,6 +50,22 @@ impl Dir {
         })
     }
 
+    /// Returns the file descriptor associated with the directory stream.
+    ///
+    /// The file descriptor is used internally by the directory stream. As a result, it is useful
+    /// only for functions which do not depend or alter the file position.
+    ///
+    /// # References
+    ///
+    ///   - [POSIX]
+    ///
+    /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/dirfd.html
+    #[inline]
+    #[doc(alias = "dirfd")]
+    pub fn fd<'a>(&'a self) -> io::Result<BorrowedFd<'a>> {
+        Ok(self.fd.as_fd())
+    }
+
     /// Borrow `fd` and construct a `Dir` that reads entries from the given
     /// directory file descriptor.
     #[inline]


### PR DESCRIPTION
Implement functions that allow us to retrieve the directory stream file descriptor, equivalent to libc's `dirfd` function.

On linux, we can simply return the file descriptor itself (I verified this is what musl does).

---

This fixes #1455. I've tried following `rustix`'s style in general. Overall, it is a fairly simple change. I don't know if you want to add some tests for it or not (I may need a little bit of guidance in that case).