### PR TITLE
Add `getcpu` system call support for getting a NUMA node of the current thread

### DIFF
--- a/src/backend/linux_raw/thread/syscalls.rs
+++ b/src/backend/linux_raw/thread/syscalls.rs
@@ -446,7 +446,7 @@ pub(crate) fn setgroups_thread(gids: &[crate::ugid::Gid]) -> io::Result<()> {
     unsafe { ret(syscall_readonly!(__NR_setgroups, len, addr)) }
 }
 
-// `sched_getcpu` has special optimizations via the vDSO on some architectures.
+// `sched_getcpu` and `getcpu` have special optimizations via the vDSO on some architectures.
 #[cfg(any(
     target_arch = "x86_64",
     target_arch = "x86",
@@ -455,18 +455,7 @@ pub(crate) fn setgroups_thread(gids: &[crate::ugid::Gid]) -> io::Result<()> {
     target_arch = "powerpc64",
     target_arch = "s390x"
 ))]
-pub(crate) use crate::backend::vdso_wrappers::sched_getcpu;
-
-// `getcpu` has special optimizations via the vDSO on some architectures.
-#[cfg(any(
-    target_arch = "x86_64",
-    target_arch = "x86",
-    target_arch = "riscv64",
-    target_arch = "powerpc",
-    target_arch = "powerpc64",
-    target_arch = "s390x"
-))]
-pub(crate) use crate::backend::vdso_wrappers::getcpu;
+pub(crate) use crate::backend::vdso_wrappers::{getcpu, sched_getcpu};
 
 // `getcpu` on platforms without a vDSO entry for it.
 #[cfg(not(any(
@@ -504,7 +493,7 @@ pub(crate) fn getcpu() -> (usize, usize) {
 pub(crate) fn sched_getcpu() -> usize {
     // We should not implement this function by using the `getcpu` function definded above
     // because we want to provide exactly one pointer to the system call.
-    
+
     let mut cpu = MaybeUninit::<u32>::uninit();
     unsafe {
         let r = ret(syscall!(__NR_getcpu, &mut cpu, zero(), zero()));

--- a/src/backend/linux_raw/vdso_wrappers.rs
+++ b/src/backend/linux_raw/vdso_wrappers.rs
@@ -340,7 +340,6 @@ fn init_clock_gettime() -> ClockGettimeType {
     target_arch = "s390x",
 ))]
 #[cold]
-#[inline(never)]
 fn init_getcpu() -> GetcpuType {
     init();
     // SAFETY: Load the function address from static storage that we just

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -381,8 +381,8 @@ mod tests {
         let nread = read(&input, &mut buf).unwrap();
         assert_eq!(nread, buf.len());
         assert_eq!(
-            &buf[..58],
-            b"//! Utilities for functions that return data via buffers.\n"
+            &buf[..57],
+            b"//! Utilities for functions that return data via buffers."
         );
         input.seek(SeekFrom::End(-1)).unwrap();
         let nread = read(&input, &mut buf).unwrap();
@@ -407,13 +407,13 @@ mod tests {
         let (init, uninit) = read(&input, &mut buf).unwrap();
         assert_eq!(uninit.len(), 0);
         assert_eq!(
-            &init[..58],
-            b"//! Utilities for functions that return data via buffers.\n"
+            &init[..57],
+            b"//! Utilities for functions that return data via buffers."
         );
         assert_eq!(init.len(), buf.len());
         assert_eq!(
-            unsafe { core::mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(&mut buf[..58]) },
-            b"//! Utilities for functions that return data via buffers.\n"
+            unsafe { core::mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(&mut buf[..57]) },
+            b"//! Utilities for functions that return data via buffers."
         );
         input.seek(SeekFrom::End(-1)).unwrap();
         let (init, uninit) = read(&input, &mut buf).unwrap();
@@ -440,8 +440,8 @@ mod tests {
         assert_eq!(nread, buf.capacity());
         assert_eq!(nread, buf.len());
         assert_eq!(
-            &buf[..58],
-            b"//! Utilities for functions that return data via buffers.\n"
+            &buf[..57],
+            b"//! Utilities for functions that return data via buffers."
         );
         buf.clear();
         input.seek(SeekFrom::End(-1)).unwrap();

--- a/src/thread/sched.rs
+++ b/src/thread/sched.rs
@@ -163,15 +163,15 @@ pub fn sched_getcpu() -> usize {
 /// `sched_getcpu()`—Get the CPU and NUMA node that the current thread is currently on.
 ///
 /// # Example
-/// 
+///
 /// ```rust
 /// use rustix::thread::getcpu;
-/// 
+///
 /// let (core, numa_node) = getcpu();
-/// 
+///
 /// println!("The current thread was on the {core} core and {numa_node} numa node.");
 /// ```
-/// 
+///
 /// # References
 ///  - [Linux]
 ///

--- a/src/thread/sched.rs
+++ b/src/thread/sched.rs
@@ -11,8 +11,8 @@ use core::{fmt, hash};
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man3/CPU_SET.3.html
-/// [`sched_setaffinity`]: crate::thread::sched_setaffinity
-/// [`sched_getaffinity`]: crate::thread::sched_getaffinity
+/// [`sched_setaffinity`]: sched_setaffinity
+/// [`sched_getaffinity`]: sched_getaffinity
 #[repr(transparent)]
 #[derive(Clone, Copy)]
 pub struct CpuSet {
@@ -158,4 +158,26 @@ pub fn sched_getaffinity(pid: Option<Pid>) -> io::Result<CpuSet> {
 #[inline]
 pub fn sched_getcpu() -> usize {
     backend::thread::syscalls::sched_getcpu()
+}
+
+/// `sched_getcpu()`—Get the CPU and NUMA node that the current thread is currently on.
+///
+/// # Example
+/// 
+/// ```rust
+/// use rustix::thread::getcpu;
+/// 
+/// let (core, numa_node) = getcpu();
+/// 
+/// println!("The current thread was on the {core} core and {numa_node} numa node.");
+/// ```
+/// 
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/getcpu.2.html
+#[cfg(linux_kernel)]
+#[inline]
+pub fn getcpu() -> (usize, usize) {
+    backend::thread::syscalls::getcpu()
 }


### PR DESCRIPTION
Not much time ago I needed to get a NUMA node of the current thread. Linux provides the `getcpu` system call for it. But I did not find any Rust library that provides this function. I read this repository code, and I like what you are doing, so I want to  help you to extend the functionality of this library. 

I implemented the `getcpu` syscall for Linux only. Also, I develop with WSL, which adds \r\n at the end of lines, so I patched tests for not reading the end of lines.