### PR TITLE
Fix current-nightly CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -617,7 +617,7 @@ jobs:
         cargo update --package=futures-task --precise=0.3.31
 
     - run: |
-        cargo test --verbose --features=all-apis --release --workspace -- --nocapture
+        cargo test --config 'patch.crates-io.rustix.path="."' --verbose --features=all-apis --release --workspace -- --nocapture
       env:
         RUST_BACKTRACE: full
         MACOSX_DEPLOYMENT_TARGET: 10.7

--- a/.github/workflows/test-users.yml
+++ b/.github/workflows/test-users.yml
@@ -2014,4 +2014,4 @@ jobs:
     - run: cd rust && ./x.py test library/std --stage=0
       # See <https://github.com/bytecodealliance/rustix/issues/76#issuecomment-962196433>
       env:
-        RUSTFLAGS: --cfg=linux_raw --cfg=asm --cfg=rustc_attrs
+        RUSTFLAGS: --cfg=linux_raw --cfg=asm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,6 +256,7 @@ check-cfg = [
     'cfg(error_in_core)',
     'cfg(fix_y2038)',
     'cfg(freebsdlike)',
+    'cfg(ip)',
     'cfg(libc)',
     'cfg(linux_kernel)',
     'cfg(linux_like)',

--- a/build.rs
+++ b/build.rs
@@ -62,10 +62,15 @@ fn main() {
     // If experimental features are enabled, auto-detect and use available
     // features.
     if rustc_dep_of_std {
-        use_feature("rustc_attrs");
+        if has_rustc_attrs() {
+            use_feature("rustc_attrs");
+        }
         use_feature("core_intrinsics");
+        use_feature_if_no_warnings("ip");
     } else if rustix_use_experimental_features {
-        use_feature_or_nothing("rustc_attrs");
+        if has_rustc_attrs() {
+            use_feature("rustc_attrs");
+        }
         use_feature_or_nothing("core_intrinsics");
     }
 
@@ -203,8 +208,26 @@ fn has_lower_upper_exp_for_non_zero() -> bool {
     can_compile("fn a(x: &core::num::NonZeroI32, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result { core::fmt::LowerExp::fmt(x, f) }")
 }
 
+fn has_rustc_attrs() -> bool {
+    can_compile(
+        "#![feature(rustc_attrs)]
+         #![allow(internal_features)]
+         #![allow(dead_code)]
+         #[rustc_layout_scalar_valid_range_start(1)]
+         #[rustc_layout_scalar_valid_range_end(10)]
+         #[rustc_nonnull_optimization_guaranteed]
+         pub struct Foo(u32);",
+    )
+}
+
 fn use_feature_or_nothing(feature: &str) {
     if has_feature(feature) {
+        use_feature(feature);
+    }
+}
+
+fn use_feature_if_no_warnings(feature: &str) {
+    if has_feature_without_warnings(feature) {
         use_feature(feature);
     }
 }
@@ -217,6 +240,15 @@ fn use_feature(feature: &str) {
 fn has_feature(feature: &str) -> bool {
     can_compile(format!(
         "#![allow(stable_features)]\n#![feature({})]",
+        feature
+    ))
+}
+
+/// Test whether the rustc at `var("RUSTC")` supports the given feature without
+/// warnings.
+fn has_feature_without_warnings(feature: &str) -> bool {
+    can_compile(format!(
+        "#![deny(warnings)]\n#![allow(stable_features)]\n#![feature({})]",
         feature
     ))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@
 #![allow(stable_features)]
 #![cfg_attr(linux_raw, deny(unsafe_code))]
 #![cfg_attr(rustc_attrs, feature(rustc_attrs))]
+#![cfg_attr(rustc_attrs, allow(internal_features))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(all(wasi_ext, target_os = "wasi", feature = "std"), feature(wasi_ext))]
 #![cfg_attr(core_ffi_c, feature(core_ffi_c))]
@@ -108,7 +109,7 @@
 #![cfg_attr(all(feature = "alloc", alloc_c_string), feature(alloc_c_string))]
 #![cfg_attr(all(feature = "alloc", alloc_ffi), feature(alloc_ffi))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "rustc-dep-of-std", feature(ip))]
+#![cfg_attr(ip, feature(ip))]
 #![cfg_attr(feature = "rustc-dep-of-std", allow(internal_features))]
 #![cfg_attr(
     any(feature = "rustc-dep-of-std", core_intrinsics),

--- a/tests/stdio/dup2_to_replace_stdio.rs
+++ b/tests/stdio/dup2_to_replace_stdio.rs
@@ -8,6 +8,8 @@ fn dup2_to_replace_stdio() {
     // separate process so that it doesn't interfere with the test harness.
     assert!(Command::new(env::var("CARGO").unwrap())
         .arg("run")
+        .arg("--config")
+        .arg(r#"patch.crates-io.rustix.path=".""#)
         .arg("--example")
         .arg("dup2_to_replace_stdio")
         .arg("--features")


### PR DESCRIPTION
Fixes the current nightly CI failures after `rustc_attrs`/`feature(ip)` behavior changed.

This is rebased on current `main` after #1594, so the previous Rust 1.63/libc pin work is gone.

Changes:
- Probe `rustc_attrs` before enabling it.
- Probe `feature(ip)` only when it is warning-clean.
- Stop forcing `--cfg=rustc_attrs` in the std test-user job.
- Patch crates.io `rustix` to the checkout in the all-apis/nested stdio test path.

Fixes #1620.

CI: https://github.com/bytecodealliance/rustix/actions/runs/28769170056
