### PR TITLE
Avoid `feature(asm_experimental_arch)` on arches that don't need it.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,15 @@
     any(feature = "rustc-dep-of-std", core_intrinsics),
     feature(core_intrinsics)
 )]
-#![cfg_attr(asm_experimental_arch, feature(asm_experimental_arch))]
+#![cfg_attr(
+    all(
+        asm_experimental_arch,
+        not(target_arch = "s390x"),
+        not(target_arch = "powerpc"),
+        not(target_arch = "powerpc64")
+    ),
+    feature(asm_experimental_arch)
+)]
 #![cfg_attr(not(feature = "all-apis"), allow(dead_code))]
 // It is common in Linux and libc APIs for types to vary between platforms.
 #![allow(clippy::unnecessary_cast)]


### PR DESCRIPTION
Per rust-lang/rust#93335, inline asm is stablized on powerpc and s390x, so avoid using `feature(asm_experimental_arch)` on those architectures.