### PR TITLE
Update macOS runner version in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -257,7 +257,38 @@ jobs:
       RUSTFLAGS: --cfg rustix_use_experimental_features
     strategy:
       matrix:
-        build: [ubuntu, ubuntu-22.04, i686-linux, aarch64-linux, powerpc-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, powerpc-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.63, i686-linux-1.63, aarch64-linux-1.63, riscv64-linux-1.63, s390x-linux-1.63, powerpc64le-linux, powerpc64le-linux-1.63, arm-linux-1.63, macos-latest, macos-13, windows, musl]
+        build:
+          [
+            ubuntu,
+            ubuntu-22.04,
+            i686-linux,
+            aarch64-linux,
+            powerpc-linux,
+            powerpc64le-linux,
+            riscv64-linux,
+            s390x-linux,
+            arm-linux,
+            ubuntu-stable,
+            i686-linux-stable,
+            aarch64-linux-stable,
+            riscv64-linux-stable,
+            s390x-linux-stable,
+            powerpc-linux-stable,
+            powerpc64le-linux-stable,
+            arm-linux-stable,
+            ubuntu-1.63,
+            i686-linux-1.63,
+            aarch64-linux-1.63,
+            riscv64-linux-1.63,
+            s390x-linux-1.63,
+            powerpc64le-linux,
+            powerpc64le-linux-1.63,
+            arm-linux-1.63,
+            macos-latest,
+            macos-15-intel,
+            windows,
+            musl,
+          ]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -457,8 +488,8 @@ jobs:
           - build: macos-latest
             os: macos-latest
             rust: stable
-          - build: macos-13
-            os: macos-13
+          - build: macos-15-intel
+            os: macos-15-intel
             rust: stable
           - build: windows
             os: windows-latest


### PR DESCRIPTION
> The macOS-13 based runner images are now retired. For more details, see https://github.com/actions/runner-images/issues/13046.