### PR TITLE
build: Remove OUT_DIR probe artifact

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -195,6 +195,11 @@ fn main() {
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_USE_LIBC");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_RUSTC_DEP_OF_STD");
     println!("cargo:rerun-if-env-changed=CARGO_CFG_MIRI");
+
+    // Remove the can_compile() probe artifact so OUT_DIR ends up empty.
+    // The emitted metadata is not byte-reproducible, and a nondeterministic
+    // OUT_DIR destabilizes the cache keys of some build systems like Bazel.
+    let _ = std::fs::remove_file(probe_file());
 }
 
 fn use_static_assertions() -> bool {
@@ -231,6 +236,10 @@ fn has_feature(feature: &str) -> bool {
     ))
 }
 
+fn probe_file() -> PathBuf {
+    PathBuf::from(var("OUT_DIR").unwrap()).join("rustix_test_can_compile")
+}
+
 /// Test whether the rustc at `var("RUSTC")` can compile the given code.
 fn can_compile<T: AsRef<str>>(test: T) -> bool {
     use std::process::Stdio;
@@ -254,14 +263,12 @@ fn can_compile<T: AsRef<str>>(test: T) -> bool {
         std::process::Command::new(rustc)
     };
 
-    let out_dir = var("OUT_DIR").unwrap();
-    let out_file = PathBuf::from(out_dir).join("rustix_test_can_compile");
     cmd.arg("--crate-type=rlib") // Don't require `main`.
         .arg("--emit=metadata") // Do as little as possible but still parse.
         .arg("--target")
         .arg(target)
         .arg("-o")
-        .arg(out_file)
+        .arg(probe_file())
         .stdout(Stdio::null()); // We don't care about the output (only whether it builds or not)
 
     // If Cargo wants to set RUSTFLAGS, use that.


### PR DESCRIPTION
Remove the `can_compile()` probe artifact from `OUT_DIR` at the end of the build script, so `OUT_DIR` ends up empty after the script runs.

Where the probe output goes has gone back and forth:

- #1200 (2024): moved the output out of `OUT_DIR` (`-o -`) because the emitted `.rmeta` is not byte-reproducible and destabilizes cache keys in build systems that capture `OUT_DIR` as a build output (e.g. Bazel).
- #1497 (2025): `-o -` made rustc create a temporary metadata directory in the current working directory, which broke sandboxed builds (ChromeOS Portage), so the output moved to `std::env::temp_dir()`.
- #1526 (2025): writing to the global temp dir left stray files on the host, so the output moved back into `OUT_DIR`, which reintroduced the nondeterminism that #1200 fixed.

Writing the probe to `OUT_DIR` and deleting it before the script exits satisfies all three constraints: no nondeterministic content left in `OUT_DIR`, no writes to the working directory, and no clutter in the system temp dir.