### PR TITLE
ci: disable riscv32imc-esp-espidf target due to broken std

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -248,7 +248,8 @@ jobs:
     - run: cargo check -Z build-std --target x86_64-unknown-haiku --all-targets --features=all-apis
     # Temporarily disable due to build errors on nightly.
     # - run: cargo check -Z build-std --target x86_64-uwp-windows-msvc --all-targets --features=all-apis
-    - run: cargo check -Z build-std --target=riscv32imc-esp-espidf --features=all-apis
+    # https://github.com/bytecodealliance/rustix/issues/1652
+    # - run: cargo check -Z build-std --target=riscv32imc-esp-espidf --features=all-apis
     - run: cargo check -Z build-std --target=aarch64-unknown-nto-qnx710 --features=all-apis
     - run: cargo check -Z build-std --target=x86_64-pc-nto-qnx710 --features=all-apis
     # Temporarily disable due to build errors on nightly.


### PR DESCRIPTION
Related issue: https://github.com/bytecodealliance/rustix/issues/1652