### PR TITLE
Remove `getifaddrs` from the "not yet" category.

### DIFF
--- a/src/not_implemented.rs
+++ b/src/not_implemented.rs
@@ -297,7 +297,6 @@ pub mod yet {
     not_implemented!(cachestat);
     not_implemented!(fanotify_init);
     not_implemented!(fanotify_mark);
-    not_implemented!(getifaddrs);
     not_implemented!(signalfd);
     not_implemented!(mount_setattr);
     not_implemented!(extattr_delete_fd);


### PR DESCRIPTION
`getifaddrs` is also in the `higher level" category, which appears to be the more appropriate.