### PR TITLE
Clean fsopen a bit & add support for `mount_setattr`

### DIFF
--- a/src/backend/libc/mount/syscalls.rs
+++ b/src/backend/libc/mount/syscalls.rs
@@ -266,3 +266,31 @@ pub(crate) fn fsconfig_create_excl(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
         ))
     }
 }
+
+#[cfg(linux_kernel)]
+pub(crate) fn mount_setattr(
+    fs_fd: BorrowedFd<'_>,
+    path: &CStr,
+    flags: super::types::MountSetAttrFlags,
+    attr: &super::types::MountAttr<'_>,
+) -> io::Result<()> {
+    syscall! {
+        fn mount_setattr(
+            dir_fd: c::c_int,
+            path: *const c::c_char,
+            flags: c::c_uint,
+            attr: *const c::mount_attr,
+            size: usize
+        ) via SYS_mount_setattr -> c::c_int
+    }
+
+    unsafe {
+        ret(mount_setattr(
+            borrowed_fd(fs_fd),
+            c_str(path),
+            flags.bits(),
+            &attr.raw,
+            core::mem::size_of_val(&attr.raw),
+        ))
+    }
+}

--- a/src/backend/libc/mount/types.rs
+++ b/src/backend/libc/mount/types.rs
@@ -161,40 +161,40 @@ bitflags! {
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MountAttrFlags: ffi::c_uint {
         /// `MOUNT_ATTR_RDONLY`
-        const MOUNT_ATTR_RDONLY = 0x0000_0001;
+        const MOUNT_ATTR_RDONLY =  c::MOUNT_ATTR_RDONLY as c::c_uint;
 
         /// `MOUNT_ATTR_NOSUID`
-        const MOUNT_ATTR_NOSUID = 0x0000_0002;
+        const MOUNT_ATTR_NOSUID = c::MOUNT_ATTR_NOSUID as c::c_uint;
 
         /// `MOUNT_ATTR_NODEV`
-        const MOUNT_ATTR_NODEV = 0x0000_0004;
+        const MOUNT_ATTR_NODEV = c::MOUNT_ATTR_NODEV as c::c_uint;
 
         /// `MOUNT_ATTR_NOEXEC`
-        const MOUNT_ATTR_NOEXEC = 0x0000_0008;
+        const MOUNT_ATTR_NOEXEC = c::MOUNT_ATTR_NOEXEC as c::c_uint;
 
         /// `MOUNT_ATTR__ATIME`
-        const MOUNT_ATTR__ATIME = 0x0000_0070;
+        const MOUNT_ATTR__ATIME = c::MOUNT_ATTR__ATIME as c::c_uint;
 
         /// `MOUNT_ATTR_RELATIME`
-        const MOUNT_ATTR_RELATIME = 0x0000_0000;
+        const MOUNT_ATTR_RELATIME = c::MOUNT_ATTR_RELATIME as c::c_uint;
 
         /// `MOUNT_ATTR_NOATIME`
-        const MOUNT_ATTR_NOATIME = 0x0000_0010;
+        const MOUNT_ATTR_NOATIME = c::MOUNT_ATTR_NOATIME as c::c_uint;
 
         /// `MOUNT_ATTR_STRICTATIME`
-        const MOUNT_ATTR_STRICTATIME = 0x0000_0020;
+        const MOUNT_ATTR_STRICTATIME =c::MOUNT_ATTR_STRICTATIME as c::c_uint;
 
         /// `MOUNT_ATTR_NODIRATIME`
-        const MOUNT_ATTR_NODIRATIME = 0x0000_0080;
+        const MOUNT_ATTR_NODIRATIME = c::MOUNT_ATTR_NODIRATIME as c::c_uint;
 
-        /// `MOUNT_ATTR_NOUSER`
-        const MOUNT_ATTR_IDMAP = 0x0010_0000;
+        /// `MOUNT_ATTR_IDMAP`
+        const MOUNT_ATTR_IDMAP = c::MOUNT_ATTR_IDMAP as c::c_uint;
 
-        /// `MOUNT_ATTR__ATIME_FLAGS`
-        const MOUNT_ATTR_NOSYMFOLLOW = 0x0020_0000;
+        /// `MOUNT_ATTR_NOSYMFOLLOW`
+        const MOUNT_ATTR_NOSYMFOLLOW = c::MOUNT_ATTR_NOSYMFOLLOW as c::c_uint;
 
-        /// `MOUNT_ATTR__ATIME_FLAGS`
-        const MOUNT_ATTR_SIZE_VER0 = 32;
+        /// `MOUNT_ATTR_SIZE_VER0`
+        const MOUNT_ATTR_SIZE_VER0 = c::MOUNT_ATTR_SIZE_VER0 as c::c_uint;
 
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
         const _ = !0;

--- a/src/backend/libc/mount/types.rs
+++ b/src/backend/libc/mount/types.rs
@@ -1,6 +1,12 @@
-use crate::backend::c;
-use crate::ffi;
+use core::marker::PhantomData;
+
 use bitflags::bitflags;
+
+use crate::{
+    backend::c,
+    fd::{AsRawFd, BorrowedFd},
+    ffi,
+};
 
 #[cfg(linux_kernel)]
 bitflags! {
@@ -154,9 +160,10 @@ pub(crate) enum FsConfigCmd {
 
 #[cfg(linux_kernel)]
 bitflags! {
-    /// `MOUNT_ATTR_*` constants for use with [`fsmount`].
+    /// `MOUNT_ATTR_*` constants for use with [`fsmount`] and [`mount_setattr`].
     ///
     /// [`fsmount`]: crate::mount::fsmount
+    /// [`mount_setattr`]: crate::mount::mount_setattr
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct MountAttrFlags: ffi::c_uint {
@@ -289,6 +296,104 @@ bitflags! {
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
         const _ = !0;
     }
+}
+
+#[cfg(linux_kernel)]
+bitflags! {
+    /// `AT_*` flags accepted by [`mount_setattr`].
+    ///
+    /// [`mount_setattr`]: crate::mount::mount_setattr
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+    pub struct MountSetAttrFlags: ffi::c_uint {
+        /// `AT_EMPTY_PATH`
+        const AT_EMPTY_PATH = c::AT_EMPTY_PATH as c::c_uint;
+
+        /// `AT_RECURSIVE`
+        const AT_RECURSIVE = c::AT_RECURSIVE as c::c_uint;
+
+        /// `AT_SYMLINK_NOFOLLOW`
+        const AT_SYMLINK_NOFOLLOW = c::AT_SYMLINK_NOFOLLOW as c::c_uint;
+
+        /// `AT_NO_AUTOMOUNT`
+        const AT_NO_AUTOMOUNT = c::AT_NO_AUTOMOUNT as c::c_uint;
+    }
+}
+
+/// `MOUNT_ATTR_*` flags that also carry a parameter.
+#[cfg(linux_kernel)]
+pub enum MountAttrParamFlags<'a> {
+    /// `MOUNT_ATTR_IDMAP`, which carries the descriptor of a user namespace.
+    IdMap(BorrowedFd<'a>),
+}
+
+#[cfg(linux_kernel)]
+impl<'a> MountAttrParamFlags<'a> {
+    fn apply(self, attr: MountAttr<'a>, operation: MountAttrOperation) -> MountAttr<'a> {
+        let mut raw = attr.raw;
+        let flags = match operation {
+            MountAttrOperation::Set => &mut raw.attr_set,
+            MountAttrOperation::Clear => &mut raw.attr_clr,
+        };
+
+        match self {
+            Self::IdMap(userns_fd) => {
+                *flags |=
+                    MountAttrFlags::from_bits_retain(c::MOUNT_ATTR_IDMAP as u32).bits() as u64;
+                raw.userns_fd = userns_fd.as_raw_fd() as u64;
+            }
+        }
+
+        MountAttr {
+            raw,
+            userns_fd: PhantomData::<BorrowedFd<'a>>,
+        }
+    }
+}
+
+/// `struct mount_attr`
+#[cfg(linux_kernel)]
+#[derive(Clone)]
+#[doc(alias = "mount_attr")]
+pub struct MountAttr<'a> {
+    pub(crate) raw: c::mount_attr,
+    userns_fd: PhantomData<BorrowedFd<'a>>,
+}
+
+#[cfg(linux_kernel)]
+impl<'a> MountAttr<'a> {
+    /// Create a `MountAttr` with the given simple fields.
+    pub fn new(
+        attr_set: MountAttrFlags,
+        attr_clr: MountAttrFlags,
+        propagation: MountPropagationFlags,
+    ) -> Self {
+        Self {
+            raw: c::mount_attr {
+                attr_set: attr_set.bits() as u64,
+                attr_clr: attr_clr.bits() as u64,
+                propagation: propagation.bits() as u64,
+                userns_fd: 0,
+            },
+            userns_fd: PhantomData,
+        }
+    }
+
+    /// Set a parameterized flag.
+    pub fn set_param_flag(self, param: MountAttrParamFlags<'a>) -> Self {
+        param.apply(self, MountAttrOperation::Set)
+    }
+
+    /// Clear a parameterized flag.
+    pub fn clear_param_flag(self, param: MountAttrParamFlags<'a>) -> Self {
+        param.apply(self, MountAttrOperation::Clear)
+    }
+}
+
+#[cfg(linux_kernel)]
+enum MountAttrOperation {
+    Set,
+    Clear,
 }
 
 #[cfg(linux_kernel)]

--- a/src/backend/libc/mount/types.rs
+++ b/src/backend/libc/mount/types.rs
@@ -187,9 +187,6 @@ bitflags! {
         /// `MOUNT_ATTR_NODIRATIME`
         const MOUNT_ATTR_NODIRATIME = c::MOUNT_ATTR_NODIRATIME as c::c_uint;
 
-        /// `MOUNT_ATTR_IDMAP`
-        const MOUNT_ATTR_IDMAP = c::MOUNT_ATTR_IDMAP as c::c_uint;
-
         /// `MOUNT_ATTR_NOSYMFOLLOW`
         const MOUNT_ATTR_NOSYMFOLLOW = c::MOUNT_ATTR_NOSYMFOLLOW as c::c_uint;
 

--- a/src/backend/libc/mount/types.rs
+++ b/src/backend/libc/mount/types.rs
@@ -190,9 +190,6 @@ bitflags! {
         /// `MOUNT_ATTR_NOSYMFOLLOW`
         const MOUNT_ATTR_NOSYMFOLLOW = c::MOUNT_ATTR_NOSYMFOLLOW as c::c_uint;
 
-        /// `MOUNT_ATTR_SIZE_VER0`
-        const MOUNT_ATTR_SIZE_VER0 = c::MOUNT_ATTR_SIZE_VER0 as c::c_uint;
-
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
         const _ = !0;
     }

--- a/src/backend/linux_raw/conv.rs
+++ b/src/backend/linux_raw/conv.rs
@@ -484,6 +484,14 @@ impl<'a, Num: ArgNumber> From<crate::backend::mount::types::MountAttrFlags> for 
 }
 
 #[cfg(feature = "mount")]
+impl<'a, Num: ArgNumber> From<crate::backend::mount::types::MountSetAttrFlags> for ArgReg<'a, Num> {
+    #[inline]
+    fn from(flags: crate::backend::mount::types::MountSetAttrFlags) -> Self {
+        c_uint(flags.bits())
+    }
+}
+
+#[cfg(feature = "mount")]
 impl<'a, Num: ArgNumber> From<crate::backend::mount::types::OpenTreeFlags> for ArgReg<'a, Num> {
     #[inline]
     fn from(flags: crate::backend::mount::types::OpenTreeFlags) -> Self {

--- a/src/backend/linux_raw/mount/syscalls.rs
+++ b/src/backend/linux_raw/mount/syscalls.rs
@@ -6,7 +6,7 @@
 #![allow(unsafe_code)]
 #![allow(clippy::undocumented_unsafe_blocks)]
 
-use crate::backend::conv::{ret, ret_owned_fd, slice, zero};
+use crate::backend::conv::{pass_usize, ret, ret_owned_fd, slice, zero};
 use crate::fd::{BorrowedFd, OwnedFd};
 use crate::ffi::CStr;
 use crate::io;
@@ -232,6 +232,25 @@ pub(crate) fn fsconfig_create_excl(fs_fd: BorrowedFd<'_>) -> io::Result<()> {
             zero(),
             zero(),
             zero()
+        ))
+    }
+}
+
+#[inline]
+pub(crate) fn mount_setattr(
+    fs_fd: BorrowedFd<'_>,
+    path: &CStr,
+    flags: super::types::MountSetAttrFlags,
+    attr: &super::types::MountAttr<'_>,
+) -> io::Result<()> {
+    unsafe {
+        ret(syscall_readonly!(
+            __NR_mount_setattr,
+            fs_fd,
+            path,
+            flags,
+            &attr.raw as *const linux_raw_sys::general::mount_attr,
+            pass_usize(core::mem::size_of_val(&attr.raw))
         ))
     }
 }

--- a/src/backend/linux_raw/mount/types.rs
+++ b/src/backend/linux_raw/mount/types.rs
@@ -182,9 +182,6 @@ bitflags! {
         /// `MOUNT_ATTR__ATIME_FLAGS`
         const MOUNT_ATTR_NOSYMFOLLOW = linux_raw_sys::general::MOUNT_ATTR_NOSYMFOLLOW;
 
-        /// `MOUNT_ATTR__ATIME_FLAGS`
-        const MOUNT_ATTR_SIZE_VER0 = linux_raw_sys::general::MOUNT_ATTR_SIZE_VER0;
-
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
         const _ = !0;
     }

--- a/src/backend/linux_raw/mount/types.rs
+++ b/src/backend/linux_raw/mount/types.rs
@@ -1,5 +1,11 @@
-use crate::ffi;
+use core::marker::PhantomData;
+
 use bitflags::bitflags;
+
+use crate::{
+    fd::{AsRawFd, BorrowedFd},
+    ffi,
+};
 
 bitflags! {
     /// `MS_*` constants for use with [`mount`].
@@ -278,6 +284,105 @@ bitflags! {
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
         const _ = !0;
     }
+}
+
+bitflags! {
+    /// `AT_*` flags accepted by [`mount_setattr`].
+    ///
+    /// [`mount_setattr`]: crate::mount::mount_setattr
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+    pub struct MountSetAttrFlags: ffi::c_uint {
+        /// `AT_EMPTY_PATH`
+        const AT_EMPTY_PATH = linux_raw_sys::general::AT_EMPTY_PATH;
+
+        /// `AT_RECURSIVE`
+        const AT_RECURSIVE = linux_raw_sys::general::AT_RECURSIVE;
+
+        /// `AT_SYMLINK_NOFOLLOW`
+        const AT_SYMLINK_NOFOLLOW = linux_raw_sys::general::AT_SYMLINK_NOFOLLOW;
+
+        /// `AT_NO_AUTOMOUNT`
+        const AT_NO_AUTOMOUNT = linux_raw_sys::general::AT_NO_AUTOMOUNT;
+    }
+}
+
+/// `MOUNT_ATTR_*` flags that also carry a parameter.
+#[cfg(linux_kernel)]
+pub enum MountAttrParamFlags<'a> {
+    /// `MOUNT_ATTR_IDMAP`, which carries the descriptor of a user namespace.
+    IdMap(BorrowedFd<'a>),
+}
+
+#[cfg(linux_kernel)]
+impl<'a> MountAttrParamFlags<'a> {
+    fn apply(self, attr: MountAttr<'a>, operation: MountAttrOperation) -> MountAttr<'a> {
+        let mut raw = attr.raw;
+        let flags = match operation {
+            MountAttrOperation::Set => &mut raw.attr_set,
+            MountAttrOperation::Clear => &mut raw.attr_clr,
+        };
+
+        match self {
+            Self::IdMap(userns_fd) => {
+                *flags |= MountAttrFlags::from_bits_retain(
+                    linux_raw_sys::general::MOUNT_ATTR_IDMAP as u32,
+                )
+                .bits() as u64;
+                raw.userns_fd = userns_fd.as_raw_fd() as u64;
+            }
+        }
+
+        MountAttr {
+            raw,
+            userns_fd: PhantomData::<BorrowedFd<'a>>,
+        }
+    }
+}
+
+/// `struct mount_attr`
+#[cfg(linux_kernel)]
+#[derive(Clone)]
+#[doc(alias = "mount_attr")]
+pub struct MountAttr<'a> {
+    pub(crate) raw: linux_raw_sys::general::mount_attr,
+    userns_fd: PhantomData<BorrowedFd<'a>>,
+}
+
+#[cfg(linux_kernel)]
+impl<'a> MountAttr<'a> {
+    /// Create a `MountAttr` with the given simple fields.
+    pub fn new(
+        attr_set: MountAttrFlags,
+        attr_clr: MountAttrFlags,
+        propagation: MountPropagationFlags,
+    ) -> Self {
+        Self {
+            raw: linux_raw_sys::general::mount_attr {
+                attr_set: attr_set.bits() as u64,
+                attr_clr: attr_clr.bits() as u64,
+                propagation: propagation.bits() as u64,
+                userns_fd: 0,
+            },
+            userns_fd: PhantomData,
+        }
+    }
+
+    /// Set a parameterized flag.
+    pub fn set_param_flag(self, param: MountAttrParamFlags<'a>) -> Self {
+        param.apply(self, MountAttrOperation::Set)
+    }
+
+    /// Clear a parameterized flag.
+    pub fn clear_param_flag(self, param: MountAttrParamFlags<'a>) -> Self {
+        param.apply(self, MountAttrOperation::Clear)
+    }
+}
+
+#[cfg(linux_kernel)]
+enum MountAttrOperation {
+    Set,
+    Clear,
 }
 
 bitflags! {

--- a/src/backend/linux_raw/mount/types.rs
+++ b/src/backend/linux_raw/mount/types.rs
@@ -179,9 +179,6 @@ bitflags! {
         /// `MOUNT_ATTR_NODIRATIME`
         const MOUNT_ATTR_NODIRATIME = linux_raw_sys::general::MOUNT_ATTR_NODIRATIME;
 
-        /// `MOUNT_ATTR_NOUSER`
-        const MOUNT_ATTR_IDMAP = linux_raw_sys::general::MOUNT_ATTR_IDMAP;
-
         /// `MOUNT_ATTR__ATIME_FLAGS`
         const MOUNT_ATTR_NOSYMFOLLOW = linux_raw_sys::general::MOUNT_ATTR_NOSYMFOLLOW;
 

--- a/src/mount/fsopen.rs
+++ b/src/mount/fsopen.rs
@@ -1,7 +1,8 @@
 //! `fsopen` and related functions in Linux's `mount` API.
 
 use crate::backend::mount::types::{
-    FsMountFlags, FsOpenFlags, FsPickFlags, MountAttrFlags, MoveMountFlags, OpenTreeFlags,
+    FsMountFlags, FsOpenFlags, FsPickFlags, MountAttr, MountAttrFlags, MountSetAttrFlags,
+    MoveMountFlags, OpenTreeFlags,
 };
 use crate::fd::{AsFd, OwnedFd};
 use crate::{backend, io, path};
@@ -243,4 +244,24 @@ pub fn fsconfig_reconfigure<Fd: AsFd>(fs_fd: Fd) -> io::Result<()> {
 #[doc(alias = "fsconfig")]
 pub fn fsconfig_create_exclusive<Fd: AsFd>(fs_fd: Fd) -> io::Result<()> {
     backend::mount::syscalls::fsconfig_create_excl(fs_fd.as_fd())
+}
+
+/// `mount_setattr(dirfd, path, flags, attr, size)`
+///
+/// This function was added in Linux 5.12.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/mount_setattr.2.html
+#[inline]
+pub fn mount_setattr<Fd: AsFd, Path: path::Arg>(
+    fs_fd: Fd,
+    path: Path,
+    flags: MountSetAttrFlags,
+    attr: MountAttr<'_>,
+) -> io::Result<()> {
+    path.into_with_c_str(|path| {
+        backend::mount::syscalls::mount_setattr(fs_fd.as_fd(), path, flags, &attr)
+    })
 }

--- a/src/mount/fsopen.rs
+++ b/src/mount/fsopen.rs
@@ -6,23 +6,23 @@ use crate::backend::mount::types::{
 use crate::fd::{AsFd, OwnedFd};
 use crate::{backend, io, path};
 
-/// `fsopen(fs_name, flags)`
+/// `fsopen(fsname, flags)`
 ///
 /// # References
-///  - [Unfinished draft]
+///  - [Linux]
 ///
-/// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsopen.md
+/// [Linux]: https://man7.org/linux/man-pages/man2/fsopen.2.html
 #[inline]
 pub fn fsopen<Fs: path::Arg>(fs_name: Fs, flags: FsOpenFlags) -> io::Result<OwnedFd> {
     fs_name.into_with_c_str(|fs_name| backend::mount::syscalls::fsopen(fs_name, flags))
 }
 
-/// `fsmount(fs_fd, flags, attr_flags)`
+/// `fsmount(fsfd, flags, attr_flags)`
 ///
 /// # References
-///  - [Unfinished draft]
+///  - [Linux]
 ///
-/// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsmount.md
+/// [Linux]: https://man7.org/linux/man-pages/man2/fsmount.2.html
 #[inline]
 pub fn fsmount<Fd: AsFd>(
     fs_fd: Fd,
@@ -32,16 +32,16 @@ pub fn fsmount<Fd: AsFd>(
     backend::mount::syscalls::fsmount(fs_fd.as_fd(), flags, attr_flags)
 }
 
-/// `move_mount(from_dfd, from_pathname, to_dfd, to_pathname, flags)`
+/// `move_mount(from_dirfd, from_path, to_dirfd, to_path, flags)`
 ///
 /// This is not the same as `mount` with the `MS_MOVE` flag. If you want to
 /// use that, use [`mount_move`] instead.
 ///
 /// # References
-///  - [Unfinished draft]
+///  - [Linux]
 ///
 /// [`mount_move`]: crate::mount::mount_move
-/// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/move_mount.md
+/// [Linux]: https://man7.org/linux/man-pages/man2/move_mount.2.html
 #[inline]
 pub fn move_mount<From: path::Arg, To: path::Arg, FromFd: AsFd, ToFd: AsFd>(
     from_dfd: FromFd,
@@ -65,12 +65,12 @@ pub fn move_mount<From: path::Arg, To: path::Arg, FromFd: AsFd, ToFd: AsFd>(
     })
 }
 
-/// `open_tree(dfd, filename, flags)`
+/// `open_tree(dirfd, path, flags)`
 ///
 /// # References
-///  - [Unfinished draft]
+///  - [Linux]
 ///
-/// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/open_tree.md
+/// [Linux]: https://man7.org/linux/man-pages/man2/open_tree.2.html
 #[inline]
 pub fn open_tree<Path: path::Arg, Fd: AsFd>(
     dfd: Fd,
@@ -81,12 +81,12 @@ pub fn open_tree<Path: path::Arg, Fd: AsFd>(
     filename.into_with_c_str(|filename| backend::mount::syscalls::open_tree(dfd, filename, flags))
 }
 
-/// `fspick(dfd, path, flags)`
+/// `fspick(dirfd, path, flags)`
 ///
 /// # References
-///  - [Unfinished draft]
+///  - [Linux]
 ///
-/// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fspick.md
+/// [Linux]: https://man7.org/linux/man-pages/man2/fspick.2.html
 #[inline]
 pub fn fspick<Path: path::Arg, Fd: AsFd>(
     dfd: Fd,
@@ -97,12 +97,12 @@ pub fn fspick<Path: path::Arg, Fd: AsFd>(
     path.into_with_c_str(|path| backend::mount::syscalls::fspick(dfd, path, flags))
 }
 
-/// `fsconfig(fs_fd, FSCONFIG_SET_FLAG, key, NULL, 0)`
+/// `fsconfig(fd, FSCONFIG_SET_FLAG, key, NULL, 0)`
 ///
 /// # References
-///  - [Unfinished draft]
+///  - [Linux]
 ///
-/// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
+/// [Linux]: https://man7.org/linux/man-pages/man2/fsconfig.2.html
 #[inline]
 #[doc(alias = "fsconfig")]
 pub fn fsconfig_set_flag<Key: path::Arg, Fd: AsFd>(fs_fd: Fd, key: Key) -> io::Result<()> {
@@ -110,12 +110,12 @@ pub fn fsconfig_set_flag<Key: path::Arg, Fd: AsFd>(fs_fd: Fd, key: Key) -> io::R
     key.into_with_c_str(|key| backend::mount::syscalls::fsconfig_set_flag(fs_fd, key))
 }
 
-/// `fsconfig(fs_fd, FSCONFIG_SET_STRING, key, value, 0)`
+/// `fsconfig(fd, FSCONFIG_SET_STRING, key, value, 0)`
 ///
 /// # References
-///  - [Unfinished draft]
+///  - [Linux]
 ///
-/// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
+/// [Linux]: https://man7.org/linux/man-pages/man2/fsconfig.2.html
 #[inline]
 #[doc(alias = "fsconfig")]
 pub fn fsconfig_set_string<Key: path::Arg, Value: path::Arg, Fd: AsFd>(
@@ -131,12 +131,12 @@ pub fn fsconfig_set_string<Key: path::Arg, Value: path::Arg, Fd: AsFd>(
     })
 }
 
-/// `fsconfig(fs_fd, FSCONFIG_SET_BINARY, key, value, value.len())`
+/// `fsconfig(fd, FSCONFIG_SET_BINARY, key, value, value.len())`
 ///
 /// # References
-///  - [Unfinished draft]
+///  - [Linux]
 ///
-/// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
+/// [Linux]: https://man7.org/linux/man-pages/man2/fsconfig.2.html
 #[inline]
 #[doc(alias = "fsconfig")]
 pub fn fsconfig_set_binary<Key: path::Arg, Fd: AsFd>(
@@ -148,12 +148,12 @@ pub fn fsconfig_set_binary<Key: path::Arg, Fd: AsFd>(
     key.into_with_c_str(|key| backend::mount::syscalls::fsconfig_set_binary(fs_fd, key, value))
 }
 
-/// `fsconfig(fs_fd, FSCONFIG_SET_PATH, key, path, fd)`
+/// `fsconfig(fd, FSCONFIG_SET_PATH, key, path, fd)`
 ///
 /// # References
-///  - [Unfinished draft]
+///  - [Linux]
 ///
-/// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
+/// [Linux]: https://man7.org/linux/man-pages/man2/fsconfig.2.html
 #[inline]
 #[doc(alias = "fsconfig")]
 pub fn fsconfig_set_path<Key: path::Arg, Path: path::Arg, Fd: AsFd, AuxFd: AsFd>(
@@ -171,12 +171,12 @@ pub fn fsconfig_set_path<Key: path::Arg, Path: path::Arg, Fd: AsFd, AuxFd: AsFd>
     })
 }
 
-/// `fsconfig(fs_fd, FSCONFIG_SET_PATH_EMPTY, key, "", fd)`
+/// `fsconfig(fd, FSCONFIG_SET_PATH_EMPTY, key, "", fd)`
 ///
 /// # References
-///  - [Unfinished draft]
+///  - [Linux]
 ///
-/// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
+/// [Linux]: https://man7.org/linux/man-pages/man2/fsconfig.2.html
 #[inline]
 #[doc(alias = "fsconfig")]
 pub fn fsconfig_set_path_empty<Key: path::Arg, Fd: AsFd, AuxFd: AsFd>(
@@ -189,12 +189,12 @@ pub fn fsconfig_set_path_empty<Key: path::Arg, Fd: AsFd, AuxFd: AsFd>(
     key.into_with_c_str(|key| backend::mount::syscalls::fsconfig_set_path_empty(fs_fd, key, fd))
 }
 
-/// `fsconfig(fs_fd, FSCONFIG_SET_FD, key, NULL, fd)`
+/// `fsconfig(fd, FSCONFIG_SET_FD, key, NULL, fd)`
 ///
 /// # References
-///  - [Unfinished draft]
+///  - [Linux]
 ///
-/// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
+/// [Linux]: https://man7.org/linux/man-pages/man2/fsconfig.2.html
 #[inline]
 #[doc(alias = "fsconfig")]
 pub fn fsconfig_set_fd<Key: path::Arg, Fd: AsFd, AuxFd: AsFd>(
@@ -207,38 +207,38 @@ pub fn fsconfig_set_fd<Key: path::Arg, Fd: AsFd, AuxFd: AsFd>(
     key.into_with_c_str(|key| backend::mount::syscalls::fsconfig_set_fd(fs_fd, key, fd))
 }
 
-/// `fsconfig(fs_fd, FSCONFIG_CMD_CREATE, key, NULL, 0)`
+/// `fsconfig(fd, FSCONFIG_CMD_CREATE, key, NULL, 0)`
 ///
 /// # References
-///  - [Unfinished draft]
+///  - [Linux]
 ///
-/// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
+/// [Linux]: https://man7.org/linux/man-pages/man2/fsconfig.2.html
 #[inline]
 #[doc(alias = "fsconfig")]
 pub fn fsconfig_create<Fd: AsFd>(fs_fd: Fd) -> io::Result<()> {
     backend::mount::syscalls::fsconfig_create(fs_fd.as_fd())
 }
 
-/// `fsconfig(fs_fd, FSCONFIG_CMD_RECONFIGURE, key, NULL, 0)`
+/// `fsconfig(fd, FSCONFIG_CMD_RECONFIGURE, key, NULL, 0)`
 ///
 /// # References
-///  - [Unfinished draft]
+///  - [Linux]
 ///
-/// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
+/// [Linux]: https://man7.org/linux/man-pages/man2/fsconfig.2.html
 #[inline]
 #[doc(alias = "fsconfig")]
 pub fn fsconfig_reconfigure<Fd: AsFd>(fs_fd: Fd) -> io::Result<()> {
     backend::mount::syscalls::fsconfig_reconfigure(fs_fd.as_fd())
 }
 
-/// `fsconfig(fs_fd, FSCONFIG_CMD_CREATE_EXCL, key, NULL, 0)`
+/// `fsconfig(fd, FSCONFIG_CMD_CREATE_EXCL, key, NULL, 0)`
 ///
 /// This function was added in Linux 6.6.
 ///
 /// # References
-///  - [Unfinished draft]
+///  - [Linux]
 ///
-/// [Unfinished draft]: https://github.com/sunfishcode/linux-mount-api-documentation/blob/main/fsconfig.md
+/// [Linux]: https://man7.org/linux/man-pages/man2/fsconfig.2.html
 #[inline]
 #[doc(alias = "fsconfig")]
 pub fn fsconfig_create_exclusive<Fd: AsFd>(fs_fd: Fd) -> io::Result<()> {


### PR DESCRIPTION
This is my attempt at supporting `mount_setattr`, taking into consideration the fact `struct mount_attr` is designed to be expandable, and that it currently borrows a user namespace's file descriptor. See discussions in  PR #1002 for more details.

The idea is to have a `MountAttr` struct that is a thin wrapper around `struct mount_attr`, that also manages lifetimes. The 
underlying type is not exposed: you can only set parameters via the constructor and setters.

While at it, I cleaned fsopen (and some related modules) a little. See the commit history.

Fixes #975.

## Test plan

```toml
[package]
name = "test"
version = "1.0.0"
rust-version = "1.63"
edition = "2021"

[dependencies]
rustix = { path = "/your/local/fork/of/rustix", features = [
    "mount",
    "linux_latest", # Or "use-libc" to test the other backend.
    "fs",
] }

```


```rust
use std::os::fd::AsFd;

use rustix::fs::{open, Mode, OFlags};
use rustix::io;
use rustix::mount::{
    mount_setattr, MountAttr, MountAttrFlags, MountPropagationFlags, MountSetAttrFlags,
};

// To create a test mount point, run:
// $ mkdir /tmp/testpoint
// # mount -t tmpfs tmpfs /tmp/testpoint

fn main() -> io::Result<()> {
    let dirfd = open("/tmp", OFlags::RDONLY | OFlags::DIRECTORY, Mode::empty())?;

    // Uncomment to test set_param_flag.
    // mount_setattr will return EINVAL, because this won't be a user namespace fd.
    // let fd = open("/dev/null", OFlags::RDONLY, Mode::empty())?;

    let attr = MountAttr::new(
        MountAttrFlags::MOUNT_ATTR_RDONLY,
        MountAttrFlags::empty(),
        MountPropagationFlags::empty(),
    );

    // Uncomment to test set_param_flag.
    // let attr = attr.set_param_flag(rustix::mount::MountAttrParamFlags::IdMap(fd.as_fd()));

    // Uncommenting this line gives a compilation error when set_param_flag is called.
    // drop(fd);

    mount_setattr(dirfd, "testpoint", MountSetAttrFlags::AT_RECURSIVE, attr)?;

    println!("/tmp/testpoint is now mounted read-only");
    Ok(())
}

```