### PR TITLE
Fix compile errors for next libc version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,7 @@ jobs:
         cargo update --package=half --precise=2.2.1
         cargo update --package=flate2 --precise=1.0.35
         cargo update --package=serde --precise=1.0.228
+        cargo update --package=web-sys --precise=0.3.104
         cargo update --package=syn --precise=2.0.106
         cargo update --package=textwrap --precise=0.16.1
         cargo update --package=parking_lot --precise=0.12.4
@@ -596,6 +597,7 @@ jobs:
         cargo update --package=half --precise=2.2.1
         cargo update --package=flate2 --precise=1.0.35
         cargo update --package=serde --precise=1.0.228
+        cargo update --package=web-sys --precise=0.3.104
         cargo update --package=syn --precise=2.0.106
         cargo update --package=textwrap --precise=0.16.1
         cargo update --package=parking_lot --precise=0.12.4

--- a/src/backend/libc/c.rs
+++ b/src/backend/libc/c.rs
@@ -474,30 +474,8 @@ mod readwrite_pv64v2 {
 ))]
 pub(super) use readwrite_pv64v2::{preadv64v2 as preadv2, pwritev64v2 as pwritev2};
 
-// Rust's libc crate lacks statx for Non-glibc targets.
-#[cfg(feature = "fs")]
-#[cfg(all(
-    linux_like,
-    linux_raw_dep,
-    not(any(
-        target_os = "emscripten",
-        target_env = "gnu",
-        all(target_arch = "loongarch64", target_env = "musl")
-    ))
-))]
-mod statx_flags {
-    pub(crate) use linux_raw_sys::general::{
-        STATX_ALL, STATX_ATIME, STATX_BASIC_STATS, STATX_BLOCKS, STATX_BTIME, STATX_CTIME,
-        STATX_DIOALIGN, STATX_GID, STATX_INO, STATX_MNT_ID, STATX_MODE, STATX_MTIME, STATX_NLINK,
-        STATX_SIZE, STATX_TYPE, STATX_UID,
-    };
-
-    pub(crate) use linux_raw_sys::general::{
-        STATX_ATTR_APPEND, STATX_ATTR_AUTOMOUNT, STATX_ATTR_COMPRESSED, STATX_ATTR_DAX,
-        STATX_ATTR_ENCRYPTED, STATX_ATTR_IMMUTABLE, STATX_ATTR_MOUNT_ROOT, STATX_ATTR_NODUMP,
-        STATX_ATTR_VERITY,
-    };
-}
+// Rust's libc crate > v0.2.189 may also define these constants,
+// so we use an explicit import.
 #[cfg(feature = "fs")]
 #[cfg(all(
     linux_like,
@@ -509,7 +487,30 @@ mod statx_flags {
         all(target_arch = "loongarch64", target_env = "musl")
     ))
 ))]
-pub(crate) use statx_flags::*;
+pub(crate) use linux_raw_sys::general::{
+    STATX_ALL, STATX_ATIME, STATX_BASIC_STATS, STATX_BLOCKS, STATX_BTIME, STATX_CTIME,
+    STATX_DIOALIGN, STATX_GID, STATX_INO, STATX_MNT_ID, STATX_MODE, STATX_MTIME, STATX_NLINK,
+    STATX_SIZE, STATX_TYPE, STATX_UID,
+};
+
+// Rust's libc crate > v0.2.189 may also define these constants,
+// so we use an explicit import.
+#[cfg(feature = "fs")]
+#[cfg(all(
+    linux_like,
+    linux_raw_dep,
+    not(any(
+        target_os = "android",
+        target_os = "emscripten",
+        target_env = "gnu",
+        all(target_arch = "loongarch64", target_env = "musl")
+    ))
+))]
+pub(crate) use linux_raw_sys::general::{
+    STATX_ATTR_APPEND, STATX_ATTR_AUTOMOUNT, STATX_ATTR_COMPRESSED, STATX_ATTR_DAX,
+    STATX_ATTR_ENCRYPTED, STATX_ATTR_IMMUTABLE, STATX_ATTR_MOUNT_ROOT, STATX_ATTR_NODUMP,
+    STATX_ATTR_VERITY,
+};
 
 #[cfg(feature = "fs")]
 #[cfg(target_os = "android")]

--- a/src/backend/libc/fs/syscalls.rs
+++ b/src/backend/libc/fs/syscalls.rs
@@ -941,6 +941,7 @@ pub(crate) fn utimensat(
                 c::c_int
             ) -> c::c_int
         }
+        #[cfg(not(any(target_os = "tvos", target_os = "watchos")))]
         extern "C" {
             fn setattrlist(
                 path: *const ffi::c_char,
@@ -950,6 +951,7 @@ pub(crate) fn utimensat(
                 options: c::c_ulong,
             ) -> c::c_int;
         }
+        #[cfg(not(any(target_os = "tvos", target_os = "watchos")))]
         const FSOPT_NOFOLLOW: c::c_ulong = 0x0000_0001;
 
         // If we have `utimensat`, use it.
@@ -962,8 +964,14 @@ pub(crate) fn utimensat(
             ));
         }
 
+        // Return `NOSYS` on platforms where `utimensat` cannot be emulated
+        // because `fork` is unavailable.
+        #[cfg(any(target_os = "tvos", target_os = "watchos"))]
+        return Err(io::Errno::NOSYS);
+
         // Convert `times`. We only need this in the child, but do it before
         // calling `fork` because it might fail.
+        #[cfg(not(any(target_os = "tvos", target_os = "watchos")))]
         let (attrbuf_size, times, attrs) = times_to_attrlist(times)?;
 
         // `setattrlistat` was introduced in 10.13 along with `utimensat`, so
@@ -971,6 +979,7 @@ pub(crate) fn utimensat(
         // Emulate it using `fork`, and `fchdir` and [`setattrlist`].
         //
         // [`setattrlist`]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/setattrlist.2.html
+        #[cfg(not(any(target_os = "tvos", target_os = "watchos")))]
         match c::fork() {
             -1 => Err(io::Errno::IO),
             0 => {

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -740,7 +740,7 @@ impl AddressFamily {
     #[cfg(target_os = "freebsd")]
     pub const SLOW: Self = Self(c::AF_SLOW as _);
     /// `AF_SYS_CONTROL`
-    #[cfg(apple)]
+    #[cfg(target_os = "macos")]
     pub const SYS_CONTROL: Self = Self(c::AF_SYS_CONTROL as _);
     /// `AF_SYSTEM`
     #[cfg(apple)]

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1116,6 +1116,7 @@ pub mod ipproto {
 }
 
 /// `SYSPROTO_*` constants.
+#[cfg(target_os = "macos")]
 pub mod sysproto {
     #[cfg(apple)]
     use {
@@ -1124,11 +1125,9 @@ pub mod sysproto {
     };
 
     /// `SYSPROTO_EVENT`
-    #[cfg(apple)]
     pub const EVENT: Protocol = Protocol(new_raw_protocol(c::SYSPROTO_EVENT as _));
 
     /// `SYSPROTO_CONTROL`
-    #[cfg(apple)]
     pub const CONTROL: Protocol = Protocol(new_raw_protocol(c::SYSPROTO_CONTROL as _));
 }
 


### PR DESCRIPTION
- Import `statx_flags` explicitly from `linux_raw_sys` to avoid conflicts with `libc`, following https://github.com/rust-lang/libc/pull/5448.
- Gate some constants to macOS, following https://github.com/rust-lang/libc/pull/5158.
- Return `NOSYS` from `utimensat` on tvOS and watchOS. These platforms do not provide `fork`, so the existing `utimensat` fallback cannot be implemented, following https://github.com/rust-lang/libc/pull/5158.

Depends on https://github.com/bytecodealliance/rustix/pull/1674.
Closes https://github.com/bytecodealliance/rustix/issues/1675

[All checks passed](https://github.com/bytecodealliance/rustix/pull/1676/checks?check_run_id=101555856500) with `libc-0.2` branch of `libc` : 3feb13a596dcbcc21efe10586e8e1faeb047fc40
[All checks passed](https://github.com/bytecodealliance/rustix/pull/1676/checks?check_run_id=101561063969) with current (v0.2.189) release of `libc`: eada0dfcd64697eecbbb43aaa2c665c9d6a36051