### PR TITLE
termios: use fcntl(F_GETPATH) for ttyname on Apple platforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,12 +76,14 @@ jobs:
         cargo update --package=futures-executor --precise=0.3.31
         cargo update --package=futures-util --precise=0.3.31
         cargo update --package=futures-channel --precise=0.3.31
-        cargo update --package=futures-core --precise=0.3.31
-        cargo update --package=futures-io --precise=0.3.31
-        cargo update --package=futures-sink --precise=0.3.31
-        cargo update --package=futures-task --precise=0.3.31
+         cargo update --package=futures-core --precise=0.3.31
+         cargo update --package=futures-io --precise=0.3.31
+         cargo update --package=futures-sink --precise=0.3.31
+         cargo update --package=futures-task --precise=0.3.31
+         cargo update --package=libc --precise=0.2.182
 
     - run: >
+
         rustup target add
         x86_64-unknown-linux-musl
         x86_64-unknown-linux-gnux32
@@ -613,12 +615,14 @@ jobs:
         cargo update --package=futures-executor --precise=0.3.31
         cargo update --package=futures-util --precise=0.3.31
         cargo update --package=futures-channel --precise=0.3.31
-        cargo update --package=futures-core --precise=0.3.31
-        cargo update --package=futures-io --precise=0.3.31
-        cargo update --package=futures-sink --precise=0.3.31
-        cargo update --package=futures-task --precise=0.3.31
+         cargo update --package=futures-core --precise=0.3.31
+         cargo update --package=futures-io --precise=0.3.31
+         cargo update --package=futures-sink --precise=0.3.31
+         cargo update --package=futures-task --precise=0.3.31
+         cargo update --package=libc --precise=0.2.182
 
     - run: |
+
         cargo test --verbose --features=all-apis --release --workspace -- --nocapture
       env:
         RUST_BACKTRACE: full

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -521,6 +521,38 @@ pub(crate) fn isatty(fd: BorrowedFd<'_>) -> bool {
 #[cfg(feature = "alloc")]
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 pub(crate) fn ttyname(dirfd: BorrowedFd<'_>, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
+    // On Apple platforms, use `fcntl(F_GETPATH)` instead of `ttyname_r`.
+    //
+    // macOS's `ttyname_r` works by walking `/dev`, calling `stat` on each
+    // entry and comparing device and inode numbers until it finds a match.
+    // This directory scan can take several seconds on a typical macOS system.
+    //
+    // `fcntl(F_GETPATH)` is a Darwin-specific API that asks the kernel to
+    // fill a buffer with the path for any open file descriptor. It is a
+    // single kernel call and is dramatically faster.
+    //
+    // The Linux `linux_raw` backend uses an analogous approach, reading the
+    // path from `/proc/self/fd/<fd>` to avoid `ttyname_r` entirely.
+    #[cfg(apple)]
+    unsafe {
+        // `F_GETPATH` works on any open fd, not just ttys. Check `isatty`
+        // first so we return `ENOTTY` for non-terminal fds, matching the
+        // behavior of POSIX `ttyname`.
+        if !isatty(dirfd) {
+            return Err(io::Errno::NOTTY);
+        }
+
+        // From the macOS `fcntl(2)` man page: `F_GETPATH` requires a buffer
+        // of at least `MAXPATHLEN` bytes. `PATH_MAX` equals `MAXPATHLEN`.
+        if buf.len() < c::PATH_MAX as usize {
+            return Err(io::Errno::RANGE);
+        }
+
+        ret(c::fcntl(borrowed_fd(dirfd), c::F_GETPATH, buf.as_mut_ptr()))?;
+        Ok(CStr::from_ptr(buf.as_ptr().cast()).to_bytes().len())
+    }
+
+    #[cfg(not(apple))]
     unsafe {
         // `ttyname_r` returns its error status rather than using `errno`.
         match c::ttyname_r(borrowed_fd(dirfd), buf.as_mut_ptr().cast(), buf.len()) {


### PR DESCRIPTION
## Problem

On macOS, `rustix::termios::ttyname` calls `libc::ttyname_r`, which works by walking `/dev` and calling `stat` on each entry, comparing device and inode numbers until it finds a match. This directory scan can take several seconds on a typical macOS system, causing significant latency for any Rust program that calls `ttyname`.

This is a known macOS libc behavior. The slowness has been observed and reported in downstream crates (e.g. [doy/rbw#11](https://github.com/doy/rbw/issues/11)) that were forced to work around it by calling `fcntl(F_GETPATH)` directly rather than going through `rustix::termios::ttyname`.

## Solution

On Apple platforms, use `fcntl(F_GETPATH)` instead of `ttyname_r`. This is a Darwin-specific API that asks the kernel to fill a buffer with the filesystem path for any open file descriptor in a single kernel call, making it dramatically faster than the `/dev` scan.

The change is in `src/backend/libc/termios/syscalls.rs`, splitting the `ttyname` function into two `#[cfg]`-guarded branches:

- `#[cfg(apple)]`: uses `fcntl(F_GETPATH)`, with an explicit `isatty` check beforehand to preserve POSIX `ENOTTY` semantics for non-terminal fds
- `#[cfg(not(apple))]`: the existing `ttyname_r` path, unchanged

## Precedent in this codebase

This follows the same reasoning as the `linux_raw` backend, which already avoids `ttyname_r` entirely by reading the path from `/proc/self/fd/<fd>`. The `fcntl(F_GETPATH)` approach on Apple is the direct analogue.

Additionally, `fcntl(F_GETPATH)` is already used within rustix itself in `src/backend/libc/fs/syscalls.rs` (`fs::getpath`), so this is consistent with established patterns in the codebase.

## Testing

All existing `ttyname` tests pass:
- `ttyname::test_ttyname_ok` — verifies a tty fd returns a valid `/dev/...` path
- `ttyname::test_ttyname_not_tty` — verifies non-tty fds return `ENOTTY`

```
cargo test --features=all-apis
```