### PR TITLE
Change the futex `timeout` argument to `u32`.

### DIFF
--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -468,14 +468,6 @@ pub(crate) unsafe fn futex_val2(
     uaddr2: *const AtomicU32,
     val3: u32,
 ) -> io::Result<usize> {
-    // Pass `val2` in the least-significant bytes of the `timeout` argument.
-    // [“the kernel casts the timeout value first to unsigned long, then to
-    // uint32_t”], so we perform that exact conversion in reverse to create
-    // the pointer.
-    //
-    // [“the kernel casts the timeout value first to unsigned long, then to uint32_t”]: https://man7.org/linux/man-pages/man2/futex.2.html
-    let timeout = val2 as usize as *const Timespec;
-
     #[cfg(all(
         target_pointer_width = "32",
         not(any(target_arch = "aarch64", target_arch = "x86_64"))
@@ -490,7 +482,7 @@ pub(crate) unsafe fn futex_val2(
                 uaddr: *const AtomicU32,
                 futex_op: c::c_int,
                 val: u32,
-                timeout: *const Timespec,
+                val2: u32,
                 uaddr2: *const AtomicU32,
                 val3: u32
             ) via SYS_futex_time64 -> c::ssize_t
@@ -500,7 +492,7 @@ pub(crate) unsafe fn futex_val2(
             uaddr,
             op as i32 | flags.bits() as i32,
             val,
-            timeout,
+            val2,
             uaddr2,
             val3,
         ))
@@ -517,7 +509,7 @@ pub(crate) unsafe fn futex_val2(
                 uaddr: *const AtomicU32,
                 futex_op: c::c_int,
                 val: u32,
-                timeout: *const Timespec,
+                val2: u32,
                 uaddr2: *const AtomicU32,
                 val3: u32
             ) via SYS_futex -> c::c_long
@@ -527,7 +519,7 @@ pub(crate) unsafe fn futex_val2(
             uaddr,
             op as i32 | flags.bits() as i32,
             val,
-            timeout.cast(),
+            val2,
             uaddr2,
             val3,
         ) as isize)

--- a/src/backend/linux_raw/thread/syscalls.rs
+++ b/src/backend/linux_raw/thread/syscalls.rs
@@ -213,14 +213,6 @@ pub(crate) unsafe fn futex_val2(
     uaddr2: *const AtomicU32,
     val3: u32,
 ) -> io::Result<usize> {
-    // Pass `val2` in the least-significant bytes of the `timeout` argument.
-    // [“the kernel casts the timeout value first to unsigned long, then to
-    // uint32_t”], so we perform that exact conversion in reverse to create
-    // the pointer.
-    //
-    // [“the kernel casts the timeout value first to unsigned long, then to uint32_t”]: https://man7.org/linux/man-pages/man2/futex.2.html
-    let timeout = val2 as usize as *const Timespec;
-
     #[cfg(target_pointer_width = "32")]
     {
         // Linux 5.1 added `futex_time64`; if we have that, use it. We don't
@@ -234,7 +226,7 @@ pub(crate) unsafe fn futex_val2(
                 uaddr,
                 (op, flags),
                 c_uint(val),
-                timeout,
+                c_uint(val2),
                 uaddr2,
                 c_uint(val3)
             ))
@@ -248,7 +240,7 @@ pub(crate) unsafe fn futex_val2(
                 uaddr,
                 (op, flags),
                 c_uint(val),
-                timeout,
+                c_uint(val2),
                 uaddr2,
                 c_uint(val3)
             ))
@@ -260,7 +252,7 @@ pub(crate) unsafe fn futex_val2(
         uaddr,
         (op, flags),
         c_uint(val),
-        timeout,
+        c_uint(val2),
         uaddr2,
         c_uint(val3)
     ))


### PR DESCRIPTION
The futex documentation has changed from documenting the `timeout` argument as being a `u32` value casted to a pointer to being a `...` argument.

So, change rustix to pass a `u32` argument instead of casting it to a pointer first. This also fixes miri errors about that cast.

Fixes #1627.