### PR TITLE
feat: Add `fs::ioctl_ficlonerange` for FICLONERANGE

### DIFF
--- a/src/backend/linux_raw/c.rs
+++ b/src/backend/linux_raw/c.rs
@@ -63,7 +63,7 @@ pub(crate) use linux_raw_sys::general::{
     XATTR_REPLACE,
 };
 
-pub(crate) use linux_raw_sys::ioctl::{BLKPBSZGET, BLKSSZGET, FICLONE};
+pub(crate) use linux_raw_sys::ioctl::{BLKPBSZGET, BLKSSZGET, FICLONE, FICLONERANGE};
 #[cfg(target_pointer_width = "32")]
 pub(crate) use linux_raw_sys::ioctl::{FS_IOC32_GETFLAGS, FS_IOC32_SETFLAGS};
 #[cfg(target_pointer_width = "64")]

--- a/src/fs/ioctl.rs
+++ b/src/fs/ioctl.rs
@@ -12,7 +12,10 @@ use {
 use bitflags::bitflags;
 
 #[cfg(all(linux_kernel, not(any(target_arch = "sparc", target_arch = "sparc64"))))]
-use crate::fd::{AsRawFd as _, BorrowedFd};
+use {
+    crate::fd::{AsRawFd as _, BorrowedFd, OwnedFd},
+    core::marker::PhantomData,
+};
 
 /// `ioctl(fd, BLKSSZGET)`—Returns the logical block size of a block device.
 ///
@@ -57,6 +60,38 @@ pub fn ioctl_ficlone<Fd: AsFd, SrcFd: AsFd>(fd: Fd, src_fd: SrcFd) -> io::Result
     unsafe { ioctl::ioctl(fd, Ficlone(src_fd.as_fd())) }
 }
 
+/// `ioctl(fd, FICLONERANGE, ...)`—share some the data of one file with another file.
+///
+/// This ioctl is not available on SPARC platforms.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/ioctl_ficlonerange.2.html
+#[cfg(all(linux_kernel, not(any(target_arch = "sparc", target_arch = "sparc64"))))]
+#[inline]
+#[doc(alias = "FICLONERANGE")]
+pub fn ioctl_ficlonerange<Fd: AsFd, SrcFd: AsFd>(
+    fd: Fd,
+    src_fd: SrcFd,
+    src_offset: u64,
+    src_length: u64,
+    dest_offset: u64,
+) -> io::Result<()> {
+    unsafe {
+        ioctl::ioctl(
+            fd,
+            Ficlonerange {
+                src_fd: i64::from(src_fd.as_fd().as_raw_fd()),
+                src_offset,
+                src_length,
+                dest_offset,
+                _phantom: PhantomData,
+            },
+        )
+    }
+}
+
 /// `ioctl(fd, EXT4_IOC_RESIZE_FS, blocks)`—Resize ext4 filesystem on fd.
 #[cfg(linux_raw_dep)]
 #[inline]
@@ -84,6 +119,39 @@ unsafe impl ioctl::Ioctl for Ficlone<'_> {
 
     fn as_ptr(&mut self) -> *mut c::c_void {
         self.0.as_raw_fd() as *mut c::c_void
+    }
+
+    unsafe fn output_from_ptr(
+        _: ioctl::IoctlOutput,
+        _: *mut c::c_void,
+    ) -> io::Result<Self::Output> {
+        Ok(())
+    }
+}
+
+#[cfg(all(linux_kernel, not(any(target_arch = "sparc", target_arch = "sparc64"))))]
+#[repr(C)]
+struct Ficlonerange<'a> {
+    // Since `src_fd` must be 64-bit, we cannot use `BorrowedFd` like we do in `Ficlone`.
+    src_fd: i64,
+    src_offset: u64,
+    src_length: u64,
+    dest_offset: u64,
+    _phantom: PhantomData<&'a OwnedFd>,
+}
+
+#[cfg(all(linux_kernel, not(any(target_arch = "sparc", target_arch = "sparc64"))))]
+unsafe impl ioctl::Ioctl for Ficlonerange<'_> {
+    type Output = ();
+
+    const IS_MUTATING: bool = false;
+
+    fn opcode(&self) -> ioctl::Opcode {
+        c::FICLONERANGE as ioctl::Opcode
+    }
+
+    fn as_ptr(&mut self) -> *mut c::c_void {
+        self as *mut Self as *mut c::c_void
     }
 
     unsafe fn output_from_ptr(

--- a/tests/fs/ioctl.rs
+++ b/tests/fs/ioctl.rs
@@ -23,3 +23,60 @@ fn test_ioctl_ficlone() {
         Err(err) => panic!("{:?}", err),
     }
 }
+
+#[cfg(all(linux_kernel, not(any(target_arch = "sparc", target_arch = "sparc64"))))]
+#[test]
+fn test_ioctl_ficlonerange() {
+    use rustix::io;
+
+    let src = std::fs::File::open("Cargo.toml").unwrap();
+    let dest = tempfile::tempfile().unwrap();
+
+    // Often the temporary directory is on a different filesystem (like tmpfs),
+    // which means the test to clone some data doesn't do anything interesting,
+    // singe the ioctl simply returns failure.
+    // Uncomment the line below to use a file in the same directory as the source,
+    // which guarantees they are on the same filesystem.
+    // let dest = std::fs::File::options()
+    //     .create(true)
+    //     .truncate(true)
+    //     .read(true)
+    //     .write(true)
+    //     .open("test_ficlonerange").unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let dir = std::fs::File::open(dir.path()).unwrap();
+
+    // `src` isn't opened for writing, so passing it as the output fails.
+    assert_eq!(
+        rustix::fs::ioctl_ficlonerange(&src, &src, 0, 4096, 0),
+        Err(io::Errno::BADF)
+    );
+
+    // `FICLONERANGE` operates on regular files, not directories.
+    assert_eq!(
+        rustix::fs::ioctl_ficlonerange(&dir, &dir, 0, 4096, 0),
+        Err(io::Errno::ISDIR)
+    );
+
+    // Now try something that might succeed, though be prepared for filesystems
+    // that don't support this.
+    // Copy 4096 bytes from offset 4096 in src to offset 8192 in dest.
+    match rustix::fs::ioctl_ficlonerange(&dest, &src, 4096, 4096, 8192) {
+        Ok(()) => {
+            use std::os::unix::fs::FileExt;
+
+            let mut expected_buf = vec![0u8; 4096];
+            let mut actual_buf = vec![0u8; 4096];
+            src.read_exact_at(expected_buf.as_mut_slice(), 4096)
+                .unwrap();
+            dest.read_exact_at(actual_buf.as_mut_slice(), 8192).unwrap();
+
+            assert_eq!(expected_buf, actual_buf);
+        }
+
+        Err(io::Errno::OPNOTSUPP) => (),
+        Err(e) if e == io::Errno::from_raw_os_error(0x12) => (),
+        Err(err) => panic!("{:?}", err),
+    }
+}


### PR DESCRIPTION
Alongside `fs::ioctl_ficlone` for FICLONE, add support for the FICLONERANGE operation.

I have tested this on a local `btrfs` filesystem and I believe XFS with reflinks should support this too.

The existing `ioctl_ficlone` claimed that SPARC is not supported. I don't have a SPARC system to test on, but I'm assuming that if whole file cloning (reflinking) isn't supported on SPARC, then neither too would range cloning.
