### PR TITLE
more precise RawDirEntry lifetime

### DIFF
--- a/src/fs/raw_dir.rs
+++ b/src/fs/raw_dir.rs
@@ -199,7 +199,7 @@ impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
     /// with GAT support once one becomes available.
     #[allow(unsafe_code)]
     #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> Option<io::Result<RawDirEntry<'_>>> {
+    pub fn next(&mut self) -> Option<io::Result<RawDirEntry<'buf>>> {
         if self.is_buffer_empty() {
             match getdents_uninit(self.fd.as_fd(), self.buf) {
                 Ok(0) => return None,


### PR DESCRIPTION
The lifetime returned by `RawDir::next()` is the `RawDir`'s lifetime and not the buffer it uses (`'buf`). The file name lives inside the buffer provided to the kernel.

## Example
```rust
fn test<'buf, 'fd>(fd: BorrowedFd<'fd>, buf: &'buf mut Vec<u8>) -> RawDirEntry<'buf> {
    RawDir::new(fd, buf.spare_capacity_mut())
        .next()
        .unwrap()
        .unwrap()
}
```

Without the change, the borrow checker will tell the following error: 
```
error: lifetime may not live long enough
  --> brr-lib/src/fs/dir.rs:40:5
   |
   |   fn test<'buf, 'fd>(fd: BorrowedFd<'fd>, buf: &'buf mut Vec<u8>) -> RawDirEntry<'buf> {
   |           -----  --- lifetime `'fd` defined here
   |           |
   |           lifetime `'buf` defined here
   | /     RawDir::new(fd, buf.spare_capacity_mut())
   | |         .next()
   | |         .unwrap()
   | |         .unwrap()
   | |_________________^ function was supposed to return data with lifetime `'buf` but it is returning data with lifetime `'fd`
   |
   = help: consider adding the following bound: `'fd: 'buf`

error[E0515]: cannot return value referencing temporary value
  --> brr-lib/src/fs/dir.rs:40:5
   |
   |       RawDir::new(fd, buf.spare_capacity_mut())
   |       ^----------------------------------------
   |       |
   |  _____temporary value created here
   | |
   | |         .next()
   | |         .unwrap()
   | |         .unwrap()
   | |_________________^ returns a value referencing data owned by the current function
```

The borrow checker passes with the change