### PR TITLE
Define flags `AT_STATX_*` for Linux musl 1.2.3

### DIFF
--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -67,15 +67,15 @@ bitflags! {
         const RESOLVE_BENEATH = bitcast!(c::AT_RESOLVE_BENEATH);
 
         /// `AT_STATX_SYNC_AS_STAT`
-        #[cfg(all(target_os = "linux", target_env = "gnu"))]
+        #[cfg(all(target_os = "linux", any(target_env = "gnu", target_arch = "loongarch64")))]
         const STATX_SYNC_AS_STAT = bitcast!(c::AT_STATX_SYNC_AS_STAT);
 
         /// `AT_STATX_FORCE_SYNC`
-        #[cfg(all(target_os = "linux", target_env = "gnu"))]
+        #[cfg(all(target_os = "linux", any(target_env = "gnu", target_arch = "loongarch64")))]
         const STATX_FORCE_SYNC = bitcast!(c::AT_STATX_FORCE_SYNC);
 
         /// `AT_STATX_DONT_SYNC`
-        #[cfg(all(target_os = "linux", target_env = "gnu"))]
+        #[cfg(all(target_os = "linux", any(target_env = "gnu", target_arch = "loongarch64")))]
         const STATX_DONT_SYNC = bitcast!(c::AT_STATX_DONT_SYNC);
 
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>


### PR DESCRIPTION
libc flags: https://github.com/rust-lang/libc/blob/e879ee90b6cd8f79b352d4d4d1f8ca05f94f2f53/src/unix/linux_like/mod.rs#L1618-L1621