### PR TITLE
ci: disable x86_64-unknown-dragonfly target due to build errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,7 +239,8 @@ jobs:
     - run: cargo check -Z build-std --target x86_64-unknown-openbsd --all-targets --features=all-apis
     # Temporarily disable due to build errors.
     # - run: cargo check -Z build-std --target mips64-openwrt-linux-musl --all-targets --features=all-apis
-    - run: cargo check -Z build-std --target x86_64-unknown-dragonfly --all-targets --features=all-apis
+    # https://github.com/bytecodealliance/rustix/issues/1648
+    # - run: cargo check -Z build-std --target x86_64-unknown-dragonfly --all-targets --features=all-apis
     # Temporarily disable due to build errors.
     # - run: cargo check -Z build-std --target sparc-unknown-linux-gnu --all-targets --features=all-apis
     - run: cargo check -Z build-std --target armv7-unknown-freebsd --all-targets --features=all-apis


### PR DESCRIPTION
Related issue: https://github.com/bytecodealliance/rustix/issues/1648