### PR TITLE
Rustix for android, part deux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -915,3 +915,75 @@ jobs:
         cargo test --verbose --features=all-apis --release --workspace -- --nocapture
       env:
         RUST_BACKTRACE: full
+
+  meson-musl:
+    name: Meson Musl
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: stable
+    - name: Install target
+      run: rustup target add x86_64-unknown-linux-musl
+    - name: Install Meson and Ninja
+      run: sudo apt-get update && sudo apt-get install -y meson ninja-build musl-tools
+    - name: Create cross file
+      run: |
+        cat <<EOF > cross_file_musl_ci.txt
+        [binaries]
+        c = 'gcc'
+        rust = ['rustc', '--target', 'x86_64-unknown-linux-musl']
+
+        [host_machine]
+        system = 'linux'
+        cpu_family = 'x86_64'
+        cpu = 'x86_64'
+        endian = 'little'
+        EOF
+    - name: Meson setup
+      run: meson setup build-musl --cross-file cross_file_musl_ci.txt
+    - name: Meson compile
+      run: meson compile -C build-musl
+
+  meson-android:
+    name: Meson Android
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: stable
+    - name: Install target
+      run: rustup target add x86_64-linux-android
+    - name: Install Meson and Ninja
+      run: sudo apt-get update && sudo apt-get install -y meson ninja-build
+    - name: Setup NDK
+      uses: nttld/setup-ndk@v1
+      id: setup-ndk
+      with:
+        ndk-version: r27b
+    - name: Create cross file
+      run: |
+        cat <<EOF > cross_file_android_ci.txt
+        [binaries]
+        c = '${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android30-clang'
+        cpp = '${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android30-clang++'
+        ar = '${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar'
+        strip = '${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip'
+        rust = ['rustc', '--target', 'x86_64-linux-android']
+
+        [host_machine]
+        system = 'android'
+        cpu_family = 'x86_64'
+        cpu = 'x86_64'
+        endian = 'little'
+        EOF
+    - name: Meson setup
+      run: meson setup build-android --cross-file cross_file_android_ci.txt
+    - name: Meson compile
+      run: meson compile -C build-android

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,46 @@
+# Copyright © 2026 Google
+# SPDX-License-Identifier: MIT
+
+project(
+  'rustix',
+  'rust',
+  version : '1.1.4',
+  license : 'Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT',
+)
+
+dep_errno = dependency('errno-0.3-rs', fallback: ['errno-0.3-rs', 'dep_errno'])
+dep_libc = dependency('libc-0.2-rs', fallback: ['libc-0.2-rs', 'dep_libc'])
+dep_bitflags = dependency('bitflags-2-rs', fallback: ['bitflags-2-rs', 'dep_bitflags'])
+
+rustix_args = [
+  '--cfg', 'libc',
+  '--cfg', 'feature="use-libc"',
+]
+
+os_deps = []
+if host_machine.system() == 'linux' or host_machine.system() == 'android'
+  rustix_args += [
+  '--cfg', 'linux_like',
+  '--cfg', 'linux_kernel',
+  '--cfg', 'feature="std"',
+  '--cfg', 'feature="alloc"',
+  '--cfg', 'feature="event"',
+  '--cfg', 'feature="fs"',
+  '--cfg', 'feature="mm"',
+  '--cfg', 'feature="net"',
+  '--cfg', 'feature="param"',
+  '--cfg', 'feature="pipe"',
+  '--cfg', 'feature="thread"',
+]
+elif host_machine.system() == 'windows'
+  os_deps += [dependency('windows-sys-0.6-rs', fallback: ['windows-sys-0.6-rs', 'dep_windows_sys'])]
+endif
+
+lib = static_library(
+  'rustix',
+  'src/lib.rs',
+  override_options : ['rust_std=2021', 'build.rust_std=2021'],
+  dependencies : [dep_errno, dep_libc, dep_bitflags] + os_deps,
+  rust_abi : 'rust',
+  rust_args: rustix_args,
+)

--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -515,6 +515,16 @@ pub(crate) use statx_flags::*;
 #[cfg(target_os = "android")]
 pub(crate) use __fsid_t as fsid_t;
 
+// Android's libc crate is missing some constants.
+// TODO(https://github.com/bytecodealliance/rustix/issues/1589): try to upstream these
+// constants to libc.
+#[cfg(target_os = "android")]
+pub(crate) const CLONE_NEWTIME: c_int = 0x00000080;
+#[cfg(target_os = "android")]
+pub(crate) const FUTEX_WAITERS: u32 = 0x80000000;
+#[cfg(target_os = "android")]
+pub(crate) const FUTEX_OWNER_DIED: u32 = 0x40000000;
+
 // FreeBSD added `timerfd_*` in FreeBSD 14. NetBSD added then in NetBSD 10.
 #[cfg(all(feature = "time", any(target_os = "freebsd", target_os = "netbsd")))]
 syscall!(pub(crate) fn timerfd_create(

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -2071,10 +2071,10 @@ pub(crate) fn statx(
     // doesn't represent all the known flags.
     //
     // [it's deprecated]: https://patchwork.kernel.org/project/linux-fsdevel/patch/20200505095915.11275-7-mszeredi@redhat.com/
-    #[cfg(any(not(linux_raw_dep), not(target_env = "musl")))]
+    #[cfg(not(target_env = "musl"))]
     const STATX__RESERVED: u32 = c::STATX__RESERVED as u32;
     #[cfg(target_env = "musl")]
-    const STATX__RESERVED: u32 = linux_raw_sys::general::STATX__RESERVED;
+    const STATX__RESERVED: u32 = 0x80000000;
     if (mask.bits() & STATX__RESERVED) == STATX__RESERVED {
         return Err(io::Errno::INVAL);
     }

--- a/src/backend/libc/thread/futex.rs
+++ b/src/backend/libc/thread/futex.rs
@@ -17,6 +17,16 @@ bitflags::bitflags! {
     }
 }
 
+// TODO(https://github.com/bytecodealliance/rustix/issues/1589): try to upstream these
+// constants to libc.
+const FUTEX2_SIZE_U8: u32 = 0;
+const FUTEX2_SIZE_U16: u32 = 1;
+const FUTEX2_SIZE_U32: u32 = 2;
+const FUTEX2_SIZE_U64: u32 = 3;
+const FUTEX2_SIZE_MASK: u32 = 3;
+const FUTEX2_NUMA: u32 = 4;
+const FUTEX2_PRIVATE: u32 = 128;
+
 bitflags::bitflags! {
     /// `FUTEX2_*` flags for use with the functions in [`Waitv`].
     ///
@@ -29,22 +39,19 @@ bitflags::bitflags! {
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct WaitFlags: u32 {
         /// `FUTEX_U8`
-        const SIZE_U8 = linux_raw_sys::general::FUTEX2_SIZE_U8;
+        const SIZE_U8 = FUTEX2_SIZE_U8;
         /// `FUTEX_U16`
-        const SIZE_U16 = linux_raw_sys::general::FUTEX2_SIZE_U16;
+        const SIZE_U16 = FUTEX2_SIZE_U16;
         /// `FUTEX_U32`
-        const SIZE_U32 = linux_raw_sys::general::FUTEX2_SIZE_U32;
+        const SIZE_U32 = FUTEX2_SIZE_U32;
         /// `FUTEX_U64`
-        const SIZE_U64 = linux_raw_sys::general::FUTEX2_SIZE_U64;
+        const SIZE_U64 = FUTEX2_SIZE_U64;
         /// `FUTEX_SIZE_MASK`
-        const SIZE_MASK = linux_raw_sys::general::FUTEX2_SIZE_MASK;
-
+        const SIZE_MASK = FUTEX2_SIZE_MASK;
         /// `FUTEX2_NUMA`
-        const NUMA = linux_raw_sys::general::FUTEX2_NUMA;
-
+        const NUMA = FUTEX2_NUMA;
         /// `FUTEX2_PRIVATE`
-        const PRIVATE = linux_raw_sys::general::FUTEX2_PRIVATE;
-
+        const PRIVATE = FUTEX2_PRIVATE;
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
         const _ = !0;
     }
@@ -85,7 +92,7 @@ pub(crate) enum Operation {
 }
 
 /// `FUTEX_WAITERS`
-pub const WAITERS: u32 = linux_raw_sys::general::FUTEX_WAITERS;
+pub const WAITERS: u32 = c::FUTEX_WAITERS;
 
 /// `FUTEX_OWNER_DIED`
-pub const OWNER_DIED: u32 = linux_raw_sys::general::FUTEX_OWNER_DIED;
+pub const OWNER_DIED: u32 = c::FUTEX_OWNER_DIED;

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -341,13 +341,13 @@ pub(crate) fn setns(fd: BorrowedFd<'_>, nstype: c::c_int) -> io::Result<c::c_int
     unsafe { ret_c_int(setns(borrowed_fd(fd), nstype)) }
 }
 
-#[cfg(linux_kernel)]
+#[cfg(all(linux_kernel, linux_raw_dep))]
 #[inline]
 pub(crate) unsafe fn unshare(flags: crate::thread::UnshareFlags) -> io::Result<()> {
     ret(c::unshare(flags.bits() as i32))
 }
 
-#[cfg(linux_kernel)]
+#[cfg(all(linux_kernel, linux_raw_dep))]
 #[inline]
 pub(crate) fn capget(
     header: &mut linux_raw_sys::general::__user_cap_header_struct,
@@ -369,7 +369,7 @@ pub(crate) fn capget(
     }
 }
 
-#[cfg(linux_kernel)]
+#[cfg(all(linux_kernel, linux_raw_dep))]
 #[inline]
 pub(crate) fn capset(
     header: &mut linux_raw_sys::general::__user_cap_header_struct,
@@ -477,6 +477,7 @@ pub(crate) unsafe fn futex_val2(
     let timeout = val2 as usize as *const Timespec;
 
     #[cfg(all(
+        linux_raw_dep,
         target_pointer_width = "32",
         not(any(target_arch = "aarch64", target_arch = "x86_64"))
     ))]
@@ -504,6 +505,16 @@ pub(crate) unsafe fn futex_val2(
             uaddr2,
             val3,
         ))
+    }
+
+    #[cfg(all(
+        not(linux_raw_dep),
+        target_pointer_width = "32",
+        not(any(target_arch = "aarch64", target_arch = "x86_64"))
+    ))]
+    {
+        let _ = (uaddr, op, flags, val, timeout, uaddr2, val3);
+        Err(io::Errno::NOSYS)
     }
 
     #[cfg(any(
@@ -548,6 +559,7 @@ pub(crate) unsafe fn futex_timeout(
     val3: u32,
 ) -> io::Result<usize> {
     #[cfg(all(
+        linux_raw_dep,
         target_pointer_width = "32",
         not(any(target_arch = "aarch64", target_arch = "x86_64"))
     ))]
@@ -585,6 +597,16 @@ pub(crate) unsafe fn futex_timeout(
         })
     }
 
+    #[cfg(all(
+        not(linux_raw_dep),
+        target_pointer_width = "32",
+        not(any(target_arch = "aarch64", target_arch = "x86_64"))
+    ))]
+    {
+        let _ = (uaddr, op, flags, val, timeout, uaddr2, val3);
+        Err(io::Errno::NOSYS)
+    }
+
     #[cfg(any(
         target_pointer_width = "64",
         target_arch = "aarch64",
@@ -618,6 +640,7 @@ pub(crate) unsafe fn futex_timeout(
 /// The raw pointers must point to valid aligned memory.
 #[cfg(linux_kernel)]
 #[cfg(all(
+    linux_raw_dep,
     target_pointer_width = "32",
     not(any(target_arch = "aarch64", target_arch = "x86_64"))
 ))]
@@ -666,8 +689,9 @@ pub(crate) fn futex_waitv(
     timeout: Option<&Timespec>,
     clockid: ClockId,
 ) -> io::Result<usize> {
+    use crate::backend::c::clockid_t;
     use futex::Wait as FutexWait;
-    use linux_raw_sys::general::__kernel_clockid_t as clockid_t;
+
     syscall! {
         fn futex_waitv(
             waiters: *const FutexWait,

--- a/src/fs/statx.rs
+++ b/src/fs/statx.rs
@@ -3,6 +3,7 @@
 use crate::fd::AsFd;
 use crate::fs::AtFlags;
 use crate::{backend, io, path};
+#[cfg(any(linux_raw_dep, not(target_env = "musl")))]
 use backend::c;
 use bitflags::bitflags;
 
@@ -274,4 +275,37 @@ mod compat {
             Err(io::Errno::NOSYS)
         }
     }
+}
+
+// These are the actual values for the constants, needed for the fallback implementation.
+// TODO(https://github.com/bytecodealliance/rustix/issues/1589): try to upstream these
+// constants to libc.
+#[cfg(all(not(linux_raw_dep), target_env = "musl"))]
+mod c {
+    pub const STATX_TYPE: u32 = 0x00000001;
+    pub const STATX_MODE: u32 = 0x00000002;
+    pub const STATX_NLINK: u32 = 0x00000004;
+    pub const STATX_UID: u32 = 0x00000008;
+    pub const STATX_GID: u32 = 0x00000010;
+    pub const STATX_ATIME: u32 = 0x00000020;
+    pub const STATX_MTIME: u32 = 0x00000040;
+    pub const STATX_CTIME: u32 = 0x00000080;
+    pub const STATX_INO: u32 = 0x00000100;
+    pub const STATX_SIZE: u32 = 0x00000200;
+    pub const STATX_BLOCKS: u32 = 0x00000400;
+    pub const STATX_BASIC_STATS: u32 = 0x000007ff;
+    pub const STATX_BTIME: u32 = 0x00000800;
+    pub const STATX_MNT_ID: u32 = 0x00001000;
+    pub const STATX_DIOALIGN: u32 = 0x00002000; // Deprecated, but here for completeness
+    pub const STATX_ALL: u32 = 0x00000fff; // Note: Doesn't include newer flags
+
+    pub const STATX_ATTR_COMPRESSED: u64 = 0x00000004;
+    pub const STATX_ATTR_IMMUTABLE: u64 = 0x00000010;
+    pub const STATX_ATTR_APPEND: u64 = 0x00000020;
+    pub const STATX_ATTR_NODUMP: u64 = 0x00000040;
+    pub const STATX_ATTR_ENCRYPTED: u64 = 0x00000800;
+    pub const STATX_ATTR_AUTOMOUNT: u64 = 0x00001000;
+    pub const STATX_ATTR_MOUNT_ROOT: u64 = 0x00020000;
+    pub const STATX_ATTR_VERITY: u64 = 0x00100000;
+    pub const STATX_ATTR_DAX: u64 = 0x00200000;
 }

--- a/src/test_macro.rs
+++ b/src/test_macro.rs
@@ -1,0 +1,3 @@
+use crate::ioctl_readwrite;
+
+fn main() {}

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -6,16 +6,16 @@ mod clock;
 pub mod futex;
 #[cfg(linux_kernel)]
 mod id;
-#[cfg(linux_kernel)]
+#[cfg(all(linux_kernel, linux_raw_dep))]
 mod libcap;
 #[cfg(linux_kernel)]
 mod membarrier;
-#[cfg(linux_kernel)]
+#[cfg(all(linux_kernel, linux_raw_dep))]
 mod prctl;
 #[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 mod sched;
 mod sched_yield;
-#[cfg(linux_kernel)]
+#[cfg(all(linux_kernel, linux_raw_dep))]
 mod setns;
 
 #[cfg(not(target_os = "redox"))]
@@ -25,13 +25,14 @@ pub use id::*;
 #[cfg(linux_kernel)]
 // #[expect(deprecated, reason = "CapabilityFlags is deprecated")]
 #[allow(deprecated)]
+#[cfg(all(linux_kernel, linux_raw_dep))]
 pub use libcap::{capabilities, set_capabilities, CapabilityFlags, CapabilitySet, CapabilitySets};
 #[cfg(linux_kernel)]
 pub use membarrier::*;
-#[cfg(linux_kernel)]
+#[cfg(all(linux_kernel, linux_raw_dep))]
 pub use prctl::*;
 #[cfg(any(freebsdlike, linux_kernel, target_os = "fuchsia"))]
 pub use sched::*;
 pub use sched_yield::sched_yield;
-#[cfg(linux_kernel)]
+#[cfg(all(linux_kernel, linux_raw_dep))]
 pub use setns::*;

--- a/subprojects/bitflags-2-rs.wrap
+++ b/subprojects/bitflags-2-rs.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = bitflags-2.9.1
+source_url = https://crates.io/api/v1/crates/bitflags/2.9.1/download
+source_filename = bitflags-2.9.1.tar.gz
+source_hash = 1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967
+patch_directory = bitflags-2-rs

--- a/subprojects/errno-0.3-rs.wrap
+++ b/subprojects/errno-0.3-rs.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = errno-0.3.12
+source_url = https://crates.io/api/v1/crates/errno/0.3.12/download
+source_filename = errno-0.3.12.tar.gz
+source_hash = cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18
+patch_directory = errno-0.3-rs

--- a/subprojects/libc-0.2-rs.wrap
+++ b/subprojects/libc-0.2-rs.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = libc-0.2.177
+source_url = https://crates.io/api/v1/crates/libc/0.2.177/download
+source_filename = libc-0.2.177.tar.gz
+source_hash = 2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976
+patch_directory = libc-0.2-rs

--- a/subprojects/packagefiles/bitflags-2-rs/meson.build
+++ b/subprojects/packagefiles/bitflags-2-rs/meson.build
@@ -1,0 +1,21 @@
+# Copyright © 2026 Google
+# SPDX-License-Identifier: MIT
+
+project(
+  'bitflags',
+  'rust',
+  version : '2.9.1',
+  license : 'MIT OR Apache-2.0',
+  meson_version : '>= 1.3.0',
+)
+
+lib = static_library(
+  'bitflags',
+  'src/lib.rs',
+  override_options : ['rust_std=2021', 'build.rust_std=2021', 'warning_level=0'],
+  rust_abi : 'rust',
+)
+
+dep_bitflags = declare_dependency(
+  link_with : [lib]
+)

--- a/subprojects/packagefiles/errno-0.3-rs/meson.build
+++ b/subprojects/packagefiles/errno-0.3-rs/meson.build
@@ -1,0 +1,28 @@
+# Copyright © 2026 Google
+# SPDX-License-Identifier: MIT
+
+project(
+  'errno',
+  'rust',
+  version : '0.3.12',
+  license : 'MIT OR Apache-2.0',
+  meson_version : '>= 1.3.0',
+)
+
+os_deps = []
+libc = subproject('libc-0.2-rs').get_variable('lib')
+if host_machine.system() == 'windows'
+  os_deps += subproject('windows-sys-0.6-rs').get_variable('lib')
+endif
+
+lib = static_library(
+  'libc_errno',
+  'src/lib.rs',
+  override_options : ['rust_std=2018', 'build.rust_std=2018', 'warning_level=0'],
+  link_with: [libc] + os_deps,
+  rust_abi : 'rust',
+)
+
+dep_errno = declare_dependency(
+  link_with : [lib]
+)

--- a/subprojects/packagefiles/libc-0.2-rs/meson.build
+++ b/subprojects/packagefiles/libc-0.2-rs/meson.build
@@ -1,0 +1,42 @@
+# Copyright © 2026 Google
+# SPDX-License-Identifier: MIT
+
+project(
+  'libc',
+  'rust',
+  version : '0.2.177',
+  license : 'MIT OR Apache-2.0',
+  meson_version : '>= 1.3.0',
+)
+
+libc_args = [
+  '--cfg', 'feature="default"',
+  '--cfg', 'feature="extra_traits"',
+  '--cfg', 'feature="std"',
+  '--cfg', 'freebsd11',
+  '--cfg', 'libc_align',
+  '--cfg', 'libc_cfg_target_vendor',
+  '--cfg', 'libc_const_extern_fn',
+  '--cfg', 'libc_const_size_of',
+  '--cfg', 'libc_core_cvoid',
+  '--cfg', 'libc_int128',
+  '--cfg', 'libc_long_array',
+  '--cfg', 'libc_non_exhaustive',
+  '--cfg', 'libc_packedN',
+  '--cfg', 'libc_priv_mod_use',
+  '--cfg', 'libc_ptr_addr_of',
+  '--cfg', 'libc_underscore_const_names',
+  '--cfg', 'libc_union',
+]
+
+lib = static_library(
+  'libc',
+  'src/lib.rs',
+  rust_abi : 'rust',
+  override_options : ['rust_std=2021', 'build.rust_std=2021', 'warning_level=0'],
+  rust_args: libc_args,
+)
+
+dep_libc = declare_dependency(
+  link_with : [lib]
+)


### PR DESCRIPTION
    rustix: add Meson build to CI to guard Android use cases
    
    Rustix has gone back-and-forth on it's policy on Android.
    Android platform developers don't want a dependency on
    linux-raw-sys.  This is documented here:
    
      https://github.com/bytecodealliance/rustix/issues/1095
      https://github.com/bytecodealliance/rustix/pull/1478
      https://github.com/rust-vsock/vsock-rs/pull/60
    
    Android app developers seem to want to use linux-raw-sys though:
    
    https://github.com/bytecodealliance/rustix/pull/1528
    
    The Android platform developers don't REALLY care about
    the cargo build though.
    
    CI/CD testing on the particular build options Android likes
    is useful.
    
    This MR adds another non-cargo build system (Meson) to the
    CI/CD, that mirrors the options Android likes.
    
    Meson is renowned for being a easy-to-maintain build system.
    
    By adding it here, we ensure the continue use of Rustix in
    core Android platform code.
