### PR TITLE
redox: Unmask most of `fs`, some of `time`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustc-std-workspace-alloc = { version = "1.0.0", optional = true } # not aliased
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_endian = "little", any(target_arch = "s390x", target_arch = "powerpc")), any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc"), all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "s390x"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
 linux-raw-sys = { version = "0.12", default-features = false, features = ["auxvec", "general", "errno", "ioctl", "no_std", "elf"] }
 libc_errno = { package = "errno", version = "0.3.10", default-features = false, optional = true }
-libc = { version = "0.2.182", default-features = false, optional = true }
+libc = { version = "0.2.186", default-features = false, optional = true }
 
 # Dependencies for platforms where only libc is supported:
 #
@@ -43,7 +43,7 @@ libc = { version = "0.2.182", default-features = false, optional = true }
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_endian = "little", any(target_arch = "s390x", target_arch = "powerpc")), any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc"), all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "s390x"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.10", default-features = false }
-libc = { version = "0.2.182", default-features = false }
+libc = { version = "0.2.189", default-features = false }
 
 # Additional dependencies for Linux and Android with the libc backend:
 #
@@ -69,7 +69,7 @@ default-features = false
 
 [dev-dependencies]
 tempfile = "3.5.0"
-libc = "0.2.171"
+libc = "0.2.189"
 libc_errno = { package = "errno", version = "0.3.10", default-features = false }
 serial_test = "2.0.0"
 memoffset = "0.9.0"

--- a/src/backend/libc/conv.rs
+++ b/src/backend/libc/conv.rs
@@ -33,10 +33,7 @@ pub(super) fn borrowed_fd(fd: BorrowedFd<'_>) -> LibcFd {
     fd.as_raw_fd() as LibcFd
 }
 
-#[cfg(all(
-    feature = "alloc",
-    not(any(windows, target_os = "espidf", target_os = "redox"))
-))]
+#[cfg(all(feature = "alloc", not(any(windows, target_os = "espidf"))))]
 #[inline]
 pub(super) fn owned_fd(fd: OwnedFd) -> LibcFd {
     fd.into_raw_fd() as LibcFd

--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -485,7 +485,7 @@ pub(crate) fn port_send(
     unsafe { ret(c::port_send(borrowed_fd(port), events, userdata)) }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn pause() {
     let r = unsafe { c::pause() };
     let errno = libc_errno::errno().0;

--- a/src/backend/libc/event/types.rs
+++ b/src/backend/libc/event/types.rs
@@ -1,10 +1,14 @@
-#[cfg(any(linux_kernel, target_os = "freebsd", target_os = "illumos"))]
+#[cfg(any(
+    linux_kernel,
+    target_os = "freebsd",
+    target_os = "illumos",
+))]
 use crate::backend::c;
 #[cfg(any(
     linux_kernel,
     target_os = "freebsd",
     target_os = "illumos",
-    target_os = "espidf"
+    target_os = "espidf",
 ))]
 use bitflags::bitflags;
 
@@ -12,7 +16,7 @@ use bitflags::bitflags;
     linux_kernel,
     target_os = "freebsd",
     target_os = "illumos",
-    target_os = "espidf"
+    target_os = "espidf",
 ))]
 bitflags! {
     /// `EFD_*` flags for use with [`eventfd`].

--- a/src/backend/libc/fs/mod.rs
+++ b/src/backend/libc/fs/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(all(feature = "alloc", not(any(target_os = "espidf", target_os = "redox"))))]
+#[cfg(all(feature = "alloc", not(target_os = "espidf")))]
 pub(crate) mod dir;
 #[cfg(linux_kernel)]
 pub mod inotify;

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -1,9 +1,9 @@
 //! libc syscalls supporting `rustix::fs`.
 
 use crate::backend::c;
-#[cfg(any(not(target_os = "redox"), feature = "alloc"))]
-use crate::backend::conv::ret_usize;
-use crate::backend::conv::{borrowed_fd, c_str, ret, ret_c_int, ret_off_t, ret_owned_fd};
+use crate::backend::conv::{
+    borrowed_fd, c_str, ret, ret_c_int, ret_off_t, ret_owned_fd, ret_usize,
+};
 use crate::fd::{BorrowedFd, OwnedFd};
 #[allow(unused_imports)]
 use crate::ffi;
@@ -12,7 +12,7 @@ use crate::ffi::CStr;
 use crate::ffi::CString;
 #[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
 use crate::fs::Access;
-#[cfg(not(any(target_os = "espidf", target_os = "redox")))]
+#[cfg(not(target_os = "espidf"))]
 use crate::fs::AtFlags;
 #[cfg(not(any(
     netbsdlike,
@@ -51,13 +51,7 @@ use crate::fs::SealFlags;
 use crate::fs::StatFs;
 #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
 use crate::fs::Timestamps;
-#[cfg(not(any(
-    apple,
-    target_os = "espidf",
-    target_os = "redox",
-    target_os = "vita",
-    target_os = "wasi"
-)))]
+#[cfg(not(any(apple, target_os = "espidf", target_os = "vita", target_os = "wasi")))]
 use crate::fs::{Dev, FileType};
 use crate::fs::{Mode, OFlags, SeekFrom, Stat};
 #[cfg(not(target_os = "wasi"))]
@@ -205,7 +199,6 @@ fn openat_via_syscall(
     }
 }
 
-#[cfg(not(target_os = "redox"))]
 pub(crate) fn openat(
     dirfd: BorrowedFd<'_>,
     path: &CStr,
@@ -287,7 +280,6 @@ pub(crate) fn readlink(path: &CStr, buf: &mut [u8]) -> io::Result<usize> {
     unsafe { ret_usize(c::readlink(c_str(path), buf.as_mut_ptr().cast(), buf.len()) as isize) }
 }
 
-#[cfg(not(target_os = "redox"))]
 #[inline]
 pub(crate) unsafe fn readlinkat(
     dirfd: BorrowedFd<'_>,
@@ -301,7 +293,6 @@ pub(crate) fn mkdir(path: &CStr, mode: Mode) -> io::Result<()> {
     unsafe { ret(c::mkdir(c_str(path), mode.bits() as c::mode_t)) }
 }
 
-#[cfg(not(target_os = "redox"))]
 pub(crate) fn mkdirat(dirfd: BorrowedFd<'_>, path: &CStr, mode: Mode) -> io::Result<()> {
     unsafe {
         ret(c::mkdirat(
@@ -337,7 +328,7 @@ pub(crate) fn link(old_path: &CStr, new_path: &CStr) -> io::Result<()> {
     unsafe { ret(c::link(c_str(old_path), c_str(new_path))) }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "redox")))]
+#[cfg(not(target_os = "espidf"))]
 pub(crate) fn linkat(
     old_dirfd: BorrowedFd<'_>,
     old_path: &CStr,
@@ -400,7 +391,7 @@ pub(crate) fn unlink(path: &CStr) -> io::Result<()> {
     unsafe { ret(c::unlink(c_str(path))) }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "redox")))]
+#[cfg(not(target_os = "espidf"))]
 pub(crate) fn unlinkat(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io::Result<()> {
     // macOS ≤ 10.9 lacks `unlinkat`.
     #[cfg(target_os = "macos")]
@@ -627,7 +618,6 @@ pub(crate) fn symlink(old_path: &CStr, new_path: &CStr) -> io::Result<()> {
     unsafe { ret(c::symlink(c_str(old_path), c_str(new_path))) }
 }
 
-#[cfg(not(target_os = "redox"))]
 pub(crate) fn symlinkat(
     old_path: &CStr,
     new_dirfd: BorrowedFd<'_>,
@@ -729,7 +719,7 @@ pub(crate) fn lstat(path: &CStr) -> io::Result<Stat> {
     }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "redox")))]
+#[cfg(not(target_os = "espidf"))]
 pub(crate) fn statat(dirfd: BorrowedFd<'_>, path: &CStr, flags: AtFlags) -> io::Result<Stat> {
     // See the comments in `fstat` about using `crate::fs::statx` here.
     #[cfg(all(
@@ -811,7 +801,6 @@ pub(crate) fn access(path: &CStr, access: Access) -> io::Result<()> {
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "horizon",
-    target_os = "redox",
     target_os = "vita"
 )))]
 pub(crate) fn accessat(
@@ -879,12 +868,7 @@ pub(crate) fn accessat(
     Ok(())
 }
 
-#[cfg(not(any(
-    target_os = "espidf",
-    target_os = "horizon",
-    target_os = "redox",
-    target_os = "vita"
-)))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
 pub(crate) fn utimensat(
     dirfd: BorrowedFd<'_>,
     path: &CStr,
@@ -1092,12 +1076,7 @@ pub(crate) fn chmod(path: &CStr, mode: Mode) -> io::Result<()> {
     unsafe { ret(c::chmod(c_str(path), mode.bits() as c::mode_t)) }
 }
 
-#[cfg(not(any(
-    linux_kernel,
-    target_os = "espidf",
-    target_os = "redox",
-    target_os = "wasi"
-)))]
+#[cfg(not(any(linux_kernel, target_os = "espidf", target_os = "wasi")))]
 pub(crate) fn chmodat(
     dirfd: BorrowedFd<'_>,
     path: &CStr,
@@ -1175,7 +1154,7 @@ pub(crate) fn fclonefileat(
     }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 pub(crate) fn chownat(
     dirfd: BorrowedFd<'_>,
     path: &CStr,
@@ -1199,7 +1178,6 @@ pub(crate) fn chownat(
     apple,
     target_os = "espidf",
     target_os = "horizon",
-    target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
 )))]

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -27,7 +27,7 @@ bitflags! {
     }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "redox")))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
 bitflags! {
     /// `AT_*` constants for use with [`openat`], [`statat`], and other `*at`
     /// functions.
@@ -620,7 +620,6 @@ impl FileType {
         target_os = "espidf",
         target_os = "haiku",
         target_os = "nto",
-        target_os = "redox",
         target_os = "vita"
     )))]
     #[inline]

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -98,7 +98,6 @@ pub(crate) fn writev(fd: BorrowedFd<'_>, bufs: &[IoSlice<'_>]) -> io::Result<usi
     target_os = "haiku",
     target_os = "horizon",
     target_os = "nto",
-    target_os = "redox",
     target_os = "solaris",
     target_os = "vita",
 )))]
@@ -129,7 +128,6 @@ pub(crate) fn preadv(
     target_os = "haiku",
     target_os = "nto",
     target_os = "horizon",
-    target_os = "redox",
     target_os = "solaris",
     target_os = "vita",
 )))]

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -13,15 +13,14 @@ use crate::pid::Pid;
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "haiku",
-    target_os = "openbsd",
     target_os = "redox",
+    target_os = "openbsd",
     target_os = "vita",
     target_os = "wasi",
 )))]
 use crate::thread::ClockId;
 #[cfg(linux_kernel)]
 use crate::thread::{Cpuid, MembarrierCommand, MembarrierQuery};
-#[cfg(not(target_os = "redox"))]
 use crate::thread::{NanosleepRelativeResult, Timespec};
 #[cfg(all(target_env = "gnu", fix_y2038))]
 use crate::timespec::LibcTimespec;
@@ -52,9 +51,9 @@ weak!(fn __nanosleep64(*const LibcTimespec, *mut LibcTimespec) -> c::c_int);
     target_os = "espidf",
     target_os = "freebsd", // FreeBSD 12 has clock_nanosleep, but libc targets FreeBSD 11.
     target_os = "haiku",
+    target_os = "redox",
     target_os = "horizon",
     target_os = "openbsd",
-    target_os = "redox",
     target_os = "vita",
     target_os = "wasi",
 )))]
@@ -243,7 +242,6 @@ fn clock_nanosleep_absolute_old(id: crate::clockid::ClockId, request: &Timespec)
     }
 }
 
-#[cfg(not(target_os = "redox"))]
 #[inline]
 pub(crate) fn nanosleep(request: &Timespec) -> NanosleepRelativeResult {
     // Old 32-bit version: libc has `nanosleep` but it is not y2038 safe by

--- a/src/backend/libc/time/syscalls.rs
+++ b/src/backend/libc/time/syscalls.rs
@@ -7,7 +7,7 @@ use crate::backend::conv::ret;
     target_os = "freebsd",
     target_os = "fuchsia",
     target_os = "illumos",
-    target_os = "netbsd"
+    target_os = "netbsd",
 ))]
 #[cfg(any(all(target_env = "gnu", fix_y2038), not(fix_y2038)))]
 use crate::backend::time::types::LibcItimerspec;
@@ -17,11 +17,7 @@ use crate::io;
 #[cfg(not(fix_y2038))]
 use crate::timespec::as_libc_timespec_mut_ptr;
 #[cfg(not(fix_y2038))]
-#[cfg(not(any(
-    target_os = "redox",
-    target_os = "wasi",
-    all(apple, not(target_os = "macos"))
-)))]
+#[cfg(not(any(target_os = "wasi", all(apple, not(target_os = "macos")))))]
 use crate::timespec::as_libc_timespec_ptr;
 #[cfg(all(target_env = "gnu", fix_y2038))]
 use crate::timespec::LibcTimespec;
@@ -32,7 +28,7 @@ use core::mem::MaybeUninit;
     target_os = "freebsd",
     target_os = "fuchsia",
     target_os = "illumos",
-    target_os = "netbsd"
+    target_os = "netbsd",
 ))]
 use {
     crate::backend::conv::{borrowed_fd, ret_owned_fd},
@@ -53,7 +49,7 @@ weak!(fn __timerfd_gettime64(c::c_int, *mut LibcItimerspec) -> c::c_int);
 #[cfg(all(target_env = "gnu", fix_y2038))]
 weak!(fn __timerfd_settime64(c::c_int, c::c_int, *const LibcItimerspec, *mut LibcItimerspec) -> c::c_int);
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(target_os = "wasi"))]
 #[inline]
 #[must_use]
 pub(crate) fn clock_getres(id: ClockId) -> Timespec {
@@ -258,11 +254,7 @@ fn clock_gettime_dynamic_old(id: c::clockid_t) -> io::Result<Timespec> {
     })
 }
 
-#[cfg(not(any(
-    target_os = "redox",
-    target_os = "wasi",
-    all(apple, not(target_os = "macos"))
-)))]
+#[cfg(not(any(target_os = "wasi", all(apple, not(target_os = "macos")))))]
 #[inline]
 pub(crate) fn clock_settime(id: ClockId, timespec: Timespec) -> io::Result<()> {
     // Old 32-bit version: libc has `clock_gettime` but it is not y2038 safe by
@@ -292,11 +284,7 @@ pub(crate) fn clock_settime(id: ClockId, timespec: Timespec) -> io::Result<()> {
     }
 }
 
-#[cfg(not(any(
-    target_os = "redox",
-    target_os = "wasi",
-    all(apple, not(target_os = "macos"))
-)))]
+#[cfg(not(any(target_os = "wasi", all(apple, not(target_os = "macos")))))]
 #[cfg(fix_y2038)]
 fn clock_settime_old(id: ClockId, timespec: Timespec) -> io::Result<()> {
     let old_timespec = c::timespec {
@@ -315,7 +303,7 @@ fn clock_settime_old(id: ClockId, timespec: Timespec) -> io::Result<()> {
     target_os = "freebsd",
     target_os = "fuchsia",
     target_os = "illumos",
-    target_os = "netbsd"
+    target_os = "netbsd",
 ))]
 pub(crate) fn timerfd_create(id: TimerfdClockId, flags: TimerfdFlags) -> io::Result<OwnedFd> {
     unsafe { ret_owned_fd(c::timerfd_create(id as c::clockid_t, bitflags_bits!(flags))) }
@@ -326,7 +314,7 @@ pub(crate) fn timerfd_create(id: TimerfdClockId, flags: TimerfdFlags) -> io::Res
     target_os = "freebsd",
     target_os = "fuchsia",
     target_os = "illumos",
-    target_os = "netbsd"
+    target_os = "netbsd",
 ))]
 pub(crate) fn timerfd_settime(
     fd: BorrowedFd<'_>,
@@ -374,7 +362,7 @@ pub(crate) fn timerfd_settime(
     target_os = "freebsd",
     target_os = "fuchsia",
     target_os = "illumos",
-    target_os = "netbsd"
+    target_os = "netbsd",
 ))]
 #[cfg(fix_y2038)]
 fn timerfd_settime_old(
@@ -447,7 +435,7 @@ fn timerfd_settime_old(
     target_os = "freebsd",
     target_os = "fuchsia",
     target_os = "illumos",
-    target_os = "netbsd"
+    target_os = "netbsd",
 ))]
 pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
     // Old 32-bit version: libc has `timerfd_gettime` but it is not y2038 safe
@@ -484,7 +472,8 @@ pub(crate) fn timerfd_gettime(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {
     target_os = "freebsd",
     target_os = "fuchsia",
     target_os = "illumos",
-    target_os = "netbsd"
+    target_os = "netbsd",
+    target_os = "redox"
 ))]
 #[cfg(fix_y2038)]
 fn timerfd_gettime_old(fd: BorrowedFd<'_>) -> io::Result<Itimerspec> {

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -11,7 +11,7 @@ pub mod epoll;
 mod eventfd;
 #[cfg(bsd)]
 pub mod kqueue;
-#[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(windows, target_os = "wasi")))]
 mod pause;
 mod poll;
 #[cfg(solarish)]
@@ -24,10 +24,10 @@ pub use crate::timespec::{Nsecs, Secs, Timespec};
     linux_kernel,
     target_os = "freebsd",
     target_os = "illumos",
-    target_os = "espidf"
+    target_os = "espidf",
 ))]
 pub use eventfd::{eventfd, EventfdFlags};
-#[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(windows, target_os = "wasi")))]
 pub use pause::*;
 pub use poll::{poll, PollFd, PollFlags};
 #[cfg(any(bsd, linux_kernel, windows, target_os = "wasi"))]

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -12,7 +12,7 @@ use crate::buffer::Buffer;
 use crate::fd::OwnedFd;
 #[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
 use crate::fs::Access;
-#[cfg(not(any(target_os = "espidf", target_os = "redox")))]
+#[cfg(not(target_os = "espidf"))]
 use crate::fs::AtFlags;
 #[cfg(apple)]
 use crate::fs::CloneFlags;
@@ -40,23 +40,13 @@ use {crate::fs::Timestamps, crate::timespec::Nsecs};
 /// `UTIME_NOW` for use with [`utimensat`].
 ///
 /// [`utimensat`]: crate::fs::utimensat
-#[cfg(not(any(
-    target_os = "espidf",
-    target_os = "horizon",
-    target_os = "redox",
-    target_os = "vita"
-)))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
 pub const UTIME_NOW: Nsecs = backend::c::UTIME_NOW as Nsecs;
 
 /// `UTIME_OMIT` for use with [`utimensat`].
 ///
 /// [`utimensat`]: crate::fs::utimensat
-#[cfg(not(any(
-    target_os = "espidf",
-    target_os = "horizon",
-    target_os = "redox",
-    target_os = "vita"
-)))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
 pub const UTIME_OMIT: Nsecs = backend::c::UTIME_OMIT as Nsecs;
 
 /// `openat(dirfd, path, oflags, mode)`—Opens a file.
@@ -73,7 +63,6 @@ pub const UTIME_OMIT: Nsecs = backend::c::UTIME_OMIT as Nsecs;
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/openat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/openat.2.html
-#[cfg(not(target_os = "redox"))]
 #[inline]
 pub fn openat<P: path::Arg, Fd: AsFd>(
     dirfd: Fd,
@@ -96,7 +85,7 @@ pub fn openat<P: path::Arg, Fd: AsFd>(
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/readlinkat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/readlinkat.2.html
-#[cfg(all(feature = "alloc", not(target_os = "redox")))]
+#[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[inline]
 pub fn readlinkat<P: path::Arg, Fd: AsFd, B: Into<Vec<u8>>>(
@@ -107,7 +96,7 @@ pub fn readlinkat<P: path::Arg, Fd: AsFd, B: Into<Vec<u8>>>(
     path.into_with_c_str(|path| _readlinkat(dirfd.as_fd(), path, reuse.into()))
 }
 
-#[cfg(all(feature = "alloc", not(target_os = "redox")))]
+#[cfg(feature = "alloc")]
 #[allow(unsafe_code)]
 fn _readlinkat(dirfd: BorrowedFd<'_>, path: &CStr, mut buffer: Vec<u8>) -> io::Result<CString> {
     buffer.clear();
@@ -171,7 +160,6 @@ fn _readlinkat(dirfd: BorrowedFd<'_>, path: &CStr, mut buffer: Vec<u8>) -> io::R
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/readlinkat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/readlinkat.2.html
-#[cfg(not(target_os = "redox"))]
 #[inline]
 pub fn readlinkat_raw<P: path::Arg, Fd: AsFd, Buf: Buffer<u8>>(
     dirfd: Fd,
@@ -194,7 +182,6 @@ pub fn readlinkat_raw<P: path::Arg, Fd: AsFd, Buf: Buffer<u8>>(
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/mkdirat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/mkdirat.2.html
-#[cfg(not(target_os = "redox"))]
 #[inline]
 pub fn mkdirat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, mode: Mode) -> io::Result<()> {
     path.into_with_c_str(|path| backend::fs::syscalls::mkdirat(dirfd.as_fd(), path, mode))
@@ -209,7 +196,7 @@ pub fn mkdirat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, mode: Mode) -> io::Re
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/linkat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/linkat.2.html
-#[cfg(not(any(target_os = "espidf", target_os = "redox")))]
+#[cfg(not(target_os = "espidf"))]
 #[inline]
 pub fn linkat<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(
     old_dirfd: PFd,
@@ -243,7 +230,7 @@ pub fn linkat<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(
 /// [`REMOVEDIR`]: AtFlags::REMOVEDIR
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/unlinkat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/unlinkat.2.html
-#[cfg(not(any(target_os = "espidf", target_os = "redox")))]
+#[cfg(not(target_os = "espidf"))]
 #[inline]
 pub fn unlinkat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, flags: AtFlags) -> io::Result<()> {
     path.into_with_c_str(|path| backend::fs::syscalls::unlinkat(dirfd.as_fd(), path, flags))
@@ -321,7 +308,6 @@ pub fn renameat_with<P: path::Arg, Q: path::Arg, PFd: AsFd, QFd: AsFd>(
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/symlinkat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/symlinkat.2.html
-#[cfg(not(target_os = "redox"))]
 #[inline]
 pub fn symlinkat<P: path::Arg, Q: path::Arg, Fd: AsFd>(
     old_path: P,
@@ -348,7 +334,7 @@ pub fn symlinkat<P: path::Arg, Q: path::Arg, Fd: AsFd>(
 /// [Linux]: https://man7.org/linux/man-pages/man2/fstatat.2.html
 /// [`Mode::from_raw_mode`]: crate::fs::Mode::from_raw_mode
 /// [`FileType::from_raw_mode`]: crate::fs::FileType::from_raw_mode
-#[cfg(not(any(target_os = "espidf", target_os = "redox")))]
+#[cfg(not(target_os = "espidf"))]
 #[inline]
 #[doc(alias = "fstatat")]
 pub fn statat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, flags: AtFlags) -> io::Result<Stat> {
@@ -371,12 +357,7 @@ pub fn statat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, flags: AtFlags) -> io:
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/faccessat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/faccessat.2.html
-#[cfg(not(any(
-    target_os = "espidf",
-    target_os = "horizon",
-    target_os = "vita",
-    target_os = "redox"
-)))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita",)))]
 #[inline]
 #[doc(alias = "faccessat")]
 pub fn accessat<P: path::Arg, Fd: AsFd>(
@@ -396,12 +377,7 @@ pub fn accessat<P: path::Arg, Fd: AsFd>(
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/utimensat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/utimensat.2.html
-#[cfg(not(any(
-    target_os = "espidf",
-    target_os = "horizon",
-    target_os = "vita",
-    target_os = "redox"
-)))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita",)))]
 #[inline]
 pub fn utimensat<P: path::Arg, Fd: AsFd>(
     dirfd: Fd,
@@ -424,7 +400,7 @@ pub fn utimensat<P: path::Arg, Fd: AsFd>(
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/fchmodat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/fchmodat.2.html
-#[cfg(not(any(target_os = "espidf", target_os = "wasi", target_os = "redox")))]
+#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 #[inline]
 #[doc(alias = "fchmodat")]
 pub fn chmodat<P: path::Arg, Fd: AsFd>(
@@ -469,7 +445,6 @@ pub fn fclonefileat<Fd: AsFd, DstFd: AsFd, P: path::Arg>(
     target_os = "horizon",
     target_os = "vita",
     target_os = "wasi",
-    target_os = "redox",
 )))]
 #[inline]
 pub fn mknodat<P: path::Arg, Fd: AsFd>(
@@ -512,7 +487,7 @@ pub fn mkfifoat<P: path::Arg, Fd: AsFd>(dirfd: Fd, path: P, mode: Mode) -> io::R
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/fchownat.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/fchownat.2.html
-#[cfg(not(any(target_os = "espidf", target_os = "wasi", target_os = "redox")))]
+#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 #[inline]
 #[doc(alias = "fchownat")]
 pub fn chownat<P: path::Arg, Fd: AsFd>(

--- a/src/io/read_write.rs
+++ b/src/io/read_write.rs
@@ -219,7 +219,6 @@ pub fn writev<Fd: AsFd>(fd: Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
     target_os = "haiku",
     target_os = "horizon",
     target_os = "nto",
-    target_os = "redox",
     target_os = "solaris",
     target_os = "vita",
 )))]
@@ -258,7 +257,6 @@ pub fn preadv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io:
     target_os = "haiku",
     target_os = "horizon",
     target_os = "nto",
-    target_os = "redox",
     target_os = "solaris",
     target_os = "vita",
 )))]

--- a/src/thread/clock.rs
+++ b/src/thread/clock.rs
@@ -9,7 +9,6 @@ pub use crate::timespec::{Nsecs, Secs, Timespec};
     target_os = "espidf",
     target_os = "freebsd", // FreeBSD 12 has clock_nanosleep, but libc targets FreeBSD 11.
     target_os = "openbsd",
-    target_os = "redox",
     target_os = "vita",
     target_os = "wasi",
 )))]

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -1,6 +1,5 @@
 //! Thread-associated operations.
 
-#[cfg(not(target_os = "redox"))]
 mod clock;
 #[cfg(linux_kernel)]
 pub mod futex;
@@ -18,7 +17,6 @@ mod sched_yield;
 #[cfg(linux_kernel)]
 mod setns;
 
-#[cfg(not(target_os = "redox"))]
 pub use clock::*;
 #[cfg(linux_kernel)]
 pub use id::*;

--- a/tests/fs/chmodat.rs
+++ b/tests/fs/chmodat.rs
@@ -27,7 +27,7 @@ fn test_chmod() {
     assert_ne!(reverted.st_mode as u64 & libc::S_IRWXU as u64, 0);
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(target_os = "wasi"))]
 #[test]
 fn test_chmodat() {
     use rustix::fs::{chmodat, openat, statat, symlinkat, AtFlags, Mode, OFlags, CWD};

--- a/tests/fs/fcntl.rs
+++ b/tests/fs/fcntl.rs
@@ -1,4 +1,4 @@
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(target_os = "wasi"))]
 #[test]
 fn test_fcntl_dupfd_cloexec() {
     use rustix::fd::AsFd as _;

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -9,7 +9,6 @@
 )))]
 use core::num::NonZeroU64;
 
-#[cfg(not(target_os = "redox"))]
 #[test]
 fn test_file() {
     rustix::fs::accessat(

--- a/tests/fs/invalid_offset.rs
+++ b/tests/fs/invalid_offset.rs
@@ -7,7 +7,7 @@
 //! These tests are disabled on iOS/macOS since those platforms kill the
 //! process with `Signal::XFSZ` instead of returning an error.
 
-#![cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#![cfg(not(target_os = "wasi"))]
 
 use rustix::fs::SeekFrom;
 

--- a/tests/fs/linkat.rs
+++ b/tests/fs/linkat.rs
@@ -29,7 +29,6 @@ fn test_link() {
     );
 }
 
-#[cfg(not(target_os = "redox"))]
 #[test]
 fn test_linkat() {
     use rustix::fs::{linkat, openat, readlinkat, statat, AtFlags, Mode, OFlags, CWD};

--- a/tests/fs/mkdirat.rs
+++ b/tests/fs/mkdirat.rs
@@ -15,7 +15,6 @@ fn test_mkdir() {
     rmdir(tmp.path().join("file")).unwrap();
 }
 
-#[cfg(not(target_os = "redox"))]
 #[test]
 fn test_mkdirat() {
     use rustix::fs::{

--- a/tests/fs/mknodat.rs
+++ b/tests/fs/mknodat.rs
@@ -1,4 +1,4 @@
-#[cfg(not(any(apple, target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(apple, target_os = "wasi")))]
 #[test]
 fn test_mknodat() {
     use rustix::fs::{

--- a/tests/fs/special.rs
+++ b/tests/fs/special.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "process")]
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(target_os = "wasi"))]
 #[test]
 fn test_special_fds() {
     use rustix::fs::{fstat, open, openat, Mode, OFlags, Stat, ABS, CWD};

--- a/tests/fs/y2038.rs
+++ b/tests/fs/y2038.rs
@@ -5,7 +5,6 @@
 #[cfg(not(all(target_env = "musl", target_pointer_width = "32")))]
 #[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
 #[cfg(not(all(target_os = "emscripten", target_pointer_width = "32")))]
-#[cfg(not(target_os = "redox"))]
 #[cfg(not(target_os = "cygwin"))]
 #[test]
 fn test_y2038_with_utimensat() {
@@ -81,7 +80,6 @@ fn test_y2038_with_utimensat() {
 #[cfg(not(all(target_env = "musl", target_pointer_width = "32")))]
 #[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
 #[cfg(not(all(target_os = "emscripten", target_pointer_width = "32")))]
-#[cfg(not(target_os = "redox"))]
 #[cfg(not(target_os = "cygwin"))]
 #[test]
 fn test_y2038_with_futimens() {

--- a/tests/thread/clocks.rs
+++ b/tests/thread/clocks.rs
@@ -8,13 +8,11 @@
     target_os = "wasi",
 )))]
 use rustix::thread::{clock_nanosleep_absolute, clock_nanosleep_relative, ClockId};
-#[cfg(not(target_os = "redox"))]
 use {
     rustix::io,
     rustix::thread::{nanosleep, NanosleepRelativeResult, Timespec},
 };
 
-#[cfg(not(target_os = "redox"))]
 #[test]
 fn test_invalid_nanosleep() {
     match nanosleep(&Timespec {
@@ -154,7 +152,6 @@ fn test_invalid_nanosleep_relative() {
     }
 }
 
-#[cfg(not(target_os = "redox"))]
 #[test]
 fn test_zero_nanosleep() {
     match nanosleep(&Timespec {


### PR DESCRIPTION
Redox supports most of the *at functions as well as some of the `time` header.

---
**Sources** :

* `accessat`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/mod.rs#L106-L125) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/redox/mod.rs#L1337)
* `chmodat`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/mod.rs#L280-L303) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/mod.rs#L1070-L1070)
* `chownat`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/mod.rs#L305-L330) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/mod.rs#L1071-L1079)
* `clock_getres`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/mod.rs#L203-L226) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/redox/mod.rs#L1561)
* `clock_settime`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/mod.rs#L228-L235) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/redox/mod.rs#L1563)
* `Dir::chdir`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/mod.rs#L275-L278) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/mod.rs#L1122-L1123)
* `Dir::fd`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/header/dirent/mod.rs#L239-L243) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/redox/mod.rs#L1333)
* `Dir::new`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/header/dirent/mod.rs#L245-L257) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/mod.rs#LL1042)
* `Dir::read`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/header/dirent/mod.rs#L274-L277) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/mod.rs#L1054)
* `Dir::rewind`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/header/dirent/mod.rs#L295-L298) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/mod.rs#L1060-L1068)
* `Dir::seek`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/header/dirent/mod.rs#L380-L389) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/redox/mod.rs#L1334)
* `Dir::stat`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/libredox.rs#L118-L155) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/mod.rs#L972)
* `Dir::statvfs`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/libredox.rs#L156-L178) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/mod.rs#L1668-L1673)
* `linkat`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/mod.rs#L759-L780) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/mod.rs#L1099-L1105)
* `mkdirat`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/mod.rs#L786-L794) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/mod.rs#L1106-L1107)
* `mknodat`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/mod.rs#L805-L808) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/redox/mod.rs#L1542)
* `nanosleep`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/mod.rs#L925-L943) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/mod.rs#L1210-L1217)
* `openat`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/mod.rs#L945-957) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/mod.rs#L1080-L1081)
* `preadv`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/header/bits_uio/mod.rs#L27-L50) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/redox/mod.rs#L1550-L1552)
* `pwritev`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/header/bits_uio/mod.rs#L60-L80) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/redox/mod.rs#L1550-L1552)
* `readlinkat`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/mod.rs#L1090-L1098) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/mod.rs#L2338-L2345)
* `statat`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/mod.rs#L460-L480) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/mod.rs#L1097)
* `symlinkat`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/mod.rs#L1496-L1505) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/mod.rs#L1115-L1116)
* `unlinkat`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/mod.rs#L1727-L1735) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/mod.rs#L1115-L1118)
* `utimensat`: [relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/381772ec81fced6d055f0f0ba6fa92c7f3256fbb/src/platform/redox/mod.rs#L510-L532) [libc](https://github.com/rust-lang/libc/blob/35c8b7d847f64265cb578343dc5d1be467fe63db/src/unix/redox/mod.rs#L1543)

