### PR TITLE
Fix build errors for the Horizon target

### DIFF
--- a/src/backend/libc/conv.rs
+++ b/src/backend/libc/conv.rs
@@ -3,7 +3,10 @@
 //! for converting between rustix's types and libc types.
 
 use super::c;
-#[cfg(all(feature = "alloc", not(any(windows, target_os = "espidf"))))]
+#[cfg(all(
+    feature = "alloc",
+    not(any(windows, target_os = "espidf", target_os = "horizon"))
+))]
 use super::fd::IntoRawFd as _;
 use super::fd::{AsRawFd as _, BorrowedFd, FromRawFd as _, LibcFd, OwnedFd, RawFd};
 #[cfg(not(windows))]
@@ -35,7 +38,12 @@ pub(super) fn borrowed_fd(fd: BorrowedFd<'_>) -> LibcFd {
 
 #[cfg(all(
     feature = "alloc",
-    not(any(windows, target_os = "espidf", target_os = "redox"))
+    not(any(
+        windows,
+        target_os = "espidf",
+        target_os = "horizon",
+        target_os = "redox"
+    ))
 ))]
 #[inline]
 pub(super) fn owned_fd(fd: OwnedFd) -> LibcFd {

--- a/src/backend/libc/event/poll_fd.rs
+++ b/src/backend/libc/event/poll_fd.rs
@@ -8,13 +8,18 @@ use bitflags::bitflags;
 use core::fmt;
 use core::marker::PhantomData;
 
+#[cfg(not(target_os = "horizon"))]
+pub(crate) type RawPollFlags = ffi::c_short;
+#[cfg(target_os = "horizon")]
+pub(crate) type RawPollFlags = ffi::c_int;
+
 bitflags! {
     /// `POLL*` flags for use with [`poll`].
     ///
     /// [`poll`]: crate::event::poll
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-    pub struct PollFlags: ffi::c_short {
+    pub struct PollFlags: RawPollFlags {
         /// `POLLIN`
         const IN = c::POLLIN;
         /// `POLLPRI`

--- a/src/backend/libc/fs/mod.rs
+++ b/src/backend/libc/fs/mod.rs
@@ -1,4 +1,7 @@
-#[cfg(all(feature = "alloc", not(any(target_os = "espidf", target_os = "redox"))))]
+#[cfg(all(
+    feature = "alloc",
+    not(any(target_os = "espidf", target_os = "horizon", target_os = "redox"))
+))]
 pub(crate) mod dir;
 #[cfg(linux_kernel)]
 pub mod inotify;

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -49,11 +49,12 @@ use crate::fs::SealFlags;
     target_os = "wasi",
 )))]
 use crate::fs::StatFs;
-#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
 use crate::fs::Timestamps;
 #[cfg(not(any(
     apple,
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -1,4 +1,5 @@
 use crate::backend::c;
+#[cfg(not(target_os = "horizon"))]
 use crate::ffi;
 use bitflags::bitflags;
 
@@ -627,6 +628,7 @@ impl FileType {
         target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
+        target_os = "horizon",
         target_os = "nto",
         target_os = "redox",
         target_os = "vita"

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -8,6 +8,7 @@ use crate::fd::{AsFd as _, BorrowedFd, OwnedFd, RawFd};
 #[cfg(not(any(
     target_os = "aix",
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "nto",
     target_os = "vita",
     target_os = "wasi"

--- a/src/backend/libc/net/sockopt.rs
+++ b/src/backend/libc/net/sockopt.rs
@@ -27,6 +27,7 @@ use crate::net::xdp::{XdpMmapOffsets, XdpOptionsFlags, XdpRingOffset, XdpStatist
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "netbsd",
     target_os = "nto",
     target_os = "vita",

--- a/src/backend/libc/pipe/syscalls.rs
+++ b/src/backend/libc/pipe/syscalls.rs
@@ -7,6 +7,7 @@ use crate::io;
     target_os = "aix",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "nto",
     target_os = "wasi"
 )))]

--- a/src/backend/libc/process/syscalls.rs
+++ b/src/backend/libc/process/syscalls.rs
@@ -10,6 +10,7 @@ use crate::backend::conv::ret_discarded_char_ptr;
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"
@@ -48,6 +49,7 @@ use crate::process::Signal;
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "vita",
     target_os = "wasi"
 )))]

--- a/src/backend/libc/process/types.rs
+++ b/src/backend/libc/process/types.rs
@@ -1,6 +1,7 @@
 #[cfg(not(any(
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"

--- a/src/backend/libc/system/syscalls.rs
+++ b/src/backend/libc/system/syscalls.rs
@@ -14,6 +14,7 @@ use {
 #[cfg(not(any(
     target_os = "emscripten",
     target_os = "espidf",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"

--- a/src/backend/libc/thread/syscalls.rs
+++ b/src/backend/libc/thread/syscalls.rs
@@ -13,6 +13,7 @@ use crate::pid::Pid;
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "openbsd",
     target_os = "redox",
     target_os = "vita",

--- a/src/fs/at.rs
+++ b/src/fs/at.rs
@@ -20,7 +20,13 @@ use crate::fs::CloneFlags;
 use crate::fs::RenameFlags;
 #[cfg(not(target_os = "espidf"))]
 use crate::fs::Stat;
-#[cfg(not(any(apple, target_os = "espidf", target_os = "vita", target_os = "wasi")))]
+#[cfg(not(any(
+    apple,
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "vita",
+    target_os = "wasi"
+)))]
 use crate::fs::{Dev, FileType};
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 use crate::fs::{Gid, Uid};
@@ -34,7 +40,7 @@ use {
     alloc::vec::Vec,
     backend::fd::BorrowedFd,
 };
-#[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))]
 use {crate::fs::Timestamps, crate::timespec::Nsecs};
 
 /// `UTIME_NOW` for use with [`utimensat`].

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -5,7 +5,10 @@ mod at;
 mod constants;
 #[cfg(linux_kernel)]
 mod copy_file_range;
-#[cfg(all(feature = "alloc", not(any(target_os = "espidf", target_os = "redox"))))]
+#[cfg(all(
+    feature = "alloc",
+    not(any(target_os = "espidf", target_os = "horizon", target_os = "redox"))
+))]
 mod dir;
 #[cfg(not(any(
     apple,
@@ -70,7 +73,10 @@ pub use at::*;
 pub use constants::*;
 #[cfg(linux_kernel)]
 pub use copy_file_range::copy_file_range;
-#[cfg(all(feature = "alloc", not(any(target_os = "espidf", target_os = "redox"))))]
+#[cfg(all(
+    feature = "alloc",
+    not(any(target_os = "espidf", target_os = "horizon", target_os = "redox"))
+))]
 pub use dir::{Dir, DirEntry};
 #[cfg(not(any(
     apple,

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -156,6 +156,7 @@ use crate::net::xdp::{XdpMmapOffsets, XdpOptionsFlags, XdpStatistics, XdpUmemReg
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "netbsd",
     target_os = "nto",
     target_os = "vita",

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -9,6 +9,7 @@ use crate::{backend, io};
     windows,
     target_os = "espidf",
     target_os = "haiku",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi",

--- a/src/process/ioctl.rs
+++ b/src/process/ioctl.rs
@@ -22,35 +22,17 @@ use backend::fd::AsFd;
 /// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=tty&sektion=4
 /// [NetBSD]: https://man.netbsd.org/tty.4
 /// [OpenBSD]: https://man.openbsd.org/tty.4
-#[cfg(not(any(
-    windows,
-    target_os = "aix",
-    target_os = "horizon",
-    target_os = "redox",
-    target_os = "wasi"
-)))]
+#[cfg(not(any(windows, target_os = "aix", target_os = "redox", target_os = "wasi")))]
 #[inline]
 #[doc(alias = "TIOCSCTTY")]
 pub fn ioctl_tiocsctty<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     unsafe { ioctl::ioctl(fd, Tiocsctty) }
 }
 
-#[cfg(not(any(
-    windows,
-    target_os = "aix",
-    target_os = "horizon",
-    target_os = "redox",
-    target_os = "wasi"
-)))]
+#[cfg(not(any(windows, target_os = "aix", target_os = "redox", target_os = "wasi")))]
 struct Tiocsctty;
 
-#[cfg(not(any(
-    windows,
-    target_os = "aix",
-    target_os = "horizon",
-    target_os = "redox",
-    target_os = "wasi"
-)))]
+#[cfg(not(any(windows, target_os = "aix", target_os = "redox", target_os = "wasi")))]
 unsafe impl ioctl::Ioctl for Tiocsctty {
     type Output = ();
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -17,7 +17,12 @@ mod exit;
 mod fcntl_getlk;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have get[gpu]id.
 mod id;
-#[cfg(not(any(target_os = "aix", target_os = "espidf", target_os = "vita")))]
+#[cfg(not(any(
+    target_os = "aix",
+    target_os = "horizon",
+    target_os = "espidf",
+    target_os = "vita"
+)))]
 mod ioctl;
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 mod kill;
@@ -74,7 +79,12 @@ pub use exit::*;
 pub use fcntl_getlk::*;
 #[cfg(not(target_os = "wasi"))]
 pub use id::*;
-#[cfg(not(any(target_os = "aix", target_os = "espidf", target_os = "vita")))]
+#[cfg(not(any(
+    target_os = "aix",
+    target_os = "espidf",
+    target_os = "horizon",
+    target_os = "vita"
+)))]
 pub use ioctl::*;
 #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 pub use kill::*;
@@ -103,6 +113,7 @@ pub use rlimit::*;
     target_os = "emscripten",
     target_os = "espidf",
     target_os = "fuchsia",
+    target_os = "horizon",
     target_os = "redox",
     target_os = "vita",
     target_os = "wasi"

--- a/src/process/types.rs
+++ b/src/process/types.rs
@@ -4,8 +4,11 @@
 
 #![allow(unsafe_code)]
 
+#[cfg(not(target_os = "horizon"))]
 use crate::backend::c;
+#[cfg(not(target_os = "horizon"))]
 use crate::pid::Pid;
+#[cfg(not(target_os = "horizon"))]
 use core::mem::transmute;
 
 /// File lock data structure used in [`fcntl_getlk`].

--- a/src/system.rs
+++ b/src/system.rs
@@ -6,7 +6,12 @@ use crate::backend;
 #[cfg(target_os = "linux")]
 use crate::backend::c;
 use crate::ffi::CStr;
-#[cfg(not(any(target_os = "espidf", target_os = "emscripten", target_os = "vita")))]
+#[cfg(not(any(
+    target_os = "espidf",
+    target_os = "emscripten",
+    target_os = "horizon",
+    target_os = "vita"
+)))]
 use crate::io;
 use core::fmt;
 


### PR DESCRIPTION
Horizon does not provide several libc APIs and types that are assumed by the generic Unix implementation. The affected code was being compiled unconditionally, resulting in missing symbols, incompatible types, and imports that are unavailable on Horizon.

- Account for Horizon's `poll` flag type, which since https://github.com/rust-lang/libc/pull/5045 uses `c_int` rather than `c_short`.
