### PR TITLE
net: use IPPROTO_IPV6 for IPV6_MULTICAST_HOPS

### DIFF
--- a/src/backend/libc/net/sockopt.rs
+++ b/src/backend/libc/net/sockopt.rs
@@ -616,12 +616,12 @@ pub(crate) fn ipv6_multicast_loop(fd: BorrowedFd<'_>) -> io::Result<bool> {
 
 #[inline]
 pub(crate) fn set_ipv6_multicast_hops(fd: BorrowedFd<'_>, multicast_hops: u32) -> io::Result<()> {
-    setsockopt(fd, c::IPPROTO_IP, c::IPV6_MULTICAST_HOPS, multicast_hops)
+    setsockopt(fd, c::IPPROTO_IPV6, c::IPV6_MULTICAST_HOPS, multicast_hops)
 }
 
 #[inline]
 pub(crate) fn ipv6_multicast_hops(fd: BorrowedFd<'_>) -> io::Result<u32> {
-    getsockopt(fd, c::IPPROTO_IP, c::IPV6_MULTICAST_HOPS)
+    getsockopt(fd, c::IPPROTO_IPV6, c::IPV6_MULTICAST_HOPS)
 }
 
 #[inline]

--- a/src/backend/linux_raw/net/sockopt.rs
+++ b/src/backend/linux_raw/net/sockopt.rs
@@ -567,12 +567,12 @@ pub(crate) fn ipv6_multicast_loop(fd: BorrowedFd<'_>) -> io::Result<bool> {
 
 #[inline]
 pub(crate) fn set_ipv6_multicast_hops(fd: BorrowedFd<'_>, multicast_hops: u32) -> io::Result<()> {
-    setsockopt(fd, c::IPPROTO_IP, c::IPV6_MULTICAST_HOPS, multicast_hops)
+    setsockopt(fd, c::IPPROTO_IPV6, c::IPV6_MULTICAST_HOPS, multicast_hops)
 }
 
 #[inline]
 pub(crate) fn ipv6_multicast_hops(fd: BorrowedFd<'_>) -> io::Result<u32> {
-    getsockopt(fd, c::IPPROTO_IP, c::IPV6_MULTICAST_HOPS)
+    getsockopt(fd, c::IPPROTO_IPV6, c::IPV6_MULTICAST_HOPS)
 }
 
 #[inline]

--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -429,8 +429,20 @@ fn test_sockopts_ipv6() {
     #[cfg(not(target_os = "netbsd"))]
     match sockopt::ipv6_multicast_hops(&s) {
         Ok(hops) => assert_eq!(hops, 0),
+        Err(io::Errno::OPNOTSUPP) => (),
         Err(io::Errno::NOPROTOOPT) => (),
         Err(io::Errno::INVAL) => (),
+        Err(err) => panic!("{:?}", err),
+    }
+
+    match sockopt::set_ipv6_multicast_hops(&s, 8) {
+        Ok(()) => match sockopt::ipv6_multicast_hops(&s) {
+            Ok(hops) => assert_eq!(hops, 8),
+            Err(err) => panic!("{:?}", err),
+        },
+        Err(io::Errno::OPNOTSUPP) => (),
+        Err(io::Errno::INVAL) => (),
+        Err(io::Errno::NOPROTOOPT) => (),
         Err(err) => panic!("{:?}", err),
     }
 
@@ -514,6 +526,20 @@ fn test_sockopts_ipv6() {
     }
 
     test_sockopts_tcp(&s);
+}
+
+#[test]
+fn test_ipv6_multicast_hops_dgram() {
+    crate::init();
+
+    let s = rustix::net::socket(AddressFamily::INET6, SocketType::DGRAM, None).unwrap();
+    match sockopt::set_ipv6_multicast_hops(&s, 8) {
+        Ok(()) => assert_eq!(sockopt::ipv6_multicast_hops(&s).unwrap(), 8),
+        Err(io::Errno::OPNOTSUPP) => (),
+        Err(io::Errno::INVAL) => (),
+        Err(io::Errno::NOPROTOOPT) => (),
+        Err(err) => panic!("{:?}", err),
+    }
 }
 
 #[cfg(linux_kernel)]

--- a/tests/net/sockopt.rs
+++ b/tests/net/sockopt.rs
@@ -424,11 +424,8 @@ fn test_sockopts_ipv6() {
     }
     assert_ne!(sockopt::ipv6_unicast_hops(&s).unwrap(), 0);
 
-    // On NetBSD, `get_ipv6_multicasthops` returns 1 here. It's not evident
-    // why it differs from other OS's.
-    #[cfg(not(target_os = "netbsd"))]
     match sockopt::ipv6_multicast_hops(&s) {
-        Ok(hops) => assert_eq!(hops, 0),
+        Ok(hops) => assert_eq!(hops, 1),
         Err(io::Errno::OPNOTSUPP) => (),
         Err(io::Errno::NOPROTOOPT) => (),
         Err(io::Errno::INVAL) => (),


### PR DESCRIPTION
IPV6_MULTICAST_HOPS is an IPPROTO_IPV6 option. Both backends were
passing IPPROTO_IP, so get/set either failed with NOPROTOOPT or
didn't actually set the hop limit.

The existing test only read the default and treated NOPROTOOPT/INVAL
as success. Added a UDP set/get round-trip, and OPNOTSUPP on the
stream-socket get (macOS returns that once the level is correct).

Fixes #1660