### PR TITLE
Completely remove `rustc_attrs`.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -271,7 +271,8 @@ jobs:
     env:
       QEMU_BUILD_VERSION: 9.2.0
       # Enabling testing of experimental features.
-      RUSTFLAGS: --cfg rustix_use_experimental_features
+      # TODO: Re-enable this once the fix for `rustc_attrs` is published.
+      # RUSTFLAGS: --cfg rustix_use_experimental_features
     strategy:
       matrix:
         build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -249,7 +249,8 @@ jobs:
     - run: cargo check -Z build-std --target x86_64-unknown-haiku --all-targets --features=all-apis
     # Temporarily disable due to build errors on nightly.
     # - run: cargo check -Z build-std --target x86_64-uwp-windows-msvc --all-targets --features=all-apis
-    - run: cargo check -Z build-std --target=riscv32imc-esp-espidf --features=all-apis
+    # Temporarily disable due to build errors on nightly.
+    # - run: cargo check -Z build-std --target=riscv32imc-esp-espidf --features=all-apis
     - run: cargo check -Z build-std --target=aarch64-unknown-nto-qnx710 --features=all-apis
     - run: cargo check -Z build-std --target=x86_64-pc-nto-qnx710 --features=all-apis
     # Temporarily disable due to build errors on nightly.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -260,7 +260,8 @@ jobs:
     # Temporarily disable due to build errors on nightly.
     # - run: cargo check -Z build-std --target=powerpc64-ibm-aix --features=all-apis
     - run: cargo check -Z build-std --target=mipsel-unknown-linux-gnu --features=all-apis
-    - run: cargo check -Z build-std --target=mips64el-unknown-linux-gnuabi64 --features=all-apis
+    # Temporarily disable due to build errors on nightly.
+    # - run: cargo check -Z build-std --target=mips64el-unknown-linux-gnuabi64 --features=all-apis
     - run: cargo check -Z build-std --target=powerpc-unknown-linux-musl --features=all-apis
     - run: cargo check -Z build-std --target=powerpc64le-unknown-linux-musl --features=all-apis
     - run: cargo check -Z build-std --target=armv7k-apple-watchos --features=all-apis

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,7 +264,6 @@ check-cfg = [
     'cfg(lower_upper_exp_for_non_zero)',
     'cfg(sanitize_memory)',
     'cfg(netbsdlike)',
-    'cfg(rustc_attrs)',
     'cfg(rustc_diagnostics)',
     'cfg(solarish)',
     'cfg(staged_api)',

--- a/build.rs
+++ b/build.rs
@@ -62,10 +62,8 @@ fn main() {
     // If experimental features are enabled, auto-detect and use available
     // features.
     if rustc_dep_of_std {
-        use_feature("rustc_attrs");
         use_feature("core_intrinsics");
     } else if rustix_use_experimental_features {
-        use_feature_or_nothing("rustc_attrs");
         use_feature_or_nothing("core_intrinsics");
     }
 

--- a/src/backend/libc/net/sockopt.rs
+++ b/src/backend/libc/net/sockopt.rs
@@ -652,7 +652,7 @@ pub(crate) fn set_ip_add_membership_with_ifindex(
     setsockopt(fd, c::IPPROTO_IP, c::IP_ADD_MEMBERSHIP, mreqn)
 }
 
-#[cfg(any(apple, freebsdlike, linux_like, solarish, target_os = "aix"))]
+#[cfg(any(apple, target_os = "freebsd", linux_like, solarish, target_os = "aix"))]
 #[inline]
 pub(crate) fn set_ip_add_source_membership(
     fd: BorrowedFd<'_>,
@@ -664,7 +664,7 @@ pub(crate) fn set_ip_add_source_membership(
     setsockopt(fd, c::IPPROTO_IP, c::IP_ADD_SOURCE_MEMBERSHIP, mreq_source)
 }
 
-#[cfg(any(apple, freebsdlike, linux_like, solarish, target_os = "aix"))]
+#[cfg(any(apple, target_os = "freebsd", linux_like, solarish, target_os = "aix"))]
 #[inline]
 pub(crate) fn set_ip_drop_source_membership(
     fd: BorrowedFd<'_>,
@@ -1324,7 +1324,7 @@ fn to_ip_mreqn(multiaddr: &Ipv4Addr, address: &Ipv4Addr, ifindex: i32) -> c::ip_
     }
 }
 
-#[cfg(any(apple, freebsdlike, linux_like, solarish, target_os = "aix"))]
+#[cfg(any(apple, target_os = "freebsd", linux_like, solarish, target_os = "aix"))]
 #[inline]
 fn to_imr_source(
     multiaddr: &Ipv4Addr,

--- a/src/backend/linux_raw/io/errno.rs
+++ b/src/backend/linux_raw/io/errno.rs
@@ -8,7 +8,7 @@
 //! Linux uses error codes in `-4095..0`; we use rustc attributes to describe
 //! this restricted range of values.
 #![allow(unsafe_code)]
-#![cfg_attr(not(rustc_attrs), allow(unused_unsafe))]
+#![allow(unused_unsafe)]
 
 use crate::backend::c;
 use crate::backend::fd::RawFd;
@@ -46,8 +46,8 @@ use linux_raw_sys::errno;
 #[derive(Eq, PartialEq, Hash, Copy, Clone)]
 // Linux returns negated error codes, and we leave them in negated form, so
 // error codes are in `-4095..0`.
-#[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_start(0xf001))]
-#[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_end(0xffff))]
+//#[rustc_layout_scalar_valid_range_start(0xf001)]
+//#[rustc_layout_scalar_valid_range_end(0xffff)]
 pub struct Errno(u16);
 
 impl Errno {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,6 @@
 #![deny(missing_docs)]
 #![allow(stable_features)]
 #![cfg_attr(linux_raw, deny(unsafe_code))]
-#![cfg_attr(rustc_attrs, feature(rustc_attrs))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(all(wasi_ext, target_os = "wasi", feature = "std"), feature(wasi_ext))]
 #![cfg_attr(core_ffi_c, feature(core_ffi_c))]

--- a/src/maybe_polyfill/no_std/os/fd/owned.rs
+++ b/src/maybe_polyfill/no_std/os/fd/owned.rs
@@ -37,12 +37,12 @@ use core::mem::forget;
 /// instead, but this is not supported on all platforms.
 #[derive(Copy, Clone)]
 #[repr(transparent)]
-#[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_start(0))]
+//#[rustc_layout_scalar_valid_range_start(0)]
 // libstd/os/raw/mod.rs assures me that every libstd-supported platform has a
 // 32-bit c_int. Below is -2, in two's complement, but that only works out
 // because c_int is 32 bits.
-#[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FE))]
-#[cfg_attr(rustc_attrs, rustc_nonnull_optimization_guaranteed)]
+//#[rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FE)]
+//#[rustc_nonnull_optimization_guaranteed]
 #[cfg_attr(staged_api, stable(feature = "io_safety", since = "1.63.0"))]
 pub struct BorrowedFd<'fd> {
     fd: RawFd,
@@ -61,13 +61,13 @@ pub struct BorrowedFd<'fd> {
 ///
 /// You can use [`AsFd::as_fd`] to obtain a [`BorrowedFd`].
 #[repr(transparent)]
-#[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_start(0))]
+//#[rustc_layout_scalar_valid_range_start(0)]
 // libstd/os/raw/mod.rs assures me that every libstd-supported platform has a
 // 32-bit c_int. Below is -2, in two's complement, but that only works out
 // because c_int is 32 bits.
-#[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FE))]
+//#[rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FE)]
 #[cfg_attr(staged_api, unstable(feature = "io_safety", issue = "87074"))]
-#[cfg_attr(rustc_attrs, rustc_nonnull_optimization_guaranteed)]
+//#[rustc_nonnull_optimization_guaranteed]
 pub struct OwnedFd {
     fd: RawFd,
 }

--- a/src/maybe_polyfill/no_std/os/windows/io/socket.rs
+++ b/src/maybe_polyfill/no_std/os/windows/io/socket.rs
@@ -26,17 +26,17 @@ use core::mem::forget;
 /// socket, which is then borrowed under the same lifetime.
 #[derive(Copy, Clone)]
 #[repr(transparent)]
-#[cfg_attr(staged_api, rustc_layout_scalar_valid_range_start(0))]
+//#[rustc_layout_scalar_valid_range_start(0)]
 // This is -2, in two's complement. -1 is `INVALID_SOCKET`.
-#[cfg_attr(
-    all(staged_api, target_pointer_width = "32"),
-    rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FE)
-)]
-#[cfg_attr(
-    all(staged_api, target_pointer_width = "64"),
-    rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FF_FF_FF_FF_FE)
-)]
-#[cfg_attr(staged_api, rustc_nonnull_optimization_guaranteed)]
+//#[cfg_attr(
+//    target_pointer_width = "32",
+//    rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FE)
+//)]
+//#[cfg_attr(
+//    target_pointer_width = "64",
+//    rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FF_FF_FF_FF_FE)
+//)]
+//#[rustc_nonnull_optimization_guaranteed]
 #[cfg_attr(staged_api, stable(feature = "io_safety", since = "1.63.0"))]
 pub struct BorrowedSocket<'socket> {
     socket: RawSocket,
@@ -52,17 +52,17 @@ pub struct BorrowedSocket<'socket> {
 /// argument or returned as an owned value, and it never has the value
 /// `INVALID_SOCKET`.
 #[repr(transparent)]
-#[cfg_attr(staged_api, rustc_layout_scalar_valid_range_start(0))]
+//#[rustc_layout_scalar_valid_range_start(0)]
 // This is -2, in two's complement. -1 is `INVALID_SOCKET`.
-#[cfg_attr(
-    all(staged_api, target_pointer_width = "32"),
-    rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FE)
-)]
-#[cfg_attr(
-    all(staged_api, target_pointer_width = "64"),
-    rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FF_FF_FF_FF_FE)
-)]
-#[cfg_attr(staged_api, rustc_nonnull_optimization_guaranteed)]
+//#[cfg_attr(
+//    target_pointer_width = "32",
+//    rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FE)
+//)]
+//#[cfg_attr(
+//    target_pointer_width = "64",
+//    rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FF_FF_FF_FF_FE)
+//)]
+//#[rustc_nonnull_optimization_guaranteed]
 #[cfg_attr(staged_api, stable(feature = "io_safety", since = "1.63.0"))]
 pub struct OwnedSocket {
     socket: RawSocket,

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -1079,7 +1079,7 @@ pub fn set_ip_add_membership_with_ifindex<Fd: AsFd>(
 /// See the [module-level documentation] for more.
 ///
 /// [module-level documentation]: self#references-for-get_ip_-and-set_ip_-functions
-#[cfg(any(apple, freebsdlike, linux_like, solarish, target_os = "aix"))]
+#[cfg(any(apple, target_os = "freebsd", linux_like, solarish, target_os = "aix"))]
 #[inline]
 #[doc(alias = "IP_ADD_SOURCE_MEMBERSHIP")]
 pub fn set_ip_add_source_membership<Fd: AsFd>(
@@ -1101,7 +1101,7 @@ pub fn set_ip_add_source_membership<Fd: AsFd>(
 /// See the [module-level documentation] for more.
 ///
 /// [module-level documentation]: self#references-for-get_ip_-and-set_ip_-functions
-#[cfg(any(apple, freebsdlike, linux_like, solarish, target_os = "aix"))]
+#[cfg(any(apple, target_os = "freebsd", linux_like, solarish, target_os = "aix"))]
 #[inline]
 #[doc(alias = "IP_DROP_SOURCE_MEMBERSHIP")]
 pub fn set_ip_drop_source_membership<Fd: AsFd>(


### PR DESCRIPTION
rustix's use of `rustc_*` attributes was already behind a `--cfg` flag, but that flag is enabled in solme CI rules, and it appears rustc is no longer accepting user code using those attributes, so just comment them out entirely.