### PR TITLE
Add EINVAL to TCGETS2/TCSETS2 fallback triggers

### DIFF
--- a/src/backend/linux_raw/termios/syscalls.rs
+++ b/src/backend/linux_raw/termios/syscalls.rs
@@ -44,7 +44,9 @@ pub(crate) fn tcgetattr(fd: BorrowedFd<'_>) -> io::Result<Termios> {
             // `TCGETS2`, for example a seccomp environment or WSL that only
             // knows about `TCGETS`. Fall back to the old `TCGETS`.
             #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
-            Err(io::Errno::NOTTY) | Err(io::Errno::ACCESS) | Err(io::Errno::INVAL) => tcgetattr_fallback(fd),
+            Err(io::Errno::NOTTY) | Err(io::Errno::ACCESS) | Err(io::Errno::INVAL) => {
+                tcgetattr_fallback(fd)
+            }
 
             Err(err) => Err(err),
         }
@@ -148,7 +150,7 @@ pub(crate) fn tcsetattr(
             // Similar to `tcgetattr_fallback`, `NOTTY` or `ACCESS` might mean
             // the OS doesn't support `TCSETS2`. Fall back to the old `TCSETS`.
             #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
-            Err(io::Errno::NOTTY) | Err(io::Errno::ACCESS) => {
+            Err(io::Errno::NOTTY) | Err(io::Errno::ACCESS) | Err(io::Errno::INVAL) => {
                 tcsetattr_fallback(fd, optional_actions, termios)
             }
 


### PR DESCRIPTION
This adds `EINVAL` to the error codes that trigger fallback from `TCGETS2`/`TCSETS2` to the legacy `TCGETS`/`TCSETS` ioctls.

## Motivation

Some emulated and virtualized environments don't implement `TCGETS2`/`TCSETS2` and return `EINVAL` rather than `ENOTTY` or `EACCES`. This includes CheerpX/WebVM (x86-to-WebAssembly virtualization in the browser).

The fallback logic already exists for `ENOTTY` and `EACCES`. This change simply adds `EINVAL` as another trigger.

## Reproducing

```rust
use rustix::pty::*;
use rustix::termios::*;

fn main() {
    let pty = openpt(OpenptFlags::empty()).expect("openpt failed");
    println!("tcgetattr: {:?}", tcgetattr(&pty));
}
```

`cargo build --target i686-unknown-linux-musl --release -F termios,pty`

Running on https://webvm.io/ outputs:

```
tcgetattr: Err(Os { code: 22, kind: InvalidInput, message: "Invalid argument" })
```

With this change, the fallback to `TCGETS` succeeds.

## Changes

- `tcgetattr`: add `Errno::INVAL` to fallback match arm
- `tcsetattr`: add `Errno::INVAL` to fallback match arm
