### PR TITLE
Add test ensuring UB can't be introduced

### DIFF
--- a/src/fs/raw_dir.rs
+++ b/src/fs/raw_dir.rs
@@ -238,3 +238,17 @@ impl<'buf, Fd: AsFd> RawDir<'buf, Fd> {
         self.offset >= self.initialized
     }
 }
+
+/// ```compile_fail
+/// use rustix::fs::{CWD, Mode, OFlags, RawDir, openat};
+/// use std::mem::MaybeUninit;
+///
+/// let mut buf = [MaybeUninit::uninit(); 47];
+/// let fd = openat(CWD, c".", OFlags::DIRECTORY, Mode::empty()).unwrap();
+/// let mut iter = RawDir::new(fd, &mut buf);
+/// let item1 = iter.next().unwrap();
+/// let item2 = iter.next().unwrap();
+/// println!("{item2:?}");
+/// println!("{item1:?}");
+/// ```
+fn _doctest() {}


### PR DESCRIPTION
If you change the return lifetime of `next` to `'buf` you'll get this error:
```
$ cargo t --workspace --doc --features all-apis
...

failures:

---- src/fs/raw_dir.rs - fs::raw_dir::_doctest (line 242) stdout ----
Test compiled successfully, but it's marked `compile_fail`.

failures:
    src/fs/raw_dir.rs - fs::raw_dir::_doctest (line 242)

test result: FAILED. 30 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.95s
```