### PR TITLE
Fix debug printing of abstract socket addrs

### DIFF
--- a/src/backend/libc/net/addr.rs
+++ b/src/backend/libc/net/addr.rs
@@ -289,6 +289,9 @@ impl fmt::Debug for SocketAddrUnix {
         }
         #[cfg(linux_kernel)]
         if let Some(name) = self.abstract_name() {
+            if let Ok(s) = core::str::from_utf8(name) {
+                return s.fmt(f);
+            }
             return name.fmt(f);
         }
         "(unnamed)".fmt(f)

--- a/src/backend/linux_raw/net/addr.rs
+++ b/src/backend/linux_raw/net/addr.rs
@@ -235,6 +235,9 @@ impl fmt::Debug for SocketAddrUnix {
             return bytes.fmt(f);
         }
         if let Some(name) = self.abstract_name() {
+            if let Ok(s) = core::str::from_utf8(name) {
+                return s.fmt(f);
+            }
             return name.fmt(f);
         }
         "(unnamed)".fmt(f)


### PR DESCRIPTION
This avoids printing the byte array