### PR TITLE
fix(ci): add pkg installation for ca_root_nss in FreeBSD 14 setup

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,6 +6,7 @@ task:
   freebsd_instance:
     image_family: freebsd-14-3
   setup_script:
+    - pkg install -y ca_root_nss # workaround for https://github.com/rust-lang/cargo/issues/16357
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh --default-toolchain stable -y --profile=minimal
     - . $HOME/.cargo/env


### PR DESCRIPTION
Install `ca_root_nss` package (Root certificate bundle from the Mozilla Project)

Fix https://github.com/bytecodealliance/rustix/issues/1597