### PR TITLE
deps: update for direct-minimal-versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ mostly-unused = true
 bitflags = { version = "2.4.0", default-features = false }
 
 # Special dependencies used in rustc-dep-of-std mode.
-core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
-rustc-std-workspace-alloc = { version = "1.0.0", optional = true } # not aliased here but in lib.rs because of name collision with the alloc feature
+core = { version = "1.0.1", optional = true, package = "rustc-std-workspace-core" }
+rustc-std-workspace-alloc = { version = "1.0.1", optional = true } # not aliased here but in lib.rs because of name collision with the alloc feature
 
 # Dependencies for platforms where linux_raw is supported, in addition to libc:
 #
@@ -69,7 +69,7 @@ default-features = false
 
 [dev-dependencies]
 tempfile = "3.5.0"
-libc = "0.2.171"
+libc = "0.2.182"
 libc_errno = { package = "errno", version = "0.3.10", default-features = false }
 serial_test = "2.0.0"
 memoffset = "0.9.0"


### PR DESCRIPTION
Fix the build with [-Z direct-minimal-versions](https://doc.rust-lang.org/cargo/reference/unstable.html#direct-minimal-versions)