### PR TITLE
fix(bug): ns->us overflow handling

### DIFF
--- a/src/backend/libc/event/syscalls.rs
+++ b/src/backend/libc/event/syscalls.rs
@@ -247,11 +247,7 @@ pub(crate) unsafe fn select(
     let timeout_data;
     let timeout_ptr = match timeout {
         Some(timeout) => {
-            // Convert from `Timespec` to `c::timeval`.
-            timeout_data = c::timeval {
-                tv_sec: timeout.tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
-                tv_usec: ((timeout.tv_nsec + 999) / 1000) as _,
-            };
+            timeout_data = timeout.to_timeval()?;
             &timeout_data
         }
         None => null(),
@@ -324,11 +320,7 @@ pub(crate) unsafe fn select(
     let timeout_data;
     let timeout_ptr = match timeout {
         Some(timeout) => {
-            // Convert from `Timespec` to `c::timeval`.
-            timeout_data = c::timeval {
-                tv_sec: timeout.tv_sec.try_into().map_err(|_| io::Errno::INVAL)?,
-                tv_usec: ((timeout.tv_nsec + 999) / 1000) as _,
-            };
+            timeout_data = timeout.to_timeval()?;
             &timeout_data
         }
         None => null(),

--- a/src/backend/libc/event/windows_syscalls.rs
+++ b/src/backend/libc/event/windows_syscalls.rs
@@ -54,14 +54,7 @@ pub(crate) fn select(
     let timeout_data;
     let timeout_ptr = match timeout {
         Some(timeout) => {
-            // Convert from `Timespec` to `TIMEVAL`.
-            timeout_data = c::TIMEVAL {
-                tv_sec: timeout
-                    .tv_sec
-                    .try_into()
-                    .map_err(|_| io::Errno::OPNOTSUPP)?,
-                tv_usec: ((timeout.tv_nsec + 999) / 1000) as _,
-            };
+            timeout_data = timeout.to_timeval()?;
             &timeout_data
         }
         None => null(),

--- a/src/backend/libc/net/sockopt.rs
+++ b/src/backend/libc/net/sockopt.rs
@@ -240,7 +240,7 @@ pub(crate) fn set_socket_timeout(
                     .unwrap_or(crate::timespec::Secs::MAX),
                 tv_nsec: timeout.subsec_nanos() as _,
             };
-            let (sec, usec) = ts.to_sec_usec();
+            let (sec, usec) = ts.to_sec_usec().unwrap_or((crate::timespec::Secs::MAX, 0));
             #[allow(deprecated)]
             let tv_sec = sec.try_into().unwrap_or(c::time_t::MAX);
             let mut timeout = c::timeval {

--- a/src/backend/libc/net/sockopt.rs
+++ b/src/backend/libc/net/sockopt.rs
@@ -653,7 +653,7 @@ pub(crate) fn set_ip_add_membership_with_ifindex(
     setsockopt(fd, c::IPPROTO_IP, c::IP_ADD_MEMBERSHIP, mreqn)
 }
 
-#[cfg(any(apple, freebsdlike, linux_like, solarish, target_os = "aix"))]
+#[cfg(any(apple, target_os = "freebsd", linux_like, solarish, target_os = "aix"))]
 #[inline]
 pub(crate) fn set_ip_add_source_membership(
     fd: BorrowedFd<'_>,
@@ -665,7 +665,7 @@ pub(crate) fn set_ip_add_source_membership(
     setsockopt(fd, c::IPPROTO_IP, c::IP_ADD_SOURCE_MEMBERSHIP, mreq_source)
 }
 
-#[cfg(any(apple, freebsdlike, linux_like, solarish, target_os = "aix"))]
+#[cfg(any(apple, target_os = "freebsd", linux_like, solarish, target_os = "aix"))]
 #[inline]
 pub(crate) fn set_ip_drop_source_membership(
     fd: BorrowedFd<'_>,
@@ -1325,7 +1325,7 @@ fn to_ip_mreqn(multiaddr: &Ipv4Addr, address: &Ipv4Addr, ifindex: i32) -> c::ip_
     }
 }
 
-#[cfg(any(apple, freebsdlike, linux_like, solarish, target_os = "aix"))]
+#[cfg(any(apple, target_os = "freebsd", linux_like, solarish, target_os = "aix"))]
 #[inline]
 fn to_imr_source(
     multiaddr: &Ipv4Addr,

--- a/src/backend/libc/net/sockopt.rs
+++ b/src/backend/libc/net/sockopt.rs
@@ -233,18 +233,19 @@ pub(crate) fn set_socket_timeout(
                 return Err(io::Errno::INVAL);
             }
 
-            // Rust's musl libc bindings deprecated `time_t` while they
-            // transition to 64-bit `time_t`. What we want here is just
-            // “whatever type `timeval`'s `tv_sec` is”, so we're ok using
-            // the deprecated type.
+            let ts = crate::timespec::Timespec {
+                tv_sec: timeout
+                    .as_secs()
+                    .try_into()
+                    .unwrap_or(crate::timespec::Secs::MAX),
+                tv_nsec: timeout.subsec_nanos() as _,
+            };
+            let (sec, usec) = ts.to_sec_usec();
             #[allow(deprecated)]
-            let tv_sec = timeout.as_secs().try_into().unwrap_or(c::time_t::MAX);
-
-            // `subsec_micros` rounds down, so we use `subsec_nanos` and
-            // manually round up.
+            let tv_sec = sec.try_into().unwrap_or(c::time_t::MAX);
             let mut timeout = c::timeval {
                 tv_sec,
-                tv_usec: ((timeout.subsec_nanos() + 999) / 1000) as _,
+                tv_usec: usec as _,
             };
             if timeout.tv_sec == 0 && timeout.tv_usec == 0 {
                 timeout.tv_usec = 1;

--- a/src/backend/linux_raw/net/sockopt.rs
+++ b/src/backend/linux_raw/net/sockopt.rs
@@ -285,11 +285,18 @@ fn duration_to_linux_sock_timeval(timeout: Option<Duration>) -> io::Result<__ker
             if timeout == Duration::ZERO {
                 return Err(io::Errno::INVAL);
             }
-            // `subsec_micros` rounds down, so we use `subsec_nanos` and
-            // manually round up.
+
+            let ts = crate::timespec::Timespec {
+                tv_sec: timeout
+                    .as_secs()
+                    .try_into()
+                    .unwrap_or(crate::timespec::Secs::MAX),
+                tv_nsec: timeout.subsec_nanos() as _,
+            };
+            let (sec, usec) = ts.to_sec_usec().unwrap_or((crate::timespec::Secs::MAX, 0));
             let mut timeout = __kernel_sock_timeval {
-                tv_sec: timeout.as_secs().try_into().unwrap_or(i64::MAX),
-                tv_usec: ((timeout.subsec_nanos() + 999) / 1000) as _,
+                tv_sec: sec.try_into().unwrap_or(i64::MAX),
+                tv_usec: usec as _,
             };
             if timeout.tv_sec == 0 && timeout.tv_usec == 0 {
                 timeout.tv_usec = 1;

--- a/src/backend/linux_raw/net/sockopt.rs
+++ b/src/backend/linux_raw/net/sockopt.rs
@@ -319,7 +319,7 @@ fn duration_to_linux_old_timeval(timeout: Option<Duration>) -> io::Result<__kern
                     .unwrap_or(crate::timespec::Secs::MAX),
                 tv_nsec: timeout.subsec_nanos() as _,
             };
-            let (sec, usec) = ts.to_sec_usec();
+            let (sec, usec) = ts.to_sec_usec().unwrap_or((crate::timespec::Secs::MAX, 0));
             let mut timeout = __kernel_old_timeval {
                 tv_sec: sec.try_into().unwrap_or(c::c_long::MAX),
                 tv_usec: usec as _,

--- a/src/backend/linux_raw/net/sockopt.rs
+++ b/src/backend/linux_raw/net/sockopt.rs
@@ -312,11 +312,17 @@ fn duration_to_linux_old_timeval(timeout: Option<Duration>) -> io::Result<__kern
                 return Err(io::Errno::INVAL);
             }
 
-            // `subsec_micros` rounds down, so we use `subsec_nanos` and
-            // manually round up.
+            let ts = crate::timespec::Timespec {
+                tv_sec: timeout
+                    .as_secs()
+                    .try_into()
+                    .unwrap_or(crate::timespec::Secs::MAX),
+                tv_nsec: timeout.subsec_nanos() as _,
+            };
+            let (sec, usec) = ts.to_sec_usec();
             let mut timeout = __kernel_old_timeval {
-                tv_sec: timeout.as_secs().try_into().unwrap_or(c::c_long::MAX),
-                tv_usec: ((timeout.subsec_nanos() + 999) / 1000) as _,
+                tv_sec: sec.try_into().unwrap_or(c::c_long::MAX),
+                tv_usec: usec as _,
             };
             if timeout.tv_sec == 0 && timeout.tv_usec == 0 {
                 timeout.tv_usec = 1;

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -1079,7 +1079,7 @@ pub fn set_ip_add_membership_with_ifindex<Fd: AsFd>(
 /// See the [module-level documentation] for more.
 ///
 /// [module-level documentation]: self#references-for-get_ip_-and-set_ip_-functions
-#[cfg(any(apple, freebsdlike, linux_like, solarish, target_os = "aix"))]
+#[cfg(any(apple, target_os = "freebsd", linux_like, solarish, target_os = "aix"))]
 #[inline]
 #[doc(alias = "IP_ADD_SOURCE_MEMBERSHIP")]
 pub fn set_ip_add_source_membership<Fd: AsFd>(
@@ -1101,7 +1101,7 @@ pub fn set_ip_add_source_membership<Fd: AsFd>(
 /// See the [module-level documentation] for more.
 ///
 /// [module-level documentation]: self#references-for-get_ip_-and-set_ip_-functions
-#[cfg(any(apple, freebsdlike, linux_like, solarish, target_os = "aix"))]
+#[cfg(any(apple, target_os = "freebsd", linux_like, solarish, target_os = "aix"))]
 #[inline]
 #[doc(alias = "IP_DROP_SOURCE_MEMBERSHIP")]
 pub fn set_ip_drop_source_membership<Fd: AsFd>(

--- a/src/timespec.rs
+++ b/src/timespec.rs
@@ -203,6 +203,41 @@ impl Timespec {
             })
             .and_then(|millis| c::c_int::try_from(millis).ok())
     }
+
+    /// Convert `Timespec` to seconds and microseconds, rounding up fractional
+    /// microseconds and carrying any overflow into seconds.
+    #[inline]
+    pub(crate) fn to_sec_usec(&self) -> (Secs, u32) {
+        let mut sec = self.tv_sec;
+        let mut usec = (self.tv_nsec + 999) / 1000;
+        if usec >= 1_000_000 {
+            sec = sec.saturating_add(1);
+            usec -= 1_000_000;
+        }
+        (sec, usec as u32)
+    }
+
+    /// Convert from `Timespec` to `c::timeval`, rounding up fractional
+    /// microseconds and carrying any overflow into seconds.
+    #[cfg(any(libc, target_os = "wasi"))]
+    pub(crate) fn to_timeval(&self) -> crate::io::Result<c::timeval> {
+        let (sec, usec) = self.to_sec_usec();
+        Ok(c::timeval {
+            tv_sec: sec.try_into().map_err(|_| crate::io::Errno::INVAL)?,
+            tv_usec: usec as _,
+        })
+    }
+
+    /// Convert from `Timespec` to `c::TIMEVAL`, rounding up fractional
+    /// microseconds and carrying any overflow into seconds.
+    #[cfg(windows)]
+    pub(crate) fn to_timeval(&self) -> crate::io::Result<c::TIMEVAL> {
+        let (sec, usec) = self.to_sec_usec();
+        Ok(c::TIMEVAL {
+            tv_sec: sec.try_into().map_err(|_| crate::io::Errno::OPNOTSUPP)?,
+            tv_usec: usec as _,
+        })
+    }
 }
 
 impl TryFrom<Timespec> for Duration {
@@ -394,6 +429,26 @@ mod tests {
         // `tv_sec` needs to be able to hold more than 32-bits of seconds.
         t.tv_sec = 0x1_0000_0000_u64 as _;
         assert_eq!(t.tv_sec as u64, 0x1_0000_0000_u64);
+    }
+
+    #[cfg(any(libc, target_os = "wasi", windows))]
+    #[test]
+    fn test_to_timeval() {
+        let ts = Timespec {
+            tv_sec: 4,
+            tv_nsec: 999_999_500,
+        };
+        let tv = ts.to_timeval().unwrap();
+        assert_eq!(tv.tv_sec, 5);
+        assert_eq!(tv.tv_usec, 0);
+
+        let ts2 = Timespec {
+            tv_sec: 2,
+            tv_nsec: 500_000_000,
+        };
+        let tv2 = ts2.to_timeval().unwrap();
+        assert_eq!(tv2.tv_sec, 2);
+        assert_eq!(tv2.tv_usec, 500_000);
     }
 
     // Test that our workarounds are needed.

--- a/src/timespec.rs
+++ b/src/timespec.rs
@@ -207,21 +207,21 @@ impl Timespec {
     /// Convert `Timespec` to seconds and microseconds, rounding up fractional
     /// microseconds and carrying any overflow into seconds.
     #[inline]
-    pub(crate) fn to_sec_usec(&self) -> (Secs, u32) {
+    pub(crate) fn to_sec_usec(&self) -> Option<(Secs, u32)> {
         let mut sec = self.tv_sec;
         let mut usec = (self.tv_nsec + 999) / 1000;
         if usec >= 1_000_000 {
-            sec = sec.saturating_add(1);
+            sec = sec.checked_add(1)?;
             usec -= 1_000_000;
         }
-        (sec, usec as u32)
+        Some((sec, usec as u32))
     }
 
     /// Convert from `Timespec` to `c::timeval`, rounding up fractional
     /// microseconds and carrying any overflow into seconds.
     #[cfg(any(libc, target_os = "wasi"))]
     pub(crate) fn to_timeval(&self) -> crate::io::Result<c::timeval> {
-        let (sec, usec) = self.to_sec_usec();
+        let (sec, usec) = self.to_sec_usec().ok_or(crate::io::Errno::INVAL)?;
         Ok(c::timeval {
             tv_sec: sec.try_into().map_err(|_| crate::io::Errno::INVAL)?,
             tv_usec: usec as _,
@@ -232,7 +232,7 @@ impl Timespec {
     /// microseconds and carrying any overflow into seconds.
     #[cfg(windows)]
     pub(crate) fn to_timeval(&self) -> crate::io::Result<c::TIMEVAL> {
-        let (sec, usec) = self.to_sec_usec();
+        let (sec, usec) = self.to_sec_usec().ok_or(crate::io::Errno::OPNOTSUPP)?;
         Ok(c::TIMEVAL {
             tv_sec: sec.try_into().map_err(|_| crate::io::Errno::OPNOTSUPP)?,
             tv_usec: usec as _,

--- a/src/timespec.rs
+++ b/src/timespec.rs
@@ -219,7 +219,7 @@ impl Timespec {
 
     /// Convert from `Timespec` to `c::timeval`, rounding up fractional
     /// microseconds and carrying any overflow into seconds.
-    #[cfg(any(libc, target_os = "wasi"))]
+    #[cfg(all(any(libc, target_os = "wasi"), not(windows)))]
     pub(crate) fn to_timeval(&self) -> crate::io::Result<c::timeval> {
         let (sec, usec) = self.to_sec_usec().ok_or(crate::io::Errno::INVAL)?;
         Ok(c::timeval {

--- a/tests/event/select.rs
+++ b/tests/event/select.rs
@@ -459,3 +459,48 @@ fn test_select_near_second_boundary_timeout() {
     .unwrap();
     assert_eq!(num, 0);
 }
+
+#[cfg(feature = "pipe")]
+#[cfg(not(windows))]
+#[test]
+fn test_select_repro_nanos_boundary() {
+    use rustix::pipe::pipe;
+
+    let (reader, _writer) = pipe().unwrap();
+    let nfds = reader.as_raw_fd() + 1;
+
+    // 999_999_000 nanoseconds -> (999_999_000 + 999)/1000 = 999_999 microseconds (valid)
+    let mut readfds1 = vec![FdSetElement::default(); fd_set_num_elements(1, nfds)];
+    fd_set_insert(&mut readfds1, reader.as_raw_fd());
+    let res1 = retry_on_intr(|| unsafe {
+        select(
+            nfds,
+            Some(&mut readfds1),
+            None,
+            None,
+            Some(&Timespec {
+                tv_sec: 0,
+                tv_nsec: 999_999_000,
+            }),
+        )
+    });
+    assert_eq!(res1.unwrap(), 0);
+
+    // 999_999_123 nanoseconds -> (999_999_123 + 999)/1000 = 1_000_000 microseconds.
+    // Before our fix, this produced tv_usec = 1_000_000, which failed with EINVAL (os error 22).
+    let mut readfds2 = vec![FdSetElement::default(); fd_set_num_elements(1, nfds)];
+    fd_set_insert(&mut readfds2, reader.as_raw_fd());
+    let res2 = retry_on_intr(|| unsafe {
+        select(
+            nfds,
+            Some(&mut readfds2),
+            None,
+            None,
+            Some(&Timespec {
+                tv_sec: 0,
+                tv_nsec: 999_999_123,
+            }),
+        )
+    });
+    assert_eq!(res2.unwrap(), 0);
+}

--- a/tests/event/select.rs
+++ b/tests/event/select.rs
@@ -429,3 +429,33 @@ fn test_select_iter() {
 fn fd_set_contains(fds: &[FdSetElement], fd: RawFd) -> bool {
     FdSetIter::new(fds).any(|x| x == fd)
 }
+
+#[cfg(feature = "pipe")]
+#[cfg(not(windows))]
+#[test]
+fn test_select_near_second_boundary_timeout() {
+    use rustix::pipe::pipe;
+
+    let (reader, _writer) = pipe().unwrap();
+    let nfds = reader.as_raw_fd() + 1;
+    let mut readfds = vec![FdSetElement::default(); fd_set_num_elements(1, nfds)];
+    fd_set_insert(&mut readfds, reader.as_raw_fd());
+
+    // 999_999_500 ns will ceiling-divide to 1_000_000 microseconds.
+    // Ensure that it rolls over to tv_sec = 1, tv_usec = 0 instead of tv_usec = 1_000_000
+    // which fails on macOS with EINVAL.
+    let num = retry_on_intr(|| unsafe {
+        select(
+            nfds,
+            Some(&mut readfds),
+            None,
+            None,
+            Some(&Timespec {
+                tv_sec: 0,
+                tv_nsec: 999_999_500,
+            }),
+        )
+    })
+    .unwrap();
+    assert_eq!(num, 0);
+}


### PR DESCRIPTION
I ran into an odd bug on macos. If my code polls for just under 5s (say 4.999_999_123 seconds), I immediately receive an `EINVAL` error.

This is due to the rounding logic. With the current logic, we set `tv_usec` to `1_000_000` when the nanosecond remainder is >= 999_999_001. This creates an invalid `timeval` on macOS and the OS returns `EINVAL`.

`tv_usec=1_000_000` is considered invalid and instead we should increase `tv_sec` by 1 and set `tv_usec=0`. 

# Solution

Checking if `tv_usec >= 1_000_000` https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/kern/kern_time.c#L670

XNU handling this issue in the same way that I propose: https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/sys/time.h#L175-L177

Linux kernel is more forgiving if you set usec to 1_000_000: https://github.com/torvalds/linux/blob/master/fs/select.c#L723-L725. So I could revert the changes here for linux code and only keep the macos fix. Please let me know what is best.

# Reproducing

This is a small example that I have tested on macOS. `select` with a timeout of `999_999_123` fails using rustix master but is fixed when using my branch.

```rust
use rustix::event::{fd_set_insert, fd_set_num_elements, select, FdSetElement, Timespec};
use rustix::fd::AsRawFd;
use rustix::pipe::pipe;

fn main() {
    // Create a pipe so we have a valid file descriptor to pass to select()
    let (reader, _writer) = pipe().unwrap();
    let raw_fd = reader.as_raw_fd();
    let nfds = raw_fd + 1;
    let num_elems = fd_set_num_elements(1, nfds);

    // 1. 999_999_000 ns -> (999_999_000 + 999)/1000 = 999_999 μs (< 1,000,000 μs)
    let mut readfds1 = vec![FdSetElement::default(); num_elems];
    fd_set_insert(&mut readfds1, raw_fd);
    let res1 = unsafe {
        select(
            nfds,
            Some(&mut readfds1),
            None,
            None,
            Some(&Timespec {
                tv_sec: 0,
                tv_nsec: 999_999_000,
            }),
        )
    };
    println!("999_999_000 ns result: {:?}", res1);

    // 2. 999_999_123 ns -> (999_999_123 + 999)/1000 = 1_000_000 μs
    let mut readfds2 = vec![FdSetElement::default(); num_elems];
    fd_set_insert(&mut readfds2, raw_fd);
    let res2 = unsafe {
        select(
            nfds,
            Some(&mut readfds2),
            None,
            None,
            Some(&Timespec {
                tv_sec: 0,
                tv_nsec: 999_999_123,
            }),
        )
    };
    println!("999_999_123 ns result: {:?}", res2);
}
```

# Testing

`invalid_offset::invalid_offset_fadvise` library test was failing on main. All other `cargo test --features=all-apis` tests pass. All `cargo test --test event --features all-apis` tests pass.