### PR TITLE
ci: fix syn pin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,7 @@ jobs:
       run: |
         cargo update --package=half --precise=2.2.1
         cargo update --package=flate2 --precise=1.0.35
+        cargo update --package=serde --precise=1.0.228
         cargo update --package=syn --precise=2.0.106
         cargo update --package=textwrap --precise=0.16.1
         cargo update --package=parking_lot --precise=0.12.4
@@ -591,6 +592,7 @@ jobs:
       run: |
         cargo update --package=half --precise=2.2.1
         cargo update --package=flate2 --precise=1.0.35
+        cargo update --package=serde --precise=1.0.228
         cargo update --package=syn --precise=2.0.106
         cargo update --package=textwrap --precise=0.16.1
         cargo update --package=parking_lot --precise=0.12.4


### PR DESCRIPTION
Fix the CI failure caused by an ambiguous `syn` package selection after multiple versions of `syn` are present in the dependency graph.

The failing command produces:

```log
error: There are multiple `syn` packages in your project, and the specification `syn` is ambiguous.
Please re-run this command with `-p <spec>` where `<spec>` is one of the following:
  syn@2.0.119
  syn@3.0.3
```