### PR TITLE
Enable ioctl and makedev on Redox

### DIFF
--- a/src/backend/libc/fs/makedev.rs
+++ b/src/backend/libc/fs/makedev.rs
@@ -14,6 +14,7 @@ use crate::fs::Dev;
     target_os = "aix",
     target_os = "android",
     target_os = "emscripten",
+    target_os = "redox",
 )))]
 #[inline]
 pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
@@ -44,6 +45,17 @@ pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
         | (u64::from(min) & 0x0000_00ff_u64)
 }
 
+#[cfg(target_os = "redox")]
+#[inline]
+pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
+    // Redox's makedev is reportedly similar to 32-bit Android's but the return
+    // type is signed.
+    ((i64::from(maj) & 0xffff_f000_i64) << 32)
+        | ((i64::from(maj) & 0x0000_0fff_i64) << 8)
+        | ((i64::from(min) & 0xffff_ff00_i64) << 12)
+        | (i64::from(min) & 0x0000_00ff_i64)
+}
+
 #[cfg(target_os = "emscripten")]
 #[inline]
 pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
@@ -70,7 +82,8 @@ pub(crate) fn makedev(maj: u32, min: u32) -> Dev {
     freebsdlike,
     target_os = "android",
     target_os = "emscripten",
-    target_os = "netbsd"
+    target_os = "netbsd",
+    target_os = "redox"
 )))]
 #[inline]
 pub(crate) fn major(dev: Dev) -> u32 {
@@ -89,7 +102,10 @@ pub(crate) fn major(dev: Dev) -> u32 {
     (unsafe { c::major(dev) }) as u32
 }
 
-#[cfg(all(target_os = "android", target_pointer_width = "32"))]
+#[cfg(any(
+    all(target_os = "android", target_pointer_width = "32"),
+    target_os = "redox"
+))]
 #[inline]
 pub(crate) fn major(dev: Dev) -> u32 {
     // 32-bit Android's `dev_t` is 32-bit, but its `st_dev` is 64-bit, so we do
@@ -109,7 +125,8 @@ pub(crate) fn major(dev: Dev) -> u32 {
     freebsdlike,
     target_os = "android",
     target_os = "emscripten",
-    target_os = "netbsd"
+    target_os = "netbsd",
+    target_os = "redox",
 )))]
 #[inline]
 pub(crate) fn minor(dev: Dev) -> u32 {
@@ -128,7 +145,10 @@ pub(crate) fn minor(dev: Dev) -> u32 {
     (unsafe { c::minor(dev) }) as u32
 }
 
-#[cfg(all(target_os = "android", target_pointer_width = "32"))]
+#[cfg(any(
+    all(target_os = "android", target_pointer_width = "32"),
+    target_os = "redox"
+))]
 #[inline]
 pub(crate) fn minor(dev: Dev) -> u32 {
     // 32-bit Android's `dev_t` is 32-bit, but its `st_dev` is 64-bit, so we do

--- a/src/backend/libc/fs/mod.rs
+++ b/src/backend/libc/fs/mod.rs
@@ -6,7 +6,6 @@ pub mod inotify;
     target_os = "espidf",
     target_os = "haiku",
     target_os = "horizon",
-    target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
 )))]

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -38,7 +38,6 @@ mod ioctl;
     target_os = "espidf",
     target_os = "haiku",
     target_os = "horizon",
-    target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
 )))]
@@ -103,7 +102,6 @@ pub use ioctl::*;
     target_os = "espidf",
     target_os = "haiku",
     target_os = "horizon",
-    target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
 )))]

--- a/src/ioctl/mod.rs
+++ b/src/ioctl/mod.rs
@@ -18,20 +18,20 @@ use crate::fd::{AsFd, BorrowedFd};
 use crate::ffi as c;
 use crate::io::Result;
 
-#[cfg(any(linux_kernel, bsd))]
+#[cfg(any(linux_kernel, bsd, target_os = "redox"))]
 use core::mem;
 
 pub use patterns::*;
 
 mod patterns;
 
-#[cfg(linux_kernel)]
+#[cfg(any(linux_kernel, target_os = "redox"))]
 mod linux;
 
 #[cfg(bsd)]
 mod bsd;
 
-#[cfg(linux_kernel)]
+#[cfg(any(linux_kernel, target_os = "redox"))]
 use linux as platform;
 
 #[cfg(bsd)]
@@ -198,7 +198,7 @@ pub unsafe trait Ioctl {
 ///
 /// If you're writing a driver and defining your own ioctl numbers, it's
 /// recommended to use these functions to compute them.
-#[cfg(any(linux_kernel, bsd))]
+#[cfg(any(linux_kernel, bsd, target_os = "redox"))]
 pub mod opcode {
     use super::*;
 

--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -27,7 +27,7 @@ mod invalid_offset;
 mod ioctl;
 mod linkat;
 mod long_paths;
-#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "haiku", target_os = "wasi")))]
 mod makedev;
 mod mkdirat;
 mod mknodat;


### PR DESCRIPTION
Submitted as #1555. Modified to avoid adding the `as Dev` on non-Redox targets.