### PR TITLE
fix: remove unused asm_experimental_arch feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,7 +246,6 @@ check-cfg = [
     'cfg(alloc_c_string)',
     'cfg(alloc_ffi)',
     'cfg(apple)',
-    'cfg(asm_experimental_arch)',
     'cfg(bsd)',
     'cfg(core_c_str)',
     'cfg(core_ffi_c)',

--- a/build.rs
+++ b/build.rs
@@ -127,9 +127,6 @@ fn main() {
         // Use the linux_raw backend.
         use_feature("linux_raw_dep");
         use_feature("linux_raw");
-        if rustix_use_experimental_asm {
-            use_feature("asm_experimental_arch");
-        }
     }
 
     // Detect whether the compiler requires us to use thumb mode on ARM.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,6 @@
     any(feature = "rustc-dep-of-std", core_intrinsics),
     feature(core_intrinsics)
 )]
-#![cfg_attr(asm_experimental_arch, feature(asm_experimental_arch))]
 #![cfg_attr(not(feature = "all-apis"), allow(dead_code))]
 // It is common in Linux and libc APIs for types to vary between platforms.
 #![allow(clippy::unnecessary_cast)]


### PR DESCRIPTION
The latest nightly compiler complains about `unused_features`.

Closes https://github.com/bytecodealliance/rustix/issues/1602

cc: @sunfishcode